### PR TITLE
Hide new case contact button if volunteer has no assigned cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: False
 
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
 # Metrics Cops
 Metrics/BlockLength:
   Enabled: False

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -16,7 +16,7 @@ class DashboardPolicy
   end
 
   def create_case_contacts?
-    user.role == "volunteer"
+    user.role == "volunteer" && user.casa_cases.present?
   end
 
   def see_cases_section?

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -20,10 +20,18 @@ RSpec.describe DashboardPolicy do
   end
 
   permissions :create_cases_section? do
-    context "when user is a volunteer" do
+    context "when user is a volunteer with casa_cases" do
       it "permits user to see cases section" do
         volunteer = create(:user, :volunteer)
+        volunteer.casa_cases << create(:casa_case)
         expect(Pundit.policy(volunteer, :dashboard).create_case_contacts?).to eq true
+      end
+    end
+
+    context "when user is a volunteer without casa_cases" do
+      it "permits user to see cases section" do
+        volunteer = create(:user, :volunteer)
+        expect(Pundit.policy(volunteer, :dashboard).create_case_contacts?).to eq false
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #251

### Checklist

* [x] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This PR adds a check that a volunteer has at least one assigned case before showing the create new case contact button.

### How is this tested?

Rspec tests have been updated.
