### PR TITLE
Fixes [#83] Add link to dashboard from page header

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -1,6 +1,12 @@
 .navbar {
   color: white;
 
+  .nav-brand a {
+    color: white;
+    &:hover {
+      text-decoration: none;
+    }
+  }
   strong {
     font-size: 2rem;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,19 @@
 module ApplicationHelper # rubocop:todo Style/Documentation
+  def page_header
+    page_header_text = "CASA - Prince George's County, MD"
+    user_signed_in? ? link_to(page_header_text, root_path) : page_header_text
+  end
+
+  def session_link
+    if user_signed_in?
+      link_to('Log out', destroy_user_session_path, class: "btn btn-light")
+    else
+      link_to('Log in', new_user_session_path, class: "btn btn-light")
+    end
+  end
+
+  def edit_profile_link
+    return unless user_signed_in?
+    link_to current_user.email, edit_volunteer_path(current_user), class: "btn btn-primary"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,20 +13,14 @@
       <div class="container">
         <ul class="navbar-nav">
           <li class="nav-brand">
-            <strong>CASA - Prince George's County, MD</strong>
+            <strong><%= page_header %></strong>
           </li>
         </ul>
-          <% if user_signed_in? %>
-            <%= link_to current_user.email, edit_volunteer_path(current_user), class: "btn btn-primary" %>
-          <% end %>
+        <%= edit_profile_link %>
       </div>
 
       <div class="navbar-nav">
-        <% if user_signed_in? %>
-          <%= link_to('Log out', destroy_user_session_path, class: "btn btn-light") %>
-        <% else %>
-          <%= link_to('Log in', new_user_session_path, class: "btn btn-light") %>
-        <% end %>
+        <%= session_link %>
       </div>
     </nav>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe ApplicationHelper do
+  describe '#page_header' do
+    let(:page_header_text) { "CASA - Prince George's County, MD" }
+
+    it 'links to the user dashboard if user logged in' do
+      allow(helper).to receive(:user_signed_in?) { true }
+      dashboard_link = helper.link_to(page_header_text, root_path)
+
+      expect(helper.page_header).to eq(dashboard_link)
+    end
+
+    it 'displays the header when user is not logged in' do
+      allow(helper).to receive(:user_signed_in?) { false }
+
+      expect(helper.page_header).to eq(page_header_text)
+    end
+  end
+
+  describe '#session_link' do
+    it 'links to the sign_out page when user is signed in' do
+      allow(helper).to receive(:user_signed_in?) { true }
+
+      expect(helper.session_link).to match(destroy_user_session_path)
+    end
+
+    it 'links to the sign_in page when user is not signed in' do
+      allow(helper).to receive(:user_signed_in?) { false }
+
+      expect(helper.session_link).to match(new_user_session_path)
+    end
+  end
+
+  describe '#edit_profile_link' do
+    it 'links to the edit volunteer path when user is signed in' do
+      current_user = User.new(id: 1)
+      allow(helper).to receive(:user_signed_in?) { true }
+      allow(helper).to receive(:current_user) { current_user }
+
+      expect(helper.edit_profile_link).to match(edit_volunteer_path(current_user))
+    end
+
+    it 'returns nothing if user is not signed in' do
+      allow(helper).to receive(:user_signed_in?) { false }
+
+      expect(helper.edit_profile_link).to be_nil
+    end
+  end
+end


### PR DESCRIPTION

Resolves #083

### Description
Adds a link to user's dashboard on the page header when user is logged in.

Added two other helpers in the application helper for the session links and edit_profile_link to remove the conditionals from the application.html.erb

### Type of change

* New feature (non-breaking change which adds functionality)

### How will this affect user permissions?

no impact

### How Has This Been Tested?

I added a helper spec to test the new application helper methods.
