### PR TITLE
Refactor the csv import to give more information. 

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -74,7 +74,7 @@ class CasaCasesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def casa_case_params
-    params.require(:casa_case).permit(:case_number, :transition_aged_youth)
+    params.require(:casa_case).permit(:case_number, :transition_aged_youth, :casa_org_id)
   end
 
   # Separate params so only admins can update the case_number

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -4,21 +4,31 @@ class ImportsController < ApplicationController
 
   def index; end
 
-  def import_volunteers
-    FileImporter.import_volunteers(params[:file], current_user.casa_org_id)
-    flash[:success] = "Volunteers imported"
+  def create
+    check_empty_attachment
+    import = import_from_csv(params[:import_type], params[:file], current_user.casa_org_id)
+    flash[import[:type]] = import[:message]
     redirect_to imports_path
   end
 
-  def import_supervisors
-    FileImporter.import_supervisors(params[:file], current_user.casa_org_id)
-    flash[:success] = "Supervisors imported"
-    redirect_to imports_path
+  private
+
+  def import_from_csv(import_type, file, org)
+    case import_type
+    when "volunteer"
+      FileImporter.new(file, org).import_volunteers
+    when "supervisor"
+      FileImporter.new(file, org).import_supervisors
+    when "casa_case"
+      FileImporter.new(file, org).import_cases
+    else
+      { type: :error, message: "Something went wrong with the import, did you attach a csv file?" }
+    end
   end
 
-  def import_cases
-    User.import_volunteers(params[:file], current_user.casa_org_id)
-    flash[:success] = "Cases imported"
+  def check_empty_attachment
+    return unless params[:file].blank?
+    flash[:error] = 'You must attach a csv file in order to import information!'
     redirect_to imports_path
   end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -5,6 +5,7 @@ class CasaCase < ApplicationRecord
   has_many(:volunteers, through: :case_assignments, source: :volunteer, class_name: "User")
   has_many :case_contacts
   validates :case_number, uniqueness: {case_sensitive: false}, presence: true
+  belongs_to :casa_org
 
   scope :ordered, -> { order(updated_at: :desc) }
   scope :actively_assigned_to,
@@ -24,8 +25,14 @@ end
 #  transition_aged_youth :boolean          default(FALSE), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  casa_org_id           :bigint           not null
 #
 # Indexes
 #
+#  index_casa_cases_on_casa_org_id  (casa_org_id)
 #  index_casa_cases_on_case_number  (case_number) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (casa_org_id => casa_orgs.id)
 #

--- a/app/models/concerns/file_importer.rb
+++ b/app/models/concerns/file_importer.rb
@@ -1,7 +1,16 @@
 class FileImporter
   require "csv"
 
-  def self.import_volunteers(import_csv, org_id)
+  attr_reader :import_csv, :org_id
+
+  def initialize(import_csv, org_id)
+    @import_csv = import_csv
+    @org_id = org_id
+    @number_imported = 0
+    @failed_imports = []
+  end
+
+  def import_volunteers
     CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
       user = User.new(row.to_hash)
       user.role = "volunteer"
@@ -9,11 +18,15 @@ class FileImporter
       user.password = "123456"
       if user.save
         user.invite!
+        @number_imported += 1
+      else
+        @failed_imports << "#{row[:display_name]} - #{row[:email]}"
       end
     end
+    build_message("volunteers")
   end
 
-  def self.import_supervisors(import_csv, org_id)
+  def import_supervisors
     CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
       user = User.new(email: row[:email], display_name: row[:display_name])
       user.role = "supervisor"
@@ -24,18 +37,37 @@ class FileImporter
         volunteers = row[:supervisor_volunteers]
         lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
         user.volunteers << lookups.compact if lookups.compact.present?
+        @number_imported += 1
+      else
+        @failed_imports << "#{row[:display_name]} - #{row[:email]}"
       end
     end
+    build_message("supervisors")
   end
 
-  def self.import_cases(import_csv, org_id)
+  def import_cases
     CSV.foreach(import_csv, headers: true, header_converters: :symbol) do |row|
       casa_case = CasaCase.new(case_number: row[:case_number], transition_aged_youth: row[:transition_aged_youth])
