### PR TITLE
Allow empty volunteer column on import

### DIFF
--- a/app/models/concerns/file_importer.rb
+++ b/app/models/concerns/file_importer.rb
@@ -33,9 +33,12 @@ class FileImporter
       user.casa_org_id, user.password = org_id, SecureRandom.hex(10)
       if user.save
         user.invite!
-        volunteers = row[:supervisor_volunteers]
-        lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
-        user.volunteers << lookups.compact if lookups.compact.present?
+
+        volunteers = String(row[:supervisor_volunteers])
+          .split(",")
+          .map { |email| User.find_by(email: email.strip) }
+          .compact
+        user.volunteers << volunteers if volunteers.present?
         @number_imported += 1
       else
         @failed_imports << row.to_hash.values.to_s
@@ -51,9 +54,11 @@ class FileImporter
       casa_case = CasaCase.new(row.to_hash.slice(:case_number, :transition_aged_youth))
       casa_case.casa_org_id = org_id
       if casa_case.save
-        volunteers = row[:case_assignment]
-        lookups = volunteers.split(",").map { |email| User.find_by(email: email.strip) }
-        casa_case.volunteers << lookups.compact if lookups.compact.present?
+        volunteers = String(row[:case_assignment])
+          .split(",")
+          .map { |email| User.find_by(email: email.strip) }
+          .compact
+        casa_case.volunteers << volunteers if volunteers.present?
         @number_imported += 1
       else
         @failed_imports << row.to_hash.values.to_s

--- a/spec/fixtures/casa_cases.csv
+++ b/spec/fixtures/casa_cases.csv
@@ -1,3 +1,4 @@
 ﻿case_number,transition_aged_youth,case_assignment
 CINA-01-4347,TRUE,volunteer1@example.net
 CINA-01-4348,FALSE,"volunteer2@example.net, volunteer3@example.net"
+CINA-01-4349,FALSE,

--- a/spec/fixtures/supervisors.csv
+++ b/spec/fixtures/supervisors.csv
@@ -1,3 +1,4 @@
 ﻿email,display_name,supervisor_volunteers
 supervisor1@example.net,Supervisor One,volunteer1@example.net
 supervisor2@example.net,Supervisor Two,"volunteer2@example.net, volunteer3@example.net"
+supervisor3@example.net,Supervisor Three,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #508

### What changed, and why?
An error was occurring if the columns containing volunteer email addresses was empty.

Allow supervisors and cases to be imported without volunteers.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Automated tests updated!