### PR TITLE
Allow admins and supervisors to create case contacts

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -6,49 +6,52 @@ class CaseContactsController < ApplicationController
   # GET /case_contacts
   # GET /case_contacts.json
   def index
-    @case_contacts = CaseContact.all.decorate
+    @case_contacts = policy_scope(CaseContact).decorate
   end
 
   # GET /case_contacts/1
   # GET /case_contacts/1.json
   def show
-    @case_contact_number = CasaCase.find(@case_contact.casa_case_id).case_number
   end
 
   # GET /case_contacts/new
   def new
+    @casa_cases = policy_scope(CasaCase)
+    # Admins and supervisors who are navigating to this page from a specific
+    # case detail page will only see that case as an option
+    @casa_cases.where!(id: params.dig(:case_contact, :casa_case_id)) if params.dig(:case_contact, :casa_case_id).present?
+
     @case_contact = CaseContact.new
-    @casa_cases = current_user.casa_cases
+  end
+
+  def create
+    @casa_cases = policy_scope(CasaCase).where(id: params.dig(:case_contact, :casa_case_id))
+
+    # Create a case contact for every case that was checked
+    case_contacts = @casa_cases.map do |casa_case|
+      casa_case.case_contacts.create(create_case_contact_params)
+    end
+
+    if case_contacts.all?(&:persisted?)
+      redirect_to root_path, notice: "Case contact was successfully created."
+    else
+      @case_contact = case_contacts.first
+      render :new
+    end
   end
 
   # GET /case_contacts/1/edit
   def edit
-    @case_contact = authorize CaseContact.find(params[:id])
-  rescue Pundit::NotAuthorizedError
-    flash[:alert] = "Sorry! You can only edit case contacts that you have logged."
-    redirect_to root_path
-  end
-
-  def create
-    casa_cases = CasaCase.where(id: params[:case_contact][:casa_case_id])
-    # Iterate over all casa_cases and put success boolean into array to decide
-    # what to render after loop finishes
-    case_contacts = casa_cases.map do |casa_case|
-      @case_contact = casa_case.case_contacts.create(create_case_contact_params)
-    end
-
-    if case_contacts.all?
-      redirect_to root_path, notice: "Case contact was successfully created."
-    else
-      render :new
-    end
+    @casa_cases = [@case_contact.casa_case]
   end
 
   # PATCH/PUT /case_contacts/1
   # PATCH/PUT /case_contacts/1.json
   def update
+    @casa_cases = [@case_contact.casa_case]
+
     respond_to do |format|
-      if @case_contact.update(case_contact_params)
+      if @case_contact.update(update_case_contact_params)
         format.html { redirect_to root_path, notice: "Case contact was successfully updated." }
         format.json { render :show, status: :ok, location: @case_contact }
       else
@@ -73,11 +76,12 @@ class CaseContactsController < ApplicationController
   private
 
   def set_case_contact
-    @case_contact = CaseContact.find(params[:id])
+    @case_contact = authorize(CaseContact.find(params[:id]))
+  rescue Pundit::NotAuthorizedError
+    flash[:alert] = "Sorry! You can only edit case contacts that you have logged."
+    redirect_to root_path
   end
 
-  # This can probably be combined with case_contact_params below, but was unsure about
-  # this line `.with_casa_case(current_user.casa_cases.first)`
   def create_case_contact_params
     CaseContactParameters
       .new(params)
@@ -85,11 +89,10 @@ class CaseContactsController < ApplicationController
       .with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
   end
 
-  def case_contact_params
+  def update_case_contact_params
+    # Updating a case contact does not change its original creator
     CaseContactParameters
       .new(params)
-      .with_creator(current_user)
-      .with_casa_case(current_user.casa_cases.first)
       .with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
   end
 end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -30,14 +30,14 @@ class CaseContactsController < ApplicationController
   end
 
   def create
+    casa_cases = CasaCase.where(id: params[:case_contact][:casa_case_id])
     # Iterate over all casa_cases and put success boolean into array to decide
     # what to render after loop finishes
