### PR TITLE
445 redirect to case after creation

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -33,7 +33,7 @@ class CaseContactsController < ApplicationController
     end
 
     if case_contacts.all?(&:persisted?)
-      redirect_to root_path, notice: "Case contact was successfully created."
+      redirect_to casa_case_path(@casa_cases.first), notice: "Case contact was successfully created."
     else
       @case_contact = case_contacts.first
       render :new
@@ -52,7 +52,7 @@ class CaseContactsController < ApplicationController
 
     respond_to do |format|
       if @case_contact.update(update_case_contact_params)
-        format.html { redirect_to root_path, notice: "Case contact was successfully updated." }
+        format.html { redirect_to  casa_case_path(@case_contact.casa_case), notice: "Case contact was successfully updated." }
         format.json { render :show, status: :ok, location: @case_contact }
       else
         format.html { render :edit }

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "/case_contacts", type: :request do
             contact_types: ["attorney"],
           }
         }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(casa_case_path(case_contact.casa_case_id))
 
         case_contact.reload
         expect(case_contact.contact_types).to eq(["attorney"])


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #445 

### What changed, and why?
When Supervisor/admin creates case contact for case, redirect to case after creation (not dashboard)

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Rewritten old test

### Screenshots please :)
![Monosnap 2020-07-27 14-03-49](https://user-images.githubusercontent.com/1007159/88535735-27dd6c00-d013-11ea-8e43-42769298d9a2.png)

