### PR TITLE
Checks user is authorized to edit case contact

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -23,7 +23,10 @@ class CaseContactsController < ApplicationController
 
   # GET /case_contacts/1/edit
   def edit
-    @casa_cases = current_user.casa_cases
+    @case_contact = authorize CaseContact.find(params[:id])
+  rescue Pundit::NotAuthorizedError
+    flash[:alert] = "Sorry! You can only edit case contacts that you have logged."
+    redirect_to root_path
   end
 
   def create

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -8,5 +8,9 @@
   <td><%= contact.decorate.reimbursement %></td>
   <td><%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %></td>
 
-  <td><%= link_to 'Edit', edit_case_contact_path(contact) %></td>
+  <td>
+    <% if Pundit.policy(current_user, contact).update?  %>
+      <%= link_to 'Edit', edit_case_contact_path(contact) %>
+    <% end %>
+  </td>
 </tr>


### PR DESCRIPTION
# What github issue is this PR for, if any?

Related to #406

### What changed, and why?

The volunteer dashboard showed edit links for case contacts that were created by other volunteers assigned to case before. It also did not check the policy on whether they are authorized. This hides the edit button for case contacts current user is not allowed to edit. If they try to guess edit path of another case contact, this prevents displaying the message, routes them to the root path with a helpful message explaining why.

### How will this affect user permissions?
- Volunteer permissions: Volunteers will no longer be able to edit case contacts created by other volunteers. This is good.
- Supervisor permissions: No change
- Admin permissions: No change

### How is this tested? (please write tests!) 💖💪

It was tested visually but I can write tests for it in a separate PR.

### Screenshots please :)

Paired over zoom with @Zrrrpy & @compwron so have seen how this looks.

### Feelings gif (optional)

![Loki, Prince of Asgard, celebrating success](https://media.tumblr.com/tumblr_ma7kq8A0LA1rsw1yf.gif)
