### PR TITLE
Supervisor dashboard filters for their own volunteers by default

### DIFF
--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -9,7 +9,7 @@
 </div>
 <hr>
 
-<%= render "volunteer_filters" %>
+<%= render "volunteer_filters", logged_in_supervisor: nil %>
 
 <%= render "volunteers_table" %>
 

--- a/app/views/dashboard/_supervisor_dashboard.html.erb
+++ b/app/views/dashboard/_supervisor_dashboard.html.erb
@@ -3,12 +3,9 @@
     <h1>Volunteers</h1>
   </div>
 </div>
-
 <hr>
-<%= render "volunteer_filters" %>
-
+<%= render "volunteer_filters", logged_in_supervisor: logged_in_supervisor %>
 <%= render "volunteers_table" %>
-
 <br>
 <%= render "casa_cases" %>
 <br>

--- a/app/views/dashboard/_volunteer_filters.html.erb
+++ b/app/views/dashboard/_volunteer_filters.html.erb
@@ -8,7 +8,14 @@
         <ul class="dropdown-menu supervisor-options" style="min-width: 15rem;">
           <% User.where(role: "supervisor").decorate.each do |supervisor| %>
             <li>
-              <a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="<%= supervisor.name %>" checked/><%= supervisor.name %></a>
+              <a class="small" data-value="option1" tabIndex="-1">
+                <input
+                  style="margin:0 8px;"
+                  type="checkbox"
+                  data-value="<%= supervisor.name %>" <%= logged_in_supervisor ? (logged_in_supervisor.id == supervisor.id ? 'checked' : '') : 'checked' %>
+                  />
+                <%= supervisor.name %>
+              </a>
             </li>
           <% end %>
         </ul>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,5 +3,5 @@
 <% elsif current_user.volunteer? %>
   <%= render 'volunteer_dashboard' %>
 <% elsif current_user.supervisor? %>
-  <%= render 'supervisor_dashboard' %>
+  <%= render 'supervisor_dashboard', logged_in_supervisor: current_user %>
 <% end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #429 

### What changed, and why?
In our meeting today, CASA mentioned again that they wanted supervisors to see their own volunteers first. This seemed like th easiest way to build it :)

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: now default to see their own volunteers first
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
It is not currently tested but it should be. :(

### Screenshots please :)
<img width="1607" alt="Screen Shot 2020-07-22 at 9 56 31 AM" src="https://user-images.githubusercontent.com/578159/88205596-e3f8fa00-cc01-11ea-8836-0afdc7a1e9de.png">
<img width="1608" alt="Screen Shot 2020-07-22 at 9 54 14 AM" src="https://user-images.githubusercontent.com/578159/88205603-e6f3ea80-cc01-11ea-9b5e-5c46c02dde8a.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![giphy](https://user-images.githubusercontent.com/578159/88205885-44883700-cc02-11ea-9230-a0373baea59c.gif)
