### PR TITLE
Remove blank padding from date display to fix flaky test

### DIFF
--- a/app/views/dashboard/_volunteers_table.html.erb
+++ b/app/views/dashboard/_volunteers_table.html.erb
@@ -22,7 +22,7 @@
       <td id="status-column"><%= volunteer.status %></td>
       <td><%= volunteer&.assigned_to_transition_aged_youth? %></td>
       <td><%= safe_join(volunteer&.casa_cases&.map { |c| link_to(c.case_number, c) }, ", ") %></td>
-      <td><%= link_to(volunteer.most_recent_contact.occurred_at.strftime('%B %e, %Y'), volunteer.most_recent_contact.casa_case) if volunteer&.most_recent_contact %></td>
+      <td><%= link_to(volunteer.most_recent_contact.occurred_at.strftime('%B %-e, %Y'), volunteer.most_recent_contact.casa_case) if volunteer&.most_recent_contact %></td>
       <td><%= volunteer&.recent_contacts_made %></td>
       <td>
         <%= link_to 'Edit', edit_volunteer_path(volunteer) %>

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe "admin views dashboard", type: :feature do
 
     visit root_path
 
-    expect(page).to have_text(volunteer.most_recent_contact.occurred_at.strftime("%B %e, %Y"))
+    expect(page).to have_text(volunteer.most_recent_contact.occurred_at.strftime("%B %-e, %Y"))
 
     within "#volunteers" do
-      click_on volunteer.most_recent_contact.occurred_at.strftime("%B %e, %Y")
+      click_on volunteer.most_recent_contact.occurred_at.strftime("%B %-e, %Y")
     end
 
     expect(page).to have_text("CASA Case Details")


### PR DESCRIPTION
### What changed, and why?

The existing PRs are failing because of a flaky test that is trying to find specific values in the `Last Contact Made` column of the volunteer table. Even though the `strftime` calls are identical in the test and the view output, it looks like spacing is being automatically fixed in the HTML on the view side, but the same correction isn't being made in the tests.

This PR changes the relevant `strftime` calls to remove any padding in both the view and the tests. 