### PR TITLE
Issue 377 remove submit button on supervisor

### DIFF
--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -36,7 +36,9 @@
       </div>
 
       <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
+        <% if policy(:user).update_supervisor_email? || policy(:user).update_supervisor_name? %>
+          <%= form.submit "Submit", class: "btn btn-primary" %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -19,7 +19,7 @@
 
       <div class="field form-group">
         <%= form.label :email %>
-        <% if policy(:user).update_supervisor_email? %>
+        <% if policy(@supervisor).update_supervisor_email? %>
           <%= form.text_field :email, class: "form-control" %>
         <% else %>
           <input class="form-control" type="text" placeholder="<%= @supervisor.email %>" readonly>
@@ -28,7 +28,7 @@
 
       <div class="field form-group">
         <%= form.label :display_name %>
-        <% if policy(:user).update_supervisor_name? %>
+        <% if policy(@supervisor).update_supervisor_name? %>
           <%= form.text_field :display_name, class: "form-control" %>
         <% else %>
           <input class="form-control" type="text" placeholder="<%= @supervisor.display_name %>" readonly>
@@ -36,7 +36,7 @@
       </div>
 
       <div class="actions">
-        <% if policy(:user).update_supervisor_email? || policy(:user).update_supervisor_name? %>
+        <% if policy(@supervisor).update_supervisor_email? || policy(@supervisor).update_supervisor_name? %>
           <%= form.submit "Submit", class: "btn btn-primary" %>
         <% end %>
       </div>

--- a/spec/features/user_views_supervisor_edit_spec.rb
+++ b/spec/features/user_views_supervisor_edit_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "view supervisor edit", type: :feature do
+  context "when the current user is a supervisor" do
+    it "displays a submit button" do
+      current_supervisor = create(:user, :supervisor)
+      other_supervisor = create(:user, :supervisor)
+
+      sign_in current_supervisor
+      visit edit_supervisor_path(other_supervisor)
+
+      expect(page).not_to have_selector(:link_or_button, "Submit")
+    end
+  end
+
+  context "when the current user is an admin" do
+    it "displays a submit button" do
+      admin = create(:user, :casa_admin)
+      supervisor = create(:user, :supervisor)
+
+      sign_in admin
+      visit edit_supervisor_path(supervisor)
+
+      expect(page).to have_selector(:link_or_button, "Submit")
+    end
+  end
+end

--- a/spec/features/user_views_supervisor_edit_spec.rb
+++ b/spec/features/user_views_supervisor_edit_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "view supervisor edit", type: :feature do
   context "when the current user is a supervisor" do
-    it "displays a submit button" do
+    it "does not a submit button" do
       current_supervisor = create(:user, :supervisor)
       other_supervisor = create(:user, :supervisor)
 
@@ -10,6 +10,17 @@ RSpec.describe "view supervisor edit", type: :feature do
       visit edit_supervisor_path(other_supervisor)
 
       expect(page).not_to have_selector(:link_or_button, "Submit")
+    end
+
+    context "when the current user is editing self" do
+      it "displays a submit button" do
+        current_supervisor = create(:user, :supervisor)
+
+        sign_in current_supervisor
+        visit edit_supervisor_path(current_supervisor)
+
+        expect(page).to have_selector(:link_or_button, "Submit")
+      end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #377 and #378 
Addressed #378 by accident before realizing the issue even existed. Can break https://github.com/rubyforgood/casa/pull/416/commits/8444ab2736df16c57db63418fd6472265c634505 (which address #378) out into a separate PR if desired.

### What changed, and why?
Conditionally display the Submit button in the supervisor edit form. Only display it if the current user can update supervisor email or update supervisor name

### How will this affect user permissions?
- Volunteer permissions: No effect
- Supervisor permissions: No effect
- Admin permissions: No effect

### How is this tested? (please write tests!) 💖💪
Tests were added to verify whether or not the Submit button is present.

#### Concerns about added tests

1. Just checking for a button with "Submit" on it seems a little brittle. I'm not very familiar with the tests that verify HTML. Is there a better check? I'm happy to update
2. I also wondered if these should be broken into two separate test files, one for admin views supervisor edit and the other for supervisor view supervisor edit. It felt funny to have tests that only did one thing -- check for a button. I'm happy to break them out into separate files. I'm worried about scope creep if we start adding other tests for the supervisor view as part of this PR. I'm not sure I have the time this weekend to build out tests for the supervisor view.

### Existing bug
(Issue #378)
A supervisor cannot edit self. That is because the policy `UserPolicy#update_supervisor_email?` and `UserPolicy#update_supervisor_name?` do not behave as expected. The check `record == user` returns false even when the user is on their own edit page. That is because `record` equals `:user`. It does not equal the object of the current logged-in user. Here is an example from the console with a user, "larrykirlin@example.org", logged in and on that user's own supervisor edit view.

```
From: /home/cmcintosh/code/rubyforgood/casa/app/policies/user_policy.rb:12 UserPolicy#update_supervisor_email?:

    10: def update_supervisor_email?
    11:   binding.pry
 => 12:   user.casa_admin? || record == user
    13: end

[1] pry(#<UserPolicy>)> record
=> :user
[2] pry(#<UserPolicy>)> user
=> #<User id: 109, email: "larrykirlin@example.org", created_at: "2020-07-12 20:50:44", updated_at: "2020-07-12 20:50:44", role: "supervisor", casa_org_id: 1, display_name: "Larry Kirlin">
[3] pry(#<UserPolicy>)> record == user
=> false
```
As part of this PR's changes, the use of these functions is updated in the supervisor edit template to allow a supervisor to edit self. See https://github.com/rubyforgood/casa/commit/8444ab2736df16c57db63418fd6472265c634505.

### Screenshots please :)

#### Before this change

The "Submit" button is visible when a supervisor is viewing the page for another supervisor
![before-removing-submit-button](https://user-images.githubusercontent.com/3824492/87855735-d54bd380-c8df-11ea-982f-796b007ed713.png)

#### After this change

The "Submit" button is not visible when a supervisor is viewing the page for another supervisor
![after-removing-submit-button](https://user-images.githubusercontent.com/3824492/87855734-d54bd380-c8df-11ea-8810-71798cb37108.png)

The "Submit" button is still visible when an admin is viewing the page for a supervisor
![admin-sees-button](https://user-images.githubusercontent.com/3824492/87855733-d4b33d00-c8df-11ea-8b59-266971deb8f6.png)

#### Bug that doesn't allow a supervisor to edit self
Covered in issue #378 

Here are screenshots showing the existing bug that doesn't allow a supervisor to edit self

Existing functionality has fields for self un-editable but Submit button visible
![supervisor-cannot-edit-self-in-master](https://user-images.githubusercontent.com/3824492/87855809-5905c000-c8e0-11ea-8496-1291274715c6.png)

After this change, the fields for self are editable and the Submit button is still visible
![supervisor-can-edit-self](https://user-images.githubusercontent.com/3824492/87856060-f6adbf00-c8e1-11ea-80c0-d921d7f354ca.png)

