### PR TITLE
Add red message when there are no active volunteers to assign to a CASA case

### DIFF
--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -89,5 +89,8 @@
 
       <%= form.submit 'Assign Volunteer', class: 'btn btn-primary' %>
     <% end %>
+    <% unless @available_volunteers.any? %>
+      <p class="text-danger">There are no active, unassigned volunteers available.</p>
+    <% end %>
   </div>
 </div>

--- a/spec/features/admin_views_dashboard_spec.rb
+++ b/spec/features/admin_views_dashboard_spec.rb
@@ -146,4 +146,18 @@ RSpec.describe "admin views dashboard", type: :feature do
 
     expect(page).to have_text("Editing Supervisor")
   end
+
+  it "can go to the supervisor edit page and see red message
+      when there are no active volunteers" do
+    create(:user, :supervisor)
+    sign_in admin
+
+    visit root_path
+
+    within "#supervisors" do
+      click_on "Edit"
+    end
+
+    expect(page).to have_text("There are no active, unassigned volunteers available")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #380 

### What changed, and why?
The red message should display when there are no active volunteers to assign to a CASA case

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added feature test


### Screenshots please :)
<img width="866" alt="PG CASA 2020-07-30 16-35-40" src="https://user-images.githubusercontent.com/1007159/88931856-09cb7200-d286-11ea-9260-7590bdc00abc.png">

