### PR TITLE
Fix case contact form

### DIFF
--- a/app/helpers/case_contacts_helper.rb
+++ b/app/helpers/case_contacts_helper.rb
@@ -27,6 +27,38 @@ module CaseContactsHelper
       class: "custom-select"
   end
 
+  def set_hours_form(case_contact)
+    if case_contact.duration_minutes
+      case_contact.duration_minutes / 60
+    else
+      0
+    end
+  end
+
+  def set_minutes_form(case_contact)
+    if case_contact.duration_minutes
+      case_contact.duration_minutes.remainder(60)
+    else
+      0
+    end
+  end
+
+  def set_contact_made_false(case_contact)
+    if case_contact.persisted? && case_contact.contact_made == false
+      true
+    else
+      false
+    end
+  end
+
+  def set_contact_made_true(case_contact)
+    if case_contact.contact_made
+      true
+    else
+      false
+    end
+  end
+
   private
 
   def build_minute_options

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,7 +5,7 @@ class CaseContact < ApplicationRecord
   validate :contact_made_chosen
   validates :contact_types, presence: true
   validate :contact_types_included
-  validates :duration_minutes, presence: true
+  validates :duration_minutes, numericality: { greater_than: 0 }
   validates :medium_type, presence: true
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -57,10 +57,10 @@
   <div class="field contact-type form-group">
     <h2><%= form.label "Contact Made" %></h2>
     <br>
-    <%= form.radio_button(:contact_made, true, checked: false, required: 'required') %>
+    <%= form.radio_button(:contact_made, true, checked: set_contact_made_true(case_contact), required: 'required') %>
     <%= form.label "Yes", for: "case_contact_contact_made_true" %>
     <br>
-    <%= form.radio_button(:contact_made, false, checked: false, required: 'required') %>
+    <%= form.radio_button(:contact_made, false, checked: set_contact_made_false(case_contact), required: 'required') %>
     <%= form.label "No", for: "case_contact_contact_made_false" %>
   </div>
 
@@ -74,21 +74,21 @@
     <h2><%= form.label "Duration" %></h2>
     <div class="row">
     <div class="ml-3 col-sm-12 col-md-4 row">
-        <%= form.text_field :duration_hours, :class=>"row col-sm-6 mr-1", :id=>"casa-contact-duration-hours-display", required: 'required' %>
+        <%= form.text_field :duration_hours, :class=>"row col-sm-6 mr-1", :id=>"casa-contact-duration-hours-display", :value=>set_hours_form(case_contact), required: 'required' %>
         <span class="col-sm-2"> hours <span>
       </div>
       <div class="col-sm-12 col-md-6">
-        <%= form.range_field :duration_hours, :min=>0, :max=>23, :value=>0, :class=>"row custom-range slide", :id=>"case-contact-duration-hours"%>
+        <%= form.range_field :duration_hours, :min=>0, :max=>23, :value=>set_hours_form(case_contact), :class=>"row custom-range slide", :id=>"case-contact-duration-hours"%>
       </div>
 
     </div>
     <div class="row">
     <div class="ml-3 col-sm-12 col-md-4 row">
-        <%= form.text_field :duration_minutes, :class=>"row col-sm-6 mr-1", :id=>"casa-contact-duration-minutes-display", :value=>0 %>
+        <%= form.text_field :duration_minutes, :class=>"row col-sm-6 mr-1", :id=>"casa-contact-duration-minutes-display", :value=>set_minutes_form(case_contact) %>
         <span class="col-sm-2"> minutes <span>
       </div>
       <div class="col-sm-12 col-md-6">
-        <%= form.range_field :duration_minutes, :min=>0, :max=>59, :step=>15, :value=>0, :class=>"row custom-range slide", :id=>"case-contact-duration-minutes"%>
+        <%= form.range_field :duration_minutes, :min=>0, :max=>59, :step=>15, :value=>set_minutes_form(case_contact), :class=>"row custom-range slide", :id=>"case-contact-duration-minutes"%>
       </div>
 
     </div>

--- a/spec/features/admin_edits_a_case_contact_spec.rb
+++ b/spec/features/admin_edits_a_case_contact_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "admin or supervisor edits a case contact", type: :feature do
+  it "is successful" do
+    admin = create(:user, :casa_admin)
+    casa_case = create(:casa_case)
+
+    sign_in admin
+
+    visit casa_case_path(casa_case.id)
+    click_on "New Case Contact"
+
+    find(:css, "input.casa-case-id-check[value='#{casa_case.id}']").set(true)
+    find(:css, "input.casa-case-contact-type[value='school']").set(true)
+    find(:css, "input#case_contact_contact_made_true").set(true)
+    fill_in "case-contact-duration-hours", with: "1"
+    fill_in "case-contact-duration-minutes", with: "45"
+    fill_in "case_contact_occurred_at", with: "04/04/2020"
+    select "Video", from: "case_contact[medium_type]"
+
+    click_on "Submit"
+
+    visit edit_case_contact_path(CaseContact.first)
+
+    select "Letter", from: "case_contact[medium_type]"
+    expect(find(:css, "input#case_contact_contact_made_true").value).to eq "true"
+
+    click_on "Submit"
+
+    expect(CaseContact.first.casa_case_id).to eq casa_case.id
+    expect(CaseContact.first.duration_minutes).to eq 105
+    expect(CaseContact.first.medium_type).to eq "letter"
+    expect(CaseContact.first.contact_made).to eq true
+  end
+end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact.errors[:occurred_at]).to eq(["can't be blank"])
   end
 
+  it "validates duration_minutes is only numeric values" do
+    case_contact = build(:case_contact, duration_minutes: nil)
+    expect(case_contact).to_not be_valid
+    expect(case_contact.errors[:duration_minutes]).to eq(["is not a number"])
+  end
+
+  it "validates duration_minutes cannot be zero values" do
+    case_contact = build(:case_contact, duration_minutes: 0)
+    expect(case_contact).to_not be_valid
+    expect(case_contact.errors[:duration_minutes]).to eq(["must be greater than 0"])
+  end
+
   it "validates contact types are of allowed types" do
     case_contact = build(:case_contact, contact_types: ["popcorn"])
     expect(case_contact).to_not be_valid

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe "/case_contacts", type: :request do
 
         patch case_contact_url(case_contact), params: {
           case_contact: {
-            contact_types: ["attorney"]
+            contact_types: ["attorney"],
+            duration_minutes: 60
           }
         }
         expect(response).to redirect_to(casa_case_path(case_contact.casa_case_id))


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #001

### What changed, and why?
Fixed edit form for CaseContact when no values were displayed for duration_minutes and contact_made fields. And they had to be filled in again.
Also, the validation method for duration_minutes has been changed. Now you can't have zero duration_minutes.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

Added models and features tests. Fix one request test.
### Screenshots please :)

