### PR TITLE
Remove volunteer assignment from edit casa_case view for volunteers

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -33,6 +33,10 @@ class CasaCasePolicy
     user.casa_admin?
   end
 
+  def assign_volunteers?
+    _is_supervisor_or_casa_admin?
+  end
+
   def permitted_attributes
     case @user.role
     when "casa_admin"

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -1,0 +1,48 @@
+<% if @casa_case.volunteers.present? %>
+  <br>
+  <div class="row">
+    <div class="col-sm-12">
+      <h3>Assigned Volunteers</h3>
+      <table class='table case-list'>
+        <thead>
+          <tr>
+            <th>Volunteer Name</th>
+            <th>Volunteer Email</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @casa_case.case_assignments.each do |assignment| %>
+            <tr>
+              <td><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
+              <td><%= assignment&.volunteer&.email %></td>
+              <td><%= button_to 'Unassign Volunteer', case_assignment_path(assignment, casa_case_id: @casa_case.id), method: :delete, class: "btn btn-danger" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>
+
+<br>
+
+<div class="row">
+  <div class="col-sm-6">
+    <h3>Assign a New Volunteer</h3>
+
+    <%= form_for CaseAssignment.new, url: case_assignments_path(casa_case_id: @casa_case.id) do |form| %>
+
+      <div class='form-group'>
+        <label for='case_assignment_casa_case_id'>Select a Volunteer</label>
+        <select name='case_assignment[volunteer_id]' class='form-control'>
+          <% User.where(role: "volunteer").all.order(:display_name).each do |volunteer| %>
+            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+          <% end %>
+        </select>
+      </div>
+
+      <%= form.submit 'Assign Volunteer', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -10,7 +10,7 @@
       <%= render "/shared/error_messages", resource: @casa_case %>
 
       <div class="field form-group">
-        <% if policy(@casa_case).update_case_number? %>
+        <% if Pundit.policy(current_user, @casa_case).update_case_number? %>
           <%= form.label :case_number %>
           <%= form.text_field :case_number, class: "form-control" %>
         <% else %>
@@ -34,51 +34,6 @@
 
 <br>
 
-<% if @casa_case.volunteers.present? %>
-  <br>
-  <div class="row">
-    <div class="col-sm-12">
-      <h3>Assigned Volunteers</h3>
-      <table class='table case-list'>
-        <thead>
-          <tr>
-            <th>Volunteer Name</th>
-            <th>Volunteer Email</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @casa_case.case_assignments.each do |assignment| %>
-            <tr>
-              <td><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
-              <td><%= assignment&.volunteer&.email %></td>
-              <td><%= button_to 'Unassign Volunteer', case_assignment_path(assignment, casa_case_id: @casa_case.id), method: :delete, class: "btn btn-danger" %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+<% if Pundit.policy(current_user, @casa_case).assign_volunteers? %>
+  <%= render "volunteer_assignment" %>
 <% end %>
-
-<br>
-
-<div class="row">
-  <div class="col-sm-6">
-    <h3>Assign a New Volunteer</h3>
-
-    <%= form_for CaseAssignment.new, url: case_assignments_path(casa_case_id: @casa_case.id) do |form| %>
-
-      <div class='form-group'>
-        <label for='case_assignment_casa_case_id'>Select a Volunteer</label>
-        <select name='case_assignment[volunteer_id]' class='form-control'>
-          <% User.where(role: "volunteer").all.order(:display_name).each do |volunteer| %>
-            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
-          <% end %>
-        </select>
-      </div>
-
-      <%= form.submit 'Assign Volunteer', class: 'btn btn-primary' %>
-    <% end %>
-  </div>
-</div>

--- a/spec/policies/casa_case_policy/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy/casa_case_policy_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe CasaCasePolicy do
     end
   end
 
+  permissions :assign_volunteers? do
+    context "when user is an admin" do
+      it "does allow volunteer assignment" do
+        expect(subject).to permit(create(:user, :casa_admin), create(:casa_case))
+      end
+    end
+
+    context "when user is a volunteer" do
+      it "does not allow volunteer assignment" do
+        expect(subject).not_to permit(create(:user, :volunteer), create(:casa_case))
+      end
+    end
+  end
+
   permissions :show? do
     it "allows casa_admins" do
       expect(subject).to permit(create(:user, :casa_admin), create(:casa_case))

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "casa_cases/edit" do
+  context "when accessed by a volunteer" do
+    it "does not include volunteer assignment" do
+      assign :casa_case, create(:casa_case)
+
+      user = build_stubbed(:user, :volunteer)
+      allow(view).to receive(:current_user).and_return(user)
+
+      render template: "casa_cases/edit"
+
+      expect(rendered).not_to include("Assign a New Volunteer")
+    end
+  end
+
+  context "when accessed by an admin" do
+    it "includes volunteer assignment" do
+      assign :casa_case, create(:casa_case)
+
+      user = build_stubbed(:user, :casa_admin)
+      allow(view).to receive(:current_user).and_return(user)
+
+      render template: "casa_cases/edit"
+
+      expect(rendered).to include("Assign a New Volunteer")
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #293 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

This PR adds a new Pundit policy method to hide the volunteer assignment section from the edit casa case page.  

### How will this affect user permissions?

- Volunteer assignment is now hidden for volunteers.

### How is this tested?

New policy specs and view specs have been added.

### Screenshots please :)

<img width="1791" alt="Screen Shot 2020-05-24 at 9 38 40 AM" src="https://user-images.githubusercontent.com/1221519/82755567-5d12d700-9da2-11ea-9e38-418476eab44b.png">
