### PR TITLE
Fix column name for creator's data in report

### DIFF
--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -33,8 +33,8 @@ class CaseContactReport
       miles_driven: case_contact&.miles_driven,
       wants_driving_reimbursement: case_contact&.want_driving_reimbursement,
       casa_case_number: case_contact&.casa_case&.case_number,
-      volunteer_email: case_contact&.creator&.email,
-      volunteer_name: case_contact&.creator&.display_name,
+      creator_email: case_contact&.creator&.email,
+      creator_name: case_contact&.creator&.display_name,
       supervisor_name: case_contact&.creator&.supervisor&.display_name
     }
   end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe CaseContactReport, type: :model do
         "Miles Driven",
         "Wants Driving Reimbursement",
         "Casa Case Number",
-        "Volunteer Email",
-        "Volunteer Name",
+        "Creator Email",
+        "Creator Name",
         "Supervisor Name"
       ])
       case_contact_data = parsed_csv[1]


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #418 

### What changed, and why?
Updated the report so the column "Volunteer name" says "Creator name" and "Creator email"

### How is this tested? (please write tests!) 💖💪
Edited old test

