### PR TITLE
Allow admins to import volunteers, supervisors, and cases.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 6.0.3"
 gem "awesome_print" # easier console reading
 gem "bootstrap", "~> 4.5.0" # frontend styling library
 gem "devise" # for authentication
+gem 'devise_invitable'
 gem "draper" # adds decorators for cleaner presentation logic
 gem "faker" # creates realistic seed data, valuable for staging and demos
 gem "font-awesome-rails"
@@ -43,6 +44,7 @@ group :development do
   gem "annotate" # for adding db field listings to models as comments
   gem "letter_opener" # Opens emails in new tab for easier testing
   gem "listen", ">= 3.0.5", "< 3.3"
+  gem "mailcatcher"
   gem "spring" # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0" # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,12 +97,16 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    daemons (1.3.1)
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise_invitable (2.0.1)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -114,6 +118,8 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
     erubi (1.9.0)
+    eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -128,6 +134,9 @@ GEM
       railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    haml (5.1.2)
+      temple (>= 0.8.0)
+      tilt
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.3)
@@ -143,6 +152,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -155,6 +165,16 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     mailgun-ruby (1.2.0)
       rest-client (~> 2.0.2)
     marcel (0.3.3)
@@ -169,6 +189,8 @@ GEM
     minitest (5.14.1)
     msgpack (1.3.3)
     msgpack (1.3.3-x64-mingw32)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.10)
@@ -197,6 +219,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.2.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -279,6 +303,7 @@ GEM
     rubocop-rspec (1.42.0)
       rubocop (>= 0.87.0)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -302,6 +327,14 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     skylight (4.3.1)
       skylight-core (= 4.3.1)
     skylight-core (4.3.1)
@@ -317,10 +350,18 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.4.2)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     standard (0.0.36)
       rubocop (>= 0.63)
     standardrb (1.0.0)
       standard
+    temple (0.8.2)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -375,6 +416,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  devise_invitable
   draper
   factory_bot_rails
   faker
@@ -384,6 +426,7 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   listen (>= 3.0.5, < 3.3)
+  mailcatcher
   mailgun-ruby
   paper_trail
   pg (>= 0.18, < 2.0)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,24 @@
+class ImportsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :must_be_admin
+
+  def index; end
+
+  def import_volunteers
+    FileImporter.import_volunteers(params[:file], current_user.casa_org_id)
+    flash[:success] = "Volunteers imported"
+    redirect_to imports_path
+  end
+
+  def import_supervisors
+    FileImporter.import_supervisors(params[:file], current_user.casa_org_id)
+    flash[:success] = "Supervisors imported"
+    redirect_to imports_path
+  end
+
+  def import_cases
+    User.import_volunteers(params[:file], current_user.casa_org_id)
+    flash[:success] = "Cases imported"
+    redirect_to imports_path
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,6 @@
 class ReportsController < ApplicationController
   before_action :authenticate_user!
+  before_action :must_be_admin
 
   def index; end
 end

--- a/app/models/concerns/file_importer.rb
+++ b/app/models/concerns/file_importer.rb
@@ -1,0 +1,42 @@
+class FileImporter
+  require "csv"
+
+  def self.import_volunteers(import_csv, org_id)
+    CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
+      user = User.new(row.to_hash)
+      user.role = "volunteer"
+      user.casa_org_id = org_id
+      user.password = "123456"
+      if user.save
+        user.invite!
+      end
+    end
+  end
+
+  def self.import_supervisors(import_csv, org_id)
+    CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
+      user = User.new(email: row[:email], display_name: row[:display_name])
+      user.role = "supervisor"
+      user.casa_org_id = org_id
+      user.password = "123456"
+      if user.save
+        user.invite!
+        volunteers = row[:supervisor_volunteers]
+        lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
+        user.volunteers << lookups.compact if lookups.compact.present?
+      end
+    end
+  end
+
+  def self.import_cases(import_csv, org_id)
+    CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
+      casa_case = CasaCase.new(case_number: row[:case_number], transition_aged_youth: row[:transition_aged_youth])
+      if casa_case.save
+        volunteers = row[:case_assignment]
+        lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
+        casa_case.volunteers << lookups.compact if lookups.compact.present?
+      end
+    end
+  end
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # model for all user roles: volunteer supervisor casa_admin inactive
 class User < ApplicationRecord
   has_paper_trail
-  devise :database_authenticatable, :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :invitable, :recoverable, :rememberable, :validatable
 
   belongs_to :casa_org
 
@@ -78,6 +78,13 @@ end
 #  display_name           :string           default("")
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  invited_by_type        :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
@@ -85,12 +92,17 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  casa_org_id            :bigint           not null
+#  invited_by_id          :bigint
 #
 # Indexes
 #
