### PR TITLE
Adds Hour & Minutes Input for Case Contacts

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -1,5 +1,6 @@
+# CaseContactsController with default actions
 class CaseContactsController < ApplicationController
-  before_action :set_case_contact, only: [:show, :edit, :update, :destroy]
+  before_action :set_case_contact, only: %i[show edit update destroy]
 
   # GET /case_contacts
   # GET /case_contacts.json
@@ -25,15 +26,7 @@ class CaseContactsController < ApplicationController
   end
 
   def create
-    info =
-      {
-        creator_id: current_user.id,
-        casa_case_id: params[:casa_case_id],
-        contact_type: params[:contact_type],
-        duration_minutes: params[:duration_minutes],
-        occurred_at: params[:case_contact][:occurred_at]
-      }
-    @case_contact = CaseContact.new(info)
+    @case_contact = CaseContact.new(create_case_contact_params)
 
     respond_to do |format|
       if @case_contact.save
@@ -76,10 +69,21 @@ class CaseContactsController < ApplicationController
     @case_contact = CaseContact.find(params[:id])
   end
 
+  # This can probably be combined with case_contact_params below, but was unsure about
+  # this line `.with_casa_case(current_user.casa_cases.first)`
+  def create_case_contact_params
+    CaseContactParameters
+      .new(params)
+      .with_creator(current_user)
+      .with_casa_case(CasaCase.find(params[:case_contact][:casa_case_id]))
+      .with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
+  end
+
   def case_contact_params
     CaseContactParameters
       .new(params)
       .with_creator(current_user)
       .with_casa_case(current_user.casa_cases.first)
+      .with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
   end
 end

--- a/app/helpers/case_contacts_helper.rb
+++ b/app/helpers/case_contacts_helper.rb
@@ -1,2 +1,26 @@
+# Helper methods for new case contact form
 module CaseContactsHelper
+  def duration_minutes_select(form, case_contact)
+    durations = []
+
+    # Generate 15, 30, 45 minute intervals
+    4.times do |i|
+      duration = i * 15
+      durations.push(OpenStruct.new(value: duration, label: "#{duration} minutes"))
+    end
+
+    form.select :duration_minutes, options_from_collection_for_select(durations, 'value', 'label', case_contact.duration_minutes&.remainder(60))
+  end
+
+  def duration_hours_select(form, case_contact)
+    durations = []
+
+    # Generate 0 through 23 hour intervals
+    24.times do |i|
+      duration = i
+      durations.push(OpenStruct.new(value: duration, label: "#{duration} #{'hour'.pluralize(i)}"))
+    end
+
+    form.select :duration_hours, options_from_collection_for_select(durations, 'value', 'label', case_contact.duration_minutes&.div(60))
+  end
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -1,5 +1,8 @@
+# CaseContact Model
 class CaseContact < ApplicationRecord
