### PR TITLE
Improve Mobile CSS

### DIFF
--- a/app/assets/stylesheets/pages/dashboard.scss
+++ b/app/assets/stylesheets/pages/dashboard.scss
@@ -1,4 +1,11 @@
 body.dashboard {
+
+  .container {
+    @media (min-width: 768px) {
+      max-width: 95%;
+    }
+  }
+
   .dashboard-table-header {
     h1 {
       display: inline-block;

--- a/app/assets/stylesheets/pages/dashboard.scss
+++ b/app/assets/stylesheets/pages/dashboard.scss
@@ -1,7 +1,7 @@
 body.dashboard {
 
   .container {
-    @media (min-width: 768px) {
+    @media (max-width: 1200px) {
       max-width: 95%;
     }
   }

--- a/app/assets/stylesheets/shared/navbar.scss
+++ b/app/assets/stylesheets/shared/navbar.scss
@@ -1,6 +1,16 @@
 .navbar {
   color: white;
 
+  .navbar-nav {
+    @media (max-width: 1000px) {
+      flex-direction: row;
+    }
+
+    .dropdown-menu {
+      position: absolute;
+    }
+  }
+
   .navbar-brand a {
     color: white;
 
@@ -10,6 +20,10 @@
   }
   strong {
     font-size: 2rem;
+
+    @media (max-width: 1000px) {
+      font-size: 1.4rem;
+    }
   }
 
   a.btn {

--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -2,6 +2,9 @@
   <div class="col-sm-12 dashboard-table-header">
     <h1>Volunteers</h1>
     <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">
+      Pick displayed columns
+    </button>
   </div>
 </div>
 <hr>
@@ -13,4 +16,3 @@
 <br>
 <%= render "casa_cases" %>
 <br>
-

--- a/app/views/dashboard/_volunteer_filters.html.erb
+++ b/app/views/dashboard/_volunteer_filters.html.erb
@@ -31,9 +31,6 @@
         <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="No" checked />No</a></li>
       </div>
     </div>
-    <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#visibleColumns">
-      Pick displayed columns
-    </button>
   </div>
 </div>
 <br>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #193 

### Checklist

* [x] I have performed a self-review of my own code
* [x] I added comments, particularly in hard-to-understand areas
* [x] `bundle exec rake` passes locally

### What changed, and why?

This PR adds small CSS changes after web browser responsive mode testing. Specifically this updates the top nav and increases the `<body>` width on tablet views. I think the mobile CSS is now good enough to close #193 and open specific issues when we notice specific problems on native devices.

There are still some issues where there's lots of blank space on certain views, but I'm not sure if there's a good fix for that besides adding some type of filler content.

### Screenshots please :)

New View:
<img width="1804" alt="Screen Shot 2020-06-06 at 9 49 31 AM" src="https://user-images.githubusercontent.com/1221519/83945798-129a4d00-a7db-11ea-829a-05939eeddee0.png">

Old View:
<img width="1804" alt="Screen Shot 2020-06-06 at 9 51 49 AM" src="https://user-images.githubusercontent.com/1221519/83945868-6442d780-a7db-11ea-8c19-e1506d162225.png">

