### PR TITLE
Adds All Case Contacts Report

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,3 +1,15 @@
+.dashboard-table-header {
+  h1 {
+    display: inline-block;
+    margin-right: 15px;
+    vertical-align: middle;
+  }
+
+  a {
+    display: inline-block;
+  }
+}
+
 .cases {
   background: lightgrey;
   padding: 10px;

--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -3,11 +3,16 @@
 
   .nav-brand a {
     color: white;
+
     &:hover {
       text-decoration: none;
     }
   }
   strong {
     font-size: 2rem;
+  }
+
+  a.btn {
+    white-space: pre;
   }
 }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,15 @@
+require 'csv'
+
+class ReportsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index; end
+
+  def show
+    @case_contacts = CaseContact.all
+
+    respond_to do |format|
+      format.csv { send_data @case_contacts.to_csv, filename: "case-contacts-report-#{Time.zone.now.to_i}.csv" }
+    end
+  end
+end

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -1,4 +1,3 @@
-# rubocop:todo Style/Documentation
 class SupervisorVolunteersController < ApplicationController
   before_action :set_supervisor_volunteer, only: %i[show edit update destroy]
 
@@ -72,4 +71,3 @@ class SupervisorVolunteersController < ApplicationController
     params.require(:supervisor_volunteer).permit(:volunteer_id, :supervisor_id)
   end
 end
-# rubocop:enable Style/Documentation

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,14 +6,9 @@ module ApplicationHelper
 
   def session_link
     if user_signed_in?
-      link_to('Log out', destroy_user_session_path, class: "btn btn-light")
+      link_to('Log out', destroy_user_session_path, class: 'btn btn-light')
     else
-      link_to('Log in', new_user_session_path, class: "btn btn-light")
+      link_to('Log in', new_user_session_path, class: 'btn btn-light')
     end
-  end
-
-  def edit_profile_link
-    return unless user_signed_in?
-    link_to current_user.email, edit_volunteer_path(current_user), class: "btn btn-primary"
   end
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -37,6 +37,36 @@ class CaseContact < ApplicationRecord
   def use_other_type_text?
     contact_type == 'other'
   end
+
+  def self.to_csv
+    attributes = report_headers
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes.map(&:titleize)
+
+      all.decorate.each do |case_contact|
+        csv << [
+          case_contact&.id,
+          case_contact&.casa_case&.case_number,
+          case_contact&.duration_minutes,
+          case_contact&.occurred_at,
+          case_contact&.creator&.email,
+          'N/A', # case_contact&.creator&.name, Add back in after user has name field
+          case_contact&.creator&.supervisor&.email,
+          case_contact&.contact_type
+        ]
+      end
+    end
+  end
+
+  def self.report_headers
+    headers = %w[case_contact_id casa_case_number duration occurred_at
+                 creator_email creator_name creator_supervisor_name contact_type]
+
+    # TODO: Issue 119 -- Enable multiple contact types for a case_contact
+    # headers.concat(CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" })
+    headers
+  end
 end
 
 # == Schema Information

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -7,6 +7,10 @@ class DashboardPolicy < Struct.new(:user, :dashboard)
     user.casa_admin?
   end
 
+  def create_case_contacts?
+    user.role == 'volunteer'
+  end
+
   def see_cases_section?
     true
   end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,9 +1,7 @@
 <% if policy(:dashboard).see_volunteers_section? %>
   <div class="row">
-    <div class="col-sm-4 col-md-3">
+    <div class="col-sm-12 dashboard-table-header">
       <h1>Volunteers</h1>
-    </div>
-    <div class="col-sm-8 col-md-9">
       <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
     </div>
   </div>
@@ -42,14 +40,12 @@
 <% if policy(:dashboard).see_cases_section? %>
   <br>
   <div class="row">
-    <div class="col-sm-3 col-md-2">
+    <div class="col-sm-12 dashboard-table-header">
       <h1>Cases</h1>
-    </div>
-    <% if policy(:dashboard).see_volunteers_section? %>
-      <div class="col-sm-9 col-md-10">
+      <% if policy(:dashboard).see_volunteers_section? %>
         <%= link_to "New Case", new_casa_case_path, class: "btn btn-primary" %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
   <table class="table case-list" id="casa_cases">
     <thead>
@@ -71,8 +67,11 @@
   </table>
   <br>
   <div class="row">
-    <div class="col-sm-6 col-md-4">
+    <div class="col-sm-12 dashboard-table-header">
       <h1>Case Contacts</h1>
+      <% if policy(:dashboard).create_case_contacts? %>
+        <%= link_to "New Case Contact", new_case_contact_path, class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,28 @@
+<nav class="navbar navbar-expand-lg bg-primary">
+  <div class="container">
+    <ul class="navbar-nav">
+      <li class="nav-brand">
+        <strong><%= page_header %></strong>
+      </li>
+    </ul>
+
+  </div>
+
+  <div class="navbar-nav">
+    <% if current_user %>
+      <div class="dropdown">
+        <button class="btn btn-light dropdown-toggle" style="margin-right:12px;" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <%= current_user.email %>
+        </button>
+        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+          <%= link_to "Edit Profile", edit_volunteer_path(current_user), class: "dropdown-item" %>
+
+          <% if current_user.role == "casa_admin" %>
+            <%= link_to "Generate Reports", reports_path, class: "dropdown-item" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <%= session_link %>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,20 +11,7 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-expand-lg bg-primary">
-      <div class="container">
-        <ul class="navbar-nav">
-          <li class="nav-brand">
-            <strong><%= page_header %></strong>
-          </li>
-        </ul>
-        <%= edit_profile_link %>
-      </div>
-
-      <div class="navbar-nav">
-        <%= session_link %>
-      </div>
-    </nav>
+    <%= render 'layouts/header' %>
 
     <div class="container">
       <p class="notice"><%= notice %></p>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,32 @@