-#  index_users_on_casa_org_id           (casa_org_id)
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_casa_org_id                        (casa_org_id)
+#  index_users_on_email                              (email) UNIQUE
+#  index_users_on_invitation_token                   (invitation_token) UNIQUE
+#  index_users_on_invitations_count                  (invitations_count)
+#  index_users_on_invited_by_id                      (invited_by_id)
+#  index_users_on_invited_by_type_and_invited_by_id  (invited_by_type,invited_by_id)
+#  index_users_on_reset_password_token               (reset_password_token) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,22 @@
+<h2><%= t "devise.invitations.edit.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :invitation_token, readonly: true %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <% resource.class.invite_key_fields.each do |field| -%>
+    <div class="field">
+      <%= f.label field %><br />
+      <%= f.text_field field %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.new.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,18 @@
+<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      A CASA/Prince George’s County volunteer console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new volunteer account.
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
+    </td>
+  </tr>
+</table>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,18 @@
+<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      A CASA/Prince George’s County volunteer console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new volunteer account.
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
+    </td>
+  </tr>
+</table>

--- a/app/views/imports/_cases.html.erb
+++ b/app/views/imports/_cases.html.erb
@@ -1,0 +1,20 @@
+<h3><i class="fa fa-download fa-2x" aria-hidden="true"></i> 1. Download example Case CSV file</h3>
+<%= link_to "/casa_cases.csv", format: :csv, class: "btn btn-xs btn-success" do %>
+  <i class="fa fa-download"></i> Download example Case csv
+<% end %>
+<br>
+<br>
+<h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
+<%= form_with(url: import_cases_imports_path, local: :true) do |f| %>
+  <ul>
+    <li>Click the choose file button and navigate to the saved file and select it.</li>
+    <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
+    <li>Then click the "Import Cases CSV" button to import your cases.</li>
+
+  </ul>
+  <%= f.file_field :file, accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
+  <br>
+  <%= button_tag :class => "btn btn-md btn-success" do %>
+    <i class="fa fa-upload"></i> Import Cases CSV
+  <% end %>
+<% end %>

--- a/app/views/imports/_supervisors.html.erb
+++ b/app/views/imports/_supervisors.html.erb
@@ -1,0 +1,21 @@
+<h3><i class="fa fa-download fa-2x" aria-hidden="true"></i> 1. Download example Supervisor CSV file</h3>
+<%= link_to "/supervisors.csv", format: :csv, class: "btn btn-xs btn-success" do %>
+  <i class="fa fa-download"></i> Download
+  example supervisor csv
+<% end %>
+<br>
+<br>
+<h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
+<%= form_with(url: import_supervisors_imports_path, local: :true) do |f| %>
+  <ul>
+    <li>Click the choose file button and navigate to the saved file and select it.</li>
+    <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
+    <li>Then click the "Import Supervisors CSV" button to import your supervisors.</li>
+
+  </ul>
+  <%= f.file_field :file, accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
+  <br>
+  <%= button_tag :class => "btn btn-md btn-success" do %>
+    <i class="fa fa-upload"></i> Import Supervisors CSV
+  <% end %>
+<% end %>

