### PR TITLE
Pin sprockets-rails to v2.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "pundit" # for authorization management - based on user.role field
 gem "sass-rails", ">= 6" # Use SCSS for stylesheets
 gem "sendgrid-ruby" # email
 gem "skylight" # automated performance testing https://www.skylight.io/
+gem "sprockets-rails", "~> 2.3.3" # Pin sprockets-rails so we can use variables within scss files
 gem "turbolinks", "~> 5" # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem "webpacker", "~> 5.1" # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     msgpack (1.3.3)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -282,13 +282,13 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
-      sprockets (>= 3.0.0)
+    sprockets-rails (2.3.3)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
     standard (0.4.0)
       rubocop (~> 0.82.0)
       rubocop-performance (~> 1.5.2)
@@ -366,6 +366,7 @@ DEPENDENCIES
   skylight
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets-rails (~> 2.3.3)
   standardrb
   turbolinks (~> 5)
   tzinfo-data

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -6,7 +6,7 @@ form {
     }
 
     input {
-      border: 1px solid #DC3545;
+      border: 1px solid $red;
     }
   }
 }


### PR DESCRIPTION
### What github issue is this PR for, if any?
N/A

### Checklist

* [X] I have performed a self-review of my own code
* [X] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [X] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?
This PR pins the `sprockets-rails` gem to v2.3.3. This seems to fix an issue where an error was thrown when using a scss variable.

```
     ActionView::Template::Error:
       Error: Undefined variable: "$red".
               on line 9:25 of app/assets/stylesheets/form.scss
       >>       border: 1px solid $red;
```

Solution found in [stack overflow question comment](https://stackoverflow.com/questions/54070093/error-undefined-variable-alert-padding-y).

### How will this affect user permissions?

- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested?
This change fixes tests that broke due to https://github.com/rubyforgood/casa/pull/269

### Screenshots please :)
N/A

### Feelings gif (optional)

What gif best describes your feeling working on this issue? https://giphy.com/

![gif](https://media.giphy.com/media/aosOPhpJHrJq8/giphy.gif)