### PR TITLE
Validate the user has an active role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,18 @@ class User < ApplicationRecord
 
     raw_token
   end
+
+  # Called by Devise during initial authentication and on each request to
+  # validate the user is active. For our purposes, the user is active if they
+  # do not have the inactive role.
+  def active_for_authentication?
+    super && !inactive?
+  end
+
+  # Called by Devise to generate an error message when a user is not active.
+  def inactive_message
+    inactive? ? :inactive : super
+  end
 end
 
 # == Schema Information

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,7 +8,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
+      inactive: "Your account is currently inactive. Please contact your supervisor for more details."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe User, type: :model do
     result = other_volunteer.case_contacts_for(sample_casa_case_id)
     expect(result.length).to eq(1)
   end
+
+  describe "#active_for_authentication?" do
+    it "is false when the user has an inactive role" do
+      user = create(:user, :inactive)
+      expect(user).not_to be_active_for_authentication
+      expect(user.inactive_message).to eq(:inactive)
+    end
+
+    it "is true otherwise" do
+      user = create(:user, :volunteer)
+      expect(user).to be_active_for_authentication
+
+      user = create(:user, :supervisor)
+      expect(user).to be_active_for_authentication
+    end
+  end
 end


### PR DESCRIPTION
If the user is inactive, display a localized error message in the flash message and do not allow them to login, nor see any pages that require authentication.

### What github issue is this PR for, if any?
Resolves #179 

### What changed, and why?
Devise has a [mechanism for determining if a user is active and refusing their login if not](https://rdoc.info/github/plataformatec/devise/master/Devise/Models/Authenticatable). This is checked at login and on every request. This PR hooks it up to our user model and inactive role model.

### How will this affect user permissions?
If a user has their role changed to inactive, they will no longer be able to login or view any content that requires authentication.

### How is this tested? (please write tests!) 💖💪
I wrote a couple of model specs. I'm open to writing a feature spec if folks think it would be valuable, as pretty much all of the underlying logic is provided by Devise.

### Screenshots please :)
![inactive user message](https://user-images.githubusercontent.com/395621/84603935-6dc5e280-ae60-11ea-8344-aed85ca69e34.png)
