### PR TITLE
Issue 408 -  Sets the "occurred at" field value as the occurred time when editing contact case

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -82,7 +82,8 @@
 
   <div class="field occurred-at form-group">
     <%= form.label :occurred_at %>
-    <%= form.date_field :occurred_at, value: Time.now.strftime('%Y-%m-%d'), class: "form-control" %>
+    <% occurred_at = @case_contact.occurred_at.present? ? @case_contact.occurred_at : Time.zone.now %>
+    <%= form.date_field :occurred_at, value: occurred_at.strftime('%Y-%m-%d'), class: "form-control" %>
   </div>
 
   <div class="field miles-driven form-group">

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -12,4 +12,17 @@ describe "case_contacts/edit" do
       expect(rendered).to include(contact_type)
     end
   end
+  
+  it "displays occurred time in the occurred at form field" do
+    case_contact = create(:case_contact)
+    case_contact.occurred_at = Time.zone.now - (3600 * 24)
+    assign :case_contact, case_contact
+    assign :casa_cases, [case_contact.casa_case]
+
+    user = build_stubbed(:user, :volunteer)
+    allow(view).to receive(:current_user).and_return(user)
+
+    render template: "case_contacts/edit"
+    expect(rendered).to include(case_contact.occurred_at.strftime('%Y-%m-%d'))
+  end
 end

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "case_contacts/new" do
+  it  "displays current time in the occurred at form field" do 
+    case_contact = create(:case_contact)
+    assign :case_contact, case_contact
+    assign :casa_cases, [case_contact.casa_case]
+
+    user = build_stubbed(:user, :volunteer)
+    allow(view).to receive(:current_user).and_return(user)
+
+    render template: "case_contacts/new"
+    expect(rendered).to include(Time.zone.now.strftime('%Y-%m-%d'))
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #408 

### What changed, and why?
The form template for a case contact now checks if the "occurred at" value is present and uses that for the "Occurred at" form field value. This change was made because the form template is used in both the "new" and "edit" forms and caused an overwrite when editing an existing case contact since it was always setting it to the current time. This unintended update was then reflected in the table row display. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
* Added test to check that when editing an existing case contact, the "occurred at" form field was set to the occurred time when present.
* Added test to check that when creating a new case contact, the "occurred at" form field was set to the current time. 

### Screenshots please :)

When updating:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/18248767/88468497-b1295d00-ceb2-11ea-958c-bb44ca1f6690.png">

After updating:
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/18248767/88468494-ae2e6c80-ceb2-11ea-990b-38081d4b7473.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