--- a/app/views/imports/_volunteers.html.erb
+++ b/app/views/imports/_volunteers.html.erb
@@ -1,0 +1,21 @@
+<h3><i class="fa fa-download fa-2x" aria-hidden="true"></i> 1. Download example Volunteer CSV file</h3>
+<%= link_to "/volunteers.csv", format: :csv, class: "btn btn-xs btn-success" do %>
+  <i class="fa fa-download"></i> Download
+  example volunteer csv
+<% end %>
+<br>
+<br>
+<h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
+<%= form_with(url: import_volunteers_imports_path, local: :true) do |f| %>
+  <ul>
+    <li>Click the choose file button and navigate to the saved file and select it.</li>
+    <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
+    <li>Then click the "Import Volunteers CSV" button to import your volunteers.</li>
+
+  </ul>
+  <%= f.file_field :file, accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
+  <br>
+  <%= button_tag :class => "btn btn-md btn-success" do %>
+    <i class="fa fa-upload"></i> Import Volunteers CSV
+  <% end %>
+<% end %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -1,0 +1,56 @@
+<div class="row">
+  <div class="col-sm-12">
+    <h1>Import Categories</h1>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="col-sm-12">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title"><strong>System Imports</strong></h5>
+        <p class="card-text">
+          You should import files in the following order:
+        <ol>
+          <li>Volunteers</li>
+          <li>Supervisors</li>
+          <li>Cases</li>
+        </ol>
+        </p>
+        <br>
+        <div class="row">
+          <ul class="nav nav-pills" id="pills-tab" role="tablist">
+            <li class="nav-item">
+              <a class="nav-link active" id="pills-volunteer-tab" data-toggle="pill" href="#pills-volunteer" role="tab" aria-controls="pills-volunteer" aria-selected="true">Import
+                Volunteers</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" id="pills-supervisor-tab" data-toggle="pill" href="#pills-supervisor" role="tab" aria-controls="pills-supervisor" aria-selected="false">Import
+                Supervisors</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" id="pills-cases-tab" data-toggle="pill" href="#pills-cases" role="tab" aria-controls="pills-cases" aria-selected="false">Import
+                Cases</a>
+            </li>
+          </ul>
+          <div class="tab-content" id="pills-tabContent">
+            <div class="tab-pane fade show active" id="pills-volunteer" role="tabpanel" aria-labelledby="pills-volunteer-tab">
+              <br>
+              <%= render "volunteers" %>
+            </div>
+            <div class="tab-pane fade" id="pills-supervisor" role="tabpanel" aria-labelledby="pills-supervisor-tab">
+              <br>
+              <%= render "supervisors" %>
+            </div>
+            <div class="tab-pane fade" id="pills-cases" role="tabpanel" aria-labelledby="pills-cases-tab">
+              <br>
+              <%= render "cases" %>
+            </div>
+          </div>
+        </div>
+        <br>
+      </div>
+    </div>
+    <%= link_to 'Return to Dashboard', root_path, class: 'btn btn-info' %>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,6 +16,7 @@
 
             <% if current_user.role == "casa_admin" %>
               <%= link_to "Generate Reports", reports_path, class: "dropdown-item" %>
+              <%= link_to "System Imports", imports_path, class: "dropdown-item" %>
             <% end %>
           </div>
         </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,10 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 } # for devise authentication
 
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025, domain: '127.0.0.1' }
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,6 +122,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  # config.invite_for = 2.weeks
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,13 @@ Rails.application.routes.draw do
   resources :casa_cases
   resources :case_contacts
   resources :reports, only: %i[index]
+  resources :imports, only: %i[index] do
+    collection do
+      post :import_volunteers
+      post :import_supervisors
+      post :import_cases
+    end
+  end
   resources :case_contact_reports, only: %i[index]
 
   resources :supervisors, only: %i[edit update]

--- a/db/migrate/20200726185103_devise_invitable_add_to_users.rb
+++ b/db/migrate/20200726185103_devise_invitable_add_to_users.rb
@@ -1,0 +1,23 @@
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[6.0]
+  def up
+    change_table :users do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitations_count
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :users do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token, :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_25_220759) do
+ActiveRecord::Schema.define(version: 2020_07_26_185103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,8 +89,20 @@ ActiveRecord::Schema.define(version: 2020_05_25_220759) do
     t.string "role", default: "volunteer", null: false
     t.bigint "casa_org_id", null: false
     t.string "display_name", default: ""
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["casa_org_id"], name: "index_users_on_casa_org_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitations_count"], name: "index_users_on_invitations_count"
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/public/casa_cases.csv
+++ b/public/casa_cases.csv
@@ -1,0 +1,3 @@
+﻿case_number,transition_aged_youth,case_assignment
+CINA-01-4347,TRUE,volunteer1@example.net
+CINA-01-4348,FALSE,"volunteer2@example.net, volunteer3@example.net"

--- a/public/supervisors.csv
+++ b/public/supervisors.csv
@@ -1,0 +1,3 @@
+﻿email,display_name,supervisor_volunteers
+supervisor1@example.net,Supervisor One,volunteer1@example.net
+supervisor2@example.net,Supervisor Two,"volunteer2@example.net, volunteer3@example.net"

--- a/public/volunteers.csv
+++ b/public/volunteers.csv
@@ -1,0 +1,4 @@
+﻿display_name,email
+Volunteer One,volunteer1@example.net
+Volunteer Two,volunteer2@example.net
+Volunteer Three,volunteer3@example.net

--- a/spec/fixtures/casa_cases.csv
+++ b/spec/fixtures/casa_cases.csv
@@ -1,0 +1,3 @@
+﻿case_number,transition_aged_youth,case_assignment
+CINA-01-4347,TRUE,volunteer1@example.net
+CINA-01-4348,FALSE,"volunteer2@example.net, volunteer3@example.net"

