### PR TITLE
volunteers can edit case contacts

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -36,6 +36,9 @@
                value="<%= contact_type %>"
                name="case_contact[contact_types][]"
                id="case_contact[contact_types][<%= index %>]"
+               <% if case_contact.contact_types.include?(contact_type) %>
+               checked=true
+               <% end %>
         >
         <label class="form-check-label" for="case_contact[contact_types][<%= index %>]">
           <%= contact_type.titleize %>

--- a/app/views/dashboard/_volunteer_dashboard.html.erb
+++ b/app/views/dashboard/_volunteer_dashboard.html.erb
@@ -40,6 +40,7 @@
       <th>Contact Made</th>
       <th>Contact Medium</th>
       <th>Type</th>
+      <th>Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -50,6 +51,7 @@
         <td><%= contact.contact_made %></td>
         <td><%= contact.medium_type %></td>
         <td><%= contact.contact_types %></td>
+        <td><%= link_to 'Edit', edit_case_contact_path(contact) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe "case_contacts/edit" do
+
+    it "is listing all the contact methods from the model" do
+      assign :case_contact, create(:case_contact)
+
+      user = build_stubbed(:user, :volunteer)
+      allow(view).to receive(:current_user).and_return(user)
+
+      contact_types = CaseContact::CONTACT_TYPES.each_with_index do |contact_type, index|
+        render template: "case_contacts/edit"
+        expect(rendered).to include(contact_type)
+      end
+    end
+
+
+
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #379: Volunteers can edit case contacts

### What changed, and why?

- Added a link to the edit page on the volunteer contact page
- Added logic to the edit form to cycle through the list of contact types and pre-check the checkboxes for applicable values

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Added case_contacts/edit is listing all the contact methods from the model to verify that the edit view is returning all the contact types for the case_contact model

### Screenshots please :)
![volunteer-edit-contact](https://user-images.githubusercontent.com/42715794/85960813-5c0e3000-b974-11ea-90c6-2c0a139f8c4f.PNG)


### Feelings gif (optional)
💪
