### PR TITLE
Removes edit link for previous volunteer

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -6,7 +6,13 @@
   <td><%= contact.decorate.contact_types %></td>
   <td><%= contact.decorate.miles_traveled %></td>
   <td><%= contact.decorate.reimbursement %></td>
-  <td><%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %></td>
+  <td>
+    <% if current_user&.casa_admin? || current_user&.supervisor? %>
+      <%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %>
+    <% else %>
+      <%= contact.creator&.display_name %>
+    <% end %>
+  </td>
 
   <td>
     <% if Pundit.policy(current_user, contact).update?  %>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #406 

### What changed, and why?

In the volunteer dashboard, we could see the link to edit profile for previous volunteers assigned to the case in the case contacts section. While clicking on that link brought you right back, it's better to not provide a link in the first place. This change checks if the current user has permissions to edit the contact creator and only them provides the edit link. For all other cases, it just shows the display name of the contact creator.

### How will this affect user permissions?

No impact

### How is this tested? (please write tests!) 💖💪

Visually. I looked at what existed in terms of tests and it looked daunting. Maybe we can pair in the near future on how to improve test coverage.

### Screenshots please :)

![PG CASA 2020-07-12 17-29-00](https://user-images.githubusercontent.com/59220/87260199-49f8bb00-c465-11ea-8ba9-c32bc9a7ed50.png)


### Feelings gif (optional)

![unsure](https://media.giphy.com/media/yj5oYHjoIwv28/giphy.gif)
