### PR TITLE
Fix formatting on volunteer deactivate warning 

### DIFF
--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -46,9 +46,7 @@
                         method: :patch,
                         class: "btn btn-outline-danger",
                         data:
-                            { confirm: "WARNING: Marking a volunteer inactive will make them unable to login.
-                                <br><br>They will receive an email saying their account has been marked inactive.
-                                <br><br>Are you sure you want to do this?".html_safe },
+                            { confirm: "WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?".html_safe },
                         hint: "NOTE: This will make connected cases unassigned and<br>
                           the volunteer won't be able to log in to the system anymore".html_safe %>
           <% end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #354 

### What changed, and why?
### Screenshots please :)
### before:
![Screen Shot 2020-06-20 at 21 15 35](https://user-images.githubusercontent.com/25162312/85214009-48434800-b33c-11ea-927d-bd957942752a.png)
### after
![Screen Shot 2020-06-20 at 21 18 33](https://user-images.githubusercontent.com/25162312/85214010-4aa5a200-b33c-11ea-9752-3500dfc77e8d.png)
