### PR TITLE
Fix New Volunteer Form Hanging on Submit

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -10,23 +10,27 @@ class VolunteersController < ApplicationController
   end
 
   def create
-    email = create_params[:email]
-    casa_org_id = create_params[:casa_org_id] # Create a new user with a dummy password
-    create_user_with_dummy_password(email, casa_org_id) # Send password reset email
+    volunteer = User.new(volunteer_params)
 
-    redirect_to root_path
+    if volunteer.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def edit; end
 
   private
 
-  def create_user_with_dummy_password(email, casa_org_id)
-    generated_password = Devise.friendly_token.first(8)
-    User.create!(email: email, password: generated_password, casa_org_id: casa_org_id)
+  def generate_devise_password
+    Devise.friendly_token.first(8)
   end
 
-  def create_params
-    params.require(:user).permit(:email, :casa_org_id)
+  def volunteer_params
+    VolunteerParameters
+      .new(params)
+      .with_password(generate_devise_password)
+      .with_role('volunteer')
   end
 end

--- a/app/values/volunteer_parameters.rb
+++ b/app/values/volunteer_parameters.rb
@@ -1,0 +1,30 @@
+class VolunteerParameters < SimpleDelegator
+  def initialize(params)
+    params =
+      params.require(:user).permit(
+        :email,
+        :casa_org_id,
+        :display_name,
+        :password,
+        :role
+      )
+
+    super(params)
+  end
+
+  def with_password(password)
+    params[:password] = password
+    self
+  end
+
+  def with_role(role)
+    params[:role] = role
+    self
+  end
+
+  private
+
+  def params
+    __getobj__
+  end
+end

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @volunteer, url: volunteers_path, id: :new_user do |form| %>
+<%= form_for @volunteer, url: volunteers_path, id: :new_user do |form| %>
   <% if volunteer.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(volunteer.errors.count, "error") %> prohibited this volunteer from being saved:</h2>


### PR DESCRIPTION
Resolved #44 

### Description

The new volunteer form currently hangs on submission. It looks like this is because the form is being submitted as JS instead of HTML and so the controller is not able to redirect the user back to the dashboard. This PR fixes that by setting remote to false for the form. It also does minor refactoring on the volunteers controller.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How will this affect user permissions?

No Impact, admins can still create volunteers.

### How Has This Been Tested?

Local testing