-    success_array = casa_cases.each_with_object([]) do |casa_case, array|
+    case_contacts = casa_cases.map do |casa_case|
       @case_contact = casa_case.case_contacts.create(create_case_contact_params)
-      array << @case_contact.save
     end
 
-    if success_array.all? true
+    if case_contacts.all?
       redirect_to root_path, notice: "Case contact was successfully created."
     else
       render :new
@@ -76,17 +76,6 @@ class CaseContactsController < ApplicationController
     @case_contact = CaseContact.find(params[:id])
   end
 
-  def casa_cases
-    # casa_case_id params are formatted like this: {"0"=>"123", "1"=>"124", "2"=>"127"}
-    case_id_array = []
-
-    params[:case_contact][:casa_case_id].each_value do |casa_case_id|
-      case_id_array << casa_case_id
-    end
-
-    CasaCase.where(id: case_id_array)
-  end
-
   # This can probably be combined with case_contact_params below, but was unsure about
   # this line `.with_casa_case(current_user.casa_cases.first)`
   def create_case_contact_params
@@ -97,8 +86,10 @@ class CaseContactsController < ApplicationController
   end
 
   def case_contact_params
-    CaseContactParameters.new(params).with_creator(current_user).with_casa_case(
-      current_user.casa_cases.first
-    ).with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
+    CaseContactParameters
+      .new(params)
+      .with_creator(current_user)
+      .with_casa_case(current_user.casa_cases.first)
+      .with_converted_duration_minutes(params[:case_contact][:duration_hours].to_i)
   end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -6,7 +6,7 @@ class CasaCase < ApplicationRecord
   has_many :case_contacts
   validates :case_number, uniqueness: {case_sensitive: false}, presence: true
 
