### PR TITLE
Allow volunteers to be re-activated

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -35,6 +35,15 @@ class VolunteersController < ApplicationController
     end
   end
 
+  def activate
+    @volunteer = User.find(params[:id])
+    if @volunteer.update(role: "volunteer")
+      redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated."
+    else
+      render :edit
+    end
+  end
+
   def deactivate
     @volunteer = User.find(params[:id])
 

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -54,6 +54,12 @@
           <div class="alert alert-danger">
             Volunteer was deactivated on: <%= @volunteer.updated_at.strftime("%m-%d-%Y") %>
           </div>
+          <% if current_user.role == "casa_admin" || @volunteer.supervisor == current_user %>
+            <%= link_to "Activate volunteer",
+                        activate_volunteer_path(@volunteer),
+                        method: :patch,
+                        class: "btn btn-outline-success" %>
+          <% end %>
         <% end %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :supervisor_volunteers, only: %i[create destroy]
   resources :volunteers, only: %i[new edit create update] do
     member do
+      patch :activate
       get :deactivate
       patch :deactivate
     end

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -22,4 +22,18 @@ RSpec.describe "Admin: Editing Volunteers", type: :system do
       volunteer.reload
     }.to change { volunteer.role }.from("volunteer").to("inactive")
   end
+
+  it "allows an admin to reactivate a volunteer" do
+    volunteer = create(:user, :volunteer, role: "inactive")
+    sign_in admin
+    visit edit_volunteer_path(volunteer)
+
+    click_on "Activate volunteer"
+
+    expect(page).not_to have_text('Volunteer was deactivated on')
+
+    expect {
+      volunteer.reload
+    }.to change { volunteer.role }.from("inactive").to("volunteer")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #353

### What changed, and why?

Adds button and functionality to activate an inactive volunteer.


### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: Their assigned volunteers may be reactivated
- Admin permissions: All volunteers may be reactivated

### How is this tested? (please write tests!) 💖💪

Spec included. Also tested in local environment.


### Screenshots please :)

<img width="1552" alt="Screen Shot 2020-07-25 at 17 21 16" src="https://user-images.githubusercontent.com/167131/88466550-88e23400-ce9b-11ea-87ef-a1bc45168b2c.png">


### Feelings gif (optional)