-  belongs_to :creator, class_name: "User"
+  attr_accessor :duration_hours
+
+  belongs_to :creator, class_name: 'User'
   belongs_to :casa_case
 
   CONTACT_TYPES = %w[
@@ -18,11 +21,25 @@ class CaseContact < ApplicationRecord
   enum contact_type: CONTACT_TYPES.zip(CONTACT_TYPES).to_h
 
   def humanized_type
-    "#{contact_type.humanize.titleize}#{ " - " + other_type_text if use_other_type_text?}"
+    "#{contact_type.humanize.titleize}#{' - ' + other_type_text if use_other_type_text?}"
   end
 
   def use_other_type_text?
     contact_type == 'other'
+  end
+
+  # This should definitely go into a decorator eventually
+  def display_duration_minutes
+    if duration_minutes >= 60
+      hour_value = duration_minutes / 60
+      minutes_value = duration_minutes.remainder(60)
+
+      return "#{hour_value} #{'hour'.pluralize(hour_value)}" if minutes_value.zero?
+
+      "#{hour_value} #{'hour'.pluralize(hour_value)} #{duration_minutes.remainder(60)} minutes"
+    else
+      "#{duration_minutes} minutes"
+    end
   end
 end
 

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -1,8 +1,9 @@
+# Calculate values when using case contact parameters
 class CaseContactParameters < SimpleDelegator
   def initialize(params)
     params = params
-      .require(:case_contact)
-      .permit(:contact_type, :other_type_text, :duration_minutes, :occurred_at)
+             .require(:case_contact)
+             .permit(:contact_type, :other_type_text, :duration_minutes, :occurred_at)
 
     super(params)
   end
@@ -14,6 +15,13 @@ class CaseContactParameters < SimpleDelegator
 
   def with_casa_case(casa_case)
     params[:casa_case] = casa_case
+    self
+  end
+
+  def with_converted_duration_minutes(duration_hours)
+    converted_duration_hours = duration_hours * 60
+    duration_minutes = params[:duration_minutes].to_i
+    params[:duration_minutes] = converted_duration_hours + duration_minutes
     self
   end
 

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -31,7 +31,7 @@
           <tbody>
             <% volunteer.case_contacts_for(@casa_case.id).each do | contact | %>
               <tr>
-                <td><%= contact.contact_type %></td><td> <%= contact.duration_minutes %></td>
+                <td><%= contact.contact_type %></td><td> <%= contact.display_duration_minutes %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -12,12 +12,12 @@
   <% end %>
   <div class="field casa-case">
     <%= form.label :casa_case_id %>
-    <%= select_tag :casa_case_id, options_from_collection_for_select(@casa_cases, 'id', 'case_number') %>
+    <%= form.select :casa_case_id, options_from_collection_for_select(current_user.casa_cases, 'id', 'case_number') %>
   </div>
   <div class="field contact-type">
     <%= form.label :contact_type %>
     <% case_contacts = CaseContact::CONTACT_TYPES.map { |contact_type| OpenStruct.new(value: contact_type, label: contact_type.titleize) } %>
-    <%= select_tag :contact_type, options_from_collection_for_select(case_contacts, 'value', 'label') %>
+    <%= form.select :contact_type, options_from_collection_for_select(case_contacts, 'value', 'label') %>
   </div>
   <div class="field other-contact-type" hidden>
     <%= form.label :other_type_text %>
@@ -25,24 +25,9 @@
   </div>
 
   <div class="field duration-minutes">
-    <%= form.label :duration_minutes %>
-    <% durations = [] %>
-    <%# For the first 2 hours %>
-    <% 7.times do |i| %>
-      <%
-        duration = (i + 1) * 15
-        durations.push(OpenStruct.new(value: duration, label: "#{duration} minutes"))
-      %>
-    <% end %>
-    <%# For the next 22 hours %>
-    <% 23.times do |i| %>
-      <%
-        duration = (i + 2) * 60
-        durations.push(OpenStruct.new(value: duration, label: "#{i + 2} hours"))
-      %>
-    <% end %>
-
-    <%= select_tag :duration_minutes, options_from_collection_for_select(durations, 'value', 'label') %>
+    <%= form.label "Duration" %>
+    <%= duration_hours_select(form, @case_contact) %>
+    <%= duration_minutes_select(form, @case_contact) %>
   </div>
 
   <div class="field occurred-at">

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -9,7 +9,7 @@
       <th>Casa case</th>
       <th>Contact type</th>
       <th>Other type text</th>
-      <th>Duration minutes</th>
+      <th>Duration</th>
       <th>Occurred at</th>
       <th colspan="3"></th>
     </tr>
@@ -22,7 +22,7 @@
         <td><%= case_contact.casa_case_id %></td>
         <td><%= case_contact.contact_type %></td>
         <td><%= case_contact.other_type_text %></td>
-        <td><%= case_contact.duration_minutes %></td>
+        <td><%= case_contact.display_duration_minutes %></td>
         <td><%= case_contact.occurred_at %></td>
         <td><%= link_to 'Show', case_contact %></td>
         <td><%= link_to 'Edit', edit_case_contact_path(case_contact) %></td>

--- a/app/views/case_contacts/show.html.erb
+++ b/app/views/case_contacts/show.html.erb
@@ -21,8 +21,8 @@
 </p>
 
 <p>
-  <strong>Duration minutes:</strong>
-  <%= @case_contact.duration_minutes %>
+  <strong>Duration:</strong>
+  <%= @case_contact.display_duration_minutes %>
 </p>
 
 <p>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -68,7 +68,7 @@
     <% @case_contacts.each do |contact| %>
       <tr>
         <td><%= time_tag contact.occurred_at %></td>
-        <td><%= pluralize(contact.duration_minutes, "minute") %></td>
+        <td><%= contact.display_duration_minutes %></td>
         <td><%= contact.humanized_type %></td>
       </tr>
     <% end %>

--- a/spec/features/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/features/volunteer_adds_a_case_contact_spec.rb
@@ -3,44 +3,46 @@ require 'rails_helper'
 RSpec.describe 'volunteer adds a case contact', type: :feature do
   it 'is successful' do
     volunteer = create(:user, :volunteer, :with_casa_cases)
-    volunteer_casa_case_1 = volunteer.casa_cases.first
+    volunteer_casa_case_one = volunteer.casa_cases.first
 
     sign_in volunteer
 
     visit new_case_contact_path
 
-    select volunteer_casa_case_1.case_number, from: 'casa_case_id'
-    select 'School', from: 'contact_type'
-    select '60 minutes', from: 'duration_minutes'
+    select volunteer_casa_case_one.case_number, from: 'case_contact[casa_case_id]'
+    select 'School', from: 'case_contact[contact_type]'
+    select '1 hour', from: 'case_contact[duration_hours]'
+    select '45 minutes', from: 'case_contact[duration_minutes]'
     fill_in 'case_contact_occurred_at', with: '04/04/2020'
 
     click_on 'Submit'
 
-    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_1.id
+    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
     expect(CaseContact.first.contact_type).to eq 'school'
-    expect(CaseContact.first.duration_minutes).to eq 60
+    expect(CaseContact.first.duration_minutes).to eq 105
   end
 
   it 'chooses other' do
     volunteer = create(:user, :volunteer, :with_casa_cases)
-    volunteer_casa_case_1 = volunteer.casa_cases.first
+    volunteer_casa_case_one = volunteer.casa_cases.first
 
     sign_in volunteer
 
     visit new_case_contact_path
 
-    select volunteer_casa_case_1.case_number, from: 'casa_case_id'
-    select 'School', from: 'contact_type'
+    select volunteer_casa_case_one.case_number, from: 'case_contact[casa_case_id]'
+    select 'School', from: 'case_contact[contact_type]'
     expect(page).not_to have_selector '#case_contact_other_type_text'
-    select '90 minutes', from: 'duration_minutes'
+    select '3 hours', from: 'case_contact[duration_hours]'
+    select '15 minutes', from: 'case_contact[duration_minutes]'
     fill_in 'case_contact_occurred_at', with: '04/04/2020'
-    select 'Other', from: 'contact_type'
+    select 'Other', from: 'case_contact[contact_type]'
 
     click_on 'Submit'
 
-    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_1.id
+    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
     expect(CaseContact.first.contact_type).to eq 'other'
-    expect(CaseContact.first.other_type_text).to eq nil
-    expect(CaseContact.first.duration_minutes).to eq 90
+    expect(CaseContact.first.other_type_text).to eq ''
+    expect(CaseContact.first.duration_minutes).to eq 195
   end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -8,4 +8,22 @@ RSpec.describe CaseContact, type: :model do
       define_enum_for(:contact_type).backed_by_column_of_type(:string)
     )
   end
