### PR TITLE
Use https when importing google fonts

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,7 @@ $primary: #00447C;
 @import "dataTables/jquery.dataTables";
 
 
-@import url(http://fonts.googleapis.com/css?family=Montserrat:400,700);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
 
 body {
   font-family: "Montserrat";


### PR DESCRIPTION
Updates for #114 

### Description

This fixes the Mixed content error being thrown by Heroku:

`
Mixed Content: The page at 'https://casa-r4g-staging.herokuapp.com/reports' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Montserrat:400,700'. This request has been blocked; the content must be served over HTTPS.
`
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How will this affect user permissions?

No Impact
