### PR TITLE
Allow supervisor to unassign any volunteer, not just own

### DIFF
--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -25,7 +25,7 @@
                 <% end %>
               </td>
               <td>
-                <% if assignment.is_active? && current_user.role == "casa_admin" || assignment.volunteer.supervisor == current_user %>
+                <% if assignment.is_active? && %w(casa_admin supervisor).include?(current_user.role) %>
                   <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
                 <% else %>
                   None


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #447

### What changed, and why?
Supervisor can now unassign any volunteer, not just volunteers that the supervisor supervises.

### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor permissions: Supervisor can now unassign any volunteer from a case. (This is only enforced/allowed based on the logic in the view.)
- Admin permissions: no change

### How is this tested? (please write tests!) 💖💪
There are no existing tests for the editing of assignments. I did not add any as a part of this change. If feature tests for assigning and unassigning volunteers need to be written, I am not sure I can guarantee a prompt update. If this is pressing and feature tests for assigning and unassigning volunteers need to be written, please feel free to pass this issue along to another person.

### Screenshots please :)

Before a new volunteer is added, the supervisor can "Unassign Volunteer" for the existing volunteer, even though the supervisor is not supervising that volunteer.

![before-adding-new-volunteer](https://user-images.githubusercontent.com/3824492/88497710-c2439e00-cf86-11ea-9349-0e5c62327dc5.png)


After a new volunteer is added, the supervisor can "Unassign Volunteer" for the new volunteer, even though the supervisor is not supervising that volunteer.

![after-adding-new-volunteer](https://user-images.githubusercontent.com/3824492/88497720-ca034280-cf86-11ea-85fe-e2ad75216190.png)


Database records showing that these volunteers are supervised by someone else.
```sql
casa_development=# select v.display_name as "volunteer name", s.email as "supervisor email", s.display_name as "supervisor name" from users v join supervisor_volunteers sv on v.id = sv.volunteer_id join users s on s.id = sv.supervisor_id where v.display_name in ('Steve Romaguera Jr.', 'Elodia Nitzsche');
   volunteer name    |       supervisor email        |  supervisor name   
---------------------+-------------------------------+--------------------
 Elodia Nitzsche     | stanfordking@example.org      | Stanford King
 Steve Romaguera Jr. | timothygusikowski@example.net | Timothy Gusikowski
(2 rows)

```

