### PR TITLE
Keep same import tab selected on import errors

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -4,12 +4,13 @@ class ImportsController < ApplicationController
   before_action :check_empty_attachment, only: [:create]
 
   def index
+    @import_type = params.fetch(:import_type, "volunteer")
   end
 
   def create
     import = import_from_csv(params[:import_type], params[:file], current_user.casa_org_id)
     flash[import[:type]] = import[:message]
-    redirect_to imports_path
+    redirect_to imports_path(import_type: params[:import_type])
   end
 
   private
@@ -30,6 +31,6 @@ class ImportsController < ApplicationController
   def check_empty_attachment
     return unless params[:file].blank?
     flash[:error] = "You must attach a csv file in order to import information!"
-    redirect_to imports_path
+    redirect_to imports_path(import_type: params[:import_type])
   end
 end

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -17,35 +17,37 @@
           <li>Cases</li>
         </ol>
         </p>
-        <br>
         <div class="row">
-          <ul class="nav nav-pills" id="pills-tab" role="tablist">
+          <ul class="nav nav-tabs" role="tablist">
             <li class="nav-item">
-              <a class="nav-link active" id="pills-volunteer-tab" data-toggle="pill" href="#pills-volunteer" role="tab" aria-controls="pills-volunteer" aria-selected="true">Import
-                Volunteers</a>
+              <%= content_tag :a, role: "tab", href: "#volunteer", id: "volunteer-tab", class: ["nav-link", ("active" if @import_type == "volunteer")].compact, data: { toggle: "tab" }, aria: { controls: "volunteer", selected: (@import_type == "volunteer") } do %>
+                Import Volunteers
+              <%- end %>
             </li>
             <li class="nav-item">
-              <a class="nav-link" id="pills-supervisor-tab" data-toggle="pill" href="#pills-supervisor" role="tab" aria-controls="pills-supervisor" aria-selected="false">Import
-                Supervisors</a>
+              <%= content_tag :a, role: "tab", href: "#supervisor", id: "supervisor-tab", class: ["nav-link", ("active" if @import_type == "supervisor")].compact, data: { toggle: "tab" }, aria: { controls: "supervisor", selected: (@import_type == "supervisor") } do %>
+                Import Supervisors
+              <%- end %>
             </li>
             <li class="nav-item">
-              <a class="nav-link" id="pills-cases-tab" data-toggle="pill" href="#pills-cases" role="tab" aria-controls="pills-cases" aria-selected="false">Import
-                Cases</a>
+              <%= content_tag :a, role: "tab", href: "#casa-case", id: "casa-case-tab", class: ["nav-link", ("active" if @import_type == "casa_case")].compact, data: { toggle: "tab" }, aria: { controls: "casa-case", selected: (@import_type == "casa_case") } do %>
+                Import Cases
+              <%- end %>
             </li>
           </ul>
-          <div class="tab-content" id="pills-tabContent">
-            <div class="tab-pane fade show active" id="pills-volunteer" role="tabpanel" aria-labelledby="pills-volunteer-tab">
+          <div class="tab-content">
+            <%= content_tag :div, role: "tabpanel", id: "volunteer", class: ["tab-pane", "fade", ("show" if @import_type == "volunteer"), ("active" if @import_type == "volunteer")].compact, aria: { labelledby: "volunteer-tab" } do %> 
               <br>
               <%= render "volunteers" %>
-            </div>
-            <div class="tab-pane fade" id="pills-supervisor" role="tabpanel" aria-labelledby="pills-supervisor-tab">
+            <%- end %>
+            <%= content_tag :div, role: "tabpanel", id: "supervisor", class: ["tab-pane", "fade", ("show" if @import_type == "supervisor"), ("active" if @import_type == "supervisor")].compact, aria: { labelledby: "supervisor-tab" } do %> 
               <br>
               <%= render "supervisors" %>
-            </div>
-            <div class="tab-pane fade" id="pills-cases" role="tabpanel" aria-labelledby="pills-cases-tab">
+            <%- end %>
+            <%= content_tag :div, role: "tabpanel", id: "casa-case", class: ["tab-pane", "fade", ("show" if @import_type == "casa_case"), ("active" if @import_type == "casa_case")].compact, aria: { labelledby: "casa-case-tab" } do %> 
               <br>
               <%= render "cases" %>
-            </div>
+            <%- end %>
           </div>
         </div>
         <br>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #504

### What changed, and why?
Previously if an admin selected 'Import Supervisors' or 'Import Cases' and there was an error with the import, they'd be directed back to the imports page with 'Import Volunteers' selected. This could easily cause confusion unless they looked closely.

Now, attempt to preserve the tab that was previously selected if there's an error.

Also change the rendering to use tabs, rather than pills, which I find a bit more clear that they are selectable. But I'm happy to switch back to pills if there's feedback that pills are superior.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
This is _mostly_ view logic changes, so I did not add any additional tests.

### Screenshots please :)

![Import Cases still selected after an error](https://user-images.githubusercontent.com/395621/90320518-0be13200-df10-11ea-82a0-2e544c7bea5a.png)
