### PR TITLE
Adds more page content spacing

### DIFF
--- a/app/assets/stylesheets/navbar.scss
+++ b/app/assets/stylesheets/navbar.scss
@@ -21,5 +21,8 @@
   text-align: center;
   padding: 8px;
   margin: 12px 0;
-  //background-color: rgba(238, 49, 36, 0.5); // Set to standard Bootstrap colors
+}
+
+.content {
+  padding: 1.5em 1em 3em;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,9 @@
         <p class="notice alert alert-danger"><%= alert %></p>
       <% end %>
 
-      <%= yield %>
+      <div class="content">
+        <%= yield %>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### What changed, and why?

Adds a little more top spacing after recent changes removing flash alerts.

### Screenshots please :)

Before:

<img width="1830" alt="Screen Shot 2020-04-27 at 9 46 42 PM" src="https://user-images.githubusercontent.com/1221519/80437892-d23cda80-88d0-11ea-988f-424727211838.png">

After:

<img width="1830" alt="Screen Shot 2020-04-27 at 9 46 48 PM" src="https://user-images.githubusercontent.com/1221519/80437887-cfda8080-88d0-11ea-888f-407b164eed1d.png">

