### PR TITLE
Issue 24: add driving fields to case contact

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -24,6 +24,7 @@ class CaseContact < ApplicationRecord
   validates :occurred_at, presence: true
   validate :contact_types_included
   validate :occurred_at_not_in_future
+  validate :reimbursement_only_when_miles_driven
 
   def contact_types_included
     contact_types&.each do |contact_type|
@@ -37,22 +38,29 @@ class CaseContact < ApplicationRecord
   end
 end
 
+  def reimbursement_only_when_miles_driven
+    return if miles_driven&.positive? || !want_driving_reimbursement
+
+    errors.add(:want_driving_reimbursement, :invalid, message: "cannot be true when no miles were driven")
+  end
 
 # == Schema Information
 #
 # Table name: case_contacts
 #
-#  id               :bigint           not null, primary key
-#  contact_made     :boolean          default(FALSE)
-#  contact_types    :string           is an Array
-#  duration_minutes :integer          not null
-#  medium_type      :string
-#  occurred_at      :datetime         not null
-#  other_type_text  :string
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  casa_case_id     :bigint           not null
-#  creator_id       :bigint           not null
+#  id                         :bigint           not null, primary key
+#  contact_made               :boolean          default(FALSE)
+#  contact_types              :string           is an Array
+#  duration_minutes           :integer          not null
+#  medium_type                :string
+#  miles_driven               :integer
+#  occurred_at                :datetime         not null
+#  other_type_text            :string
+#  want_driving_reimbursement :boolean          default(FALSE)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  casa_case_id               :bigint           not null
+#  creator_id                 :bigint           not null
 #
 # Indexes
 #

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -8,6 +8,8 @@ class CaseContactParameters < SimpleDelegator
         :occurred_at,
         :contact_made,
         :medium_type,
+        :miles_driven,
+        :want_driving_reimbursement,
         contact_types: []
       )
 

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -77,6 +77,16 @@
     <%= form.date_field :occurred_at, value: Time.now.strftime('%Y-%m-%d'), class: "form-control" %>
   </div>
 
+  <div class="field miles-driven form-group">
+    <%= form.label :miles_driven %>
+    <%= form.number_field :miles_driven, class: "form-control" %>
+  </div>
+
+  <div class="field want-driving-reimbursement form-group">
+    <%= form.label :want_driving_reimbursement %>
+    <%= form.select :want_driving_reimbursement, options_for_select([['Yes', true], ['No', false]], case_contact.want_driving_reimbursement), {}, class: "custom-select" %>
+  </div>
+
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary" %>
   </div>

