### PR TITLE
Updates Casa Case Pundit Policies and Styles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,11 @@ RSpec/ExampleLength:
 
 RSpec/NamedSubject:
   Enabled: False
+
+RSpec/RepeatedExample:
+  Exclude:
+    - 'spec/policies/**/*'
+
+RSpec/RepeatedDescription:
+  Exclude:
+    - 'spec/policies/**/*'

--- a/app/assets/stylesheets/casa_cases.scss
+++ b/app/assets/stylesheets/casa_cases.scss
@@ -1,5 +1,4 @@
 
 .case-contact-list {
     margin-bottom: 20px;
-    background: lightgrey;
 }

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -5,20 +5,25 @@ class CasaCasesController < ApplicationController
   # GET /casa_cases
   # GET /casa_cases.json
   def index
-    @casa_cases = CasaCase.all
+    @casa_cases = policy_scope(CasaCase.all)
   end
 
   # GET /casa_cases/1
   # GET /casa_cases/1.json
-  def show; end
+  def show
+    authorize @casa_case
+  end
 
   # GET /casa_cases/new
   def new
     @casa_case = CasaCase.new
+    authorize @casa_case
   end
 
   # GET /casa_cases/1/edit
-  def edit; end
+  def edit
+    authorize @casa_case
+  end
 
   # POST /casa_cases
   # POST /casa_cases.json

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/activestorage").start()
 require("channels")
 require("jquery")
 require("packs/new_casa_contact")
+require("packs/show_casa_case")
 require("packs/dashboard")
 require('datatables.net-dt')
 import 'bootstrap'

--- a/app/javascript/packs/show_casa_case.js
+++ b/app/javascript/packs/show_casa_case.js
@@ -1,0 +1,7 @@
+$('document').ready(() => {
+  // Enable all data tables on dashboard but only filter on volunteers table
+  $('.show-volunteer-case-contacts').on('click', function(e) {
+    var table_target = $(e.target).data('target');
+    $(table_target).toggleClass('collapse');
+  })
+});

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -57,7 +57,7 @@ class CasaCasePolicy
   end
 
   def update?
-    _is_supervisor_or_casa_admin?
+    _is_supervisor_or_casa_admin? || _is_volunteer_actively_assigned_to_case?
   end
 
   def destroy?

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -40,33 +40,37 @@ class CasaCasePolicy
     end
   end
 
-  # TODO: Uncomment and test the below as necessary, please.
+  def show?
+    _is_supervisor_or_casa_admin? || _is_volunteer_actively_assigned_to_case?
+  end
 
-  # def index?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def edit?
+    _is_supervisor_or_casa_admin? || _is_volunteer_actively_assigned_to_case?
+  end
 
-  # def show?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def new?
+    _is_supervisor_or_casa_admin?
+  end
 
-  # def create?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def create?
+    _is_supervisor_or_casa_admin?
+  end
 
-  # def new?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def update?
+    _is_supervisor_or_casa_admin?
+  end
 
-  # def update?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def destroy?
+    _is_supervisor_or_casa_admin?
+  end
 
-  # def edit?
-  #   casa_admin_of_org?(user, record)
-  # end
+  private
 
-  # def destroy?
-  #   casa_admin_of_org?(user, record)
-  # end
+  def _is_supervisor_or_casa_admin?
+    user.casa_admin? || user.supervisor?
+  end
+
+  def _is_volunteer_actively_assigned_to_case?
+    record.case_assignments.exists?(volunteer_id: user.id, is_active: true)
+  end
 end

--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -7,10 +7,6 @@ class CaseContactPolicy
     @record = record
   end
 
-  def _is_creator_or_casa_admin?
-    casa_admin_of_org?(user, record) || record.creator == user
-  end
-
   def index?
     _is_creator_or_casa_admin?
   end
@@ -24,7 +20,8 @@ class CaseContactPolicy
   end
 
   def new?
-    _is_creator_or_casa_admin?
+    # Everyone should be allowed to create a case_contact
+    true
   end
 
   def update?
@@ -57,5 +54,11 @@ class CaseContactPolicy
         raise 'unrecognized role'
       end
     end
