### PR TITLE
Enforce server-side that at least one case must be selected

### DIFF
--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe "/case_contacts", type: :request do
         expect(response).to be_successful
       end
     end
+
+    context "with no cases selected" do
+      it "presents the user with a relevant error message" do
+        expect {
+          post case_contacts_url, params: {
+            case_contact: valid_attributes.merge(casa_case_id: []),
+          }
+        }.to change(CaseContact, :count).by(0)
+
+        expect(response).to be_successful
+        expect(flash[:alert]).to be_present
+      end
+    end
   end
 
   describe "PATCH /update" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #268

### What changed, and why?
There's already client-side validation to make sure a user selects at least one case, but this should also be present server-side in case a browser doesn't enforce it properly.

Additionally, if a user is not assigned any cases at all, there will be no checkboxes to select, so the client-side validation may be inadvertently bypassed.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

Via local development environment and a new request spec.

I waffled on introducing a higher level feature spec, but decided against it because it seemed like an edge case. I'd be happy to take in feedback about this decision though.

### Screenshots please :)
![Screenshot 2020-07-26 at 21 54 53](https://user-images.githubusercontent.com/395621/88496321-c5d92400-cf8a-11ea-8f53-681ea4425962.png)
