### PR TITLE
Adds basic password reset styles

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,53 @@
-<p>Hello <%= @resource.email %>!</p>
+<!DOCTYPE html>
+<html>
+<body style="margin: 0 !important; padding: 0 !important; background-color: #edefed">
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<!-- HEADER -->
+<table border="0" cellpadding="0" cellspacing="0" width="600" align="center">
+  <tr>
+    <td bgcolor="#edefed" align="center">
+      <h1 style="font-size: 36px; font-family: Helvetica, Arial, sans-serif;">Casa Password Reset</h1>
+    </td>
+  </tr>
+  <tr>
+    <td bgcolor="#ffffff" align="center" style="padding: 30px 10px 30px 10px; border-radius: 7px;">
+      <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 530px;">
+        <tr>
+          <td>
+            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+              <tr>
+                <td>
+                  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td align="left" style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #333333; padding-top: 0px;" class="padding">
+                        <p>If you've lost your password or wish to reset it, click the button below. If you didn’t request this, you can safely ignore this email.</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td align="center">
+                  <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td align="center" style="padding-top: 15px;">
+                        <table border="0" cellspacing="0" cellpadding="0">
+                          <tr>
+                            <td align="left" bgcolor="#00447C"><a href="<%= "#{edit_password_url(@resource, reset_password_token: @token)}" %>" target="_blank" style="font-size: 20px;font-family: Helvetica, Arial, sans-serif;color: #ffffff;text-decoration: none; text-decoration: none;padding:15px 20px;display: inline-block;">Reset your password</a></td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+</body>
+</html>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Contributes to #125 

### Checklist

* [x] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

Adds basic styles for password reset email. No logos or special fonts added in this PR.

### How will this affect user permissions?

No Impact

### How is this tested?

Local testing

### Screenshots please :)

<img width="1795" alt="Screen Shot 2020-04-26 at 12 32 17 PM" src="https://user-images.githubusercontent.com/1221519/80313639-243f0c80-87ba-11ea-9c2a-2a055df69a41.png">
