### PR TITLE
Adds link for most recent contact in volunteer table

### DIFF
--- a/app/views/dashboard/_volunteers_table.html.erb
+++ b/app/views/dashboard/_volunteers_table.html.erb
@@ -22,7 +22,7 @@
       <td id="status-column"><%= volunteer.status %></td>
       <td><%= volunteer&.assigned_to_transition_aged_youth? %></td>
       <td><%= safe_join(volunteer&.casa_cases&.map { |c| link_to(c.case_number, c) }, ", ") %></td>
-      <td><%= volunteer&.most_recent_contact&.occurred_at&.strftime('%B %e, %Y') %></td>
+      <td><%= link_to(volunteer.most_recent_contact.occurred_at.strftime('%B %e, %Y'), volunteer.most_recent_contact.casa_case) if volunteer&.most_recent_contact %></td>
       <td><%= volunteer&.recent_contacts_made %></td>
       <td>
         <%= link_to 'Edit', edit_volunteer_path(volunteer) %>

--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     contact_types { ["therapist"] }
     duration_minutes { 60 }
     occurred_at { Time.zone.now }
+    contact_made { false }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -26,5 +26,12 @@ FactoryBot.define do
         create_list(:case_assignment, 2, volunteer: user)
       end
     end
+
+    trait :with_case_contact do
+      after(:create) do |user, _|
+        create(:case_assignment, volunteer: user)
+        create(:case_contact, creator: user, casa_case: user.casa_cases.first, contact_made: true)
+      end
+    end
   end
 end

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "admin views dashboard", type: :feature do
 
   it "can see volunteers and navigate to their cases" do
     volunteer = create(:user, :volunteer, :with_casa_cases, email: "casa@example.com")
+    create(:case_contact, creator: volunteer, casa_case: volunteer.casa_cases.first)
     casa_case = volunteer.casa_cases[0]
     sign_in admin
 
@@ -15,6 +16,21 @@ RSpec.describe "admin views dashboard", type: :feature do
 
     within "#volunteers" do
       click_on volunteer.casa_cases.first.case_number
+    end
+
+    expect(page).to have_text("CASA Case Details")
+  end
+
+  it "can see the last case contact and navigate to it" do
+    volunteer = create(:user, :volunteer, :with_case_contact, email: "casa@example.com")
+    sign_in admin
+
+    visit root_path
+
+    expect(page).to have_text(volunteer.most_recent_contact.occurred_at.strftime("%B %e, %Y"))
+
+    within "#volunteers" do
+      click_on volunteer.most_recent_contact.occurred_at.strftime("%B %e, %Y")
     end
 
     expect(page).to have_text("CASA Case Details")

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "admin views dashboard", type: :feature do
 
   it "can see volunteers and navigate to their cases" do
     volunteer = create(:user, :volunteer, :with_casa_cases, email: "casa@example.com")
-    create(:case_contact, creator: volunteer, casa_case: volunteer.casa_cases.first)
     casa_case = volunteer.casa_cases[0]
     sign_in admin
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #265

### Checklist

* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally

### What changed, and why?
Updated volunteer table in the dashboard so that the Last Contact Made is a link to the case for that contact.

### How will this affect user permissions?
 It will not affect user permissions

### How is this tested?
Test was added to verify that link is visible and clicking it takes the user to the cases view.

### Questions

1. #265 asks for the addition of this column with the title "Last Case contact". Since the column already exists as "Last Contact Made", I left the name of the column as is. Please let me know if the column name should be changed.
2. Is there a better way to do the link? I mostly work on JSON APIs and don't do a lot of views in Rails. If there is a better way to do the link, please let me know.

### Screenshots

Note the link in the bottom left corner from hovering over the last contact date.
![link-for-last-contact-made](https://user-images.githubusercontent.com/3824492/82832857-f533bd80-9e81-11ea-8b41-85045333e74d.png)

Page viewed when clicking on link. Note id of the case in the URL matches the link in previous screenshot.
![case-from-link](https://user-images.githubusercontent.com/3824492/82832856-f49b2700-9e81-11ea-8f70-3e0dce4668e2.png)

### Console output showing this case is the right one

Note that the case for this user's most recent contact is case 98.

```ruby
$ bundle exec rails c   
W, [2020-05-25T12:23:29.451102 #92889]  WARN -- Skylight: [SKYLIGHT] [4.3.0] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
Loading development environment (Rails 6.0.3.1)
irb(main):001:0> ali = User.find_by(display_name: 'Ali Larkin')
  User Load (1.3ms)  SELECT "users".* FROM "users" WHERE "users"."display_name" = $1 LIMIT $2  [["display_name", "Ali Larkin"], ["LIMIT", 1]]
irb(main):002:0> ali
=> #<User id: 99, email: "alilarkin@example.com", created_at: "2020-05-25 14:45:36", updated_at: "2020-05-25 14:45:36", role: "volunteer", casa_org_id: 1, display_name: "Ali Larkin">
irb(main):003:0> ali.most_recent_contact
  CaseContact Load (0.8ms)  SELECT "case_contacts".* FROM "case_contacts" WHERE "case_contacts"."creator_id" = $1 AND "case_contacts"."contact_made" = $2 ORDER BY "case_contacts"."occurred_at" ASC LIMIT $3  [["creator_id", 99], ["contact_made", true], ["LIMIT", 1]]
=> #<CaseContact id: 5221, creator_id: 99, casa_case_id: 98, other_type_text: nil, duration_minutes: 30, occurred_at: "2020-04-25 14:46:17", created_at: "2020-05-25 14:46:17", updated_at: "2020-05-25 16:08:31", contact_made: true, medium_type: "letter", contact_types: ["court", "foster_parent", "youth"]>
irb(main):004:0> ali.most_recent_contact.casa_case
  CaseContact Load (1.4ms)  SELECT "case_contacts".* FROM "case_contacts" WHERE "case_contacts"."creator_id" = $1 AND "case_contacts"."contact_made" = $2 ORDER BY "case_contacts"."occurred_at" ASC LIMIT $3  [["creator_id", 99], ["contact_made", true], ["LIMIT", 1]]
  CasaCase Load (1.0ms)  SELECT "casa_cases".* FROM "casa_cases" WHERE "casa_cases"."id" = $1 LIMIT $2  [["id", 98], ["LIMIT", 1]]
=> #<CasaCase id: 98, case_number: "CINA-07-8049", transition_aged_youth: true, created_at: "2020-05-25 14:45:40", updated_at: "2020-05-25 14:45:40">
irb(main):005:0> 
```