### PR TITLE
Issue 360 add supervisor view to admin dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -15,5 +15,7 @@ class DashboardController < ApplicationController
     @case_contacts = policy_scope(
       CaseContact.all
     ).order(occurred_at: :desc).decorate
+
+    @supervisors = policy_scope(User.where(role: %w[supervisor]))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,10 @@ class User < ApplicationRecord
   def inactive_message
     inactive? ? :inactive : super
   end
+
+  def serving_transition_aged_youth?
+    casa_cases.where(transition_aged_youth: true).any?
+  end
 end
 
 # == Schema Information

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -22,4 +22,8 @@ class DashboardPolicy
   def see_cases_section?
     true
   end
+
+  def see_supervisors_section?
+    user.casa_admin?
+  end
 end

--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -15,4 +15,7 @@
 
 <br>
 <%= render "casa_cases" %>
+
+<br>
+<%= render "supervisors_table" %>
 <br>

--- a/app/views/dashboard/_supervisors_table.html.erb
+++ b/app/views/dashboard/_supervisors_table.html.erb
@@ -1,0 +1,37 @@
+<% if policy(:dashboard).see_supervisors_section? %>
+  <div class="row">
+    <div class="col-sm-12 dashboard-table-header">
+      <h1>Supervisors</h1>
+    </div>
+  </div>
+  <table class="table table-striped table-bordered" id="supervisors">
+    <thead>
+    <tr>
+      <th>Supervisor Name</th>
+      <th>Volunteer Assignments</th>
+      <th>Serving Transition Aged Youth</th>
+      <th>No Contact</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% @supervisors.each do |supervisor| %>
+      <tr>
+        <td id="name"> <%= supervisor.display_name %></td>
+        <td id="volunteer-assignments"> <%= supervisor.volunteers.count %></td>
+        <td id="serving-transition-aged-youth">
+          <%= supervisor.volunteers.select { |v| v.serving_transition_aged_youth? }.count %>
+        </td>
+        <td id="no-contact">
+          <%=
+            days_since_contact = 14
+            supervisor.volunteers.select { |v| v.recent_contacts_made(days_since_contact) < 1 }.count
+          %>
+        </td>
+        <td><%= link_to 'Edit', edit_supervisor_path(supervisor) %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:email) { |n| "email#{n}@example.com" }
     password { "123456" }
     password_confirmation { "123456" }
+    case_assignments { [] }
 
     trait :volunteer do
       role { :volunteer }

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -108,4 +108,28 @@ RSpec.describe "admin views dashboard", type: :feature do
 
     expect(page.all("table#volunteers tr").count).to eq 3
   end
+
+  it "can see supervisors" do
+    supervisor_name = "Leslie Knope"
+    create(:user, :supervisor, display_name: supervisor_name)
+    sign_in admin
+
+    visit root_path
+
+    expect(page).to have_text(supervisor_name)
+  end
+
+  it "can go to the supervisor edit page from the supervisor list" do
+    supervisor_name = "Leslie Knope"
+    create(:user, :supervisor, display_name: supervisor_name)
+    sign_in admin
+
+    visit root_path
+
+    within "#supervisors" do
+      click_on "Edit"
+    end
+
+    expect(page).to have_text("Editing Supervisor")
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,4 +63,34 @@ RSpec.describe User, type: :model do
       expect(user).to be_active_for_authentication
     end
   end
+
+  describe "#serving_transition_aged_youth?" do
+    let(:case_assignment_with_a_transition_aged_youth) do
+      create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: true))
+    end
+    let(:case_assignment_without_transition_aged_youth) do
+      create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: false))
+    end
+
+    context "when the user has a transition-aged-youth case" do
+      it "is true" do
+        case_assignments = [
+          case_assignment_with_a_transition_aged_youth,
+          case_assignment_without_transition_aged_youth
+        ]
+        user = create(:user, :volunteer, case_assignments: case_assignments)
+
+        expect(user).to be_serving_transition_aged_youth
+      end
+    end
+
+    context "when the user does not have a transition-aged-youth case" do
+      it "is false" do
+        case_assignments = [case_assignment_without_transition_aged_youth]
+        user = create(:user, :volunteer, case_assignments: case_assignments)
+
+        expect(user).not_to be_serving_transition_aged_youth
+      end
+    end
+  end
 end

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -51,4 +51,18 @@ RSpec.describe DashboardPolicy do
       end
     end
   end
+
+  permissions :see_supervisors_section? do
+    it "allows casa_admins" do
+      expect(subject).to permit(create(:user, :casa_admin))
+    end
+
+    it "does not allow supervisors" do
+      expect(subject).not_to permit(create(:user, :supervisor))
+    end
+
+    it "does not allow volunteers" do
+      expect(subject).not_to permit(create(:user, :volunteer))
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #360 

### What changed, and why?
Added to the dashboard a table showing all supervisors, visible only for admins

### How will this affect user permissions?
- Volunteer permissions: no effect
- Supervisor permissions: no effect
- Admin permissions: added dashboard policy to allow admin to see supervisors

### Concerns
The dashboard is pretty big now! You really have to scroll to reach the supervisors table.

### How is this tested?
Tests written

### Screenshots
Supervisors table is only visible to admins. These screenshots show the views for an admin, a supervisor and a volunteer

When logged in as casa_admin1@example.org, the supervisors are visible in a table at the bottom of the (very long) page. Note the hover in the bottom left showing the target for the Edit link.
![admin-sees-supervisors](https://user-images.githubusercontent.com/3824492/87879156-8c168500-c9ae-11ea-924c-eb97060a5fe6.png)

When logged in as supervisor1@example.com, the user does not see the supervisors table below the cases.
![supervisor-does-not-see-supervisors](https://user-images.githubusercontent.com/3824492/87879155-8b7dee80-c9ae-11ea-965d-696c6d917b05.png)

When logged in as volunteer1@example.com, the user does not see the supervisors table.
![volunteer-does-not-see-supervisors](https://user-images.githubusercontent.com/3824492/87879154-8b7dee80-c9ae-11ea-804f-95040c96526a.png)
