### PR TITLE
Adds default email layout and actionmailer previews

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,141 @@
 <!DOCTYPE html>
-<html>
+<html style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <style>
-      /* Email styles need to be inline */
-    </style>
+  <meta name="viewport" content="width=device-width" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>Actionable emails e.g. reset password</title>
+
+
+  <style type="text/css">
+  img {
+  max-width: 100%;
+  }
+  body {
+  -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em;
+  }
+  body {
+  background-color: #f6f6f6;
+  }
+  @media only screen and (max-width: 640px) {
+    body {
+      padding: 0 !important;
+    }
+    h1 {
+      font-weight: 800 !important; margin: 20px 0 5px !important;
+    }
+    h2 {
+      font-weight: 800 !important; margin: 20px 0 5px !important;
+    }
+    h3 {
+      font-weight: 800 !important; margin: 20px 0 5px !important;
+    }
+    h4 {
+      font-weight: 800 !important; margin: 20px 0 5px !important;
+    }
+    h1 {
+      font-size: 22px !important;
+    }
+    h2 {
+      font-size: 18px !important;
+    }
+    h3 {
+      font-size: 16px !important;
+    }
+    .container {
+      padding: 0 !important; width: 100% !important;
+    }
+    .content {
+      padding: 0 !important;
+    }
+    .content-wrap {
+      padding: 10px !important;
+    }
+    .invoice {
+      width: 100% !important;
+    }
+  }
+  </style>
   </head>
 
-  <body>
-    <%= yield %>
+  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+    <table class="main-body" style="box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; height: 100%; background-color: rgb(234, 236, 237);" width="100%" height="100%" bgcolor="rgb(234, 236, 237)">
+      <tbody style="box-sizing: border-box;">
+        <tr class="row" style="box-sizing: border-box; vertical-align: top;" valign="top">
+          <td class="main-body-cell" style="box-sizing: border-box;">
+            <table class="container" style="box-sizing: border-box; font-family: Helvetica, serif; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-top: auto; margin-right: auto; margin-bottom: auto; margin-left: auto; height: 0px; width: 90%; max-width: 550px;" width="90%" height="0">
+              <tbody style="box-sizing: border-box;">
+                <tr style="box-sizing: border-box;">
+                  <td class="container-cell" style="box-sizing: border-box; vertical-align: top; font-size: medium; padding-bottom: 50px;" valign="top">
+                    <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#728089;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;" width="70%" valign="middle">
+                            <div class="c1144" style="box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px; font-size: 17px; font-weight: 500;text-align: center;color: #fff;">Court Appointed Special Advocate (CASA) / Prince George's County
+                              <br style="box-sizing: border-box;">
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#fff;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
+                            <img src="https://user-images.githubusercontent.com/62810851/81514853-1e7f1600-92e6-11ea-8122-2b9faad228b3.jpg" alt="GrapesJS." class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); width: 50%; font-size: 50px; height: 265px;padding-top:10px;background:#fff;" height="531">
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="card" style="background:#fff;box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-bottom: 20px; height: 0px;" height="0">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="card-cell" style="box-sizing: border-box; background-color: rgb(255, 255, 255); overflow-x: hidden; overflow-y: hidden; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px; text-align: center;" bgcolor="rgb(255, 255, 255)" align="center">
+                            <table class="table100 c1357" style="box-sizing: border-box; width: 100%; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; height: 0px; margin-top: 0px; margin-right: 0px; margin-bottom: 0px; margin-left: 0px; border-collapse: collapse;" width="100%" height="0">
+                              <tbody style="box-sizing: border-box;">
+                                <tr style="box-sizing: border-box;">
+                                  <td class="card-content" style="box-sizing: border-box; font-size: 13px; line-height: 20px; color: rgb(111, 119, 125); padding-top: 10px; padding-right: 20px; padding-bottom: 0px; padding-left: 20px; vertical-align: top;" valign="top">
+                                    <%= yield %>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="footer" style="box-sizing: border-box; margin-top: 50px; color: rgb(152, 156, 165); text-align: center; font-size: 11px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px;" align="center">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="footer-cell" style="box-sizing: border-box;">
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div class="c2577" style="text-align:center;box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px;">
+                      <p class="footer-info" style="box-sizing: border-box;">Court Appointed Special Advocate (CASA) / Prince George's County
+                        <br style="box-sizing: border-box;">
+                        <br style="box-sizing: border-box;">6811 Kenilworth Ave. Suite 402, Riverdale, MD, 20737
+                      </p>
+                      <table id="iwvod" style="box-sizing: border-box; height: 150px; margin: 0 auto 10px auto; padding: 5px 5px 5px 5px; width: 100%;" width="100%" height="150">
+                        <tbody style="box-sizing: border-box;">
+                          <tr style="box-sizing: border-box;">
+                            <td id="igyvi" style="box-sizing: border-box; font-size: 12px; font-weight: 300; vertical-align: top; color: rgb(111, 119, 125); margin: 0; padding: 0; width: 50%;" width="50%" valign="top">
+                              <a id="izi4m" style="box-sizing: border-box; color: #000;">About CASA</a>
+                            </td>
+                            <td id="idvsy" style="box-sizing: border-box; font-size: 12px; font-weight: 300; vertical-align: top; color: rgb(111, 119, 125); margin: 0; padding: 0; width: 50%;" width="50%" valign="top">
+                              <a id="ilo0w" style="box-sizing: border-box; color: #000;">Update Profile</a>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </body>
 </html>

