### PR TITLE
Issue 424 - Makes supervisor name a link in admin dashboard

### DIFF
--- a/app/views/dashboard/_supervisors_table.html.erb
+++ b/app/views/dashboard/_supervisors_table.html.erb
@@ -18,7 +18,9 @@
     <tbody>
     <% @supervisors.each do |supervisor| %>
       <tr>
-        <td id="name"> <%= supervisor.display_name %></td>
+        <td id="name">
+          <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
+        </td>
         <td id="volunteer-assignments"> <%= supervisor.volunteers.count %></td>
         <td id="serving-transition-aged-youth">
           <%= supervisor.volunteers.select { |v| v.serving_transition_aged_youth? }.count %>

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -132,4 +132,18 @@ RSpec.describe "admin views dashboard", type: :feature do
 
     expect(page).to have_text("Editing Supervisor")
   end
+
+  it "can go to the supervisor edit page from the supervisor's name" do
+    supervisor_name = "Leslie Knope"
+    create(:user, :supervisor, display_name: supervisor_name)
+    sign_in admin
+
+    visit root_path
+
+    within "#supervisors" do
+      click_on supervisor_name
+    end
+
+    expect(page).to have_text("Editing Supervisor")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #424 

### What changed, and why?
On the Supervisors section in the admin dashboard, the supervisor's name is changed to be a link that points to the supervisor edit page.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added test to check that clicking the supervisor's name takes the user to the supervisor edit page

### Screenshots please :)
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/18248767/88442236-cb473a80-cde1-11ea-8ef7-d564f6fe46ee.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