+<%= link_to "Back", :back %>
+
+<div class="row">
+  <div class="col-sm-12">
+    <h1>Report Categories</h1>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="col-sm-4">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title"><strong>All Case Contacts Report</strong></h5>
+        <p class="card-text">
+          This CSV is a listing of all fields of all existing case contacts including:
+        </p>
+        <ul>
+          <li>ID</li>
+          <li>Case Number</li>
+          <li>Duration</li>
+          <li>Occurred At</li>
+          <li>Creator Email</li>
+          <li>Creator Name</li>
+          <li>Create Supervisor</li>
+          <li>Contact Type</li>
+        </ul>
+        <%= link_to "Download Report", report_path(id: Time.zone.now.to_i, format: :csv), class: "btn btn-primary" %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :casa_orgs
   resources :case_assignments
   resources :supervisor_volunteers
-  resources :volunteers, only: [:new, :edit, :create]
+  resources :volunteers, only: %i[new edit create]
   resources :users, only: [:create]
+  resources :reports, only: %i[show index]
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,14 +5,14 @@ describe ApplicationHelper do
     let(:page_header_text) { "CASA - Prince George's County, MD" }
 
     it 'links to the user dashboard if user logged in' do
-      allow(helper).to receive(:user_signed_in?) { true }
+      allow(helper).to receive(:user_signed_in?).and_return(true)
       dashboard_link = helper.link_to(page_header_text, root_path)
 
       expect(helper.page_header).to eq(dashboard_link)
     end
 
     it 'displays the header when user is not logged in' do
-      allow(helper).to receive(:user_signed_in?) { false }
+      allow(helper).to receive(:user_signed_in?).and_return(false)
 
       expect(helper.page_header).to eq(page_header_text)
     end
@@ -20,31 +20,15 @@ describe ApplicationHelper do
 
   describe '#session_link' do
     it 'links to the sign_out page when user is signed in' do
-      allow(helper).to receive(:user_signed_in?) { true }
+      allow(helper).to receive(:user_signed_in?).and_return(true)
 
       expect(helper.session_link).to match(destroy_user_session_path)
     end
 
     it 'links to the sign_in page when user is not signed in' do
-      allow(helper).to receive(:user_signed_in?) { false }
+      allow(helper).to receive(:user_signed_in?).and_return(false)
 
       expect(helper.session_link).to match(new_user_session_path)
-    end
-  end
-
-  describe '#edit_profile_link' do
-    it 'links to the edit volunteer path when user is signed in' do
-      current_user = User.new(id: 1)
-      allow(helper).to receive(:user_signed_in?) { true }
-      allow(helper).to receive(:current_user) { current_user }
-
-      expect(helper.edit_profile_link).to match(edit_volunteer_path(current_user))
-    end
-
-    it 'returns nothing if user is not signed in' do
-      allow(helper).to receive(:user_signed_in?) { false }
-
-      expect(helper.edit_profile_link).to be_nil
     end
   end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CaseContact, type: :model do
-  it { is_expected.to(belong_to(:creator).class_name("User")) }
+  it { is_expected.to(belong_to(:creator).class_name('User')) }
   it { is_expected.to(belong_to(:casa_case)) }
+
   it do
     is_expected.to(
       define_enum_for(:contact_type).backed_by_column_of_type(:string)

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe '/reports', type: :request do
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      sign_in create(:user, :volunteer)
+
+      get reports_url
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a csv file to download' do
+      sign_in create(:user, :volunteer)
+      create(:case_contact)
+
+      get report_url(Time.zone.now.to_i, format: :csv)
+
+      expect(response).to be_successful
+      expect(response.headers['Content-Disposition']).to include 'attachment; filename="case-contacts-report-'
+    end
+  end
+end


### PR DESCRIPTION
Resolves #122

### Description

This PR:
- Adds new reports controller to list and download reports
- Changes header nav to a dropdown which gives edit profile and reports links

Alternate Implementations:
I wasn't sure of the best way to show a link to the reports page. I ended up replacing the "Edit Profile" button with a dropdown that includes a link to "Edit Profile" and the new reports page.

Two other possibilities I considered were adding buttons on the dashboard next to "New Case Contact" labeled something like "Export Case Contacts", but it sounded like we might have different kinds of reports moving forward that wouldn't fit so easily into single buttons on the dashboard. I also considered adding a fourth section to the dashboard page listing reports similar to the reports#index in the current PR, but I decided against that because I was worried the dashboard would become too busy if we kept adding sections. 

I'd be happy to change this around if one of those other implementations fits better with what the stakeholder might want. The current reports#index doesn't look great at the moment because it's so empty.

### Type of change

* New feature (non-breaking change which adds functionality)

### How will this affect user permissions?

Only admins can access the reports page to download reports

### How Has This Been Tested?

Local testing, existing rspec tests pass, added several new rspec tests for reports controller

### Screenshots

<img width="1629" alt="Screen Shot 2020-04-20 at 5 44 15 PM" src="https://user-images.githubusercontent.com/1221519/79802780-992fc380-832e-11ea-9c10-7dded794f6de.png">
