### PR TITLE
Allow case_assignments to be unassigned

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -17,6 +17,23 @@ class CaseAssignmentsController < ApplicationController
     redirect_to after_action_path(case_assignment_parent)
   end
 
+  def unassign
+    case_assignment = CaseAssignment.find(params[:id])
+    casa_case = case_assignment.casa_case
+    volunteer = case_assignment.volunteer
+    flash_message = "Volunteer was unassigned from Case #{casa_case.case_number}."
+
+    if case_assignment.update_attributes(is_active: false)
+      if params[:redirect_to_path] == "volunteer"
+        redirect_to edit_volunteer_path(volunteer), notice: flash_message
+      else
+        redirect_to after_action_path(casa_case), notice: flash_message
+      end
+    else
+      render :edit
+    end
+  end
+
   private
 
   def case_assignment_parent

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -8,6 +8,7 @@
           <tr>
             <th>Volunteer Name</th>
             <th>Volunteer Email</th>
+            <th>Status</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -16,7 +17,20 @@
             <tr>
               <td><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
               <td><%= assignment&.volunteer&.email %></td>
-              <td><%= button_to 'Unassign Volunteer', case_assignment_path(assignment, casa_case_id: @casa_case.id), method: :delete, class: "btn btn-danger" %></td>
+              <td>
+                <% if assignment.is_active? %>
+                  <span class='badge badge-success text-uppercase'>Assigned</span>
+                <% else %>
+                  <span class="badge badge-danger text-uppercase">Unassigned</span>
+                <% end %>
+              </td>
+              <td>
+                <% if assignment.is_active? %>
+                  <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
+                <% else %>
+                  N/A
+                <% end %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -25,7 +25,7 @@
                 <% end %>
               </td>
               <td>
-                <% if assignment.is_active? %>
+                <% if assignment.is_active? && current_user.role == "casa_admin" || assignment.volunteer.supervisor == current_user %>
                   <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
                 <% else %>
                   N/A

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -78,7 +78,7 @@
             <tr>
               <td><%= link_to assignment.casa_case.case_number, edit_casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.transition_aged_youth %></td>
-              <td><%= button_to 'Unassign Case', case_assignment_path(assignment, volunteer_id: @volunteer.id), method: :delete, class: "btn btn-danger" %></td>
+              <td><%= button_to 'Unassign Case', case_assignment_path(assignment, volunteer_id: @volunteer.id), method: :delete, class: "btn btn-danger" if current_user.role == "casa_admin" || @volunteer.supervisor == current_user%></td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,12 @@ Rails.application.routes.draw do
   resources :case_contact_reports, only: %i[index]
 
   resources :volunteers, only: %i[new edit create update]
-  resources :case_assignments, only: %i[create destroy]
+  resources :case_assignments, only: %i[create destroy] do
+    member do
+      get :unassign
+      patch :unassign
+    end
+  end
 
   resources :users, only: [] do
     collection do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #20 (Also related to number 230)

### What changed, and why?
- Added unassign endpoint
- Includes redirect to volunteer if unassigning from Volunteer edit
- Added Status column to index

### Notes
- Would really prefer not to have to add get and patch routes. Any advice here?

### How will this affect user permissions?
- Admin permissions: Admins can unassign (remove) a Volunteer from a CasaCase

### How is this tested? (please write tests!) 💖💪
Help, please!

### Screenshots please :)
<img width="1293" alt="Screen Shot 2020-06-14 at 2 48 18 PM" src="https://user-images.githubusercontent.com/7607813/84601486-76adb880-ae4e-11ea-9a5d-b7e7425c4452.png">

