### PR TITLE
Require case assignments to be to active volunteers

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -4,7 +4,12 @@ class CaseAssignmentsController < ApplicationController
 
   def create
     case_assignment = case_assignment_parent.case_assignments.new(case_assignment_params)
-    case_assignment.save
+    if case_assignment.save
+      flash.notice = "Volunteer assigned to case"
+    else
+      errors = case_assignment.errors.full_messages.join(". ")
+      flash.alert = "Unable to assign volunteer to case: #{errors}."
+    end
 
     redirect_to after_action_path(case_assignment_parent)
   end

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -5,6 +5,12 @@ class CaseAssignment < ApplicationRecord
   belongs_to :volunteer, class_name: "User", inverse_of: "case_assignments"
 
   validates :casa_case_id, uniqueness: {scope: :volunteer_id} # only 1 row allowed per case-volunteer pair
+  validates :volunteer, presence: true
+  validate :assignee_must_be_volunteer
+
+  def assignee_must_be_volunteer
+    errors.add(:volunteer, "Case assignee must be a volunteer") unless volunteer.active_volunteer
+  end
 end
 
 # == Schema Information

--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CaseAssignment do
+  it "should only allow active volunteers to be assigned" do
+    casa_case = create(:casa_case)
+    volunteer = create(:user, :volunteer)
+    inactive = create(:user, :inactive)
+    supervisor = create(:user, :supervisor)
+
+    expect(casa_case.case_assignments.new(volunteer: volunteer)).to be_valid
+    casa_case.reload
+
+    expect(casa_case.case_assignments.new(volunteer: inactive)).to be_invalid
+    casa_case.reload
+
+    expect(casa_case.case_assignments.new(volunteer: supervisor)).to be_invalid
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #340 

### What changed, and why?

In #340, it is reported that a case can be assigned to a Supervisor. I could not find a way to do this without either hacking the form using browser developer tools or changing the select box to include supervisors. Regardless, it was not prevented server-side, so the issue makes sense.

This PR adds a validation on case assignments to prevent any assignment to anything other than an active volunteer. Additionally, it adds a flash notification (where there was not one previously) to confirm the action when an assignment is made. See screenshots for examples.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

New spec file added for case_assignment model.

### Screenshots please :)

<img width="1163" alt="Screen Shot 2020-07-25 at 18 55 40" src="https://user-images.githubusercontent.com/167131/88467755-75899580-cea8-11ea-8407-61c49eadc284.png">
<img width="1163" alt="Screen Shot 2020-07-25 at 18 51 11" src="https://user-images.githubusercontent.com/167131/88467757-77ebef80-cea8-11ea-934c-8dc0abd55cf8.png">



