### PR TITLE
Convert bugsnag API key to ENV variable

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,3 @@
 Bugsnag.configure do |config|
-  config.api_key = 'c2c2efde084a0f8e7f772324577a110b'
+  config.api_key = ENV['BUGSNAG_API_KEY']
 end


### PR DESCRIPTION
### Description
To prevent development errors popping up in the Slack channel and for security reasons, I changed the hardcoded API key to an ENV variable.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How will this affect user permissions?

No Impact

### How Has This Been Tested?

Local testing
