### PR TITLE
Supervisors can edit all volunteer fields except email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_url
   end
 
-    def must_be_admin_or_supervisor
+  def must_be_admin_or_supervisor
     return if current_user&.casa_admin? || current_user&.supervisor?
 
     flash[:notice] = "You do not have permission to view that page."

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,11 @@ class ApplicationController < ActionController::Base
     flash[:notice] = "You do not have permission to view that page."
     redirect_to root_url
   end
+
+    def must_be_admin_or_supervisor
+    return if current_user&.casa_admin? || current_user&.supervisor?
+
+    flash[:notice] = "You do not have permission to view that page."
+    redirect_to root_url
+  end
 end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -1,7 +1,8 @@
 class VolunteersController < ApplicationController
-  # NOTE: I don't know what auth levels to use here, but am pretty certain it needs SOMETHING.
+  # Uses authenticate_user to redirect if no user is signed in
+  # and must_be_admin_or_supervisor to check user's role is appropriate
   before_action :authenticate_user!
-  before_action :must_be_admin
+  before_action :must_be_admin_or_supervisor
 
   def new
     @volunteer = User.new(role: :volunteer)

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -1,0 +1,13 @@
+class VolunteerPolicy
+  include PolicyHelper
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def update_volunteer_email?
+    user.casa_admin?
+  end
+end

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -19,7 +19,11 @@
 
       <div class="field form-group">
         <%= form.label :email %>
-        <%= form.text_field :email, class: "form-control" %>
+        <% if policy(:volunteer).update_volunteer_email? %>
+          <%= form.text_field :email, class: "form-control" %>
+        <% else %>
+          <input class="form-control" type="text" placeholder="<%= @volunteer.email %>" readonly>
+        <% end %>
       </div>
 
       <div class="field form-group">

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DashboardPolicy do
+RSpec.describe VolunteerPolicy do
   subject { described_class }
 
   permissions :update_volunteer_email? do

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe DashboardPolicy do
+  subject { described_class }
+
+  permissions :update_volunteer_email? do
+    context "when user is a supervisor" do
+      it "does not permit the user to update volunteer email" do
+        supervisor = create(:user, :supervisor)
+        expect(Pundit.policy(supervisor, :volunteer).update_volunteer_email?).to eq false
+      end
+    end
+
+    context "when user is an admin" do
+      it "permits the user to update volunteer email" do
+        admin = create(:user, :casa_admin)
+        expect(Pundit.policy(admin, :volunteer).update_volunteer_email?).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #260 

### Checklist

* [ ] I have performed a self-review of my own code
* [ ] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [ ] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This gives supervisors the ability to edit all volunteer fields except their email address.

### How will this affect user permissions?

- Supervisors can now edit volunteers

### How is this tested?

Tests have been updated with new policies.

### Screenshots please :)

<img width="1830" alt="Screen Shot 2020-05-16 at 3 27 57 PM" src="https://user-images.githubusercontent.com/1221519/82128530-d5b5da00-9789-11ea-86fe-e18de1080639.png">
