### PR TITLE
Unassign volunteer cleanup

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -11,9 +11,10 @@ class SupervisorVolunteersController < ApplicationController
 
   def destroy
     supervisor_volunteer = SupervisorVolunteer.find(params[:id])
+    supervisor = supervisor_volunteer.supervisor
     supervisor_volunteer.delete
 
-    redirect_to after_action_path(supervisor_volunteer_parent)
+    redirect_to after_action_path(supervisor)
   end
 
   private

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -1,5 +1,6 @@
 class SupervisorVolunteersController < ApplicationController
   before_action :authenticate_user!
+  before_action :must_be_admin_or_supervisor, only: :destroy
 
   def create
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.new(supervisor_volunteer_params)

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -60,7 +60,7 @@
             <tr>
               <td><%= link_to assignment.volunteer.decorate.name, edit_volunteer_path(assignment.volunteer) %></td>
               <td><%= assignment.volunteer.email %></td>
-              <td><%= button_to 'Unassign', supervisor_volunteer_path(assignment, supervisor_id: @supervisor.id), method: :delete, class: "btn btn-danger" %></td>
+              <td><%= button_to 'Unassign', supervisor_volunteer_path(assignment), method: :delete, class: "btn btn-danger" %></td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -1,18 +1,50 @@
 require "rails_helper"
 
 RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
-  it "destroys the assignment of a volunteer to a supervisor" do
-    admin = create(:user, :casa_admin)
-    supervisor = create(:user, :supervisor)
-    volunteer = create(:user, :volunteer)
-    assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+  context "when the logged in user is an admin" do
+    it "destroys the assignment of a volunteer to a supervisor" do
+      admin = create(:user, :casa_admin)
+      supervisor = create(:user, :supervisor)
+      volunteer = create(:user, :volunteer)
+      assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
 
-    sign_in admin
+      sign_in admin
 
-    expect do
-      delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
-    end.to change(supervisor.volunteers, :count).by(-1)
+      expect do
+        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+      end.to change(supervisor.volunteers, :count).by(-1)
 
-    expect(response).to redirect_to edit_supervisor_path(supervisor)
+      expect(response).to redirect_to edit_supervisor_path(supervisor)
+    end
+  end
+
+  context "when the logged in user is a supervisor" do
+    it "destroys the assignment of a volunteer to a supervisor" do
+      supervisor = create(:user, :supervisor)
+      volunteer = create(:user, :volunteer)
+      assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+      sign_in supervisor
+
+      expect do
+        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+      end.to change(supervisor.volunteers, :count).by(-1)
+
+      expect(response).to redirect_to edit_supervisor_path(supervisor)
+    end
+  end
+
+  context "when the logged in user is not an admin or supervisor" do
+    it "does not destroy the assignment" do
+      supervisor = create(:user, :supervisor)
+      volunteer = create(:user, :volunteer)
+      assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+      sign_in volunteer
+
+      expect do
+        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+      end.to change(supervisor.volunteers, :count).by(0)
+    end
   end
 end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
       sign_in admin
 
       expect do
-        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+        delete supervisor_volunteer_path(assignment)
       end.to change(supervisor.volunteers, :count).by(-1)
 
       expect(response).to redirect_to edit_supervisor_path(supervisor)
@@ -27,7 +27,7 @@ RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
       sign_in supervisor
 
       expect do
-        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+        delete supervisor_volunteer_path(assignment)
       end.to change(supervisor.volunteers, :count).by(-1)
 
       expect(response).to redirect_to edit_supervisor_path(supervisor)
@@ -43,7 +43,7 @@ RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
       sign_in volunteer
 
       expect do
-        delete supervisor_volunteer_path(assignment, supervisor_id: supervisor.id)
+        delete supervisor_volunteer_path(assignment)
       end.to change(supervisor.volunteers, :count).by(0)
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
A follow up to #400, which addressed #362.  

### What changed, and why?
As per discussion in #400 (see [this comment](https://github.com/rubyforgood/casa/pull/400#pullrequestreview-442779204)), this makes two improvements to unassigning a volunteer:
1. It limits this ability to supervisors and admins
2. It removes the requirement that the supervisor's ID be passed in as a parameter.

See this comment: 

### How will this affect user permissions?
- Volunteer permissions: a volunteer cannot unassign a volunteer from a supervisor
- Supervisor permissions: no change
- Admin permissions: no change

### How is this tested? (please write tests!) 💖💪
Unit tests
Exercised

### Screenshots please :)
#### Before unassigning a volunteer from a supervisor
Database record showing relationship between volunteer bradfordbogan@example.org and supervisor mrs.franecki.rachell@example.com
```sql
casa_development=# select u.email as volunteer_email, su.email as supervisor_email from users u join supervisor_volunteers sv on u.id = sv.volunteer_id join users su on su.id = sv.supervisor_id where u.email = 'bradfordbogan@example.org';
      volunteer_email      |         supervisor_email         
---------------------------+----------------------------------
 bradfordbogan@example.org | mrs.franecki.rachell@example.com
(1 row)

```
Screen showing Bradford Bogan at top of list of volunteers for the supervisor
![before-unassigning-bradford](https://user-images.githubusercontent.com/3824492/87256086-786e9a00-c455-11ea-8c04-543f204b5e8c.png)


#### After unassigning a volunteer from a supervisor
Database record showing relationship no longer exists between volunteer bradfordbogan@example.org and supervisor mrs.franecki.rachell@example.com
```sql
casa_development=# select u.email as volunteer_email, su.email as supervisor_email from users u join supervisor_volunteers sv on u.id = sv.volunteer_id join users su on su.id = sv.supervisor_id where u.email = 'bradfordbogan@example.org';
 volunteer_email | supervisor_email 
-----------------+------------------
(0 rows)

```
Screen showing Bradford Bogan no longer at top of list of volunteers for the supervisor
![after-unassigning-bradford](https://user-images.githubusercontent.com/3824492/87256095-7e647b00-c455-11ea-80fd-0b30379aa8ec.png)


