### PR TITLE
Adds edit volunteer page for admins

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -1,17 +1,13 @@
 class CaseAssignmentsController < ApplicationController
   before_action :must_be_admin
 
-  def index
-    @volunteer = User.find(params[:volunteer_id]).decorate
-  end
-
   def create
     volunteer = User.find(params[:volunteer_id])
     case_assignment = volunteer.case_assignments.new(case_assignment_params)
 
     case_assignment.save
 
-    redirect_to volunteer_case_assignments_path(volunteer)
+    redirect_to edit_volunteer_path(volunteer)
   end
 
   def destroy
@@ -20,7 +16,7 @@ class CaseAssignmentsController < ApplicationController
 
     case_assignment.destroy
 
-    redirect_to volunteer_case_assignments_path(volunteer)
+    redirect_to edit_volunteer_path(volunteer)
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,7 +4,8 @@ class DashboardController < ApplicationController
   def show
     authorize :dashboard
 
-    @volunteers = policy_scope(User.volunteer).decorate
+    # Return all active/inactive volunteers, inactive will be filtered by default
+    @volunteers = policy_scope(User.where(role: ['inactive', 'volunteer'])).decorate
     @casa_cases = policy_scope(CasaCase.all)
     @case_contacts = policy_scope(CaseContact.all).order(occurred_at: :desc).decorate
   end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -6,7 +6,7 @@ class VolunteersController < ApplicationController
   end
 
   def create
-    volunteer = User.new(volunteer_params)
+    volunteer = User.new(create_volunteer_params)
 
     if volunteer.save
       redirect_to root_path
@@ -19,16 +19,30 @@ class VolunteersController < ApplicationController
     @volunteer = User.find(params[:id])
   end
 
+  def update
+    @volunteer = User.find(params[:id])
+
+    if @volunteer.update(update_volunteer_params)
+      redirect_to edit_volunteer_path(@volunteer), notice: 'Volunteer was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
   private
 
   def generate_devise_password
     Devise.friendly_token.first(8)
   end
 
-  def volunteer_params
+  def create_volunteer_params
     VolunteerParameters
       .new(params)
       .with_password(generate_devise_password)
       .with_role('volunteer')
+  end
+
+  def update_volunteer_params
+    VolunteerParameters.new(params)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def body_class
-    qualified_controller_name = controller.controller_path.tr("/", "-")
+    qualified_controller_name = controller.controller_path.tr('/', '-')
     "#{qualified_controller_name} #{qualified_controller_name}-#{controller.action_name}"
   end
 

--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -35,7 +35,7 @@
         <td><%= volunteer&.most_recent_contact&.occurred_at&.strftime('%B %e, %Y') %></td>
         <td><%= volunteer&.recent_contacts_made %></td>
         <td>
-          <%= link_to 'Edit', volunteer_case_assignments_path(volunteer) %>
+          <%= link_to 'Edit', edit_volunteer_path(volunteer) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -1,3 +1,106 @@
 <%= link_to 'Back', root_path %>
 
 <h1>Editing Volunteer</h1>
+
+<div class="row">
+  <div class="col-sm-6">
+    <%= form_for @volunteer, url: volunteer_path(@volunteer) do |form| %>
+      <% if @volunteer.errors.any? %>
+        <div id="error_explanation">
+          <h2><%= pluralize(@volunteer.errors.count, "error") %> prohibited this volunteer from being saved:</h2>
+
+          <ul>
+            <% @volunteer.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="field form-group">
+        <%= form.label :email %>
+        <%= form.text_field :email, class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= form.label :display_name %>
+        <%= form.text_field :display_name, class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= form.label "Start Date" %>
+        <input class="form-control" type="text" placeholder="<%= @volunteer.created_at.strftime('%m/%d/%Y ') %>" readonly>
+      </div>
+
+
+      <div class="field form-group">
+        <%= form.label "Status" %>
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio1" value="volunteer" <% if @volunteer.role == "volunteer" %> checked<% end %>>
+          <label class="form-check-label" for="statusRadio1">
+            Active
+          </label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio2" value="inactive" <% if @volunteer.role == "inactive" %> checked<% end %>>
+          <label class="form-check-label" for="statusRadio2">
+            Inactive
+          </label>
+        </div>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "Submit", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if @volunteer.casa_cases %>
+  <br>
+  <div class="row">
+    <div class="col-sm-12">
+      <h3>Assigned Cases</h3>
+      <table class='table case-list'>
+        <thead>
+          <tr>
+            <th>Case Number</th>
+            <th>Transition Aged Youth</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @volunteer.case_assignments.each do |assignment| %>
+            <tr>
+              <td><%= assignment.casa_case.case_number %></td>
+              <td><%= assignment.casa_case.transition_aged_youth %></td>
+              <td><%= button_to 'Unassign Case', volunteer_case_assignment_path(@volunteer, assignment), method: :delete, class: "btn btn-danger" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>
+
+<br>
+
+<div class="row">
+  <div class="col-sm-6">
+    <h3>Assign a New Case</h3>
+
+    <%= form_for CaseAssignment.new, url: volunteer_case_assignments_path(@volunteer) do |form| %>
+
+      <div class='form-group'>
+        <label for='case_assignment_casa_case_id'>Select a Case</label>
+        <select name='case_assignment[casa_case_id]' class='form-control'>
+          <% CasaCase.all.each do |casa_case| %>
+            <option value="<%= casa_case.id %>"><%= casa_case.case_number %></option>
+          <% end %>
+        </select>
+      </div>
+
+      <%= form.submit 'Assign Case', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
   resources :casa_orgs
   resources :reports, only: %i[show index]
 
