### PR TITLE
Adds full contacts table to casa_case#show

### DIFF
--- a/app/assets/stylesheets/casa_cases.scss
+++ b/app/assets/stylesheets/casa_cases.scss
@@ -1,4 +1,16 @@
 body.casa_cases {
+  .form-header {
+    h1 {
+      display: inline-block;
+      margin-right: 15px;
+      vertical-align: middle;
+    }
+
+    a {
+      display: inline-block;
+    }
+  }
+
   .case-contact-list {
       margin-bottom: 20px;
   }

--- a/app/javascript/packs/dashboard.js
+++ b/app/javascript/packs/dashboard.js
@@ -68,7 +68,7 @@ $('document').ready(() => {
   })
 
   $('table#casa_cases').DataTable({"searching": false});
-  $('table#case_contacts').DataTable({"searching": false});
+  $('table#case_contacts').DataTable({"searching": false, "order": [[0, "desc" ]]});
 
   $('.volunteer-filters input[type="checkbox"]').on('click', function() {
     volunteers_table.draw();

--- a/app/javascript/packs/show_casa_case.js
+++ b/app/javascript/packs/show_casa_case.js
@@ -1,7 +1,3 @@
 $('document').ready(() => {
-  // Enable all data tables on dashboard but only filter on volunteers table
-  $('.show-volunteer-case-contacts').on('click', function(e) {
-    var table_target = $(e.target).data('target');
-    $(table_target).toggleClass('collapse');
-  })
+
 });

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,61 +1,53 @@
 <%= link_to 'Back', :back %>
 
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header">
+  <div class="col-sm-12 form-header">
     <h1>CASA Case Details</h1>
     <%= link_to 'Edit Case Details', edit_casa_case_path(@casa_case), class: "btn btn-primary" %>
   </div>
 </div>
 
 <p>
-  <h3>Case number:</h3>
-  <%= @casa_case.case_number %>
+  <h6><strong>Case number:</strong> <%= @casa_case.case_number %></h6>
+
 </p>
 
 <p>
-  <h3>Transition Aged Youth:</h3>
-  <%= @casa_case.transition_aged_youth %>
+  <h6><strong>Transition Aged Youth:</strong> <%= @casa_case.transition_aged_youth %></h6>
+
 </p>
 
 <div>
-  <h3>Assigned Volunteers:</h3>
-  <br>
-  <% policy_scope(@casa_case.volunteers).each_with_index do |volunteer, index|  %>
-    <h6><%= index + 1 %>. Email: <%=  volunteer.email %></h6>
-    <br/>
-    <button class="btn btn-primary show-volunteer-case-contacts" type="button" data-toggle="collapse" data-target="#collapseVolunteer<%= index %>" aria-expanded="false" aria-controls="collapseVolunteer<%= index %>">
-      Show/Hide Case Contacts of Volunteer
-    </button>
-    <div class="collapse" id="collapseVolunteer<%= index %>">
-      <div class="case-contact-list">
-        <h6 style="margin: 8px 0;"><strong>Case Contacts for <%=  volunteer.email %></strong></h6>
-
-        <div>
-          <table class="table table-bordered table-striped table-sm">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Duration</th>
-                <th>Contact Made</th>
-                <th>Contact Medium</th>
-                <th>Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% volunteer.case_contacts_for(@casa_case.id).each do |contact| %>
-                <tr>
-                  <td data-sort="<%= contact.occurred_at.strftime("%Y%m%d%H%M%s") %>"><%= contact.occurred_at.strftime('%B %e, %Y') %></td>
-                  <td><%= contact.decorate.duration_minutes %></td>
-                  <td><%= contact.contact_made %></td>
-                  <td><%= contact.medium_type %></td>
-                  <td><%= contact.humanized_type %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-    <hr>
+  <h6><strong>Assigned Volunteers:</strong></h6>
+  <% policy_scope(@casa_case.volunteers).each_with_index do |volunteer, index| %>
+    <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %></p>
   <% end %>
+  <br>
+
+  <div>
+    <table class="table table-bordered table-striped table-sm" id="case_contacts">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Duration</th>
+          <th>Contact Made</th>
+          <th>Contact Medium</th>
+          <th>Type</th>
+          <th>Volunteer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @casa_case.case_contacts.each do |contact| %>
+          <tr>
+            <td data-sort="<%= contact.occurred_at.strftime("%Y%m%d%H%M%s") %>"><%= contact.occurred_at.strftime('%B %e, %Y') %></td>
+            <td><%= contact.decorate.duration_minutes %></td>
+            <td><%= contact.contact_made %></td>
+            <td><%= contact.medium_type %></td>
+            <td><%= contact.humanized_type %></td>
+            <td><%= contact.creator&.display_name %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #205 
Resolves #192 

### Checklist

* [ ] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [ ] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This commit reorganizes the casa case detail view to put all case contacts in one jquery datatable. Also adds volunteer names as links in the Assigned Volunteer sections.

### How will this affect user permissions?

No Impact

### How is this tested?

Local testing and all existing tests pass

### Screenshots please :)

<img width="1774" alt="Screen Shot 2020-04-29 at 11 46 06 AM" src="https://user-images.githubusercontent.com/1221519/80616544-09b1a100-8a0f-11ea-9f1f-91671ea3c872.png">

