### PR TITLE
Fix login image asset path for Heroku environment

### DIFF
--- a/app/assets/stylesheets/pages/login.scss
+++ b/app/assets/stylesheets/pages/login.scss
@@ -5,7 +5,7 @@ body.devise-sessions-new {
 
   aside {
     background-position: right;
-    background-image: url('login.jpg');
+    background-image: asset-url('login.jpg');
     min-height: 700px;
     background-repeat: no-repeat;
     background-size: cover;


### PR DESCRIPTION
Uses Rails asset path to display login page image on Heroku