+  end
+
+  private
+
+  def _is_creator_or_casa_admin?
+    user.casa_admin? || record.creator == user
   end
 end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -11,14 +11,14 @@
     </div>
   <% end %>
 
-  <div class="field">
+  <div class="field form-group">
     <%= form.label :case_number %>
-    <%= form.text_field :case_number %>
+    <%= form.text_field :case_number, class: "form-control" %>
   </div>
 
-  <div class="field">
-    <%= form.label :teen_program_eligible %>
-    <%= form.check_box :teen_program_eligible %>
+  <div class="field form-group">
+    <%= form.label :teen_program_eligible, class: "form-check-label" %>
+    <%= form.check_box :teen_program_eligible, class: "form-check-input" %>
   </div>
 
   <div class="actions">

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -1,3 +1,5 @@
+<%= link_to 'Back', :back %>
+
 <h1>Editing CASA Case</h1>
 
 <br>
@@ -31,6 +33,3 @@
 </div>
 
 <br>
-
-<%= link_to 'Show', @casa_case %> |
-<%= link_to 'Back', :back %>

--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -1,11 +1,20 @@
-<h1>CASA Cases</h1>
+<%= link_to 'Back', :back %>
 
-<table>
+<div class="row">
+  <div class="col-sm-12 dashboard-table-header">
+    <h1>CASA Cases</h1>
+    <%= link_to 'New CASA Case', new_casa_case_path, class: "btn btn-primary" %>
+  </div>
+</div>
+
+<br>
+
+<table class="table table-striped">
   <thead>
     <tr>
       <th>Case number</th>
       <th>Teen program eligible</th>
-      <th colspan="3"></th>
+      <th colspan="3">Actions</th>
     </tr>
   </thead>
 
@@ -23,5 +32,3 @@
 </table>
 
 <br>
-
-<%= link_to 'New CASA Case', new_casa_case_path %>

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -25,5 +25,5 @@
     <% end %>
   </div>
 </div>
-
+<br>
 <%= link_to 'Back', :back %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,4 +1,11 @@
-<h1>CASA Case Details</h1>
+<%= link_to 'Back', :back %>
+
+<div class="row">
+  <div class="col-sm-12 dashboard-table-header">
+    <h1>CASA Case Details</h1>
+    <%= link_to 'Edit Case Details', edit_casa_case_path(@casa_case), class: "btn btn-primary" %>
+  </div>
+</div>
 
 <p>
   <h3>Case number:</h3>
@@ -11,35 +18,44 @@
 </p>
 
 <div>
-  <h3>Assigned Volunteers</h3>
-  <% @casa_case.volunteers.each do  |volunteer|  %>
-    <span> Email: <%=  volunteer.email %></span>
+  <h3>Assigned Volunteers:</h3>
+  <br>
+  <% policy_scope(@casa_case.volunteers).each_with_index do |volunteer, index|  %>
+    <h6><%= index + 1 %>. Email: <%=  volunteer.email %></h6>
+    <br/>
+    <button class="btn btn-primary show-volunteer-case-contacts" type="button" data-toggle="collapse" data-target="#collapseVolunteer<%= index %>" aria-expanded="false" aria-controls="collapseVolunteer<%= index %>">
+      Show/Hide Case Contacts of Volunteer
+    </button>
+    <div class="collapse" id="collapseVolunteer<%= index %>">
+      <div class="case-contact-list">
+        <h6 style="margin: 8px 0;"><strong>Case Contacts for <%=  volunteer.email %></strong></h6>
 
-    <div class="case-contact-list">
-      <strong>Case Contacts</strong>
-      <div>
-        <table>
-          <thead>
-            <tr>
-              <th>Contact type</th>
-              <th>Duration</th>
-              <th colspan="3"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% volunteer.case_contacts_for(@casa_case.id).each do |contact| %>
+        <div>
+          <table class="table table-bordered table-striped table-sm">
+            <thead>
               <tr>