--- a/spec/fixtures/supervisors.csv
+++ b/spec/fixtures/supervisors.csv
@@ -1,0 +1,3 @@
+﻿email,display_name,supervisor_volunteers
+supervisor1@example.net,Supervisor One,volunteer1@example.net
+supervisor2@example.net,Supervisor Two,"volunteer2@example.net, volunteer3@example.net"

--- a/spec/fixtures/volunteers.csv
+++ b/spec/fixtures/volunteers.csv
@@ -1,0 +1,4 @@
+﻿display_name,email
+Volunteer One,volunteer1@example.net
+Volunteer Two,volunteer2@example.net
+Volunteer Three,volunteer3@example.net

--- a/spec/models/file_importer_spec.rb
+++ b/spec/models/file_importer_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe FileImporter, type: :concern do
+
+  describe "#import_volunteers" do
+
+    it "imports volunteers from a csv file" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      expect { FileImporter.import_volunteers(import_file_path, import_user.casa_org.id) }.to change(User, :count).by(3)
+    end
+
+    it "does not import duplicate volunteers from csv files" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+      expect { FileImporter.import_volunteers(import_file_path, import_user.casa_org.id) }.to change(User, :count).by(0)
+    end
+  end
+
+  describe "#import_supervisors" do
+    it "imports supervisors and associates volunteers with them" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+
+      import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
+      expect { FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id) }.to change(User, :count).by(2)
+
+      supervisor = User.find_by(email: "supervisor2@example.net")
+      expect(supervisor.volunteers.size).to eq(2)
+    end
+
+    it "does not import duplicate supervisors from csv files" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+
+      import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
+      FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id)
+      expect { FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id) }.to change(User, :count).by(0)
+    end
+  end
+
+  describe "#import_cases" do
+    it "imports cases and associates volunteers with them" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+
+      import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
+      expect { FileImporter.import_cases(import_case_path, import_user.casa_org.id) }.to change(CasaCase, :count).by(2)
+
+      # correctly imports true/false transition_aged_youth
+      expect(CasaCase.last.transition_aged_youth).to be_falsey
+      expect(CasaCase.first.transition_aged_youth).to be_truthy
+
+      # correctly adds volunteers
+      expect(CasaCase.first.volunteers.size).to be(1)
+      expect(CasaCase.last.volunteers.size).to be(2)
+    end
+
+    it "does not duplicate casa case files from csv files" do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+
+      import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
+      FileImporter.import_cases(import_case_path, import_user.casa_org.id)
+      expect { FileImporter.import_cases(import_case_path, import_user.casa_org.id) }.to change(CasaCase, :count).by(0)
+    end
+  end
+end

--- a/spec/requests/imports_request_spec.rb
+++ b/spec/requests/imports_request_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "/imports", type: :request do
+  describe "GET /index" do
+    it "renders an unsuccessful response when the user is not an admin" do
+      sign_in create(:user, :volunteer)
+
+      get imports_url
+
+      expect(response).to_not be_successful
+    end
+
+    it "renders a successful response when the user is an admin" do
+      sign_in create(:user, :casa_admin)
+
+      get imports_url
+
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "/reports", type: :request do
   describe "GET /index" do
     it "renders a successful response" do
-      sign_in create(:user, :volunteer)
+      sign_in create(:user, :casa_admin)
 
       get reports_url
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #18 

### What changed, and why?

This PR does a bit more than the issue of just importing volunteers. I also allows the importation of supervisors and casa cases.

I added in the `devise_invitable` gem to make sending emails to new volunteers and supervisors easy. Also added in the mailcatcher gem with some configurations in `development.rb` to enable the testing of sending the emails.

The general process for importing csv's is for folks to download the example csv, edit it, and then upload it.

I also notice that while the dropdown that shows the reports link checks if the person is a casa_admin, the `reports_controller` didn't validate that the user on the page was a casa admin. I updated the controller to use the `before_action :must_be_admin` as well as updated the user in the reports request spec to be a casa_admin.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions: Only admins can do this.

### How is this tested? (please write tests!) 💖💪
I added in a new imports route that is tested with a request spec and I create a `FileImporter` class that is tested in /spec/models directory. (Probably not the best spot for it.)
I also added in a fixtures directory with example csv's for the three different import types (volunteers, supervisors, casa_cases.)

### Screenshots please :)

![menu_item](https://user-images.githubusercontent.com/667909/88497472-74329880-cf8e-11ea-84bb-ff2bbfef8c10.jpg)

![imports](https://user-images.githubusercontent.com/667909/88497485-7dbc0080-cf8e-11ea-86fe-5baac8e856c5.jpg)

### Feelings gif (optional)

![](https://i.giphy.com/media/SggILpMXO7Xt6/giphy.webp)