### PR TITLE
Fix validate error when duration_minutes == 15

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,7 +5,7 @@ class CaseContact < ApplicationRecord
   validate :contact_made_chosen
   validates :contact_types, presence: true
   validate :contact_types_included
-  validates :duration_minutes, numericality: {greater_than: 15, message: "Minimum case contact duration should be 15 minutes." }
+  validates :duration_minutes, numericality: { greater_than_or_equal_to: 15, message: "Minimum case contact duration should be 15 minutes." }
   validates :medium_type, presence: true
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future


### PR DESCRIPTION
### What changed, and why?
Only values greater than 15 minutes were valid, but not exactly 15


