### PR TITLE
Adds new fields to case contacts report

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,7 +5,7 @@ class DashboardController < ApplicationController
     authorize :dashboard
 
     # Return all active/inactive volunteers, inactive will be filtered by default
-    @volunteers = policy_scope(User.where(role: ['inactive', 'volunteer'])).decorate
+    @volunteers = policy_scope(User.where(role: %w[inactive volunteer])).decorate
     @casa_cases = policy_scope(CasaCase.all)
     @case_contacts = policy_scope(CaseContact.all).order(occurred_at: :desc).decorate
   end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -26,21 +26,6 @@ class CaseContact < ApplicationRecord
   def humanized_type
     contact_type.humanize.titleize.to_s
   end
-
-  # Generate array of attributes for All Case Contacts report
-  def attributes_to_array
-    [
-      id,
-      casa_case&.case_number,
-      duration_minutes,
-      occurred_at,
-      creator&.email,
-      'N/A',
-      # creator&.name, Add back in after user has name field
-      creator&.supervisor&.email,
-      contact_type
-    ]
-  end
 end
 
 # == Schema Information

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -5,16 +5,61 @@ class CaseContactReport < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << attributes.map(&:titleize)
 
-      CaseContact.all.decorate.each { |case_contact| csv << case_contact.attributes_to_array }
+      CaseContact.all.each do |case_contact|
+        csv << generate_row(case_contact)
+      end
     end
   end
 
   def self.report_headers
-    headers = %w[case_contact_id casa_case_number duration occurred_at
-                 creator_email creator_name creator_supervisor_name contact_type]
+    headers = %w[ internal_contact_number duration contact_type contact_made
+                  contact_medium occurred_at added_to_system_at casa_case_number
+                  volunteer_email volunteer_name supervisor_name]
 
     # TODO: Issue 119 -- Enable multiple contact types for a case_contact
     # headers.concat(CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" })
     headers
+  end
+
+  def self.generate_row(case_contact)
+    row_data = []
+
+    row_data << case_contact_fields(case_contact)
+    row_data << casa_case_fields(case_contact.casa_case)
+    row_data << volunteer_fields(case_contact.creator)
+    row_data << supervisor_fields(case_contact.creator&.supervisor)
+
+    row_data.flatten
+  end
+
+  def self.case_contact_fields(case_contact)
+    [
+      case_contact&.id,
+      case_contact&.duration_minutes,
+      case_contact&.contact_type,
+      case_contact&.contact_made,
+      case_contact&.medium_type,
+      case_contact&.occurred_at&.strftime('%B %e, %Y'),
+      case_contact&.created_at
+    ]
+  end
+
+  def self.casa_case_fields(casa_case)
+    [
+      casa_case&.case_number
+    ]
+  end
+
+  def self.volunteer_fields(volunteer)
+    [
+      volunteer&.email,
+      volunteer&.display_name
+    ]
+  end
+
+  def self.supervisor_fields(supervisor)
+    [
+      supervisor&.display_name
+    ]
   end
 end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe '/volunteers', type: :request do
 
       patch volunteer_path(volunteer), params: update_volunteer_params
       volunteer.reload
-      
+
       expect(volunteer.display_name).to eq 'New Name'
       expect(volunteer.email).to eq 'newemail@gmail.com'
       expect(volunteer.role).to eq 'inactive'


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #181

### Checklist

* [ ] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [ ] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This commit adds newly added fields to the case contacts report, e.g. contact_medium, user/supervisor names, and created_at. It also refactors the report generation code to all be inside the CaseContactReport class.

### How will this affect user permissions?

No impact

### How is this tested?

Local testing

### Screenshots please :)

<img width="1716" alt="Screen Shot 2020-04-29 at 10 35 16 AM" src="https://user-images.githubusercontent.com/1221519/80608713-2ba62600-8a05-11ea-821f-b3e42f421968.png">
