### PR TITLE
Saves datatable state on page reload

### DIFF
--- a/app/javascript/packs/dashboard.js
+++ b/app/javascript/packs/dashboard.js
@@ -40,6 +40,7 @@ $('document').ready(() => {
   // Enable all data tables on dashboard but only filter on volunteers table
   var volunteers_table = $('table#volunteers').DataTable({
     "autoWidth": false,
+    "stateSave": true,
     "columnDefs": [
       {
         "targets": [1],
@@ -54,6 +55,18 @@ $('document').ready(() => {
         "visible": false
       }
     ]});
+
+  // Because the table saves state, we have to check/uncheck modal inputs based on what
+  // columns are visible
+  volunteers_table.columns().every(function (index) {
+    var column_visible = this.visible();
+
+    if(column_visible)
+      $('#visibleColumns input[data-column="' + index + '"]').prop('checked', true);
+    else
+      $('#visibleColumns input[data-column="' + index + '"]').prop('checked', false)
+  })
+
   $('table#casa_cases').DataTable({"searching": false});
   $('table#case_contacts').DataTable({"searching": false});
 

--- a/app/views/dashboard/_volunteer_filters.html.erb
+++ b/app/views/dashboard/_volunteer_filters.html.erb
@@ -31,18 +31,18 @@
         <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="No" checked />No</a></li>
       </div>
     </div>
-    <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#exampleModal">
+    <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#visibleColumns">
       Pick displayed columns
     </button>
   </div>
 </div>
 <br>
 
-<div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="visibleColumns" tabindex="-1" role="dialog" aria-labelledby="visibleColumnsLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">Pick Displayed Columns</h5>
+        <h5 class="modal-title" id="visibleColumnsLabel">Pick Displayed Columns</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #194 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This PR leverages the jquery datatables savestate feature to keep filtered columns and search terms saved across page reloads using browser localstorage. There's also a new javascript function to check the appropriate boxes in the "Pick Displayed Column" modal if state has been saved.

### How will this affect user permissions?

No impact.

### How is this tested?

Local testing
