### PR TITLE
Simplify case contact report headers with new contact_types

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,9 +6,11 @@ class ReportsController < ApplicationController
   def index; end
 
   def show
+    case_contact_report = CaseContactReport.new(CaseContact.all)
+
     respond_to do |format|
       format.csv do
-        send_data CaseContactReport.to_csv,
+        send_data case_contact_report.to_csv,
                   filename: "case-contacts-report-#{Time.zone.now.to_i}.csv"
       end
     end

--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -27,7 +27,7 @@ class CaseContactDecorator < Draper::Decorator
   def contact_types
     object.contact_types
       &.map { |ct| ct.humanize.titleize }
-      &.to_sentence(last_word_connector: ', and ') || ""
+      &.to_sentence(last_word_connector: ', and ') || ''
   end
 
   def medium_type

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -28,25 +28,6 @@ class CaseContact < ApplicationRecord
       errors.add(:contact_types, :invalid) unless CONTACT_TYPES.include? contact_type
     end
   end
-
-  def use_other_type_text?
-    contact_types.include?('other')
-  end
-
-  # Generate array of attributes for All Case Contacts report
-  def attributes_to_array
-    [
-      id,
-      casa_case&.case_number,
-      duration_minutes,
-      occurred_at,
-      creator&.email,
-      'N/A',
-      # creator&.name, Add back in after user has name field
-      creator&.supervisor&.email,
-      contact_types
-    ]
-  end
 end
 
 # == Schema Information

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -1,28 +1,29 @@
-class CaseContactReport < ApplicationRecord
-  def self.to_csv
-    attributes = report_headers
+class CaseContactReport
+  attr_reader :case_contacts
 
+  def initialize(case_contacts)
+    @case_contacts = case_contacts
+  end
+
+  def to_csv
     CSV.generate(headers: true) do |csv|
-      csv << attributes.map(&:titleize)
+      csv << column_headers.map(&:titleize)
 
-      CaseContact.all.each do |case_contact|
+      CaseContact.all.decorate.each do |case_contact|
         csv << generate_row(case_contact)
       end
     end
   end
 
-  def self.report_headers
-    headers = %w[internal_contact_number duration]
-    contact_type_headers = CaseContact::CONTACT_TYPES.map { |t| "contact_type: #{t}" }
-    headers.concat(contact_type_headers)
-
-    headers.concat(%w[contact_made contact_medium occurred_at added_to_system_at
-                      casa_case_number volunteer_email volunteer_name supervisor_name])
-
-    headers
+  def column_headers
+    # Note: these header labels are for stakeholders and do not match the
+    # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
+    %w[internal_contact_number duration contact_types contact_made
+       contact_medium occurred_at added_to_system_at casa_case_number
+       volunteer_email volunteer_name supervisor_name]
   end
 
-  def self.generate_row(case_contact)
+  def generate_row(case_contact)
     row_data = []
 
     row_data << case_contact_fields(case_contact)
@@ -33,8 +34,10 @@ class CaseContactReport < ApplicationRecord
     row_data.flatten
   end
 
+  private
+
   # @param case_contact [CaseContact]
-  def self.case_contact_fields(case_contact)
+  def case_contact_fields(case_contact)
     [
       case_contact&.id,
       case_contact&.duration_minutes,
@@ -43,23 +46,23 @@ class CaseContactReport < ApplicationRecord
       case_contact&.medium_type,
       case_contact&.occurred_at&.strftime('%B %e, %Y'),
       case_contact&.created_at
-    ].flatten
+    ]
   end
 
-  def self.casa_case_fields(casa_case)
+  def casa_case_fields(casa_case)
     [
       casa_case&.case_number
     ]
   end
 
-  def self.volunteer_fields(volunteer)
+  def volunteer_fields(volunteer)
     [
       volunteer&.email,
       volunteer&.display_name
     ]
   end
 
-  def self.supervisor_fields(supervisor)
+  def supervisor_fields(supervisor)
     [
       supervisor&.display_name
     ]

