### PR TITLE
Make case numbers clickable in volunteer view

### DIFF
--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -31,7 +31,7 @@
         <td id="supervisor-column"><%= volunteer&.supervisor&.decorate&.name %></td>
         <td id="status-column"><%= volunteer.status %></td>
         <td><%= volunteer&.assigned_to_transition_aged_youth? %></td>
-        <td><%= volunteer&.casa_cases&.pluck(:case_number)&.join(', ') %></td>
+        <td><%= safe_join(volunteer&.casa_cases&.map { |c| link_to(c.case_number, c) }, ", ") %></td>
         <td><%= volunteer&.most_recent_contact&.occurred_at&.strftime('%B %e, %Y') %></td>
         <td><%= volunteer&.recent_contacts_made %></td>
         <td>

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -2,7 +2,5 @@ FactoryBot.define do
   factory :casa_case do
     sequence(:case_number) { |n| n }
     transition_aged_youth { false }
-
-    before(:create) { |casa_case, _| create(:case_assignment, casa_case: casa_case) }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -18,9 +18,8 @@ FactoryBot.define do
     end
 
     trait :with_casa_cases do
-      before(:create) do |user, _|
-        create(:case_assignment, volunteer: user)
-        create(:case_assignment, volunteer: user)
+      after(:create) do |user, _|
+        create_list(:case_assignment, 2, volunteer: user)
       end
     end
   end

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'admin views dashboard', type: :feature do
   let(:admin) { create(:user, :casa_admin) }
 
-  it 'can see volunteers' do
+  it 'can see volunteers and navigate to their cases' do
     volunteer = create(:user, :volunteer, :with_casa_cases, email: 'casa@example.com')
     casa_case = volunteer.casa_cases[0]
     sign_in admin
@@ -12,6 +12,12 @@ RSpec.describe 'admin views dashboard', type: :feature do
 
     expect(page).to have_text('casa@example.com')
     expect(page).to have_text(casa_case.case_number)
+
+    within '#volunteers' do
+      click_on volunteer.casa_cases.first.case_number
+    end
+
+    expect(page).to have_text('CASA Case Details')
   end
 
   it 'can go to the volunteer edit page from the volunteer list' do


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #206

### Checklist

* [x] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

* Make each case clickable as described in #206
* Create associations in factory _after_ the dependent model is saved (otherwise the ID may be `nil`)
* Remove 'loop' in factory: previously `create(:user, :with_casa_cases)` would create 2 `case_assignment` models, which would each create a `casa_case` which would each create another `user`. Effectively calls to `create(:user)` were creating 3 users, instead of 1. If a future test would like a `casa_case` to come with an assignment, maybe it could be added as a `trait` instead?

### How will this affect user permissions?

- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested?

Via rspec feature specs and locally

### Screenshots please :)

![screenshot](https://user-images.githubusercontent.com/395621/80897743-1ada0680-8cca-11ea-85f3-e95a371e2024.png)