### PR TITLE
Issue 457 - Allows volunteers to be reassigned to a casa case

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -3,12 +3,24 @@ class CaseAssignmentsController < ApplicationController
   before_action :must_be_admin_or_supervisor # admins and supervisors can create/delete ALL case assignments
 
   def create
-    case_assignment = case_assignment_parent.case_assignments.new(case_assignment_params)
-    if case_assignment.save
-      flash.notice = "Volunteer assigned to case"
+    case_assignments = case_assignment_parent.case_assignments
+    existing_case_assignment = case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], is_active: false).first
+
+    if existing_case_assignment.present?
+      if existing_case_assignment.update(is_active: true)
+        flash.notice = "Volunteer reassigned to case"
+      else
+        errors = existing_case_assignment.errors.full_messages.join(". ")
+        flash.alert = "Unable to reassigned volunteer to case: #{errors}."
+      end
     else
-      errors = case_assignment.errors.full_messages.join(". ")
-      flash.alert = "Unable to assign volunteer to case: #{errors}."
+      case_assignment = case_assignment_parent.case_assignments.new(case_assignment_params)
+      if case_assignment.save
+        flash.notice = "Volunteer assigned to case"
+      else
+        errors = case_assignment.errors.full_messages.join(". ")
+        flash.alert = "Unable to assign volunteer to case: #{errors}."
+      end
     end
 
     redirect_to after_action_path(case_assignment_parent)

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -2,6 +2,24 @@ require "rails_helper"
 
 RSpec.describe "/case_assignments", type: :request do
   describe "POST /create" do
+    context "when the volunteer has been previously assigned to the casa_case" do
+      it "reassigns the volunteer to the casa_case" do
+        admin = create(:user, :casa_admin)
+        volunteer = create(:user, :volunteer)
+        casa_case = create(:casa_case)
+        assignment = create(:case_assignment, is_active: false, volunteer: volunteer, casa_case: casa_case)
+
+        sign_in admin
+
+        expect do
+          post case_assignments_url(casa_case_id: casa_case.id),
+               params: { case_assignment: { volunteer_id: volunteer.id } }
+        end.to change { casa_case.case_assignments.first.is_active }.from(false).to(true)
+
+        expect(response).to redirect_to edit_casa_case_path(casa_case)
+      end
+    end
+
     context "when the case assignment parent is a volunteer" do
       it "creates a new case assignment for the volunteer" do
         admin = create(:user, :casa_admin)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #457 

### What changed, and why?
A bug was found where a volunteer who was unassigned from a casa case was not able to be reassigned to that casa case. This PR allows volunteers to be reassigned to casa cases by checking if the case_assigment already exists where `is_active` was set to false, then updates the existing case_assignment by setting `is_active` to true. This reassigns the volunteer to the casa case and gives the volunteer the "ASSIGNED" status in the "Assigned Volunteers" table.  

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
A test was added to check when trying to assign a previously assigned volunteer to a casa case, the already existing case_assigment is updated by setting`is_active` to true. 

### Screenshots please :)
Before reassignment:
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/18248767/88877208-f3c0a180-d1f2-11ea-90c9-7f58036a9dde.png">

After reassignment:
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/18248767/88877230-ff13cd00-d1f2-11ea-86ca-fe7eaaf5c1ee.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
