### PR TITLE
Render case contact form with validation errors

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -41,6 +41,7 @@ class CaseContactsController < ApplicationController
     if case_contacts.all?(&:persisted?)
       redirect_to casa_case_path(@casa_cases.first), notice: "Case contact was successfully created."
     else
+      @case_contact = case_contacts.first
       render :new
     end
   end

--- a/spec/features/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/features/volunteer_adds_a_case_contact_spec.rb
@@ -27,5 +27,25 @@ RSpec.describe "volunteer adds a case contact", type: :feature do
     expect(CaseContact.first.duration_minutes).to eq 105
   end
 
+  context "with invalid inputs" do
+    it "re-renders the form with error messages" do
+      volunteer = create(:user, :volunteer, :with_casa_cases)
+      volunteer_casa_case_one = volunteer.casa_cases.first
+
+      sign_in volunteer
+
+      visit new_case_contact_path
+
+      find(:css, "input.casa-case-id-check[value='#{volunteer_casa_case_one.id}']").set(true)
+
+      expect {
+        click_on "Submit"
+      }.not_to change(CaseContact, :count)
+
+      expect(page).to have_text("Contact types can't be blank")
+      expect(page).to have_text("Medium type can't be blank")
+    end
+  end
+
   #   TODO test case_contact.js behavior
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #464

### What changed, and why?
We should use `CaseContact` model that has been validated so that the form is displayed with errors, if there are any.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Added a feature spec.