### PR TITLE
Fixes repeated supervisor filter on volunteer table

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -7,6 +7,12 @@ class UserDecorator < Draper::Decorator
     'Active'
   end
 
+  def name
+    return object.email if object.display_name.blank?
+
+    object.display_name
+  end
+
   # If all of a volunteers cases are not transition youth eligible, then
   # we return "No", otherwise they have at least one transition youth eligible case
   # and we return "Yes"

--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -28,7 +28,7 @@
       <tr>
         <td data-search="<%= volunteer.past_names %>"><%= volunteer.display_name %></td>
         <td><%= volunteer.email %></td>
-        <td id="supervisor-column"><%= volunteer&.supervisor&.email %></td>
+        <td id="supervisor-column"><%= volunteer&.supervisor&.decorate&.name %></td>
         <td id="status-column"><%= volunteer.status %></td>
         <td><%= volunteer&.assigned_to_transition_aged_youth? %></td>
         <td><%= volunteer&.casa_cases&.pluck(:case_number)&.join(', ') %></td>

--- a/app/views/dashboard/_volunteer_filters.html.erb
+++ b/app/views/dashboard/_volunteer_filters.html.erb
@@ -6,9 +6,9 @@
         Supervisor
       </button>
         <ul class="dropdown-menu supervisor-options" style="min-width: 15rem;">
-          <% SupervisorVolunteer.all.each do |relationship| %>
+          <% User.where(role: "supervisor").decorate.each do |supervisor| %>
             <li>
-              <a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="<%= relationship.supervisor.email %>" checked/><%= relationship.supervisor.email %></a>
+              <a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="<%= supervisor.name %>" checked/><%= supervisor.name %></a>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #191 
Resolved #190 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [ ] `bundle exec rake` passes locally
* [x] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This PR fixes a bug where we were iterating over the supervisor_volunteer join table instead of users with the supervisor role giving us lots of duplication. It also changes supervisor column value from email to display_name.

### How will this affect user permissions?

No impact.

### How is this tested?

Local testing