-  scope :ordered, -> { sort_by(&:updated_at).reverse }
+  scope :ordered, -> { order(updated_at: :desc) }
   scope :actively_assigned_to,
     lambda { |volunteer|
       joins(:case_assignments).where(

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -21,11 +21,6 @@ class CaseContactParameters < SimpleDelegator
     self
   end
 
-  def with_casa_case(casa_case)
-    params[:casa_case] = casa_case
-    self
-  end
-
   def with_converted_duration_minutes(duration_hours)
     converted_duration_hours = duration_hours * 60
     duration_minutes = params[:duration_minutes].to_i

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -3,6 +3,9 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1>CASA Case Details</h1>
+    <%- if policy(:case_contact).new? %>
+      <%= link_to "New Case Contact", new_case_contact_path(case_contact: { casa_case_id: @casa_case.id }), class: "btn btn-primary" %>
+    <%- end %>
     <%= link_to 'Edit Case Details', edit_casa_case_path(@casa_case), class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -19,7 +19,7 @@
     <% end %>
     <% current_user.casa_cases.each_with_index do |casa_case, index| %>
       <div class="form-check">
-        <input class="form-check-input casa-case-id-check" type="checkbox" value="<%= casa_case.id %>" name="case_contact[casa_case_id][<%= index %>]" <% if index.zero? %>checked required<% end %>>
+        <input class="form-check-input casa-case-id-check" type="checkbox" value="<%= casa_case.id %>" name="case_contact[casa_case_id][]" <% if index.zero? %>checked required<% end %>>
         <label class="form-check-label" for="casa-case-id-check">
           <%= casa_case.case_number %>
         </label>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -12,12 +12,12 @@
   <% end %>
 
   <div class="field casa-case form-group">
-    <% if current_user.casa_cases.length > 1 %>
+    <% if casa_cases.length > 1 %>
       <label for="case_contact_casa_case">Select all relevant CASA cases</label>
     <% else %>
       <label for="case_contact_casa_case">CASA case</label>
     <% end %>
-    <% current_user.casa_cases.each_with_index do |casa_case, index| %>
+    <% casa_cases.each_with_index do |casa_case, index| %>
       <div class="form-check">
         <input class="form-check-input casa-case-id-check" type="checkbox" value="<%= casa_case.id %>" name="case_contact[casa_case_id][]" <% if index.zero? %>checked required<% end %>>
         <label class="form-check-label" for="casa-case-id-check">

--- a/app/views/case_contacts/edit.html.erb
+++ b/app/views/case_contacts/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row">
   <div class="col-sm-6">
-    <%= render 'form', case_contact: @case_contact %>
+    <%= render 'form', case_contact: @case_contact, casa_cases: @casa_cases %>
   </div>
 </div>
 

--- a/app/views/case_contacts/new.html.erb
+++ b/app/views/case_contacts/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="row">
   <div class="col-sm-6">
-    <%= render 'form', case_contact: @case_contact %>
+    <%= render 'form', case_contact: @case_contact, casa_cases: @casa_cases %>
   </div>
 </div>
 

--- a/app/views/case_contacts/show.html.erb
+++ b/app/views/case_contacts/show.html.erb
@@ -5,7 +5,7 @@
 
 <p>
   <strong>CASA Case:</strong>
-  <%= @case_contact_number %>
+  <%= @case_contact.casa_case.case_number %>
 </p>
 
 <p>

--- a/spec/features/admin_adds_a_case_contact_spec.rb
+++ b/spec/features/admin_adds_a_case_contact_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "admin or supervisor adds a case contact", type: :feature do
+  it "is successful" do
+    admin = create(:user, :casa_admin)
+    casa_case = create(:casa_case)
+
+    sign_in admin
+
+    visit casa_case_path(casa_case.id)
+    click_on "New Case Contact"
+
+    find(:css, "input.casa-case-id-check[value='#{casa_case.id}']").set(true)
+    find(:css, "input.casa-case-contact-type[value='school']").set(true)
+    find(:css, "input.casa-case-contact-type[value='therapist']").set(true)
+    select "1 hour", from: "case_contact[duration_hours]"
+    select "45 minutes", from: "case_contact[duration_minutes]"
+    fill_in "case_contact_occurred_at", with: "04/04/2020"
+
+    expect {
+      click_on "Submit"
+    }.to change(CaseContact, :count).by(1)
+
+    expect(CaseContact.first.casa_case_id).to eq casa_case.id
+    expect(CaseContact.first.contact_types).to include "school"
+    expect(CaseContact.first.contact_types).to include "therapist"
+    expect(CaseContact.first.duration_minutes).to eq 105
+  end
+end

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -3,10 +3,9 @@ require "rails_helper"
 describe "case_contacts/edit" do
 
   it "is listing all the contact methods from the model" do
-    assign :case_contact, create(:case_contact)
-
-    user = build_stubbed(:user, :volunteer)
-    allow(view).to receive(:current_user).and_return(user)
+    case_contact = create(:case_contact)
+    assign :case_contact, case_contact
+    assign :casa_cases, [case_contact.casa_case]
 
     contact_types = CaseContact::CONTACT_TYPES.each_with_index do |contact_type, index|
       render template: "case_contacts/edit"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #426
Resolves #393

### What changed, and why?
* Make sure all models in CaseContactsController run through Pundit for authorization.
* Allow CaseContactsController#new to accept URL params to specify which cases to display as checkboxes. Otherwise, admins and supervisors would see an unweildy list as they can create contacts for any case.
* Create 'New Case Contact' button on case details page as described in #393.
* Inadvertently fix #426 along the way: no longer reset `creator` for updates.

### How will this affect user permissions?

As far as I know, no permissions are changed (no policies were changed), but we do enforce them more consistently in CaseContactsController.

### How is this tested? (please write tests!) 💖💪

There's a new feature spec, and I updated several request and view specs along the way.

### Screenshots please :)

![Screenshot 2020-07-25 at 10 47 03](https://user-images.githubusercontent.com/395621/88459550-47826200-ce64-11ea-8d9d-ea3b5b3ca3aa.png)
