### PR TITLE
show casa case admin view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 $primary: #00447C;
 
 @import "bootstrap";
+@import "casa_cases";
 @import "dashboard";
 @import "navbar";
 

--- a/app/assets/stylesheets/casa_cases.scss
+++ b/app/assets/stylesheets/casa_cases.scss
@@ -1,3 +1,5 @@
-// Place all the styles related to the CasaCases controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+
+.case-contact-list {
+    margin-bottom: 20px;
+    background: lightgrey;
+}

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -8,6 +8,7 @@ class CasaCase < ApplicationRecord
     source: :volunteer,
     class_name: "User"
   )
+  has_many :case_contacts
 
   scope :ordered, -> { sort_by(&:updated_at).reverse }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,12 @@ class User < ApplicationRecord
 
   ALL_ROLES = %w[inactive volunteer supervisor casa_admin].freeze
   enum role: ALL_ROLES.zip(ALL_ROLES).to_h
+
+  # all contacts this user has with this casa case
+  def case_contacts_for(casa_case_id)
+    found_casa_case = casa_cases.find{|cc| cc.id == casa_case_id}
+    found_casa_case.case_contacts.filter{|contact| contact.creator_id == self.id}
+  end
 end
 
 # == Schema Information

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,14 +1,46 @@
 <p id="notice"><%= notice %></p>
 
+<h1>Casa Case Details</h1>
+
 <p>
-  <strong>Case number:</strong>
+  <h3>Case number:</h3>
   <%= @casa_case.case_number %>
 </p>
 
 <p>
-  <strong>Teen program eligible:</strong>
+  <h3>Teen program eligible:</h3>
   <%= @casa_case.teen_program_eligible %>
 </p>
+
+<div>
+  <h3>Assigned Volunteers</h3>
+  <% @casa_case.volunteers.each do  |volunteer|  %>
+    <span> Email: <%=  volunteer.email %></span>
+
+    <div class="case-contact-list">
+      <strong>Case Contacts</strong>
+      <div>
+        <table>
+          <thead>
+            <tr>
+              <th>Contact type</th>
+              <th>Duration (minutes)</th>
+              <th colspan="3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% volunteer.case_contacts_for(@casa_case.id).each do | contact | %>
+              <tr>
+                <td><%= contact.contact_type %></td><td> <%= contact.duration_minutes %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+</div>
+
 
 <%= link_to 'Edit', edit_casa_case_path(@casa_case) %> |
 <%= link_to 'Back', casa_cases_path %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,4 +11,38 @@ RSpec.describe User, type: :model do
       define_enum_for(:role).backed_by_column_of_type(:string)
     )
   end
+
+  it "returns all case_contacts associated with this user and the casa case id supplied" do
+
+    volunteer_1 = create(:user, :volunteer, :with_casa_cases)
+
+    case_of_interest = volunteer_1.casa_cases.first
+    create(:case_contact, creator: volunteer_1, casa_case: case_of_interest)
+    create(:case_contact, creator: volunteer_1, casa_case: volunteer_1.casa_cases.second)
+
+    sample_casa_case_id = case_of_interest.id
+
+    result = volunteer_1.case_contacts_for(sample_casa_case_id)
+
+    expect(result.length).to eq(1)
+  end
+
+  it "does not return case_contacts associated with another volunteer user" do
+    volunteer_1 = create(:user, :volunteer, :with_casa_cases)
+    volunteer_2 = create(:user, :volunteer, :with_casa_cases)
+
+    case_of_interest = volunteer_1.casa_cases.first
+    create(:case_contact, creator: volunteer_1, casa_case: case_of_interest)
+    create(:case_contact, creator: volunteer_1, casa_case: volunteer_1.casa_cases.second)
+    create(:case_assignment, casa_case: case_of_interest, volunteer: volunteer_2)
+    create(:case_contact, creator: volunteer_2, casa_case: case_of_interest)
+    create(:case_contact)
+
+    sample_casa_case_id = case_of_interest.id
+
+    result = volunteer_1.case_contacts_for(sample_casa_case_id)
+    expect(result.length).to eq(1)
+    result = volunteer_2.case_contacts_for(sample_casa_case_id)
+    expect(result.length).to eq(1)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 require 'capybara/rspec'
-require "pundit/rspec"
+require 'pundit/rspec'
+require 'pry'
 SimpleCov.start
 
 RSpec.configure do |config|


### PR DESCRIPTION
Resolves #48 

### Description
Shows details for casa_case show path, including case_contacts nested by volunteer.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Test added for method only returning case_contacts for the given volunteer and casa_case and not case_contacts for any other volunteer associated with that casa_case

### Screenshots
![Screen Shot 2020-04-05 at 4 16 42 PM](https://user-images.githubusercontent.com/7121497/78512382-e6217080-7758-11ea-8d80-990a35c4339f.png)
