### PR TITLE
Supervisor dashboard performance

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,15 +6,15 @@ class DashboardController < ApplicationController
 
     # Return all active/inactive volunteers, inactive will be filtered by default
     @volunteers = policy_scope(
-      Volunteer.includes(:case_assignments, :casa_cases, versions: [:item])
+      Volunteer.includes(:supervisor, :case_assignments, :case_contacts, :casa_cases, versions: [:item])
     ).decorate
 
-    @casa_cases = policy_scope(CasaCase.includes(:case_assignments, :volunteers).all)
+    @casa_cases = policy_scope(CasaCase.includes(:case_assignments, :volunteers))
 
     @case_contacts = policy_scope(
       CaseContact.all
     ).order(occurred_at: :desc).decorate
 
-    @supervisors = policy_scope(Supervisor.all)
+    @supervisors = policy_scope(Supervisor.includes(:supervisor_volunteers, :volunteers))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,11 +58,22 @@ class User < ApplicationRecord
   end
 
   def recent_contacts_made(days_counter = 60)
-    case_contacts.where(contact_made: true, occurred_at: days_counter.days.ago..Date.today).count
+    case_contacts.where(contact_made: true, occurred_at: days_counter.days.ago..Date.today).size
   end
 
   def most_recent_contact
     case_contacts.where(contact_made: true).order(:occurred_at).last
+  end
+
+  def volunteers_serving_transistion_aged_youth
+    volunteers.includes(:casa_cases)
+        .where(casa_cases: {transition_aged_youth: true}).size
+  end
+
+  def no_contact_for_two_weeks
+    volunteers.includes(:case_contacts)
+        .where(case_contacts: {contact_made: true})
+        .where.not(case_contacts: { occurred_at: 14.days.ago..Date.today}).size
   end
 
   def past_names

--- a/app/views/dashboard/_supervisors_table.html.erb
+++ b/app/views/dashboard/_supervisors_table.html.erb
@@ -23,15 +23,12 @@
         <td id="name">
           <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
         </td>
-        <td id="volunteer-assignments"> <%= supervisor.volunteers.count %></td>
+        <td id="volunteer-assignments"> <%= supervisor.volunteers.size %></td>
         <td id="serving-transition-aged-youth">
-          <%= supervisor.volunteers.select { |v| v.serving_transition_aged_youth? }.count %>
+          <%= supervisor.volunteers_serving_transistion_aged_youth %>
         </td>
         <td id="no-contact">
-          <%=
-            days_since_contact = 14
-            supervisor.volunteers.select { |v| v.recent_contacts_made(days_since_contact) < 1 }.count
-          %>
+          <%= supervisor.no_contact_for_two_weeks %>
         </td>
         <td><%= link_to 'Edit', edit_supervisor_path(supervisor) %></td>
       </tr>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe User, type: :model do
     expect(result.length).to eq(1)
   end
 
+  describe "supervisors" do
+    context "#volunteers_serving_transistion_aged_youth" do
+      it 'returns the number of transition aged youth on a supervisor' do
+        assignment1 = create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: true))
+        assignment2 = create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: true))
+        assignment3 = create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: false))
+        supervisor = create(:supervisor)
+        create(:volunteer, case_assignments: [assignment1], supervisor: supervisor)
+        create(:volunteer, case_assignments: [assignment2], supervisor: supervisor)
+        create(:volunteer, case_assignments: [assignment3], supervisor: supervisor)
+        expect(supervisor.volunteers_serving_transistion_aged_youth).to eq(2)
+      end
+    end
+
+    context "#no_contact_for_two_weeks" do
+      it 'returns the number of volunteers who have not made contact in over 2 weeks' do
+        supervisor = create(:supervisor)
+
+        volunteer = create(:volunteer, :with_casa_cases, supervisor: supervisor)
+
+        case_of_interest = volunteer.casa_cases.first
+        create(:case_contact, creator: volunteer, casa_case: case_of_interest, contact_made: true, occurred_at: 3.weeks.ago)
+        expect(supervisor.no_contact_for_two_weeks).to eq(1)
+      end
+    end
+  end
+
   describe "#active_for_authentication?" do
     it "is false when the user is inactive" do
       user = create(:volunteer, :inactive)
@@ -73,8 +100,8 @@ RSpec.describe User, type: :model do
     context "when the user has a transition-aged-youth case" do
       it "is true" do
         case_assignments = [
-          case_assignment_with_a_transition_aged_youth,
-          case_assignment_without_transition_aged_youth
+            case_assignment_with_a_transition_aged_youth,
+            case_assignment_without_transition_aged_youth
         ]
         user = create(:volunteer, case_assignments: case_assignments)
 


### PR DESCRIPTION
First PR for speeding up the dashboard -- this focuses on the supervisor table and cuts about a second from the load time. There is still the volunteer table and some tweaking on the supervisors but I wanted to get this up for @armahillo to see.