### PR TITLE
Text mailer converted to a proper text email

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,18 +1,4 @@
-<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
-<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      A CASA/Prince George’s County volunteer console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
-    </td>
-  </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new volunteer account.
-    </td>
-  </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
-    </td>
-  </tr>
-</table>
+A CASA/Prince George’s County volunteer console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
+
+Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new volunteer account.
+<%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #510 

### What changed, and why?
invitation_instructions.text.erb should have text and not HTML. This converted to a proper text email.



