### PR TITLE
Add edit hyperlink on case contacts page for admins and supervisors

### DIFF
--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -25,11 +25,11 @@ class CaseContactPolicy
   end
 
   def update?
-    _is_creator_or_casa_admin?
+    _is_creator_or_supervisor_or_casa_admin?
   end
 
   def edit?
-    _is_creator_or_casa_admin?
+    _is_creator_or_supervisor_or_casa_admin?
   end
 
   def destroy?
@@ -61,6 +61,22 @@ class CaseContactPolicy
   private
 
   def _is_creator_or_casa_admin?
-    user.casa_admin? || record.creator == user
+    _is_admin? || _is_creator?
+  end
+
+  def _is_creator_or_supervisor_or_casa_admin?
+    _is_admin? || _is_supervisor? || _is_creator?
+  end
+
+  def _is_admin?
+    user.casa_admin?
+  end
+
+  def _is_supervisor?
+    user.supervisor?
+  end
+
+  def _is_creator?
+    record.creator == user
   end
 end

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -15,7 +15,7 @@
   </td>
 
   <td>
-    <% if Pundit.policy(current_user, contact).update?  %>
+    <% if current_user&.casa_admin? || current_user&.supervisor? %>
       <%= link_to 'Edit', edit_case_contact_path(contact) %>
     <% end %>
   </td>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -15,7 +15,7 @@
   </td>
 
   <td>
-    <% if current_user&.casa_admin? || current_user&.supervisor? %>
+    <% if Pundit.policy(current_user, contact).update?  %>
       <%= link_to 'Edit', edit_case_contact_path(contact) %>
     <% end %>
   </td>

--- a/spec/policies/case_contact_policy/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy/case_contact_policy_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe CaseContactPolicy do
       expect(subject).to permit(create(:user, :casa_admin), create(:case_contact))
     end
 
+    it "allows supervisors" do
+      expect(subject).to permit(create(:user, :supervisor), create(:case_contact))
+    end
+
     context "when volunteer is assigned" do
       it "allows the volunteer" do
         volunteer = create(:user, :volunteer)
@@ -60,6 +64,10 @@ RSpec.describe CaseContactPolicy do
 
     it "does not allow volunteers" do
       expect(subject).not_to permit(create(:user, :volunteer), create(:case_contact))
+    end
+
+    it "allows supervisors" do
+      expect(subject).to permit(create(:user, :supervisor), create(:case_contact))
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #425

### What changed, and why?
Changes permissions for case contact edit page according to specs laid out in #425. This commit allows supervisors to edit case contacts as well.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: Edit and update case contacts
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added policy specs and tested in the browser

### Screenshots please :)
![Screen Shot 2020-07-28 at 3 26 38 PM](https://user-images.githubusercontent.com/54157657/88717882-d1d9f880-d0e6-11ea-9831-a36491660abd.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
Feeling great!!! 😎🤝