### PR TITLE
Disable check_yarn_integrity to avoid yarn error

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
Changed check_yarn_integrity to false to avoid the yard error we were getting on setup:
`error @rails/webpacker@4.2.2: The engine "yarn" is incompatible with this module. Expected version ">=1.0.0".
error Found incompatible module`