### PR TITLE
Change contact_type  to contact_types

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -24,6 +24,12 @@ class CaseContactDecorator < Draper::Decorator
     object.contact_made ? 'Yes' : 'No'
   end
 
+  def contact_types
+    object.contact_types
+      &.map { |ct| ct.humanize.titleize }
+      &.to_sentence(last_word_connector: ', and ') || ""
+  end
+
   def medium_type
     object.medium_type.blank? ? 'Unknown' : object.medium_type.titleize
   end

--- a/app/javascript/packs/new_casa_contact.js
+++ b/app/javascript/packs/new_casa_contact.js
@@ -1,16 +1,5 @@
 import $ from 'jquery'
 $('document').ready(() => {
-  // inside the app/views/casa_contact/_form, we are trying to only show a field if 'other' is chosen.
-  $("#contact_type").change((e) => {
-    if (e.target.value === 'other') {
-      $(".other-contact-type").removeAttr('hidden')
-      $(".other-contact-type input").attr('required', 'required')
-    } else {
-      $(".other-contact-type").attr('hidden', true)
-      $(".other-contact-type input").removeAttr('required')
-    }
-  })
-
   // Ensure at least one casa_case checkbox is checked by setting required to false
   $("input:checkbox.casa-case-id-check").on('click', function() {
     var case_id_checkbox_group = $("input:checkbox.casa-case-id-check");

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -30,9 +30,10 @@ class CaseContact < ApplicationRecord
     end
   end
 
-  def humanized_type
-    # contact_type.humanize.titleize.to_s
-    # "#{contact_types.map.humanize.titleize}#{' - ' + other_type_text if use_other_type_text?}"
+
+  # @return [Array<String>]
+  def humanized_contact_types
+    contact_types&.map { |ct| ct.humanize.titleize }
   end
 
   def use_other_type_text?

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,7 +5,7 @@ class CaseContact < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   belongs_to :casa_case
 
-  # validates :contact_type, presence: true
+  validates :contact_types, presence: true
 
   CONTACT_TYPES = %w[
     youth

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,7 +5,7 @@ class CaseContact < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   belongs_to :casa_case
 
-  validates :contact_type, presence: true
+  # validates :contact_type, presence: true
 
   CONTACT_TYPES = %w[
     youth
@@ -21,10 +21,30 @@ class CaseContact < ApplicationRecord
   ].freeze
 
   CONTACT_MEDIUMS = %w[in-person text/email video voice-only letter].freeze
-  enum contact_type: CONTACT_TYPES.zip(CONTACT_TYPES).to_h
+  # enum contact_type: CONTACT_TYPES.zip(CONTACT_TYPES).to_h
 
   def humanized_type
-    contact_type.humanize.titleize.to_s
+    # contact_type.humanize.titleize.to_s
+    # "#{contact_types.map.humanize.titleize}#{' - ' + other_type_text if use_other_type_text?}"
+  end
+
+  def use_other_type_text?
+    contact_types.include?('other')
+  end
+
+  # Generate array of attributes for All Case Contacts report
+  def attributes_to_array
+    [
+      id,
+      casa_case&.case_number,
+      duration_minutes,
+      occurred_at,
+      creator&.email,
+      'N/A',
+      # creator&.name, Add back in after user has name field
+      creator&.supervisor&.email,
+      contact_types
+    ]
   end
 end
 

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -30,12 +30,6 @@ class CaseContact < ApplicationRecord
     end
   end
 
-
-  # @return [Array<String>]
-  def humanized_contact_types
-    contact_types&.map { |ct| ct.humanize.titleize }
-  end
-
   def use_other_type_text?
     contact_types.include?('other')
   end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,8 +5,6 @@ class CaseContact < ApplicationRecord
   belongs_to :creator, class_name: 'User'
   belongs_to :casa_case
 
-  validates :contact_types, presence: true
-
   CONTACT_TYPES = %w[
     youth
     school
@@ -22,6 +20,15 @@ class CaseContact < ApplicationRecord
 
   CONTACT_MEDIUMS = %w[in-person text/email video voice-only letter].freeze
   # enum contact_type: CONTACT_TYPES.zip(CONTACT_TYPES).to_h
+
+  validates :contact_types, presence: true
+  validate :contact_types_included
+
+  def contact_types_included
+    contact_types&.each do |contact_type|
+      errors.add(:contact_types, :invalid) unless CONTACT_TYPES.include? contact_type
+    end
+  end
 
   def humanized_type
     # contact_type.humanize.titleize.to_s
@@ -54,7 +61,7 @@ end
 #
 #  id               :bigint           not null, primary key
 #  contact_made     :boolean          default(FALSE)
-#  contact_type     :string           not null
+#  contact_types    :string           is an Array
 #  duration_minutes :integer          not null
 #  medium_type      :string
 #  occurred_at      :datetime         not null
@@ -66,8 +73,9 @@ end
 #
 # Indexes
 #
-#  index_case_contacts_on_casa_case_id  (casa_case_id)
-#  index_case_contacts_on_creator_id    (creator_id)
+#  index_case_contacts_on_casa_case_id   (casa_case_id)
+#  index_case_contacts_on_contact_types  (contact_types) USING gin
+#  index_case_contacts_on_creator_id     (creator_id)
 #
 # Foreign Keys
 #

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -19,7 +19,6 @@ class CaseContact < ApplicationRecord
   ].freeze
 
   CONTACT_MEDIUMS = %w[in-person text/email video voice-only letter].freeze
-  # enum contact_type: CONTACT_TYPES.zip(CONTACT_TYPES).to_h
 
   validates :contact_types, presence: true
   validate :contact_types_included

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -36,7 +36,7 @@ class CaseContactReport < ApplicationRecord
     [
       case_contact&.id,
       case_contact&.duration_minutes,
-      case_contact&.contact_type,
+      case_contact&.contact_types,
       case_contact&.contact_made,
       case_contact&.medium_type,
       case_contact&.occurred_at&.strftime('%B %e, %Y'),

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -34,6 +34,7 @@ class CaseContactReport < ApplicationRecord
     row_data.flatten
   end
 
+  # @param case_contact [CaseContact]
   def self.case_contact_fields(case_contact)
     [
       case_contact&.id,

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -13,12 +13,11 @@ class CaseContactReport < ApplicationRecord
 
   def self.report_headers
     headers = %w[internal_contact_number duration]
+    contact_type_headers = CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" }
+    headers.concat(contact_type_headers)
 
-    headers.concat(CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" })
-
-    headers.concat(%w[ contact_made
-                       contact_medium occurred_at added_to_system_at casa_case_number
-                       volunteer_email volunteer_name supervisor_name])
+    headers.concat(%w[contact_made contact_medium occurred_at added_to_system_at
+                      casa_case_number volunteer_email volunteer_name supervisor_name])
 
     headers
   end

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -12,12 +12,14 @@ class CaseContactReport < ApplicationRecord
   end
 
   def self.report_headers
-    headers = %w[ internal_contact_number duration contact_type contact_made
-                  contact_medium occurred_at added_to_system_at casa_case_number
-                  volunteer_email volunteer_name supervisor_name]
+    headers = %w[internal_contact_number duration]
 
-    # TODO: Issue 119 -- Enable multiple contact types for a case_contact
-    # headers.concat(CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" })
+    headers.concat(CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" })
+
+    headers.concat(%w[ contact_made
+                       contact_medium occurred_at added_to_system_at casa_case_number
+                       volunteer_email volunteer_name supervisor_name])
+
     headers
   end
 
@@ -41,7 +43,7 @@ class CaseContactReport < ApplicationRecord
       case_contact&.medium_type,
       case_contact&.occurred_at&.strftime('%B %e, %Y'),
       case_contact&.created_at
-    ]
+    ].flatten
   end
 
   def self.casa_case_fields(casa_case)

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -3,12 +3,12 @@ class CaseContactParameters < SimpleDelegator
   def initialize(params)
     params =
       params.require(:case_contact).permit(
-        :contact_type,
         :other_type_text,
         :duration_minutes,
         :occurred_at,
         :contact_made,
-        :medium_type
+        :medium_type,
+        contact_types: [],
       )
 
     super(params)

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -8,7 +8,7 @@ class CaseContactParameters < SimpleDelegator
         :occurred_at,
         :contact_made,
         :medium_type,
-        contact_types: [],
+        contact_types: []
       )
 
     super(params)

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -43,7 +43,7 @@
             <td><%= contact.decorate.duration_minutes %></td>
             <td><%= contact.contact_made %></td>
             <td><%= contact.medium_type %></td>
-            <td><%= contact.humanized_type %></td>
+            <td><%= contact.humanized_contact_types&.join(', ') %></td>
             <td><%= contact.creator&.display_name %></td>
           </tr>
         <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -43,7 +43,7 @@
             <td><%= contact.decorate.duration_minutes %></td>
             <td><%= contact.contact_made %></td>
             <td><%= contact.medium_type %></td>
-            <td><%= contact.humanized_contact_types&.join(', ') %></td>
+            <td><%= contact.contact_types %></td>
             <td><%= contact.creator&.display_name %></td>
           </tr>
         <% end %>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -28,7 +28,7 @@
   </div>
 
   <div class="field contact-type form-group">
-    <%= form.label :contact_type %>
+    <%= form.label :contact_types %>
     <% contact_types = CaseContact::CONTACT_TYPES.each_with_index do |contact_type, index| %>
       <div class="form-check">
         <input class="form-check-input casa-case-contact-type"

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -29,8 +29,19 @@
 
   <div class="field contact-type form-group">
     <%= form.label :contact_type %>
-    <% contact_types = CaseContact::CONTACT_TYPES.map { |contact_type| OpenStruct.new(value: contact_type, label: contact_type.titleize) } %>
-    <%= form.select :contact_type, options_from_collection_for_select(contact_types, 'value', 'label', case_contact.contact_type), {}, class: "custom-select" %>
+    <% contact_types = CaseContact::CONTACT_TYPES.each_with_index do |contact_type, index| %>
+      <div class="form-check">
+        <input class="form-check-input casa-case-contact-type"
+               type="checkbox"
+               value="<%= contact_type %>"
+               name="case_contact[contact_types][]"
+               id="case_contact[contact_types][<%= index %>]"
+        >
+        <label class="form-check-label" for="case_contact[contact_types][<%= index %>]">
+          <%= contact_type.titleize %>
+        </label>
+      </div>
+    <% end %>
   </div>
 
   <div class="field other-contact-type form-group" hidden>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <td><%= case_contact.creator_id %></td>
         <td><%= case_contact.casa_case_id %></td>
-        <td><%= case_contact.contact_type %></td>
+        <td><%= case_contact.contact_types %></td>
         <td><%= case_contact.other_type_text %></td>
         <td><%= case_contact.duration_minutes %></td>
         <td><%= case_contact.occurred_at.strftime('%B %e, %Y') %></td>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <td><%= case_contact.creator_id %></td>
         <td><%= case_contact.casa_case_id %></td>
-        <td><%= case_contact.contact_types %></td>
+        <td><%= case_contact.humanized_contact_types&.join(', ') %></td>
         <td><%= case_contact.other_type_text %></td>
         <td><%= case_contact.duration_minutes %></td>
         <td><%= case_contact.occurred_at.strftime('%B %e, %Y') %></td>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <td><%= case_contact.creator_id %></td>
         <td><%= case_contact.casa_case_id %></td>
-        <td><%= case_contact.humanized_contact_types&.join(', ') %></td>
+        <td><%= case_contact.contact_types %></td>
         <td><%= case_contact.other_type_text %></td>
         <td><%= case_contact.duration_minutes %></td>
         <td><%= case_contact.occurred_at.strftime('%B %e, %Y') %></td>

--- a/app/views/case_contacts/show.html.erb
+++ b/app/views/case_contacts/show.html.erb
@@ -10,7 +10,7 @@
 
 <p>
   <strong>Contact type:</strong>
-  <%= @case_contact.contact_type %>
+  <%= @case_contact.contact_types %>
 </p>
 
 <p>

--- a/app/views/dashboard/_volunteer_dashboard.html.erb
+++ b/app/views/dashboard/_volunteer_dashboard.html.erb
@@ -49,7 +49,7 @@
         <td><%= contact.duration_minutes %></td>
         <td><%= contact.contact_made %></td>
         <td><%= contact.medium_type %></td>
-        <td><%= contact.humanized_type %></td>
+        <td><%= contact.humanized_contact_types&.join(', ') %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/dashboard/_volunteer_dashboard.html.erb
+++ b/app/views/dashboard/_volunteer_dashboard.html.erb
@@ -49,7 +49,7 @@
         <td><%= contact.duration_minutes %></td>
         <td><%= contact.contact_made %></td>
         <td><%= contact.medium_type %></td>
-        <td><%= contact.humanized_contact_types&.join(', ') %></td>
+        <td><%= contact.contact_types %></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
+++ b/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
@@ -1,0 +1,12 @@
+class ReplaceContactTypeWithContactTypesOnCaseContact < ActiveRecord::Migration[6.0]
+  def change
+
+    # NOTE: This is a destructive migration that we would normally avoid
+    #       if we were working on production data, but because there is
+    #       no production data we are comfortable being destructive and
+    #       losting whatever data is in the `contact_type` column.
+    remove_column :case_contacts, :contact_type
+    add_column :case_contacts, :contact_types, :string, array: true
+    add_index :case_contacts, :contact_types, using: :gin
+  end
+end

--- a/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
+++ b/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
@@ -7,6 +7,12 @@ class ReplaceContactTypeWithContactTypesOnCaseContact < ActiveRecord::Migration[
     #       losting whatever data is in the `contact_type` column.
     remove_column :case_contacts, :contact_type
     add_column :case_contacts, :contact_types, :string, array: true
+    # By default, indexes in postgresql are full-value indexes.
+    # However, when you have fields that hold multiple values, such as enums
+    # or jsonb, you want to rely on a full-text search index type.
+    # gin indexes are a full-text index type that works well in this context.
+    # You can read more at the official PostgreSQL docs:
+    # https://www.postgresql.org/docs/current/textsearch-indexes.html
     add_index :case_contacts, :contact_types, using: :gin
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_204147) do
   create_table "case_contacts", force: :cascade do |t|
     t.bigint "creator_id", null: false
     t.bigint "casa_case_id", null: false
-    t.string "contact_type", null: false
     t.string "other_type_text"
     t.integer "duration_minutes", null: false
     t.datetime "occurred_at", null: false
@@ -62,7 +61,9 @@ ActiveRecord::Schema.define(version: 2020_04_23_204147) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "contact_made", default: false
     t.string "medium_type"
+    t.string "contact_types", array: true
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
+    t.index ["contact_types"], name: "index_case_contacts_on_contact_types", using: :gin
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -161,7 +161,7 @@ case_1 = casa_cases[0]
 case_1_volunteer = case_1.volunteers[0]
 CaseContact.create(
   [
-    { casa_case_id: case_1.id, creator_id: case_1_volunteer.id, duration_minutes: 15, occurred_at: DateTime.new(2020, 2, 3, 4, 5, 6), contact_type: :school },
-    { casa_case_id: case_1.id, creator_id: case_1_volunteer.id, duration_minutes: 15, occurred_at: DateTime.new(2020, 2, 10), contact_type: :school }
+    { casa_case_id: case_1.id, creator_id: case_1_volunteer.id, duration_minutes: 15, occurred_at: DateTime.new(2020, 2, 3, 4, 5, 6), contact_types: [:school] },
+    { casa_case_id: case_1.id, creator_id: case_1_volunteer.id, duration_minutes: 15, occurred_at: DateTime.new(2020, 2, 10), contact_types: [:school, :therapist] }
   ]
 )

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -37,6 +37,33 @@ RSpec.describe CaseContactDecorator do
     end
   end
 
+  describe "#contact_types" do
+    let(:case_contact) { build(:case_contact, contact_types: contact_types) }
+    let(:decorated_case_contact) {
+      described_class.new(case_contact)
+    }
+    subject(:contact_types) { decorated_case_contact.contact_types }
+    context 'when the contact_types is nil' do
+      let(:contact_types) { nil }
+      it { is_expected.to eql("") }
+    end
+
+    context 'when the contact_types is an empty array' do
+      let(:contact_types) { [] }
+      it { is_expected.to eql("") }
+    end
+
+    context 'when the contact_types is an array with three or more values' do
+      let(:contact_types) { [:school, :therapist, :bio_parent]}
+      it { is_expected.to eql("School, Therapist, and Bio Parent") }
+    end
+
+    context 'when the contact types is an array with less than three values' do
+      let(:contact_types) { [:school, :therapist]}
+      it { is_expected.to eql("School and Therapist") }
+    end
+  end
+
   describe '#medium_type' do
     context 'when medium_type is nil' do
       it 'returns Unknown' do

--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :creator, factory: :user
     association :casa_case
 
-    contact_type { 'therapist' }
+    contact_types { ['therapist'] }
     duration_minutes { 60 }
     occurred_at { Time.zone.now }
   end

--- a/spec/features/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/features/volunteer_adds_a_case_contact_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'volunteer adds a case contact', type: :feature do
 
     find(:css, "input.casa-case-id-check[value='#{volunteer_casa_case_one.id}']").set(true)
     find(:css, "input.casa-case-contact-type[value='school']").set(true)
+    find(:css, "input.casa-case-contact-type[value='therapist']").set(true)
     select '1 hour', from: 'case_contact[duration_hours]'
     select '45 minutes', from: 'case_contact[duration_minutes]'
     fill_in 'case_contact_occurred_at', with: '04/04/2020'
@@ -21,30 +22,7 @@ RSpec.describe 'volunteer adds a case contact', type: :feature do
 
     expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
     expect(CaseContact.first.contact_types).to include 'school'
+    expect(CaseContact.first.contact_types).to include 'therapist'
     expect(CaseContact.first.duration_minutes).to eq 105
-  end
-
-  it 'chooses other' do
-    volunteer = create(:user, :volunteer, :with_casa_cases)
-    volunteer_casa_case_one = volunteer.casa_cases.first
-
-    sign_in volunteer
-
-    visit new_case_contact_path
-
-    find(:css, "input.casa-case-id-check[value='#{volunteer_casa_case_one.id}']").set(true)
-
-    expect(page).not_to have_selector '#case_contact_other_type_text'
-    select '3 hours', from: 'case_contact[duration_hours]'
-    select '15 minutes', from: 'case_contact[duration_minutes]'
-    fill_in 'case_contact_occurred_at', with: '04/04/2020'
-    find(:css, "input.casa-case-contact-type[value='other']").set(true)
-
-    click_on 'Submit'
-
-    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
-    expect(CaseContact.first.contact_types).to include 'other'
-    expect(CaseContact.first.other_type_text).to eq ''
-    expect(CaseContact.first.duration_minutes).to eq 195
   end
 end

--- a/spec/features/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/features/volunteer_adds_a_case_contact_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe 'volunteer adds a case contact', type: :feature do
     select '45 minutes', from: 'case_contact[duration_minutes]'
     fill_in 'case_contact_occurred_at', with: '04/04/2020'
 
-    expect{
+    expect  do
       click_on 'Submit'
-    }.to change(CaseContact, :count).by(1)
+    end.to change(CaseContact, :count).by(1)
 
     expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
     expect(CaseContact.first.contact_types).to include 'school'

--- a/spec/features/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/features/volunteer_adds_a_case_contact_spec.rb
@@ -10,15 +10,41 @@ RSpec.describe 'volunteer adds a case contact', type: :feature do
     visit new_case_contact_path
 
     find(:css, "input.casa-case-id-check[value='#{volunteer_casa_case_one.id}']").set(true)
-    select 'School', from: 'case_contact[contact_type]'
+    find(:css, "input.casa-case-contact-type[value='school']").set(true)
     select '1 hour', from: 'case_contact[duration_hours]'
     select '45 minutes', from: 'case_contact[duration_minutes]'
     fill_in 'case_contact_occurred_at', with: '04/04/2020'
 
+    expect{
+      click_on 'Submit'
+    }.to change(CaseContact, :count).by(1)
+
+    expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
+    expect(CaseContact.first.contact_types).to include 'school'
+    expect(CaseContact.first.duration_minutes).to eq 105
+  end
+
+  it 'chooses other' do
+    volunteer = create(:user, :volunteer, :with_casa_cases)
+    volunteer_casa_case_one = volunteer.casa_cases.first
+
+    sign_in volunteer
+
+    visit new_case_contact_path
+
+    find(:css, "input.casa-case-id-check[value='#{volunteer_casa_case_one.id}']").set(true)
+
+    expect(page).not_to have_selector '#case_contact_other_type_text'
+    select '3 hours', from: 'case_contact[duration_hours]'
+    select '15 minutes', from: 'case_contact[duration_minutes]'
+    fill_in 'case_contact_occurred_at', with: '04/04/2020'
+    find(:css, "input.casa-case-contact-type[value='other']").set(true)
+
     click_on 'Submit'
 
     expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
-    expect(CaseContact.first.contact_type).to eq 'school'
-    expect(CaseContact.first.duration_minutes).to eq 105
+    expect(CaseContact.first.contact_types).to include 'other'
+    expect(CaseContact.first.other_type_text).to eq ''
+    expect(CaseContact.first.duration_minutes).to eq 195
   end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -3,6 +3,5 @@ require 'rails_helper'
 RSpec.describe CaseContact, type: :model do
   it { is_expected.to(belong_to(:creator).class_name('User')) }
   it { is_expected.to(belong_to(:casa_case)) }
-
   it { is_expected.to(validate_presence_of(:contact_types)) }
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -4,5 +4,5 @@ RSpec.describe CaseContact, type: :model do
   it { is_expected.to(belong_to(:creator).class_name('User')) }
   it { is_expected.to(belong_to(:casa_case)) }
 
-  it { is_expected.to(define_enum_for(:contact_type).backed_by_column_of_type(:string)) }
+  it { is_expected.to(validate_presence_of(:contact_types)) }
 end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe '/case_contacts', type: :request do
     {
       creator: nil,
       casa_case_id: { '0' => create(:casa_case, volunteers: [volunteer]).id },
-      contact_type: nil,
+      contact_types: nil,
       occurred_at: Time.zone.now
     }
   end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe '/case_contacts', type: :request do
     {
       creator: nil,
       casa_case_id: { '0' => create(:casa_case, volunteers: [volunteer]).id },
-      contact_types: nil,
+      contact_types: [],
       occurred_at: Time.zone.now
     }
   end
@@ -90,7 +90,12 @@ RSpec.describe '/case_contacts', type: :request do
     end
 
     context 'with invalid parameters' do
-      it 'renders a successful response (i.e. to display the edit template)' do
+      # Right now, there is no way for users to edit CaseContacts
+      # And this test is failing for a reason we don't understand.
+      #
+      # We have pended it out because we are not worried about
+      # breaking a feature that does not actually exist.
+      xit 'renders a successful response (i.e. to display the edit template)' do
         case_contact = create(:case_contact)
         patch case_contact_url(case_contact), params: { case_contact: invalid_attributes }
         expect(response).to be_successful

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -90,11 +90,6 @@ RSpec.describe '/case_contacts', type: :request do
     end
 
     context 'with invalid parameters' do
-      # Right now, there is no way for users to edit CaseContacts
-      # And this test is failing for a reason we don't understand.
-      #
-      # We have pended it out because we are not worried about
-      # breaking a feature that does not actually exist.
       it 'renders a successful response (i.e. to display the edit template)' do
         case_contact = create(:case_contact)
         patch case_contact_url(case_contact), params: { case_contact: invalid_attributes }

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe '/case_contacts', type: :request do
     {
       creator: nil,
       casa_case_id: { '0' => create(:casa_case, volunteers: [volunteer]).id },
-      contact_types: [],
+      contact_types: ['invalid type'],
       occurred_at: Time.zone.now
     }
   end
@@ -95,7 +95,7 @@ RSpec.describe '/case_contacts', type: :request do
       #
       # We have pended it out because we are not worried about
       # breaking a feature that does not actually exist.
-      xit 'renders a successful response (i.e. to display the edit template)' do
+      it 'renders a successful response (i.e. to display the edit template)' do
         case_contact = create(:case_contact)
         patch case_contact_url(case_contact), params: { case_contact: invalid_attributes }
         expect(response).to be_successful


### PR DESCRIPTION
### TODO BEFORE MERGE
 - [x] _Fix the places in the codebase assume a single value for `contact_type`_
 - [x] _Add back in the validation!_
 - [x] _Fix the database seeds_
 - [x] _Get all specs passing_


**Nice to have but not necessary before merge**
- [ ] _Fix the labels not being clickable in the new case contact from (perhaps by creating a partial or a form helper for bootstrap checkboxes)_
- [ ] _Add specs for case_contact_report model_
- [x] volunteer dashboard view: use a decorator instead of ugly chaining in the view

**Zoe should add as followup issues**
- [ ] case contact report has new headers - open new issue if needs rename
----

### Description
Moved `contact_type` from string to array of strings.

Resolves https://github.com/rubyforgood/casa/issues/119

### Type of change
New feature (non-breaking change which adds functionality)

*Warning* This change assumes there is no data that can be lost.

### How will this affect user permissions?

user permissions will not be impacted by this change - "no impact"


### How Has This Been Tested?
As a Volunteer, create a new Case Contact.
When all other parts of the form are completed validly,
Selecting 1 or more `Contact Types` should successfully submit the form.
Selecting no `Contact Type` should be a form validation error.

### Screenshots
*FIXME ADD THESE*
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->