--- a/db/migrate/20200525220759_add_driving_fields_to_case_contact.rb
+++ b/db/migrate/20200525220759_add_driving_fields_to_case_contact.rb
@@ -1,0 +1,20 @@
+class AddDrivingFieldsToCaseContact < ActiveRecord::Migration[6.0]
+  def up
+    add_column :case_contacts, :miles_driven, :integer, null: true
+    add_column :case_contacts, :want_driving_reimbursement, :boolean, default: false
+    execute <<-SQL
+      ALTER TABLE case_contacts
+        ADD CONSTRAINT want_driving_reimbursement_only_when_miles_driven
+        CHECK ((miles_driven IS NOT NULL) OR (NOT want_driving_reimbursement));
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE case_contacts
+        DROP CONSTRAINT want_driving_reimbursement_only_when_miles_driven
+    SQL
+    remove_column :case_contacts, :miles_driven, :integer
+    remove_column :case_contacts, :want_driving_reimbursement, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_204147) do
+ActiveRecord::Schema.define(version: 2020_05_25_220759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(version: 2020_04_23_204147) do
     t.boolean "contact_made", default: false
     t.string "medium_type"
     t.string "contact_types", array: true
+    t.integer "miles_driven"
+    t.boolean "want_driving_reimbursement", default: false
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
     t.index ["contact_types"], name: "index_case_contacts_on_contact_types", using: :gin
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"

--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -7,5 +7,7 @@ FactoryBot.define do
     duration_minutes { 60 }
     occurred_at { Time.zone.now }
     contact_made { false }
+    miles_driven { nil }
+    want_driving_reimbursement { false }
   end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CaseContact, type: :model do
   it "belongs to a creator" do
     case_contact = build(:case_contact, creator: nil)
-    expect(case_contact).to_not be_valid
+    expect(case_contact).not_to be_valid
     expect(case_contact.errors[:creator]).to eq(["must exist"])
   end
 
@@ -35,5 +35,22 @@ RSpec.describe CaseContact, type: :model do
     case_contact = build(:case_contact, occurred_at: Time.now + 1.week)
     expect(case_contact).to_not be_valid
     expect(case_contact.errors[:occurred_at]).to eq(["cannot be in the future"])
+  end
+
+  it "validates want_driving_reimbursement can be true when miles_driven is  positive" do
+    case_contact = build(:case_contact, want_driving_reimbursement: true, miles_driven: 1)
+    expect(case_contact).to be_valid
+  end
+
+  it "validates want_driving_reimbursement cannot be true when miles_driven is nil" do
+    case_contact = build(:case_contact, want_driving_reimbursement: true, miles_driven: nil)
+    expect(case_contact).not_to be_valid
+    expect(case_contact.errors[:want_driving_reimbursement]).to eq(["cannot be true when no miles were driven"])
+  end
+
+  it "validates want_driving_reimbursement cannot be true when miles_driven is not positive" do
+    case_contact = build(:case_contact, want_driving_reimbursement: true, miles_driven: 0)
+    expect(case_contact).not_to be_valid
+    expect(case_contact.errors[:want_driving_reimbursement]).to eq(["cannot be true when no miles were driven"])
   end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CaseContact, type: :model do
   it "belongs to a creator" do
     case_contact = build(:case_contact, creator: nil)
-    expect(case_contact).not_to be_valid
+    expect(case_contact).to_not be_valid
     expect(case_contact.errors[:creator]).to eq(["must exist"])
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #24 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally

### What changed, and why?
Two fields are added to `CaseContact`:
- `miles_driven`
- `want_driving_reimbursement`

### How will this affect user permissions?
Does not affect permissions

### How is this tested?
Specs and exercised functionality

### Screenshots please

**Cannot ask for reimbursement when no miles driven**
![validate-when-no-miles-driven](https://user-images.githubusercontent.com/3824492/82851097-4c5a8200-9ec4-11ea-97d7-df7143eb7cd4.png)

**Cannot ask for reimbursement when zero miles driven**
![validate-when-zero-miles-driven](https://user-images.githubusercontent.com/3824492/82851096-4c5a8200-9ec4-11ea-975e-95f57155cad2.png)

**Case contacts saved, one with miles and reimbursement, one without**

Data
```sql
casa_development=# select occurred_at, duration_minutes, contact_made, medium_type, contact_types, miles_driven, want_driving_reimbursement from case_contacts order by id desc limit 2;
     occurred_at     | duration_minutes | contact_made | medium_type | contact_types | miles_driven | want_driving_reimbursement 
---------------------+------------------+--------------+-------------+---------------+--------------+----------------------------
 2020-05-25 00:00:00 |              105 | f            | in-person   | {school}      |              | f
 2020-05-25 00:00:00 |               30 | f            | in-person   | {attorney}    |            1 | t
(2 rows)
```
Screenshot
![case-contacts-saved](https://user-images.githubusercontent.com/3824492/82851095-4bc1eb80-9ec4-11ea-94ad-66dbf61d9ec5.png)

## Data

**Migration succeeds**
```
$ be rails db:migrate               
W, [2020-05-25T20:00:48.926442 #102574]  WARN -- Skylight: [SKYLIGHT] [4.3.0] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
== 20200525220759 AddDrivingFieldsToCaseContact: migrating ====================
-- add_column(:case_contacts, :miles_driven, :integer, {:null=>true})
   -> 0.0018s
-- add_column(:case_contacts, :want_driving_reimbursement, :boolean, {:default=>false})
   -> 0.0470s
-- execute("      ALTER TABLE case_contacts\n        ADD CONSTRAINT want_driving_reimbursement_only_when_miles_driven\n        CHECK ((miles_driven IS NOT NULL) OR (NOT want_driving_reimbursement));\n")
   -> 0.0019s
== 20200525220759 AddDrivingFieldsToCaseContact: migrated (0.0508s) ===========

Annotated (1): app/models/case_contact.rb
```

**Table after migration**
```
casa_development=# \d case_contacts
                                                  Table "public.case_contacts"
           Column           |              Type              | Collation | Nullable |                  Default                  
----------------------------+--------------------------------+-----------+----------+-------------------------------------------
 id                         | bigint                         |           | not null | nextval('case_contacts_id_seq'::regclass)
 creator_id                 | bigint                         |           | not null | 
 casa_case_id               | bigint                         |           | not null | 
 other_type_text            | character varying              |           |          | 
 duration_minutes           | integer                        |           | not null | 
 occurred_at                | timestamp without time zone    |           | not null | 
 created_at                 | timestamp(6) without time zone |           | not null | 
 updated_at                 | timestamp(6) without time zone |           | not null | 
 contact_made               | boolean                        |           |          | false
 medium_type                | character varying              |           |          | 
 contact_types              | character varying[]            |           |          | 
 miles_driven               | integer                        |           |          | 
 want_driving_reimbursement | boolean                        |           |          | false
Indexes:
    "case_contacts_pkey" PRIMARY KEY, btree (id)
    "index_case_contacts_on_casa_case_id" btree (casa_case_id)
    "index_case_contacts_on_contact_types" gin (contact_types)
    "index_case_contacts_on_creator_id" btree (creator_id)
Check constraints:
    "want_driving_reimbursement_only_when_miles_driven" CHECK (miles_driven IS NOT NULL OR NOT want_driving_reimbursement)
Foreign-key constraints:
    "fk_rails_bce35352df" FOREIGN KEY (casa_case_id) REFERENCES casa_cases(id)
    "fk_rails_d41e0a2209" FOREIGN KEY (creator_id) REFERENCES users(id)

```
**Rollback works**
```
$ be rails db:rollback
W, [2020-05-25T20:00:55.521123 #102767]  WARN -- Skylight: [SKYLIGHT] [4.3.0] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
== 20200525220759 AddDrivingFieldsToCaseContact: reverting ====================
-- execute("      ALTER TABLE case_contacts\n        DROP CONSTRAINT want_driving_reimbursement_only_when_miles_driven\n")
   -> 0.0019s
-- remove_column(:case_contacts, :miles_driven, :integer)
   -> 0.0009s
-- remove_column(:case_contacts, :want_driving_reimbursement, :boolean)
   -> 0.0010s
== 20200525220759 AddDrivingFieldsToCaseContact: reverted (0.0040s) ===========

Annotated (1): app/models/case_contact.rb
```