+      casa_case.casa_org_id = org_id
       if casa_case.save
         volunteers = row[:case_assignment]
         lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
         casa_case.volunteers << lookups.compact if lookups.compact.present?
+        @number_imported += 1
+      else
+        @failed_imports << "#{row[:case_number]} - #{row[:transition_aged_youth]}"
       end
+    end
+    build_message("casa_cases")
+  end
+
+  def build_message(type)
+    return_value = {}
+    if @failed_imports.empty?
+      {type: :success, message: "You successfully imported #{@number_imported} #{type}."}
+    else
+      {type: :error, message: "You successfully imported #{@number_imported} #{type}, the "\
+        "following #{type} were not imported: #{@failed_imports.join(", ")}."}
     end
   end
 end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -21,6 +21,8 @@
     <%= form.check_box :transition_aged_youth, class: "form-check-input" %>
   </div>
 
+  <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
+
   <div class="actions">
     <%= form.submit casa_case.persisted? ? 'Update CASA Case' : 'Create CASA Case' %>
   </div>

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -17,6 +17,8 @@
         <%= form.check_box :transition_aged_youth %>
       </div>
 
+      <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
+
       <br>
 
       <div class="actions">

--- a/app/views/imports/_cases.html.erb
+++ b/app/views/imports/_cases.html.erb
@@ -5,12 +5,12 @@
 <br>
 <br>
 <h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
-<%= form_with(url: import_cases_imports_path, local: :true) do |f| %>
+<%= form_with(url: imports_path, local: :true) do |f| %>
+  <%= f.hidden_field :import_type, value: "casa_case" %>
   <ul>
     <li>Click the choose file button and navigate to the saved file and select it.</li>
     <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
     <li>Then click the "Import Cases CSV" button to import your cases.</li>
-
   </ul>
   <%= f.file_field :file, accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
   <br>

--- a/app/views/imports/_supervisors.html.erb
+++ b/app/views/imports/_supervisors.html.erb
@@ -6,7 +6,8 @@
 <br>
 <br>
 <h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
-<%= form_with(url: import_supervisors_imports_path, local: :true) do |f| %>
+<%= form_with(url: imports_path, local: :true) do |f| %>
+  <%= f.hidden_field :import_type, value: "supervisor" %>
   <ul>
     <li>Click the choose file button and navigate to the saved file and select it.</li>
     <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>

--- a/app/views/imports/_volunteers.html.erb
+++ b/app/views/imports/_volunteers.html.erb
@@ -6,7 +6,8 @@
 <br>
 <br>
 <h3><i class="fa fa-file-text-o fa-2x" aria-hidden="true"></i> 2. Upload your CSV file</h3>
-<%= form_with(url: import_volunteers_imports_path, local: :true) do |f| %>
+<%= form_with(url: imports_path, local: :true) do |f| %>
+  <%= f.hidden_field :import_type, value: "volunteer" %>
   <ul>
     <li>Click the choose file button and navigate to the saved file and select it.</li>
     <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,13 +7,7 @@ Rails.application.routes.draw do
   resources :casa_cases
   resources :case_contacts
   resources :reports, only: %i[index]
-  resources :imports, only: %i[index] do
-    collection do
-      post :import_volunteers
-      post :import_supervisors
-      post :import_cases
-    end
-  end
+  resources :imports, only: %i[index create]
   resources :case_contact_reports, only: %i[index]
 
   resources :supervisors, only: %i[edit update]

--- a/db/migrate/20200729002247_add_casa_org_to_casa_case.rb
+++ b/db/migrate/20200729002247_add_casa_org_to_casa_case.rb
@@ -1,0 +1,5 @@
+class AddCasaOrgToCasaCase < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :casa_cases, :casa_org, null: false, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_26_185103) do
+ActiveRecord::Schema.define(version: 2020_07_29_002247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2020_07_26_185103) do
     t.boolean "transition_aged_youth", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "casa_org_id", null: false
+    t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number"], name: "index_casa_cases_on_case_number", unique: true
   end
 
