### PR TITLE
Casa volunteer deactivate

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -21,6 +21,7 @@ class VolunteersController < ApplicationController
 
   def edit
     @volunteer = User.find(params[:id])
+    @volunteer_active = @volunteer.active_volunteer
   end
 
   def update
@@ -28,6 +29,17 @@ class VolunteersController < ApplicationController
 
     if @volunteer.update(update_volunteer_params)
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  def deactivate
+    @volunteer = User.find(params[:id])
+
+    if @volunteer.update_attributes(role: "inactive")
+      @volunteer.case_assignments.update_all(is_active: false)
+      redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else
       render :edit
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
   ALL_ROLES = %w[volunteer supervisor casa_admin inactive].freeze
   enum role: ALL_ROLES.zip(ALL_ROLES).to_h
 
+  def active_volunteer
+    role == "volunteer" # !inactive
+  end
+
   # all contacts this user has with this casa case
   def case_contacts_for(casa_case_id)
     found_casa_case = casa_cases.find { |cc| cc.id == casa_case_id }

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -56,7 +56,7 @@
         </select>
       </div>
 
-      <%= form.submit 'Assign Volunteer', class: 'btn btn-primary' %>
+      <%= form.submit 'Assign Volunteer', class: 'btn btn-secondary' %>
     <% end %>
   </div>
 </div>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -21,7 +21,7 @@
                 <% if assignment.is_active? %>
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
-                  <span class="badge badge-danger text-uppercase">Unassigned</span>
+                  <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
                 <% end %>
               </td>
               <td>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -40,16 +40,18 @@
       <div class="field form-group">
         <% if @volunteer_active %>
           Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
