### PR TITLE
Display volunteer's active cases in dashboard

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -21,7 +21,7 @@ class CasaCasePolicy # rubocop:todo Style/Documentation
         # scope.in_casa_administered_by(@user)
         scope.ordered
       when 'volunteer'
-        []
+        scope.actively_assigned_to(user)
       else
         raise "unrecognized role"
       end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -23,13 +23,13 @@
     </tbody>
   </table>
 
+  <%= link_to "New Case", new_casa_case_path, class: "btn btn-primary" %>
+
 <% end %>
 
 
 <% if policy(:dashboard).see_cases_section? %>
   <h1>Cases</h1>
-
-  <%= link_to "New Case", new_casa_case_path, class: "btn btn-primary" %>
   <table class="case-list">
     <tr>
       <th>Case Number</th>

--- a/spec/policies/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe CasaCasePolicy::Scope, "#resolve" do
     expect(scope.resolve).to contain_exactly(*all_casa_cases)
   end
 
-  it "returns empty array when user is volunteer" do
+  it "returns volunteer's active cases when user is volunteer" do
     user = create(:user, :volunteer)
-    all_casa_cases = create_list(:casa_case, 2)
+    create_list(:casa_case, 2)
+    casa_cases = create_list(:casa_case, 2, volunteers: [user])
 
     scope = CasaCasePolicy::Scope.new(user, CasaCase)
 
-    expect(scope.resolve).to eq []
+    expect(scope.resolve).to eq casa_cases
   end
 end


### PR DESCRIPTION
This commit also disallows the volunteer from creating new cases
themselves. Instead, only admins should (currently) have that ability.


### Description
Display volunteer's active cases in dashboard

This commit also disallows the volunteer from creating new cases
themselves. Instead, only admins should (currently) have that ability.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

### How will this affect user permissions?

<!-- Please outline how each level of user permissions will be affected by this change. 
(If user permissions will not be impacted by this change, please say "no impact") 

This removes volunteers' ability to create cases and allows admins to create cases.


### How Has This Been Tested?

Automated tests and confirmed in browser.