### PR TITLE
Remove bootstrap 3 styles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= render 'shared/favicons' %>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #387 

### What changed, and why?
Styles for the whole site are adjusted. This affects ever page. The top nav bar is different as well as other content. Bootstrap 4 styles are now properly applied rather than bootstrap 4 and 3 conflicting with each other.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
I clicked around a few pages, but someone who knows the app better should visually check various pages for oddities.

### Screenshots please :)
*Before*
<img width="578" alt="Screen Shot 2020-06-24 at 11 41 18 PM" src="https://user-images.githubusercontent.com/5741299/85651067-fe789b80-b674-11ea-9dc3-8b083c9d93f4.png">
<img width="1567" alt="Screen Shot 2020-06-24 at 11 40 47 PM" src="https://user-images.githubusercontent.com/5741299/85651080-03d5e600-b675-11ea-9fd7-3025f09a8383.png">

*After*
<img width="651" alt="Screen Shot 2020-06-24 at 11 41 34 PM" src="https://user-images.githubusercontent.com/5741299/85651114-17814c80-b675-11ea-979b-14ca1c53c984.png">
<img width="693" alt="Screen Shot 2020-06-24 at 11 41 07 PM" src="https://user-images.githubusercontent.com/5741299/85651116-1a7c3d00-b675-11ea-9dd7-08976ca27883.png">
<img width="1675" alt="Screen Shot 2020-06-24 at 11 40 58 PM" src="https://user-images.githubusercontent.com/5741299/85651119-1ea85a80-b675-11ea-9d78-8518567dcff5.png">
<img width="1674" alt="Screen Shot 2020-06-24 at 11 40 20 PM" src="https://user-images.githubusercontent.com/5741299/85651125-223be180-b675-11ea-8de5-b16b88952dc1.png">