-          <%= link_to "Deactivate volunteer",
-                      deactivate_volunteer_path(@volunteer),
-                      method: :patch,
-                      class: "btn btn-outline-danger",
-                      data:
-                          { confirm: "WARNING: Marking a volunteer inactive will make them unable to login.
-                              <br><br>They will receive an email saying their account has been marked inactive.
-                              <br><br>Are you sure you want to do this?".html_safe },
-                      hint: "NOTE: This will make connected cases unassigned and<br>
-                        the volunteer won't be able to log in to the system anymore".html_safe %>
+          <% if current_user.role == "casa_admin" || @volunteer.supervisor == current_user %>
+            <%= link_to "Deactivate volunteer",
+                        deactivate_volunteer_path(@volunteer),
+                        method: :patch,
+                        class: "btn btn-outline-danger",
+                        data:
+                            { confirm: "WARNING: Marking a volunteer inactive will make them unable to login.
+                                <br><br>They will receive an email saying their account has been marked inactive.
+                                <br><br>Are you sure you want to do this?".html_safe },
+                        hint: "NOTE: This will make connected cases unassigned and<br>
+                          the volunteer won't be able to log in to the system anymore".html_safe %>
+          <% end %>
         <% else %>
           <div class="alert alert-danger">
             Volunteer was deactivated on: <%= @volunteer.updated_at.strftime("%m-%d-%Y") %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -38,19 +38,23 @@
 
 
       <div class="field form-group">
-        <%= form.label "Status" %>
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio1" value="volunteer" <% if @volunteer.role == "volunteer" %> checked<% end %>>
-          <label class="form-check-label" for="statusRadio1">
-            Active
-          </label>
-        </div>
-        <div class="form-check">
-          <input class="form-check-input" type="radio" name="user[role]" id="statusRadio2" value="inactive" <% if @volunteer.role == "inactive" %> checked<% end %> onclick="return confirm('WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?')">
-          <label class="form-check-label" for="statusRadio2">
-            Inactive
-          </label>
-        </div>
+        <% if @volunteer_active %>
+          Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
+          <%= link_to "Deactivate volunteer",
+                      deactivate_volunteer_path(@volunteer),
+                      method: :patch,
+                      class: "btn btn-outline-danger",
+                      data:
+                          { confirm: "WARNING: Marking a volunteer inactive will make them unable to login.
+                              <br><br>They will receive an email saying their account has been marked inactive.
+                              <br><br>Are you sure you want to do this?".html_safe },
+                      hint: "NOTE: This will make connected cases unassigned and<br>
+                        the volunteer won't be able to log in to the system anymore".html_safe %>
+        <% else %>
+          <div class="alert alert-danger">
+            Volunteer was deactivated on: <%= @volunteer.updated_at.strftime("%m-%d-%Y") %>
+          </div>
+        <% end %>
       </div>
 
       <div class="actions">
@@ -70,7 +74,10 @@
           <tr>
             <th>Case Number</th>
             <th>Transition Aged Youth</th>
-            <th>Actions</th>
+            <th>Assignment status</th>
+            <% if @volunteer_active %>
+              <th>Actions</th>
+            <% end %>
           </tr>
         </thead>
         <tbody>
@@ -78,7 +85,22 @@
             <tr>
               <td><%= link_to assignment.casa_case.case_number, edit_casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.transition_aged_youth %></td>
-              <td><%= button_to 'Unassign Case', case_assignment_path(assignment, volunteer_id: @volunteer.id), method: :delete, class: "btn btn-danger" %></td>
+              <td>
+                <% if assignment.is_active? %>
+                  <span class='badge badge-success text-uppercase'>Assigned</span>
+                <% else %>
+                  <span class='badge badge-danger text-uppercase'><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
+                <% end %>
+              </td>
+              <% if @volunteer_active %>
+                <td>
+                  <% if assignment.is_active? %>
+                    <%= link_to 'Unassign Case', unassign_case_assignment_path(assignment, redirect_to_path: "volunteer"), method: :patch, class: "btn btn-outline-danger" %>
+                  <% else %>
+                    N/A
+                  <% end %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>
@@ -87,24 +109,26 @@
   </div>
 <% end %>
 
-<br>
+<% if @volunteer_active %>
+  <br>
 
-<div class="row">
-  <div class="col-sm-6">
-    <h3>Assign a New Case</h3>
+  <div class="row">
+    <div class="col-sm-6">
+      <h3>Assign a New Case</h3>
 
-    <%= form_for CaseAssignment.new, url: case_assignments_path(volunteer_id: @volunteer.id) do |form| %>
+      <%= form_for CaseAssignment.new, url: case_assignments_path(volunteer_id: @volunteer.id) do |form| %>
 
-      <div class='form-group'>
-        <label for='case_assignment_casa_case_id'>Select a Case</label>
-        <select name='case_assignment[casa_case_id]' class='form-control'>
-          <% CasaCase.all.each do |casa_case| %>
-            <option value="<%= casa_case.id %>"><%= casa_case.case_number %></option>
-          <% end %>
-        </select>
-      </div>
+        <div class='form-group'>
+          <label for='case_assignment_casa_case_id'>Select a Case</label>
+          <select name='case_assignment[casa_case_id]' class='form-control'>
+            <% CasaCase.all.each do |casa_case| %>
+              <option value="<%= casa_case.id %>"><%= casa_case.case_number %></option>
+            <% end %>
+          </select>
+        </div>
 
-      <%= form.submit 'Assign Case', class: 'btn btn-primary' %>
-    <% end %>
+        <%= form.submit 'Assign Case', class: 'btn btn-primary' %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,12 @@ Rails.application.routes.draw do
   resources :reports, only: %i[index]
   resources :case_contact_reports, only: %i[index]
 
-  resources :volunteers, only: %i[new edit create update]
+  resources :volunteers, only: %i[new edit create update] do
+    member do
+      get :deactivate
+      patch :deactivate
+    end
+  end
   resources :case_assignments, only: %i[create destroy] do
     member do
       get :unassign

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -9,16 +9,15 @@ RSpec.describe "Admin: Editing Volunteers", type: :system do
     visit edit_volunteer_path(volunteer)
 
     dismiss_confirm do
-      choose "Inactive"
+      click_on "Deactivate volunteer"
     end
-    expect(find_field("statusRadio2")).not_to be_checked
+    expect(page).not_to have_text('Volunteer was deactivated on')
 
     accept_confirm do
-      choose "Inactive"
+      click_on "Deactivate volunteer"
     end
-    expect(find_field("statusRadio2")).to be_checked
+    expect(page).to have_text('Volunteer was deactivated on')
 
-    click_on "Submit"
     expect {
       volunteer.reload
     }.to change { volunteer.role }.from("volunteer").to("inactive")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #230: Admins can Deactivate volunteers from Volunteer Edit
Depends on casa-cases-unassign PR

### What changed, and why?
- Added deactivate endpoint/route
- Add `active_volunteer` method on `user` to indicate if volunteer is active 
  - Wanted a DRY approach to determining if the volunteer's current role is 'volunteer' (vs 'inactive')
  - Naming this `is_active` isn't quite right bc they might be an active Supervisor, CasaAdmin, etc. Don't love calling @volunteer.active_volunteer, but, seems needed here bc of volunteer/user obfuscation
- Changed Actions column on Assigned Cases section to only show if volunteer active
- Changed "Assign Volunteer" button to secondary so there's only one primary on the page
- Conditionally displaying Add Cases section only if volunteer is active
- Change casa_case edit `volunteer_assignment` to differentiate between having been `unassigned` vs `deactivated`

### Notes
- Would prefer not to have to add both get and patch here. Any advice?

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions: Admins can Deactivate volunteers from Volunteer Edit

### How is this tested? (please write tests!) 💖💪
- Help, please!

### Screenshots please :)
<img width="1283" alt="Screen Shot 2020-06-14 at 2 49 10 PM" src="https://user-images.githubusercontent.com/7607813/84601541-f9cf0e80-ae4e-11ea-9b48-a092187d5171.png">
