### PR TITLE
362/unassign volunteer

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -8,6 +8,13 @@ class SupervisorVolunteersController < ApplicationController
     redirect_to after_action_path(supervisor_volunteer_parent)
   end
 
+  def destroy
+    supervisor_volunteer = SupervisorVolunteer.find(params[:id])
+    supervisor_volunteer.delete
+
+    redirect_to after_action_path(supervisor_volunteer_parent)
+  end
+
   private
 
   def supervisor_volunteer_params

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -52,6 +52,7 @@
           <tr>
             <th>Volunteer Name</th>
             <th>Volunteer Email</th>
+            <th>Unassign</th>
           </tr>
         </thead>
         <tbody>
@@ -59,6 +60,7 @@
             <tr>
               <td><%= link_to assignment.volunteer.decorate.name, edit_volunteer_path(assignment.volunteer) %></td>
               <td><%= assignment.volunteer.email %></td>
+              <td><%= button_to 'Unassign', supervisor_volunteer_path(assignment, supervisor_id: @supervisor.id), method: :delete, class: "btn btn-danger" %></td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
   resources :reports, only: %i[index]
   resources :case_contact_reports, only: %i[index]
 
-resources :supervisors, only: %i[edit update]
-  resources :supervisor_volunteers, only: :create
+  resources :supervisors, only: %i[edit update]
+  resources :supervisor_volunteers, only: %i[create destroy]
   resources :volunteers, only: %i[new edit create update] do
     member do
       get :deactivate

--- a/spec/factories/supervisor_volunteer.rb
+++ b/spec/factories/supervisor_volunteer.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :supervisor_volunteer do
+    association :supervisor, factory: :user
+    association :volunteer, factory: :user
+  end
+end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
+  it "destroys the assignment of a volunteer to a supervisor" do
+    admin = create(:user, :casa_admin)
+    supervisor = create(:user, :supervisor)
+    volunteer = create(:user, :volunteer)
+    assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+    sign_in admin
+
+    expect do
+      delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+    end.to change(supervisor.volunteers, :count).by(-1)
+
+    expect(response).to redirect_to edit_supervisor_path(supervisor)
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #362

### What changed, and why?
In each row in the list of volunteers in the edit supervisor view, a button was added to unassign the volunteer from the supervisor. When this button is clicked, the `SupervisorVolunteer` relationship between the two is deleted.

### How will this affect user permissions?
- Volunteer permissions: no changes
- Supervisor permissions: no changes
- Admin permissions: no changes

### How is this tested? 
Spec created for endpoint to delete supervisor_volunteer relationship

### Concerns

- The button that was added: Is a red button the right choice? Different color? Link instead?
- Header above the button: is "Unassign". Is there something better to go there?
- Should a `before_action :must_be_admin_or_supervisor` be added to the `SupervisorVolunteersController`?
- Passing supervisor id as a parameter to the delete as a way to return to the supervisor edit view. I have mixed feelings about this. It results in a request that has a query param, like `DELETE "/supervisor_volunteers/7?supervisor_id=104"`. This is to match the way that the redirect works for `SupervisorVolunteersController#create`. However, an alternative would be to make the method look something like this:

```ruby
def destroy
    supervisor_volunteer = SupervisorVolunteer.find(params[:id])
    supervisor = supervisor_volunteer.supervisor
    supervisor_volunteer.delete

    redirect_to edit_supervisor_path(supervisor)
  end
```

### Screenshots

#### Before unassigning a volunteer from a supervisor
Database record showing relationship between desmonddaugherty@example.com and supervisor1@example.com
```sql
casa_development=# select u.email as volunteer_email, su.email as supervisor_email from users u join supervisor_volunteers sv on u.id = sv.volunteer_id join users su on su.id = sv.supervisor_id where u.email = 'desmonddaugherty@example.com';
       volunteer_email        |    supervisor_email     
------------------------------+-------------------------
 desmonddaugherty@example.com | supervisor1@example.com
(1 row)
```
Screen showing Desmond Daugherty at top of list of volunteers for the supervisor
![before-unassigning-desmond](https://user-images.githubusercontent.com/3824492/86550016-d572c900-bf06-11ea-8143-161a0190d589.png)

#### After unassigning a volunteer from a supervisor
Database record showing relationship no longer exists between desmonddaugherty@example.com and supervisor1@example.com
```sql
casa_development=# select u.email as volunteer_email, su.email as supervisor_email from users u join supervisor_volunteers sv on u.id = sv.volunteer_id join users su on su.id = sv.supervisor_id where u.email = 'desmonddaugherty@example.com';
 volunteer_email | supervisor_email 
-----------------+------------------
(0 rows)
```
Screen showing Desmond Daugherty no longer at top of list of volunteers for the supervisor
![after-unassigning-desmond](https://user-images.githubusercontent.com/3824492/86550068-0226e080-bf07-11ea-9a34-efc1685a1d80.png)