-                <td><%= contact.contact_type %></td>
-                <td><%= contact.decorate.duration_minutes %></td>
+                <th>Date</th>
+                <th>Duration</th>
+                <th>Contact Made</th>
+                <th>Contact Medium</th>
+                <th>Type</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              <% volunteer.case_contacts_for(@casa_case.id).each do |contact| %>
+                <tr>
+                  <td data-sort="<%= contact.occurred_at.strftime("%Y%m%d%H%M%s") %>"><%= contact.occurred_at.strftime('%B %e, %Y') %></td>
+                  <td><%= contact.decorate.duration_minutes %></td>
+                  <td><%= contact.contact_made %></td>
+                  <td><%= contact.medium_type %></td>
+                  <td><%= contact.humanized_type %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
+    <hr>
   <% end %>
 </div>
-
-
-<%= link_to 'Edit', edit_casa_case_path(@casa_case) %> |
-<%= link_to 'Back', casa_cases_path %>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -1,6 +1,7 @@
+<%= link_to 'Back', :back %>
 <h1>Case Contacts</h1>
 
-<table>
+<table class="table table-striped">
   <thead>
     <tr>
       <th>Creator</th>
@@ -21,7 +22,7 @@
         <td><%= case_contact.contact_type %></td>
         <td><%= case_contact.other_type_text %></td>
         <td><%= case_contact.duration_minutes %></td>
-        <td><%= case_contact.occurred_at %></td>
+        <td><%= case_contact.occurred_at.strftime('%B %e, %Y') %></td>
         <td><%= link_to 'Show', case_contact %></td>
         <td><%= link_to 'Edit', edit_case_contact_path(case_contact) %></td>
         <td><%= link_to 'Destroy', case_contact, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -29,16 +29,18 @@
           <td id="status-column"><%= volunteer.status %></td>
           <td><%= volunteer.assigned_to_transition_aged_youth? %></td>
           <td><%= volunteer.casa_cases.pluck(:case_number).join(', ') %></td>
-          <td><%= link_to 'Edit', edit_volunteer_path(volunteer) %></td>
+          <td>
+            <%= link_to 'Edit', edit_volunteer_path(volunteer) %>
+          </td>
         </tr>
       <% end %>
     </tbody>
   </table>
+  <br>
 <% end %>
 
 
 <% if policy(:dashboard).see_cases_section? %>
-  <br>
   <div class="row">
     <div class="col-sm-12 dashboard-table-header">
       <h1>Cases</h1>
@@ -53,6 +55,7 @@
         <th>Case Number</th>
         <th>Teen Program Eligible</th>
         <th>Actions</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -60,7 +63,8 @@
         <tr>
           <td><%= casa_case.case_number %></td>
           <td><%= casa_case.teen_program_eligible %></td>
-          <td><%= link_to("Edit", edit_casa_case_path(casa_case)) %></td>
+          <td><%= link_to 'Detail View', casa_case_path(casa_case) %></td>
+          <td><%= link_to 'Edit', edit_casa_case_path(casa_case) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/spec/policies/casa_case_policy/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy/casa_case_policy_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe CasaCasePolicy do
       expect(subject).to permit(create(:user, :casa_admin))
     end
 
-    it 'does not allow volunteers' do
-      expect(subject).not_to permit(create(:user, :volunteer))
+    it 'does not allow volunteers who are unassigned' do
+      expect(subject).not_to permit(create(:user, :volunteer), create(:casa_case))
     end
   end
 

--- a/spec/policies/casa_case_policy/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy/casa_case_policy_spec.rb
@@ -5,19 +5,97 @@ RSpec.describe CasaCasePolicy do
 
   permissions :update_case_number? do
     context 'when user is an admin' do
-      it 'returns true' do
-        casa_case = create(:casa_case)
-        admin = create(:user, :casa_admin)
-        expect(Pundit.policy(admin, casa_case).update_case_number?).to eq true
+      it 'does allow update case number' do
+        expect(subject).to permit(create(:user, :casa_admin), create(:casa_case))
       end
     end
 
     context 'when user is a volunteer' do
-      it 'returns false' do
-        casa_case = create(:casa_case)
-        volunteer = create(:user, :volunteer)
-        expect(Pundit.policy(volunteer, casa_case).update_case_number?).to eq false
+      it 'does not allow update case number' do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:casa_case))
       end
