### PR TITLE
Add date range to report generator

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 
 @import "bootstrap";
 @import "dataTables/jquery.dataTables";
+@import 'bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css';
 
 @import "shared/flashes";
 @import "shared/footer";

--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -4,7 +4,7 @@ class CaseContactReportsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    case_contact_report = CaseContactReport.new
+    case_contact_report = CaseContactReport.new(report_params)
 
     respond_to do |format|
       format.csv do
@@ -17,6 +17,6 @@ class CaseContactReportsController < ApplicationController
   private
 
   def report_params
-    params.require(:case_contact_report).permit(:start_date, :end_date)
+    params.permit(:start_date, :end_date)
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,11 +7,14 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("jquery")
+require("bootstrap-datepicker")
 require('datatables.net-dt')
+require("packs/index_reports")
 require("packs/new_casa_contact")
 require("packs/show_casa_case")
 require("packs/dashboard")
-import 'bootstrap'
+
+import "bootstrap"
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/index_reports.js
+++ b/app/javascript/packs/index_reports.js
@@ -1,0 +1,19 @@
+$('document').ready(() => {
+  $('input[data-input-type="datepicker"]').datepicker({
+    format: 'yyyy-mm-dd'
+  });
+
+  // onDateChange update the download report link because the current implementation
+  // of CSV download does not work with form submission
+  $('input[data-input-type="datepicker"]').on('changeDate', function() {
+    let $form = $(this).parents('form');
+
+    let start_date = $form.find('input[name="start_date"]').val()
+    let end_date = $form.find('input[name="end_date"]').val()
+
+    let download_button = $form.find('a[data-link-type="download-report"]')
+    let download_url = '/case_contact_reports.csv?' + 'start_date=' + start_date + '&end_date=' + end_date
+
+    download_button.attr('href', download_url)
+  });
+});

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -13,7 +13,7 @@ class CaseContactReport
     CSV.generate(headers: true) do |csv|
       csv << column_headers.map(&:titleize)
 
-      CaseContact.includes(:casa_case, creator: :supervisor).all.decorate.each do |case_contact|
+      @case_contacts.includes(:casa_case, creator: :supervisor).decorate.each do |case_contact|
         csv << generate_row(case_contact)
       end
     end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -12,21 +12,33 @@
       <div class="card-body">
         <h5 class="card-title"><strong>Case Contacts Report</strong></h5>
         <p class="card-text">
-          This CSV is a listing of all fields of all existing case contacts including:
+          This CSV is a listing of all fields for the case contacts of all volunteers. Select the start
+          and end date.
         </p>
 
-        <ul>
-          <li>ID</li>
-          <li>Case Number</li>
-          <li>Duration</li>
-          <li>Occurred At</li>
-          <li>Creator Email</li>
-          <li>Creator Name</li>
-          <li>Create Supervisor</li>
-          <li>Contact Type</li>
-        </ul>
+        <hr>
 
-        <%= link_to "Download Report", case_contact_reports_path(format: :csv), class: "btn btn-primary" %>
+        <form>
+          <div class="field form-group">
+            <label><strong>Starting From:</strong></label>
+            <input name="start_date" class="form-control" data-input-type="datepicker" value="<%= 1.month.ago.to_date %>" />
+          </div>
+
+          <div class="field form-group">
+            <label><strong>Ending At:</strong></label>
+            <input name="end_date" class="form-control" data-input-type="datepicker" value="<%= Date.today.to_date %>" />
+          </div>
+
+          <!--
+            It seems like the send_data method used to download the CSV here does not work
+            with form submission whether the action is POST or GET, so for now we are
+            constructing the URL using the inputs above with javascript.
+          -->
+          <%= link_to "Download Report",
+              case_contact_reports_path(start_date: 1.month.ago.to_date, end_date: Date.today.to_date, format: :csv),
+              class: "btn btn-primary",
+              data: { link_type: "download-report" } %>
+        </form>
       </div>
     </div>
 

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -1,4 +1,5 @@
 # Preview all emails at http://localhost:3000/rails/mailers/volunteer_mailer
+# :nocov:
 class VolunteerMailerPreview < ActionMailer::Preview
   def deactivation
     VolunteerMailer.deactivation(User.last)
@@ -8,3 +9,4 @@ class VolunteerMailerPreview < ActionMailer::Preview
     VolunteerMailer.account_setup(User.last)
   end
 end
+# :nocov:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "bootstrap": "4.3.1",
+    "bootstrap-datepicker": "^1.9.0",
     "datatables.net-dt": "^1.10.20",
     "jquery": "^3.5.0",
     "popper.js": "^1.16.1",

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "/case_contact_reports", type: :request do
-  describe "GET /case_contact_reports" do
+  describe "GET /case_contact_reports with start_date and end_date" do
     it "renders a csv file to download" do
       sign_in create(:user, :volunteer)
       create(:case_contact)
@@ -15,12 +15,24 @@ RSpec.describe "/case_contact_reports", type: :request do
     end
   end
 
+  describe "GET /case_contact_reports without start_date and end_date" do
+    it "renders a csv file to download" do
+      sign_in create(:user, :volunteer)
+      create(:case_contact)
+
+      get case_contact_reports_url(format: :csv)
+
+      expect(response).to be_successful
+      expect(
+        response.headers["Content-Disposition"]
+      ).to include 'attachment; filename="case-contacts-report-'
+    end
+  end
+
   def case_contact_report_params
     {
-      case_contact_report: {
-        start_date: 1.month.ago,
-        end_date: Date.today
-      }
+      start_date: 1.month.ago,
+      end_date: Date.today
     }
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #304

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] I added tests that prove my fix is effective or that my feature works
* [x] `bundle exec rake` passes locally

### What changed, and why?

This PR adds a date range fields to the report generator page. The datepicker inputs use the bootstrap datepicker npm package. Unfortunately I was not able to use the send_data method with form submission, so I had to resort to using javascript to set the "Download Report" href attribute for now. I've left comments clarifying the unintuitive code.

### How will this affect user permissions?

No effect.

### How is this tested?

New tests have been added and existing tests pass.

### Screenshots please :)

<img width="1804" alt="Screen Shot 2020-06-05 at 2 50 15 PM" src="https://user-images.githubusercontent.com/1221519/83912693-4a9e8300-a73c-11ea-9886-e823596830f4.png">