--- a/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
+++ b/db/migrate/20200422180727_replace_contact_type_with_contact_types_on_case_contact.rb
@@ -5,7 +5,7 @@ class ReplaceContactTypeWithContactTypesOnCaseContact < ActiveRecord::Migration[
     #       if we were working on production data, but because there is
     #       no production data we are comfortable being destructive and
     #       losting whatever data is in the `contact_type` column.
-    remove_column :case_contacts, :contact_type
+    remove_column :case_contacts, :contact_type, :string
     add_column :case_contacts, :contact_types, :string, array: true
     # By default, indexes in postgresql are full-value indexes.
     # However, when you have fields that hold multiple values, such as enums

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -37,30 +37,36 @@ RSpec.describe CaseContactDecorator do
     end
   end
 
-  describe "#contact_types" do
-    let(:case_contact) { build(:case_contact, contact_types: contact_types) }
-    let(:decorated_case_contact) {
-      described_class.new(case_contact)
-    }
+  describe '#contact_types' do
     subject(:contact_types) { decorated_case_contact.contact_types }
+
+    let(:case_contact) { build(:case_contact, contact_types: contact_types) }
+    let(:decorated_case_contact) do
+      described_class.new(case_contact)
+    end
+
     context 'when the contact_types is nil' do
       let(:contact_types) { nil }
-      it { is_expected.to eql("") }
+
+      it { is_expected.to eql('') }
     end
 
     context 'when the contact_types is an empty array' do
       let(:contact_types) { [] }
-      it { is_expected.to eql("") }
+
+      it { is_expected.to eql('') }
     end
 
     context 'when the contact_types is an array with three or more values' do
-      let(:contact_types) { [:school, :therapist, :bio_parent]}
-      it { is_expected.to eql("School, Therapist, and Bio Parent") }
+      let(:contact_types) { %i[school therapist bio_parent] }
+
+      it { is_expected.to eql('School, Therapist, and Bio Parent') }
     end
 
     context 'when the contact types is an array with less than three values' do
-      let(:contact_types) { [:school, :therapist]}
-      it { is_expected.to eql("School and Therapist") }
+      let(:contact_types) { %i[school therapist] }
+
+      it { is_expected.to eql('School and Therapist') }
     end
   end
 

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -2,19 +2,37 @@ require 'rails_helper'
 
 RSpec.describe UserDecorator do
   describe '#status' do
-    context 'when volunteer role is inactive' do
+    context 'when user role is inactive' do
       it 'returns Inactive' do
-        volunteer = create(:user, role: 'inactive')
+        volunteer = build(:user, role: 'inactive')
 
         expect(volunteer.decorate.status).to eq 'Inactive'
       end
     end
 
-    context 'when duration_minutes is greater than 60' do
+    context 'when user role is volunteer' do
       it 'returns Active' do
-        volunteer = create(:user, role: 'volunteer')
+        volunteer = build(:user, role: 'volunteer')
 
         expect(volunteer.decorate.status).to eq 'Active'
+      end
+    end
+  end
+
+  describe '#name' do
+    context 'when user has a name' do
+      it 'returns the name' do
+        user = build(:user, display_name: "User Name")
+
+        expect(user.decorate.name).to eq user.display_name
+      end
+    end
+
+    context 'when user has no name' do
+      it 'returns the email' do
+        user = build(:user)
+
+        expect(user.decorate.name).to eq user.email
       end
     end
   end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe CaseContactReport, type: :model do
+  describe '#generate_headers' do
+    it 'matches the length of row data' do
+      case_contact = create(:case_contact)
+      case_contact_report = described_class.new(case_contact)
+
+      header_column_count = case_contact_report.column_headers.length
+      data_column_count = case_contact_report.generate_row(case_contact).length
+
+      expect(header_column_count).to eq data_column_count
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

Initially, the case_contact_report was supposed to have one column for each possible contact_type, e.g. `... type: supervisor, type: therapist, type: youth ...`. This commit adds one `contact_types` column for now to fix a bug where the headers do not align with the row data. It also adds a test to check the number of header columns matches the number of columns in the row data.

This PR also autocorrects some rubocop warnings and removes two deprecated methods in the CaseContact method.

### How will this affect user permissions?

No impact

### How is this tested?

New tests have been added.

### Screenshots please :)

<img width="1808" alt="Screen Shot 2020-04-29 at 7 32 53 PM" src="https://user-images.githubusercontent.com/1221519/80656865-3e921800-8a50-11ea-8e0d-ac67b9894853.png">