@@ -116,6 +118,7 @@ ActiveRecord::Schema.define(version: 2020_07_26_185103) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "casa_cases", "casa_orgs"
   add_foreign_key "case_assignments", "casa_cases"
   add_foreign_key "case_assignments", "users", column: "volunteer_id"
   add_foreign_key "case_contacts", "casa_cases"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -149,6 +149,7 @@ end
 casa_cases = []
 CASA_CASE_COUNT.times do |index|
   new_casa_case = CasaCase.create(
+      casa_org_id: pg_casa.id,
       case_number: case_number_generator,
       transition_aged_youth: chance_of_transition_aged
   )

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :casa_case do
     sequence(:case_number) { |n| n }
     transition_aged_youth { false }
+    casa_org
   end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CasaCase do
   subject { build(:casa_case) }
 
   it { is_expected.to have_many(:case_assignments) }
+  it { is_expected.to belong_to(:casa_org) }
   it { is_expected.to validate_presence_of(:case_number) }
   it { is_expected.to validate_uniqueness_of(:case_number).case_insensitive }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }

--- a/spec/models/file_importer_spec.rb
+++ b/spec/models/file_importer_spec.rb
@@ -8,15 +8,38 @@ RSpec.describe FileImporter, type: :concern do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      expect { FileImporter.import_volunteers(import_file_path, import_user.casa_org.id) }.to change(User, :count).by(3)
+      importer = FileImporter.new(import_file_path, import_user.casa_org.id)
+      expect { importer.import_volunteers }.to change(User, :count).by(3)
     end
 
     it "does not import duplicate volunteers from csv files" do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
-      expect { FileImporter.import_volunteers(import_file_path, import_user.casa_org.id) }.to change(User, :count).by(0)
+      importer = FileImporter.new(import_file_path, import_user.casa_org.id)
+      importer.import_volunteers
+      expect { importer.import_volunteers }.to change(User, :count).by(0)
+    end
+
+    it 'returns a success message with the number of volunteers imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      importer = FileImporter.new(import_file_path, import_user.casa_org.id)
+      alert = importer.import_volunteers
+      expect(alert[:type]).to eq(:success)
+      expect(alert[:message]).to eq("You successfully imported 3 volunteers.")
+    end
+
+    it 'returns an error message when there are volunteers not imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+
+      alert = FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to include("You successfully imported 0 volunteers, the following volunteers were not")
     end
   end
 
@@ -25,10 +48,12 @@ RSpec.describe FileImporter, type: :concern do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
 
       import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
-      expect { FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id) }.to change(User, :count).by(2)
+      supervisor_importer = FileImporter.new(import_supervisor_path, import_user.casa_org.id)
+
+      expect { supervisor_importer.import_supervisors }.to change(User, :count).by(2)
 
       supervisor = User.find_by(email: "supervisor2@example.net")
       expect(supervisor.volunteers.size).to eq(2)
@@ -38,11 +63,42 @@ RSpec.describe FileImporter, type: :concern do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
 
       import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
-      FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id)
-      expect { FileImporter.import_supervisors(import_supervisor_path, import_user.casa_org.id) }.to change(User, :count).by(0)
+      supervisor_importer = FileImporter.new(import_supervisor_path, import_user.casa_org.id)
+
+      supervisor_importer.import_supervisors
+
+      expect { supervisor_importer.import_supervisors }.to change(User, :count).by(0)
+    end
+
+    it 'returns a success message with the number of supervisors imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+
+      import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
+      supervisor_importer = FileImporter.new(import_supervisor_path, import_user.casa_org.id)
+
+      alert = supervisor_importer.import_supervisors
+      expect(alert[:type]).to eq(:success)
+      expect(alert[:message]).to eq("You successfully imported 2 supervisors.")
+    end
+
+    it 'returns an error message when there are volunteers not imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+
+      import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisors.csv")
+      FileImporter.new(import_supervisor_path, import_user.casa_org.id).import_supervisors
+
+      alert = FileImporter.new(import_file_path, import_user.casa_org.id).import_supervisors
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to include("You successfully imported 0 supervisors, the following supervisors were not")
     end
   end
 
