### PR TITLE
Unify access denied handling, hide New Case button if not authorized

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   before_action :set_paper_trail_whodunnit
 
+  rescue_from Pundit::NotAuthorizedError, with: :not_authorized
+
+  private
+
   def must_be_admin
     return if current_user&.casa_admin?
 
@@ -15,5 +19,12 @@ class ApplicationController < ActionController::Base
 
     flash[:notice] = "You do not have permission to view that page."
     redirect_to root_url
+  end
+
+  def not_authorized(exception)
+    policy_name = exception.policy.class.to_s.underscore
+
+    flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
+    redirect_to(request.referrer || root_url)
   end
 end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -84,9 +84,6 @@ class CaseContactsController < ApplicationController
 
   def set_case_contact
     @case_contact = authorize(CaseContact.find(params[:id]))
-  rescue Pundit::NotAuthorizedError
-    flash[:alert] = "Sorry! You can only edit case contacts that you have logged."
-    redirect_to root_path
   end
 
   def create_case_contact_params

--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -3,7 +3,9 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header">
     <h1>CASA Cases</h1>
-    <%= link_to 'New CASA Case', new_casa_case_path, class: "btn btn-primary" %>
+    <%- if policy(:casa_case).new? %>
+      <%= link_to 'New CASA Case', new_casa_case_path, class: "btn btn-primary" %>
+    <%- end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,10 @@
 
 en:
   hello: "Hello world"
+  pundit:
+    default: "Sorry, you are not authorized to perform this action."
+    casa_case_policy:
+      new?: "Sorry, you are not authorized to create CASA cases."
+    case_contact_policy:
+      edit?: "Sorry, you can only edit case contacts that you have logged."
+      update?: "Sorry, you can only edit case contacts that you have logged."

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -30,9 +30,19 @@ RSpec.describe "/casa_cases", type: :request do
 
   describe "GET /new" do
     it "renders a successful response" do
-      sign_in create(:casa_admin)
       get new_casa_case_url
       expect(response).to be_successful
+    end
+
+    context "as a volunteer" do
+      before { sign_in create(:volunteer) }
+
+      it "denies access and redirects elsewhere" do
+        get new_casa_case_url
+
+        expect(response).not_to be_successful
+        expect(flash[:error]).to match(/you are not authorized/)
+      end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #499

### What changed, and why?
* Unify authorization errors, [as suggested in Pundit's README](https://github.com/varvet/pundit#rescuing-a-denied-authorization-in-rails)
* Hide the New CASA Case button if a user is not authorized to create a CASA case

### How will this affect user permissions?
- Volunteer permissions: No policy changes. Will no longer see New CASA Case button
- Supervisor permissions: No changes
- Admin permissions: No changes

### How is this tested? (please write tests!) 💖💪
Request spec added.