### PR TITLE
Displays login and logout links that work

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,5 +12,14 @@
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
     <%= yield %>
+    <% if user_signed_in? %>
+      <p class="logout-button button">
+        <%= link_to('Logout', destroy_user_session_path) %>
+      </p>
+    <% else %>
+      <p class="login-button button">
+        <%= link_to('Login', new_user_session_path) %>
+      </p>
+    <% end %>
   </body>
 </html>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -254,7 +254,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
Resolves #36 

### Description
There was no logout link, we added a logout link for when you are logged in and a login link for when you are logged out as part of the layout.

### Type of change
* New feature (non-breaking change which adds functionality)
