### PR TITLE
add start and end date to list of assignments

### DIFF
--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -9,6 +9,8 @@
             <th>Volunteer Name</th>
             <th>Volunteer Email</th>
             <th>Status</th>
+            <th>Start Date</th>
+            <th>End Date</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -22,6 +24,12 @@
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
                   <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
+                <% end %>
+              </td>
+              <td><%= assignment.created_at.strftime('%B %e, %Y') %></td>
+              <td>
+                <% unless assignment.is_active? %>
+                  <%= assignment.updated_at.strftime('%B %e, %Y') %>
                 <% end %>
               </td>
               <td>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -17,22 +17,22 @@
         <tbody>
           <% @casa_case.case_assignments.each do |assignment| %>
             <tr>
-              <td><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
-              <td><%= assignment&.volunteer&.email %></td>
-              <td>
+              <td id="volunteer-name"><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
+              <td id="volunteer-email"><%= assignment&.volunteer&.email %></td>
+              <td id="assigned">
                 <% if assignment.is_active? %>
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
                   <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
                 <% end %>
               </td>
-              <td><%= assignment.created_at.strftime('%B %e, %Y') %></td>
-              <td>
+              <td id="assignment-start"><%= assignment.created_at.strftime('%B %e, %Y') %></td>
+              <td id="assignment-end">
                 <% unless assignment.is_active? %>
                   <%= assignment.updated_at.strftime('%B %e, %Y') %>
                 <% end %>
               </td>
-              <td>
+              <td id="action">
                 <% if assignment.is_active? && (current_user.supervisor? || current_user.casa_admin?) %>
                   <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
                 <% elsif !assignment.volunteer.active_volunteer && policy(assignment.volunteer).activate? %>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -26,10 +26,10 @@
                   <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
                 <% end %>
               </td>
-              <td id="assignment-start"><%= assignment.created_at.strftime('%B %e, %Y') %></td>
+              <td id="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
               <td id="assignment-end">
                 <% unless assignment.is_active? %>
-                  <%= assignment.updated_at.strftime('%B %e, %Y') %>
+                  <%= assignment.updated_at.strftime("%B %e, %Y") %>
                 <% end %>
               </td>
               <td id="action">

--- a/spec/features/admin_assign_a_volunteer_to_case_spec.rb
+++ b/spec/features/admin_assign_a_volunteer_to_case_spec.rb
@@ -15,24 +15,50 @@ RSpec.describe "admin or supervisor assign and unassign a volunteer to case", ty
     click_on "Assign Volunteer"
   end
 
-  it "when a volunteer assign to a case" do
-    expect(casa_case.case_assignments.count).to eq 1
+  context "when a volunteer is assigned to a case" do
+    it 'marks the volunteer as assigned and shows the start date of the assignment' do
+      expect(casa_case.case_assignments.count).to eq 1
 
-    unassign_button = page.find("input.btn-outline-danger")
-    expect(unassign_button.value).to eq "Unassign Volunteer"
+      unassign_button = page.find("input.btn-outline-danger")
+      expect(unassign_button.value).to eq "Unassign Volunteer"
 
-    assign_badge = page.find("span.badge-success")
-    expect(assign_badge.text).to eq "Assigned"
+      assign_badge = page.find("span.badge-success")
+      expect(assign_badge.text).to eq "Assigned"
+
+      end
+
+    it "shows an assignment start date and no assignment end date" do
+      expected_start_date = Date.today.strftime("%B %e, %Y")
+      assignment_start = page.find("#assignment-start").text
+      assignment_end = page.find("#assignment-end").text
+
+      expect(assignment_start).to eq(expected_start_date)
+      expect(assignment_end).to be_empty
+    end
   end
 
-  it "when a volunteer unassign from a case" do
-    unassign_button = page.find("input.btn-outline-danger")
-    expect(unassign_button.value).to eq "Unassign Volunteer"
+  context "when a volunteer is unassigned from a case" do
+    it "marks the volunteer as unassigned" do
+      unassign_button = page.find("input.btn-outline-danger")
+      expect(unassign_button.value).to eq "Unassign Volunteer"
 
-    click_on "Unassign Volunteer"
+      click_on "Unassign Volunteer"
 
-    assign_badge = page.find("span.badge-danger")
-    expect(assign_badge.text).to eq "Unassigned"
+      assign_badge = page.find("span.badge-danger")
+      expect(assign_badge.text).to eq "Unassigned"
+    end
+
+    it "shows an assignment start date and an assignment end date" do
+      expected_start_and_end_date = Date.today.strftime("%B %e, %Y")
+
+      click_on "Unassign Volunteer"
+
+      assignment_start = page.find("#assignment-start").text
+      assignment_end = page.find("#assignment-end").text
+
+      expect(assignment_start).to eq(expected_start_and_end_date)
+      expect(assignment_end).to eq(expected_start_and_end_date)
+    end
   end
 
   it "when a volunteer unassign from a case by other a supervisor" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #538

### What changed, and why?
add start date and end date columns to the table that shows volunteer assignments

### How will this affect user permissions?
- Volunteer permissions: no effect
- Supervisor permissions: no effect
- Admin permissions: no effect

### How is this tested? (please write tests!) 💖💪
~~No tests! AFAICT, there are no tests for this view written yet. If we want them written as part of this PR, please say so, and we can figure out how to set up tests for this view.~~

I had originally missed the existing tests for the case assignments feature. Tests for the presence of the dates have now been added.

### Screenshots
![sample-start-end-dates](https://user-images.githubusercontent.com/3824492/90347330-4d97d880-dff5-11ea-88b2-43259234594f.png)
