### PR TITLE
Clear localStorage on login

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ require("src/case_contact")
 require("src/dashboard")
 require("src/index_reports")
 require("src/new_casa_contact")
+require("src/sessions")
 
 import "bootstrap"
 

--- a/app/javascript/src/sessions.js
+++ b/app/javascript/src/sessions.js
@@ -1,0 +1,5 @@
+$('document').ready(() => {
+  $('form#new_user').on('submit', function() {
+    localStorage.clear();
+  });
+});


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #451

Proposes using [the tactic suggested by @bklang of clearing all localStorage on login](https://github.com/rubyforgood/casa/issues/451#issuecomment-667559659). (/cc @cliftonmcintosh)

### What changed, and why?
Prevent DataTable saved state from bleeding between sessions.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Manually. Also stepped through via a JavaScript debugger.