--- a/app/views/volunteer_mailer/deactivation.html.erb
+++ b/app/views/volunteer_mailer/deactivation.html.erb
@@ -1,38 +1,13 @@
-<!DOCTYPE html>
-<html>
-<body style="margin: 0 !important; padding: 0 !important; background-color: #edefed">
-
-<!-- HEADER -->
-<table border="0" cellpadding="0" cellspacing="0" width="600" align="center">
-  <tr>
-    <td bgcolor="#edefed" align="center">
-      <h1 style="font-size: 36px; font-family: Helvetica, Arial, sans-serif;">CASA Deactivation Email</h1>
+<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Your account has been set to inactive. If you believe this was an error please contact a supervisor or click the button below.
     </td>
   </tr>
-  <tr>
-    <td bgcolor="#ffffff" align="center" style="padding: 30px 10px 30px 10px; border-radius: 7px;">
-      <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 530px;">
-        <tr>
-          <td>
-            <table width="100%" border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td>
-                  <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                    <tr>
-                      <td align="left" style="font-size: 20px; font-family: Helvetica, Arial, sans-serif; color: #333333; padding-top: 0px;" class="padding">
-                        <p>Your volunteer account has been deactivated. If you believe this to be a mistake, please contact an admin or supervisor.</p>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-      </table>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      <a href="http://www.mailgun.com" class="btn-primary" itemprop="url" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Re-activate Account</a>
     </td>
   </tr>
 </table>
-
-</body>
-</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,6 @@ module Casa
     config.assets.compile = true
     config.serve_static_assets = true
     config.skylight.environments << "staging"
+    config.action_mailer.preview_path = "#{Rails.root}/lib/mailers/previews"
   end
 end

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/volunteer_mailer
+class VolunteerMailerPreview < ActionMailer::Preview
+  def deactivation
+    VolunteerMailer.deactivation(User.last)
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #201 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [ ] I updated the `/docs`
* [ ] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally
* [ ] My PR title includes "WIP" or is [draft PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if work is in progress

### What changed, and why?

Updates layouts/mailer with better default template for system emails. Styles are still a little rough, especially in the footer, so this will probably need another pass down the road after review from CASA stakeholders.

### How will this affect user permissions?

No effect.

### How is this tested?

This PR sets up ActionMailer previews, so emails can be previewed in the browser.

### Screenshots please :)

<img width="1791" alt="Screen Shot 2020-05-24 at 5 56 50 PM" src="https://user-images.githubusercontent.com/1221519/82765835-2790dc80-9de8-11ea-9f0d-276021a940a9.png">
