### PR TITLE
Allow users to change their passwords.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "bootstrap", "~> 4.5.0" # frontend styling library
 gem "devise" # for authentication
 gem "draper" # adds decorators for cleaner presentation logic
 gem "faker" # creates realistic seed data, valuable for staging and demos
+gem "font-awesome-rails"
 gem "jbuilder", "~> 2.7" # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jquery-datatables-rails", "~> 3.4.0"
 gem "jquery-rails" # Add jquery to asset pipeline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       i18n (>= 1.6, < 2)
     ffi (1.12.2)
     ffi (1.12.2-x64-mingw32)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     http-cookie (1.0.3)
@@ -376,6 +378,7 @@ DEPENDENCIES
   draper
   factory_bot_rails
   faker
+  font-awesome-rails
   jbuilder (~> 2.7)
   jquery-datatables-rails (~> 3.4.0)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "bootstrap";
 @import "dataTables/jquery.dataTables";
 @import 'bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css';
+@import "font-awesome";
 
 @import "shared/flashes";
 @import "shared/footer";

--- a/app/assets/stylesheets/shared/flashes.scss
+++ b/app/assets/stylesheets/shared/flashes.scss
@@ -3,3 +3,7 @@
   padding: 8px;
   margin: 12px 0;
 }
+
+.alert-dismissible .close {
+  padding: 0.5rem 0.75rem;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,13 +9,29 @@ class UsersController < ApplicationController
     @user = current_user
 
     if @user.update(user_params)
-      redirect_to edit_users_path, notice: "Profile was successfully updated."
+      flash[:success] = "Profile was successfully updated."
+      redirect_to edit_users_path
     else
       render :edit
     end
   end
 
+  def update_password
+    @user = current_user
+    if @user.update(password_params)
+      bypass_sign_in(@user)
+      flash[:success] = "Password was successfully updated."
+      redirect_to edit_users_path
+    else
+      render "edit"
+    end
+  end
+
   private
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
 
   def user_params
     if current_user.casa_admin?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,28 @@ module ApplicationHelper
       link_to("Log in", new_user_session_path, class: "btn btn-light")
     end
   end
+
+  def flash_class(level)
+    case level
+    when "notice" then "alert notice alert-info"
+    when "success" then "alert success alert-success"
+    when "error" then "alert error alert-danger"
+    when "alert" then "alert alert-warning"
+    end
+  end
+
+  def errors_for(object)
+    if object.errors.any?
+      content_tag(:div, class: "card border-danger") do
+        concat(content_tag(:div, class: "card-header bg-danger text-white") do
+          concat "#{pluralize(object.errors.count, "error")} prohibited this #{object.class.name.downcase} from being saved:"
+        end)
+        concat(content_tag(:ul, class: 'mb-0 list-group list-group-flush') do
+          object.errors.full_messages.each do |msg|
+            concat content_tag(:li, msg, class: 'list-group-item')
+          end
+        end)
+      end
+    end
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,6 +16,12 @@ require("src/new_casa_contact")
 
 import "bootstrap"
 
+window.setTimeout(function() {
+  $(".alert").not(".error").fadeTo(1000, 0).slideUp(1000, function() {
+    $(this).remove();
+  });
+}, 2500);
+
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn btn-info' %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,10 +15,11 @@
     <main>
       <div class="container">
         <div class="header-flash">
-          <% if notice %>
-            <p class="notice alert alert-success"><%= notice %></p>
-          <% elsif alert %>
-            <p class="notice alert alert-danger"><%= alert %></p>
+          <% flash.each do |key, value| %>
+            <div class="<%= flash_class(key) %> alert-dismissible fade show" role="alert">
+              <a href="#" class="close" data-dismiss="alert" aria-label="Close" style="text-decoration: none;"><%= fa_icon('times') %></a>
+              <%= sanitize(value, tags: %w(ul li)) %>
+            </div>
           <% end %>
         </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,21 +1,10 @@
-<%= link_to "Back", root_path %>
+<%= errors_for(@user) %>
 
 <h1>Edit Profile</h1>
 
 <div class="row">
   <div class="col-sm-6">
     <%= form_for @user, url: users_path do |form| %>
-      <% if @user.errors.any? %>
-        <div id="error_explanation">
-          <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
-          <ul>
-            <% user.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
 
       <div class="field form-group">
         <%= form.label :email %>
@@ -31,7 +20,28 @@
 
       <div class="actions">
         <%= form.submit "Update Profile", class: "btn btn-primary" %>
+        <%= link_to "Back", root_path, class: "btn btn-primary"  %>
+        <button class="btn btn-warning accordion"  id="accordionExample" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+          Change Password
+        </button>
       </div>
-    <% end %>
+      <% end %>
+      <br>
+      <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+        <%= form_for(@user, :url => { :action => "update_password" } ) do |f| %>
+          <div class="field form-group">
+            <%= f.label :password, "Password" %><br />
+            <%= f.password_field :password, :autocomplete => "off", class: "form-control"  %>
+          </div>
+          <div class="field form-group">
+            <%= f.label :password_confirmation, "Password Confirmation" %><br />
+            <%= f.password_field :password_confirmation, class: "form-control" %>
+          </div>
+          <div class="action_container">
+            <%= f.submit "Update Password", class: "btn btn-danger" %>
+          </div>
+        <% end %>
+      </div>
+      <br>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     collection do
       get :edit
       patch :update
+      patch 'update_password'
     end
   end
 end

--- a/spec/system/edit_user_system_spec.rb
+++ b/spec/system/edit_user_system_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Editing Profile", type: :system do
+  let(:volunteer) { create(:user, :volunteer) }
+
+  it "displays password errors messages when user is unable to set a password", js: true do
+    sign_in volunteer
+    visit edit_users_path
+
+    click_on "Change Password"
+
+    fill_in "Password", with: "123"
+    fill_in "Password Confirmation", with: "1234"
+
+    click_on "Update Password"
+
+    expect(page).to have_text("Password confirmation doesn't match Password")
+    expect(page).to have_text("Password is too short (minimum is 6 characters)")
+  end
+
+  it "notifies a user when they update their password", js: true do
+    sign_in volunteer
+    visit edit_users_path
+
+    click_on "Change Password"
+
+    fill_in "Password", with: "1234567"
+    fill_in "Password Confirmation", with: "1234567"
+
+    click_on "Update Password"
+
+    expect(page).to have_text("Password was successfully updated.")
+  end
+end


### PR DESCRIPTION
 Add in some error helpers. Font Awesome. And a bit more.

This resolves #189 

At the core this resolves #189 allowing folks to change their password. We already have the ability for folks to reset their password if they forgot it so the work done, primarily, is for logged in folks.

A summary of stuff with pictures:
-Changed the forgot password button link on the sign-in page to a button to make it more obvious it exists:

![image](https://user-images.githubusercontent.com/667909/88468655-d0c18500-ceb4-11ea-9ef8-5ffda01f0bca.png)

becomes: 

![image](https://user-images.githubusercontent.com/667909/88468659-e3d45500-ceb4-11ea-8c7c-4a731922b691.png)

Next I changed the edit profile page around a bit:

![edit_profit](https://user-images.githubusercontent.com/667909/88468685-272ec380-ceb5-11ea-9329-b84229c34ac3.jpg)

becomes:

![new_profile](https://user-images.githubusercontent.com/667909/88468703-52b1ae00-ceb5-11ea-824a-3586789fb57e.jpg)

When you click the change password button it opens up the following:

![change_password](https://user-images.githubusercontent.com/667909/88468715-7b39a800-ceb5-11ea-922f-dc366f1802b4.jpg)

I also added in a helper method with styling for the error messages so they are not plain text and more visible. 
So, rather than doing something like this in our views:
```
      <% if @user.errors.any? %>	
        <div id="error_explanation">	
          <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>	

          <ul>	
            <% user.errors.full_messages.each do |message| %>	
              <li><%= message %></li>	
            <% end %>	
          </ul>	
        </div>	
      <% end %>
```
We can just do `<%= errors_for(@user) %>`

Error messages now look like this: 

![error messages](https://user-images.githubusercontent.com/667909/88468734-cb186f00-ceb5-11ea-9ede-b33c0482331e.jpg)

I also updated the flash messages how they are shown in the `application.html.erb` and made them dismissible. I also added in `font-awesome-rails` to the gemfile to put in an X into the alerts. (Plus it is handy to use elsewhere)

I also put in a tiny javascript function that will auto close alerts from pages after a couple of seconds.

The new alerts look like this:

![alerts](https://user-images.githubusercontent.com/667909/88468789-978a1480-ceb6-11ea-97d5-188d6aca03b9.jpg)

It is still a WIP because I have a couple questions:

How is the team testing stuff that overlaps with gems? I'm happy to add in tests for the changing password functionality but it kind of feels like I'm testing stuff that overlaps with devise and didn't want to add cruft to the app.

I also added in Font Awesome which you all may not be cool with.

I'm also not sure where that tiny js function should live -- it is currently in `application.js`.

Let me know what you want me to do with all this and I'll move it forward.