-  resources :volunteers, only: %i[new edit create] do
-    resources :case_assignments, only: %i[create destroy index]
+  resources :volunteers, only: %i[new edit create update] do
+    resources :case_assignments, only: %i[create destroy]
   end
 
   resources :users, only: [] do

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'admin views dashboard', type: :feature do
       click_on 'Edit'
     end
 
-    expect(page).to have_text('Edit Volunteer Assignments')
+    expect(page).to have_text('Editing Volunteer')
   end
 
   it 'can go to the new volunteer page' do

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -1,31 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe '/case_assignments', type: :request do
-  describe 'GET /index' do
-    context 'with a volunteer signed in' do
-      it 'redirects back to dashboard with an unauthorized notice' do
-        volunteer = create(:user, :volunteer)
-        sign_in volunteer
-
-        get volunteer_case_assignments_path(volunteer)
-
-        expect(response).to redirect_to(root_path)
-      end
-    end
-
-    context 'with an admin signed in' do
-      it 'renders a successful response' do
-        admin = create(:user, :casa_admin)
-        volunteer = create(:user, :volunteer)
-        sign_in admin
-
-        get volunteer_case_assignments_path(volunteer)
-
-        expect(response).to be_successful
-      end
-    end
-  end
-
   describe 'POST /create' do
     it 'creates a new case assignment' do
       admin = create(:user, :casa_admin)
@@ -39,7 +14,7 @@ RSpec.describe '/case_assignments', type: :request do
              params: { case_assignment: { casa_case_id: casa_case.id } }
       end.to change(volunteer.casa_cases, :count).by(1)
 
-      expect(response).to redirect_to volunteer_case_assignments_path(volunteer)
+      expect(response).to redirect_to edit_volunteer_path(volunteer)
     end
   end
 
@@ -56,7 +31,7 @@ RSpec.describe '/case_assignments', type: :request do
         delete volunteer_case_assignment_url(volunteer, assignment)
       end.to change(volunteer.casa_cases, :count).by(-1)
 
-      expect(response).to redirect_to volunteer_case_assignments_path(volunteer)
+      expect(response).to redirect_to edit_volunteer_path(volunteer)
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe '/users', type: :request do
   end
 
   describe 'PATCH /update' do
-    it 'renders a csv file to download' do
+    it 'updates the user' do
       volunteer = create(:user, :volunteer)
       sign_in volunteer
 

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe '/volunteers', type: :request do
       expect(response).to redirect_to root_path
     end
   end
+
+  describe 'PATCH /update' do
+    it 'updates the volunteer' do
+      sign_in admin
+
+      patch volunteer_path(volunteer), params: update_volunteer_params
+      volunteer.reload
+      
+      expect(volunteer.display_name).to eq 'New Name'
+      expect(volunteer.email).to eq 'newemail@gmail.com'
+      expect(volunteer.role).to eq 'inactive'
+    end
+  end
+
+  def update_volunteer_params
+    { user: { email: 'newemail@gmail.com', display_name: 'New Name', role: 'inactive' } }
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #5 
Resolved #203 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

Replaces the case assignments page with an edit volunteer page that includes the relevant editable volunteer fields.

### How will this affect user permissions?

Admins can now edit a volunteer's name, email, and active/inactive status.

### How is this tested?

Rspec tests have been added.

### Screenshots please :)

<img width="1762" alt="Screen Shot 2020-04-28 at 1 16 48 PM" src="https://user-images.githubusercontent.com/1221519/80517114-8c285b00-8952-11ea-8fcd-830093939f77.png">

