### PR TITLE
use data attribute for accessing repeated column for test

### DIFF
--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -17,22 +17,22 @@
         <tbody>
           <% @casa_case.case_assignments.each do |assignment| %>
             <tr>
-              <td id="volunteer-name"><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
-              <td id="volunteer-email"><%= assignment&.volunteer&.email %></td>
-              <td id="assigned">
+              <td data-test="volunteer-name"><%= link_to assignment&.volunteer&.display_name, edit_volunteer_path(assignment.volunteer) %></td>
+              <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
+              <td data-test="assigned">
                 <% if assignment.is_active? %>
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
                   <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
                 <% end %>
               </td>
-              <td id="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
-              <td id="assignment-end">
+              <td data-test="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
+              <td data-test="assignment-end">
                 <% unless assignment.is_active? %>
                   <%= assignment.updated_at.strftime("%B %e, %Y") %>
                 <% end %>
               </td>
-              <td id="action">
+              <td data-test="action">
                 <% if assignment.is_active? && (current_user.supervisor? || current_user.casa_admin?) %>
                   <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
                 <% elsif !assignment.volunteer.active_volunteer && policy(assignment.volunteer).activate? %>

--- a/spec/features/admin_assign_a_volunteer_to_case_spec.rb
+++ b/spec/features/admin_assign_a_volunteer_to_case_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "admin or supervisor assign and unassign a volunteer to case", ty
 
     it "shows an assignment start date and no assignment end date" do
       expected_start_date = Date.today.strftime("%B %e, %Y")
-      assignment_start = page.find("#assignment-start").text
-      assignment_end = page.find("#assignment-end").text
+      assignment_start = page.find("td[data-test=assignment-start]").text
+      assignment_end = page.find("td[data-test=assignment-end]").text
 
       expect(assignment_start).to eq(expected_start_date)
       expect(assignment_end).to be_empty
@@ -53,8 +53,8 @@ RSpec.describe "admin or supervisor assign and unassign a volunteer to case", ty
 
       click_on "Unassign Volunteer"
 
-      assignment_start = page.find("#assignment-start").text
-      assignment_end = page.find("#assignment-end").text
+      assignment_start = page.find("td[data-test=assignment-start]").text
+      assignment_end = page.find("td[data-test=assignment-end]").text
 
       expect(assignment_start).to eq(expected_start_and_end_date)
       expect(assignment_end).to eq(expected_start_and_end_date)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #538 

### What changed, and why?
Element ids are changed to `data-test` attributes in the volunteers table that appears when editing a case.

This is a follow-up to #551. As @compwron [noted](https://github.com/rubyforgood/casa/pull/551#discussion_r471617645), element ids should be unique. When there is more than volunteer in the table, then the ids added in #551 would no longer be unique. Using a data element instead allows for identifying and accessing a column during test without breaking the rule that ids should be unique

### How will this affect user permissions?
- Volunteer permissions: no effect
- Supervisor permissions: no effect
- Admin permissions: no effect

### How is this tested? (please write tests!) 💖💪
tests updated