+    end
+  end
+
+  permissions :show? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:casa_case))
+    end
+
+    context 'when volunteer is assigned' do
+      it 'allows the volunteer' do
+        volunteer = create(:user, :volunteer)
+        casa_case = create(:casa_case)
+        volunteer.casa_cases << casa_case
+        expect(subject).to permit(volunteer, casa_case)
+      end
+    end
+
+    context 'when volunteer is not assigned' do
+      it 'does not allow the volunteer' do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:casa_case))
+      end
+    end
+  end
+
+  permissions :edit? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:casa_case))
+    end
+
+    context 'when volunteer is assigned' do
+      it 'allows the volunteer' do
+        volunteer = create(:user, :volunteer)
+        casa_case = create(:casa_case)
+        volunteer.casa_cases << casa_case
+        expect(subject).to permit(volunteer, casa_case)
+      end
+    end
+
+    context 'when volunteer is not assigned' do
+      it 'does not allow the volunteer' do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:casa_case))
+      end
+    end
+  end
+
+  permissions :new? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer))
+    end
+  end
+
+  permissions :update? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer))
+    end
+  end
+
+  permissions :create? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer))
+    end
+  end
+
+  permissions :destroy? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer))
     end
   end
 end

--- a/spec/policies/case_contact_policy/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy/case_contact_policy_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe CaseContactPolicy do
+  subject { described_class }
+
+  permissions :show? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
+    end
+
+    context 'when volunteer is the creator' do
+      it 'allows the volunteer' do
+        volunteer = create(:user, :volunteer)
+        case_contact = create(:case_contact, creator: volunteer)
+        expect(subject).to permit(volunteer, case_contact)
+      end
+    end
+
+    context 'when volunteer is not the creator' do
+      it 'does not allow the volunteer' do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+      end
+    end
+  end
+
+  permissions :edit? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
+    end
+
+    context 'when volunteer is assigned' do
+      it 'allows the volunteer' do
+        volunteer = create(:user, :volunteer)
+        case_contact = create(:case_contact, creator: volunteer)
+        expect(subject).to permit(volunteer, case_contact)
+      end
+    end
+
+    context 'when volunteer is not the creator' do
+      it 'does not allow the volunteer' do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+      end
+    end
+  end
+
+  permissions :new? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it 'does allow volunteers' do
+      expect(subject).to permit(create(:user, :volunteer), CaseContact.new)
+    end
+  end
+
+  permissions :update? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+    end
+  end
+
+  permissions :create? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+    end
+  end
+
+  permissions :destroy? do
+    it 'allows casa_admins' do
+      expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
+    end
+
+    it 'does not allow volunteers' do
+      expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+    end
+  end
+end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe '/casa_cases', type: :request do
 
   describe 'GET /new' do
     it 'renders a successful response' do
-      sign_in create(:user)
+      sign_in create(:user, :casa_admin)
       get new_casa_case_url
       expect(response).to be_successful
     end


### PR DESCRIPTION
Resolves #108
Resolves #153 
Resolved #95 

### Description
- Updates CasaCasePolicy permissions to block volunteers from certain actions
- Adds basic bootstrap styles to all casa case and case contact views
- Adds Rspec tests for CaseContactPolicy

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How will this affect user permissions?

This PR has lots of permission changes for casa_cases. Breaking it down by action:

1) casa_case#index
  accessible by all but only shows cases scoped by CasaCasePolicy

2) casa_case#show
  accessible by supervisor/casa_admin or volunteer assigned to case

3) casa_case#edit
  accessible by supervisor/casa_admin or volunteer assigned to case

4) casa_case#new
  only accessible by supervisor/casa_admin

5) casa_case#create
  only accessible by supervisor/casa_admin

6) casa_case#update
  only accessible by supervisor/casa_admin 
  volunteer assigned to case can update fields besides case_number

7) casa_case#destroy
  only accessible by supervisor/casa_admin

### How Has This Been Tested?

Local testing, existing RSpec tests pass, and new rspec tests added

### Screenshots
<img width="1748" alt="Screen Shot 2020-04-22 at 10 52 56 AM" src="https://user-images.githubusercontent.com/1221519/79997335-782eb600-8487-11ea-9b5c-078856dc0025.png">

<img width="1748" alt="Screen Shot 2020-04-22 at 10 54 01 AM" src="https://user-images.githubusercontent.com/1221519/79997444-998fa200-8487-11ea-88c0-137dc2893400.png">
