### PR TITLE
removing deprecation warning: update_attributes

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -22,7 +22,7 @@ class CaseAssignmentsController < ApplicationController
     volunteer = case_assignment.volunteer
     flash_message = "Volunteer was unassigned from Case #{casa_case.case_number}."
 
-    if case_assignment.update_attributes(is_active: false)
+    if case_assignment.update(is_active: false)
       if params[:redirect_to_path] == "volunteer"
         redirect_to edit_volunteer_path(volunteer), notice: flash_message
       else

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -38,7 +38,7 @@ class VolunteersController < ApplicationController
   def deactivate
     @volunteer = User.find(params[:id])
 
-    if @volunteer.update_attributes(role: "inactive")
+    if @volunteer.update(role: "inactive")
       @volunteer.case_assignments.update_all(is_active: false)
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else


### PR DESCRIPTION
### What changed, and why?
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1

app/controllers/case_assignments_controller.rb
app/controllers/volunteers_controller.rb

### Screenshots please :)

![Screen Shot 2020-06-20 at 19 35 02](https://user-images.githubusercontent.com/25162312/85212836-2bebdf00-b32d-11ea-8d33-f36d8ce3a671.png)