+
+  describe '#display_duration_minutes' do
+    context 'when duration_minutes is less than 60' do
+      it 'returns only minutes' do
+        case_contact = create(:case_contact, duration_minutes: 30)
+
+        expect(case_contact.display_duration_minutes).to eq '30 minutes'
+      end
+    end
+
+    context 'when duration_minutes is greater than 60' do
+      it 'returns minutes and hours' do
+        case_contact = create(:case_contact, duration_minutes: 135)
+
+        expect(case_contact.display_duration_minutes).to eq '2 hours 15 minutes'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #88

### Description
I ended up implementing the first recommended solution and added two drop down menus: one for duration_minutes and one for duration hours. I then added a new method to the existing CaseContactParameters to calculate the duration_minutes when the form is submitted on update and create.

I also added a new case_contact model method for displaying duration_minutes as hours + minutes. This should probably be moved to a decorator if we add that into the project, but I wasn't sure what the teams thoughts were on draper or other options, so I just left it in the model for now.

I also moved the select_tag generation code into two helper methods in the helpers/case_contacts_helper.rb file.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How will this affect user permissions?

No impact. 

### How Has This Been Tested?

I've updated the rspec tests and tested creating and updating new case_contacts locally.

### Screenshots
<img width="1826" alt="Screen Shot 2020-04-16 at 10 07 03 PM" src="https://user-images.githubusercontent.com/1221519/79524703-33da8a80-802f-11ea-9e2a-3a001c55efb5.png">

