### PR TITLE
Remove sign up option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Many adults circulate in and out of a Foster Youth's life, but very few of them 
 #### Common issues
 
 1. If your rake/rake commands hang forever instead of running, try: `rails app:update:bin #`
+1. There is currently no option for a user to sign up and create an account through the UI. This is intentional. If you want to log in, use a pre-seeded user account and its credentials.
 
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_paper_trail
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable,
          :recoverable, :rememberable, :validatable
 
   belongs_to :casa_org

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/doc/architecture-decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture-decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-04-04
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/architecture-decisions/0002-disallow-ui-sign-ups
+++ b/doc/architecture-decisions/0002-disallow-ui-sign-ups
@@ -1,0 +1,19 @@
+# 2. Disallow user sign-ups from the UI
+
+Date: 2020-04-04
+
+## Status
+
+Accepted
+
+## Context
+
+We want it to be easy for people to join the organization, however we don't want random people signing up and spamming us. We want admin users to have control over who has accounts on the system. We don't have the capacity to handle this properly through the user interface right now.
+
+## Decision
+
+We are going to disable Devise 'registerable' for the user model so that there will no longer be a public sign up option on the site. Creation of new accounts will be done on the backend.
+
+## Consequences
+
+Admins have to do more work to sign up users, but this gives them more control over who can access the site.


### PR DESCRIPTION

Resolves #35 

### Description
- #35 turn off ability to create your own account
- remove devise 'registerable' functionality from user model

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* This change requires a documentation update
