### PR TITLE
Add confirm for deactivation of volunteer

### DIFF
--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -42,7 +42,7 @@
           </label>
         </div>
         <div class="form-check">
-          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio2" value="inactive" <% if @volunteer.role == "inactive" %> checked<% end %>>
+          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio2" value="inactive" <% if @volunteer.role == "inactive" %> checked<% end %> onclick="return confirm('WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?')">
           <label class="form-check-label" for="statusRadio2">
             Inactive
           </label>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ end
 RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Warden::Test::Helpers
   config.after do
     Warden.test_reset!

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -8,18 +8,19 @@ RSpec.describe 'Admin: Editing Volunteers', type: :system do
     sign_in admin
     visit edit_volunteer_path(volunteer)  
 
-    choose "Inactive"
-
     dismiss_confirm do
-      click_on "Submit"
+      choose "Inactive"
     end
-    volunteer.reload
-    expect(volunteer).to be_is_active
+    expect(find_field("statusRadio2")).not_to be_checked
 
     accept_confirm do
-      click_on "Submit"
+      choose "Inactive"
     end
-    volunteer.reload
-    expect(volunteer).not_to be_is_active
+    expect(find_field("statusRadio2")).to be_checked
+
+    click_on "Submit"
+    expect do
+      volunteer.reload
+    end.to change{volunteer.role}.from("volunteer").to("inactive")
   end  
 end

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin: Editing Volunteers', type: :system do
+  let(:admin) { create(:user, :casa_admin) }
+  let(:volunteer) { create(:user, :volunteer) }
+
+  it 'saves the user as inactive, but only if the admin confirms' do  
+    sign_in admin
+    visit edit_volunteer_path(volunteer)  
+
+    choose "Inactive"
+
+    dismiss_confirm do
+      click_on "Submit"
+    end
+    volunteer.reload
+    expect(volunteer).to be_is_active
+
+    accept_confirm do
+      click_on "Submit"
+    end
+    volunteer.reload
+    expect(volunteer).not_to be_is_active
+  end  
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #228

### Checklist

* [x] I have performed a self-review of my own code
* [x] (n/a) I added comments, particularly in hard-to-understand areas
* [x] (n/a) I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [x] (n/a) My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?
I took the most direct path to implement this feature: I added an `onclick` attribute to the "Inactive" radio button. The error message is basically what was described in the issue. There is no existing javascript code in the app assets, so I did not wire this to any javascript events.

Additional thoughts:
 - The issue requested the dialog box show up when "Submit" is clicked. That would be a little more complicated than what I did, but practically speaking, this should be the same thing.
 - If UI Javascript is added later (for things along these lines) the `onclick` should be extracted from here and put into one of those files
 - If the user has JS disabled, they will not see this message; that is the only difference, practically. The radio button would function normally.
 - The spec written is *kinda* nosy. It knows how the role would change. I tried to add as little as possible, but IMHO there should probably be a predicate or something that encapsulates this as a behavior (ie. `inactive?`). Should that be added later, the spec could be updated.

### How will this affect user permissions?
n/a

### How is this tested?
I tested it manually, to be sure.

I also created a system spec. This was the only real "new" thing I added. I had to use a system spec because headless chrome was only being used for system specs, and I needed that driver to be able to verify the modal was showing up correctly. I added "system" to the list of test types that get Warden Helpers too (in the `rails_helper.rb`). I could have changed the driver to be applied to feature specs, but that seemed like it would have been a riskier change.

The spec verifies that the button is only checked if they accept the confirmation dialog.

### Screenshots please :)
![Screenshot from 2020-05-11 10-09-02](https://user-images.githubusercontent.com/502363/81571137-8ded1800-936f-11ea-8227-5d06ba541424.png)

