### PR TITLE
Removed duplication testing of log_in admin in admin_new_case_spec.rb

### DIFF
--- a/spec/features/admin_adds_new_case_spec.rb
+++ b/spec/features/admin_adds_new_case_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'admin adds a new case', type: :feature do
     admin = create(:user, :casa_admin)
     case_number = '12345'
     sign_in admin
-    login_as admin
     visit root_path
     expect(page).to have_selector('.case-list')
 


### PR DESCRIPTION
Resolves #52 

### Description
Removed `login_in admin` from `admin_new_case_spec.rb`. 

### How Has This Been Tested?
All tests passed before the branch was created. 
After the edits, all tests pass. 
