### PR TITLE
Switch back to sendinblue which works its just slooooow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "pg", ">= 0.18", "< 2.0" # Use postgresql as the database for Active Record
 gem "puma", "~> 4.3" # Use Puma as the app server
 gem "pundit" # for authorization management - based on user.role field
 gem "sass-rails", ">= 6" # Use SCSS for stylesheets
-gem 'sendgrid-ruby' # Emails
 gem "skylight" # automated performance testing https://www.skylight.io/
 gem "sprockets-rails" # TODO remove (deprecated) Provides Sprockets implementation for Rails Asset Pipeline.
 gem "turbolinks", "~> 5" # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,6 @@ GEM
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
-    ruby_http_client (3.5.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -303,8 +302,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
-    sendgrid-ruby (6.3.3)
-      ruby_http_client (~> 3.4)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
     simplecov (0.18.5)
@@ -417,7 +414,6 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
   selenium-webdriver
-  sendgrid-ruby
   shoulda-matchers
   simplecov (~> 0.18.5)
   skylight

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,17 +1,16 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.action_mailer.default_url_options = { host: ENV["DEFAULT_URL_HOST"] } # for devise authentication
+  config.action_mailer.default_url_options = {host: ENV["DEFAULT_URL_HOST"]} # for devise authentication
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.smtp_settings = {
-      :user_name => ENV['SENDGRID_USERNAME'],
-      :password => ENV['SENDGRID_PASSWORD'],
-      :domain => ENV["DOMAIN"],
-      :address => 'smtp.sendgrid.net',
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { # WARNING do not let standardrb linter change this block, it breaks
+      :address => 'smtp-relay.sendinblue.com',
       :port => 587,
-      :authentication => :plain,
+      :user_name => ENV["SENDINBLUE_EMAIL"],
+      :password => ENV["SENDINBLUE_PASSWORD"],
+      :authentication => 'login',
       :enable_starttls_auto => true
   }
   # Code is not reloaded between requests.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -12,17 +12,16 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # email
-  config.action_mailer.default_url_options = { host: ENV["DEFAULT_URL_HOST"] } # for devise authentication
+  config.action_mailer.default_url_options = {host: ENV["DEFAULT_URL_HOST"]} # for devise authentication
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.smtp_settings = {
-      :user_name => ENV['SENDGRID_USERNAME'],
-      :password => ENV['SENDGRID_PASSWORD'],
-      :domain => ENV["DOMAIN"],
-      :address => 'smtp.sendgrid.net',
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { # WARNING do not let standardrb linter change this block, it breaks
+      :address => 'smtp-relay.sendinblue.com',
       :port => 587,
-      :authentication => :plain,
+      :user_name => ENV["SENDINBLUE_EMAIL"],
+      :password => ENV["SENDINBLUE_PASSWORD"],
+      :authentication => 'login',
       :enable_starttls_auto => true
   }
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "no-reply@casa-production.herokuapp.com"
+  config.mailer_sender = "no-reply@#{ENV["DEFAULT_URL_HOST"]}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "no-reply@#{ENV["DEFAULT_URL_HOST"]}"
+  config.mailer_sender = "no-reply@casa-production.herokuapp.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
This reverts commit 1863663194226d5a63703d668e8ade66aa48038e.

Backstory:
Currently we are banned from sendgrid for unknown reasons. I and Sean have both opened tickets to try to get this fixed. 
We have supervisor training coming up on wednesday and we would really like them to have accounts by then. 
Log into https://my.sendinblue.com/dashboard# by choosing "log in with google" and logging in as casa@ rubyforgood. Sean or I have the password. (you should not need to do this, but just in case)
See emails sent at https://app-smtp.sendinblue.com/statistics
Keep in mind that email delivery is *very* slow. On 4 August 2020 it took about 4-6 hours. On 6 August 2020 it took about 30 minutes. I guess that's what we get for free :/ 

You can see where the env variables used here are configured at: https://dashboard.heroku.com/apps/casa-r4g-staging/settings

<img width="728" alt="Screen Shot 2020-08-09 at 10 55 12 AM" src="https://user-images.githubusercontent.com/578159/89738591-d24f8900-da2e-11ea-9708-c9ba2d3b9341.png">
<img width="712" alt="Screen Shot 2020-08-09 at 10 56 00 AM" src="https://user-images.githubusercontent.com/578159/89738618-f4490b80-da2e-11ea-8843-e3cc029e7d7b.png">

<img width="838" alt="Screen Shot 2020-08-09 at 10 48 44 AM" src="https://user-images.githubusercontent.com/578159/89738517-21e18500-da2e-11ea-8ea4-57caf81287f3.png">