@@ -51,10 +107,10 @@ RSpec.describe FileImporter, type: :concern do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
 
       import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
-      expect { FileImporter.import_cases(import_case_path, import_user.casa_org.id) }.to change(CasaCase, :count).by(2)
+      expect { FileImporter.new(import_case_path, import_user.casa_org.id).import_cases }.to change(CasaCase, :count).by(2)
 
       # correctly imports true/false transition_aged_youth
       expect(CasaCase.last.transition_aged_youth).to be_falsey
@@ -69,11 +125,40 @@ RSpec.describe FileImporter, type: :concern do
       import_user = create(:user, :casa_admin)
 
       import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
-      FileImporter.import_volunteers(import_file_path, import_user.casa_org.id)
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
 
       import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
-      FileImporter.import_cases(import_case_path, import_user.casa_org.id)
-      expect { FileImporter.import_cases(import_case_path, import_user.casa_org.id) }.to change(CasaCase, :count).by(0)
+      FileImporter.new(import_case_path, import_user.casa_org.id).import_cases
+
+      expect { FileImporter.new(import_case_path, import_user.casa_org.id).import_cases }.to change(CasaCase, :count).by(0)
+    end
+
+    it 'returns a success message with the number of cases imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+
+      import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
+      case_importer = FileImporter.new(import_case_path, import_user.casa_org.id)
+
+      alert = case_importer.import_cases
+      expect(alert[:type]).to eq(:success)
+      expect(alert[:message]).to eq("You successfully imported 2 casa_cases.")
+    end
+
+    it 'returns an error message when there are cases not imported' do
+      import_user = create(:user, :casa_admin)
+
+      import_file_path = Rails.root.join("spec", "fixtures", "volunteers.csv")
+      FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
+
+      import_case_path = Rails.root.join("spec", "fixtures", "casa_cases.csv")
+      FileImporter.new(import_case_path, import_user.casa_org.id).import_cases
+
+      alert = FileImporter.new(import_case_path, import_user.casa_org.id).import_cases
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to include("You successfully imported 0 casa_cases, the following casa_cases were not")
     end
   end
 end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 RSpec.describe "/casa_cases", type: :request do
   # CasaCase. As you add validations to CasaCase, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true} }
+
+  let(:casa_org) { create(:casa_org) }
+
+  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true, casa_org_id: casa_org.id} }
 
   let(:invalid_attributes) { {case_number: nil} }
 


### PR DESCRIPTION
When I was adding in the ability for the casa to import csv files I noticed that casa_case's were not attached to a casa_org. This PR adds in a migration to do that.  Since it is a `belongs_to` this will likely break dev environments for folks. People will either need to do a drop/create/migrate/seed or jump into a console and run something like `CasaCase.update_all(casa_org_id: 1)`

All tests, forms, and whatnot have been updated to have casa_cases use the casa_org_id. Note: In the forms just set it has a hidden_field pointing at the current_user's casa_org id.

I also went and cleaned up the csv import stuff. Namely to make the routes more restful (use the create action) and to add in information about the imports. It also quickly doesn't error out now if the user forgets to attach a csv file. 

Now when an admin imports csv they will see the number of volunteers, supervisors, casa cases they have imported. It will also let them know which cases/users/supervisors failed to import.

Successful volunteer import (supervisor looks the same):

![volunteer-success](https://user-images.githubusercontent.com/667909/88745326-c5ba5f00-d117-11ea-83d4-37701cb1e1ae.jpg)

Volunteer import with fails (supervisor looks the same):

![volunteer - fail](https://user-images.githubusercontent.com/667909/88745365-db2f8900-d117-11ea-8ad2-ffa8d47311f6.jpg)

Successful case import:
![case - success](https://user-images.githubusercontent.com/667909/88745381-e4b8f100-d117-11ea-9131-869a36b95cf7.jpg)

Failed case import:

![case - fail](https://user-images.githubusercontent.com/667909/88745414-fd290b80-d117-11ea-8fc4-38ae5948f9cf.jpg)

### Feelings gif (optional)

![](https://i.giphy.com/media/1d7F9xyq6j7C1ojbC5/giphy.webp)
