### PR TITLE
Fix filtering on "Assigned to Transition Aged Youth" column

### DIFF
--- a/app/views/dashboard/_volunteer_filters.html.erb
+++ b/app/views/dashboard/_volunteer_filters.html.erb
@@ -27,7 +27,7 @@
         Assigned to Transition Aged Youth
       </button>
       <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="Yes" checked />Yes</a></li>
+        <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="Yes 🐛🦋" checked />Yes</a></li>
         <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="No" checked />No</a></li>
       </div>
     </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #374

### What changed, and why?
The value now includes two emoji. Since we test for an exact match, the `data-value` needs to be updated as well.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
By default, the only volunteers that should be filtered out on the initial page load are those that are inactive. I verified this is the case again.