### PR TITLE
Remove db:migrate (already handled in db:setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ If you have any troubles, also look at `.travis.yml` which is what makes the CI 
 1. `bundle exec rails webpacker:compile`
 1. `bundle exec rails db:setup # requires running local postgres`
 1. `bundle exec rails spec`
-1. `rails db:migrate`
 1. `bundle exec rails server` # run server
 1. `bundle exec standardrb --fix # auto-fix linting issues (optional)` [more linter info](https://github.com/testdouble/standard)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
n/a afaik

### What changed, and why?
- Remove reference to db:migrate (db:setup already handles that)

