### PR TITLE
Move auth logic into pundit policyfile

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -36,7 +36,7 @@ class VolunteersController < ApplicationController
   end
 
   def activate
-    @volunteer = User.find(params[:id])
+    @volunteer = authorize User.find(params[:id])
     if @volunteer.update(role: "volunteer")
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated."
     else
@@ -45,7 +45,7 @@ class VolunteersController < ApplicationController
   end
 
   def deactivate
-    @volunteer = User.find(params[:id])
+    @volunteer = authorize User.find(params[:id])
 
     if @volunteer.update(role: "inactive")
       @volunteer.case_assignments.update_all(is_active: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,15 @@ class User < ApplicationRecord
   ALL_ROLES = %w[volunteer supervisor casa_admin inactive].freeze
   enum role: ALL_ROLES.zip(ALL_ROLES).to_h
 
+  def policy_class
+    case self.role
+    when "volunteer", "inactive"
+      VolunteerPolicy
+    else
+      UserPolicy
+    end
+  end
+
   def active_volunteer
     role == "volunteer" # !inactive
   end

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -10,4 +10,12 @@ class VolunteerPolicy
   def update_volunteer_email?
     user.casa_admin?
   end
+
+  def activate?
+    @user.casa_admin? || @record.supervisor == @user
+  end
+
+  def deactivate?
+    activate?
+  end
 end

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -40,7 +40,7 @@
       <div class="field form-group">
         <% if @volunteer_active %>
           Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
-          <% if current_user.role == "casa_admin" || @volunteer.supervisor == current_user %>
+          <% if policy(@volunteer).deactivate? %>
             <%= link_to "Deactivate volunteer",
                         deactivate_volunteer_path(@volunteer),
                         method: :patch,
@@ -54,7 +54,7 @@
           <div class="alert alert-danger">
             Volunteer was deactivated on: <%= @volunteer.updated_at.strftime("%m-%d-%Y") %>
           </div>
-          <% if current_user.role == "casa_admin" || @volunteer.supervisor == current_user %>
+          <% if policy(@volunteer).activate? %>
             <%= link_to "Activate volunteer",
                         activate_volunteer_path(@volunteer),
                         method: :patch,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #441

### What changed, and why?

Check the Volunteer policy for activating and deactivating users, instead of relying on view logic.

This also adds logic to the User model to consult the `VolunteerPolicy` for all `volunteer` and `inactive` users.

### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: No effective change, permissions check moved to policy
- Admin permissions: No effective change, permissions check moved to policy

### How is this tested? (please write tests!) 💖💪

Existing specs and manual testing in the browser.

### Screenshots please :)

No visible changes


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
