### PR TITLE
435 Add Transition Aged Youth emoji to Volunteer page

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -5,6 +5,10 @@ class CasaCaseDecorator < Draper::Decorator
     object.transition_aged_youth ? "Yes 🐛🦋" : "No"
   end
 
+  def transition_aged_youth_only_icon
+    object.transition_aged_youth ? "🐛🦋" : ""
+  end
+
   def case_contacts_ordered_by_occurred_at
     object.case_contacts.sort_by(&:occurred_at)
   end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-sm-12 form-header">
-    <h1>CASA Case Details</h1>
+    <h1><%= @casa_case.decorate.transition_aged_youth_only_icon %> CASA Case Details</h1>
     <%- if policy(:case_contact).new? %>
       <%= link_to "New Case Contact", new_case_contact_path(case_contact: { casa_case_id: @casa_case.id }), class: "btn btn-primary" %>
     <%- end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #435 

### What changed, and why?
Add Transition Aged Youth emoji to Volunteer page(to h1 title)

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
N/A But passed all old tests

### Screenshots please :)
<img width="1337" alt="PG CASA 2020-07-26 10-22-12" src="https://user-images.githubusercontent.com/1007159/88473908-9db9d880-cf2a-11ea-9069-93111c9656a8.png">

