### PR TITLE
Fixes #325

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,10 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :display_name)
+    if current_user.casa_admin?
+      params.require(:user).permit(:email, :display_name)
+    else
+      params.require(:user).permit(:display_name)
+    end
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,7 +19,7 @@
 
       <div class="field form-group">
         <%= form.label :email %>
-        <%= form.text_field :email, class: "form-control" %>
+        <p class="form-control"><%= @user.email %></p>
       </div>
 
       <div class="field form-group">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #325 

### What changed, and why?
This changes the email form field in users#edit to render as a <p> tag
instead. It uses the form-control class so it appears as it did before.
The UsersController has had its Strong Params modified to only allow
:email as a permissible field if the current_user is a casa_admin
(role).

The Strong Params should probably be done differently, ideally as a
Pundit policy, or similar, but that was not set up for this model, and
felt out of scope.

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Tested manually. Can come back and add tests if necessary (this PR was done as part of a live-stream and time didn't permit testing 😬 )

### Screenshots please :)
This looks identical because the `p` tag uses the `form-control` class, so it's rendered similarly to the input field.

### Feelings gif (optional)
grimacing.gif
