### PR TITLE
Issue 449 track non active supervisor volunteer relationships

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -3,7 +3,8 @@ class SupervisorVolunteersController < ApplicationController
   before_action :must_be_admin_or_supervisor, only: :unassign
 
   def create
-    supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.new(supervisor_volunteer_params)
+    supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
+    supervisor_volunteer.is_active = true
     supervisor_volunteer.save
 
     redirect_to after_action_path(supervisor_volunteer_parent)

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -1,21 +1,12 @@
 class SupervisorVolunteersController < ApplicationController
   before_action :authenticate_user!
-  before_action :must_be_admin_or_supervisor, only: %i[destroy unassign]
+  before_action :must_be_admin_or_supervisor, only: :unassign
 
   def create
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.new(supervisor_volunteer_params)
     supervisor_volunteer.save
 
     redirect_to after_action_path(supervisor_volunteer_parent)
-  end
-
-  def destroy
-    volunteer = Volunteer.find(params[:id])
-    supervisor_volunteer = volunteer.supervisor_volunteer
-    supervisor = supervisor_volunteer.supervisor
-    supervisor_volunteer.delete
-
-    redirect_to after_action_path(supervisor)
   end
 
   def unassign

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -4,8 +4,13 @@ class SupervisorVolunteersController < ApplicationController
 
   def create
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
-    supervisor_volunteer.is_active = true
+    supervisor_volunteer.is_active = true unless supervisor_volunteer.is_active?
     supervisor_volunteer.save
+
+    SupervisorVolunteer
+      .where(volunteer_id: supervisor_volunteer.volunteer, is_active: false)
+      .where.not(supervisor_id: supervisor_volunteer.supervisor.id)
+      .destroy_all
 
     redirect_to after_action_path(supervisor_volunteer_parent)
   end

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -1,6 +1,6 @@
 class SupervisorVolunteersController < ApplicationController
   before_action :authenticate_user!
-  before_action :must_be_admin_or_supervisor, only: :destroy
+  before_action :must_be_admin_or_supervisor, only: %i[destroy unassign]
 
   def create
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.new(supervisor_volunteer_params)
@@ -16,6 +16,17 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.delete
 
     redirect_to after_action_path(supervisor)
+  end
+
+  def unassign
+    volunteer = Volunteer.find(params[:id])
+    supervisor_volunteer = volunteer.supervisor_volunteer
+    supervisor_volunteer.is_active = false
+    supervisor_volunteer.save
+    supervisor = volunteer.supervisor
+    flash_message = "#{volunteer.decorate.name} was unassigned from #{supervisor.decorate.name}."
+
+    redirect_to after_action_path(supervisor), notice: flash_message
   end
 
   private

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -47,7 +47,7 @@ class SupervisorsController < ApplicationController
   private
 
   def available_volunteers
-    @available_volunteers = Supervisor.volunteers_with_no_supervisor(current_user.casa_org)
+    @available_volunteers = Volunteer.volunteers_with_no_supervisor(current_user.casa_org)
   end
 
   def supervisor_values

--- a/app/models/supervisor_volunteer.rb
+++ b/app/models/supervisor_volunteer.rb
@@ -11,6 +11,7 @@ end
 # Table name: supervisor_volunteers
 #
 #  id            :bigint           not null, primary key
+#  is_active     :boolean          default(TRUE)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  supervisor_id :bigint           not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,10 +17,13 @@ class User < ApplicationRecord
   has_one :supervisor_volunteer, foreign_key: "volunteer_id"
   has_one :supervisor, through: :supervisor_volunteer
 
-  def self.volunteers_with_no_supervisor(org)
-    # TODO make this a scope
-    Volunteer.active.includes(:supervisor_volunteer).where(casa_org_id: org.id).where(supervisor_volunteers: {id: nil})
-  end
+  scope :volunteers_with_no_supervisor, lambda { |org|
+    joins('left join supervisor_volunteers on supervisor_volunteers.volunteer_id = users.id')
+      .where(active: true)
+      .where(casa_org_id: org.id)
+      .where(supervisor_volunteers: { id: nil })
+  }
+
   def casa_admin?
     is_a?(CasaAdmin)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,9 @@ class User < ApplicationRecord
   has_one :supervisor, through: :supervisor_volunteer
 
   scope :volunteers_with_no_supervisor, lambda { |org|
-    joins('left join supervisor_volunteers on supervisor_volunteers.volunteer_id = users.id')
+    joins("left join supervisor_volunteers "\
+          "on supervisor_volunteers.volunteer_id = users.id "\
+          "and supervisor_volunteers.is_active")
       .where(active: true)
       .where(casa_org_id: org.id)
       .where(supervisor_volunteers: { id: nil })

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -58,11 +58,18 @@
           </tr>
         </thead>
         <tbody>
-          <% @assigned_volunteers.each do |assignment| %>
+          <% @assigned_volunteers.each do |volunteer| %>
             <tr>
-              <td><%= link_to assignment.decorate.name, edit_volunteer_path(assignment) %></td>
-              <td><%= assignment.email %></td>
-              <td><%= button_to 'Unassign', supervisor_volunteer_path(assignment), method: :delete, class: "btn btn-danger" %></td>
+              <td><%= link_to volunteer.decorate.name, edit_volunteer_path(volunteer) %></td>
+              <td><%= volunteer.email %></td>
+              <td>
+                <% if volunteer.supervisor_volunteer.is_active? %>
+                  <%= button_to 'Unassign', unassign_supervisor_volunteer_path(volunteer), method: :patch, class: "btn btn-danger" %>
+                <% else %>
+                  Unassigned
+                <% end %>
+
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,11 @@ Rails.application.routes.draw do
   resources :case_contact_reports, only: %i[index]
 
   resources :supervisors, only: %i[edit update new create]
-  resources :supervisor_volunteers, only: %i[create destroy]
+  resources :supervisor_volunteers, only: %i[create destroy] do
+    member do
+      patch :unassign
+    end
+  end
   resources :volunteers, only: %i[new edit create update] do
     member do
       patch :activate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :case_contact_reports, only: %i[index]
 
   resources :supervisors, only: %i[edit update new create]
-  resources :supervisor_volunteers, only: %i[create destroy] do
+  resources :supervisor_volunteers, only: %i[create] do
     member do
       patch :unassign
     end

--- a/db/migrate/20200818220659_add_is_active_to_supervisor_volunteers.rb
+++ b/db/migrate/20200818220659_add_is_active_to_supervisor_volunteers.rb
@@ -1,0 +1,6 @@
+class AddIsActiveToSupervisorVolunteers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :supervisor_volunteers, :is_active, :boolean, default: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_01_192923) do
+ActiveRecord::Schema.define(version: 2020_08_18_220659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2020_08_01_192923) do
     t.bigint "volunteer_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_active", default: true
     t.index ["supervisor_id"], name: "index_supervisor_volunteers_on_supervisor_id"
     t.index ["volunteer_id"], name: "index_supervisor_volunteers_on_volunteer_id"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "#volunteers_with_no_supervisor?" do
-    subject { Supervisor.volunteers_with_no_supervisor(casa_org) }
+    subject { User.volunteers_with_no_supervisor(casa_org) }
     let(:casa_org) { create(:casa_org) }
     context "no volunteers" do
       it "returns none" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,14 +104,15 @@ RSpec.describe User, type: :model do
       let!(:unassigned1) { create(:volunteer, display_name: "aaa", casa_org: casa_org) }
       let!(:unassigned2) { create(:volunteer, display_name: "bbb", casa_org: casa_org) }
       let!(:unassigned2_different_org) { create(:volunteer, display_name: "ccc") }
-      let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1) }
       let!(:assigned1) { create(:volunteer, display_name: "ddd", casa_org: casa_org) }
       let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1) }
       let!(:assigned2_different_org) { assignment1.volunteer }
-      let!(:unassigned_inactive) { create(:volunteer, display_name: "eee", casa_org: casa_org, active: false) }
+      let!(:unassigned_inactive_volunteer) { create(:volunteer, display_name: "eee", casa_org: casa_org, active: false) }
+      let!(:previously_assigned) { create(:volunteer, display_name: "fff", casa_org: casa_org) }
+      let!(:inactive_assignment) { create(:supervisor_volunteer, volunteer: previously_assigned, is_active: false) }
 
       it "returns unassigned volunteers" do
-        expect(subject.map(&:display_name).sort).to eq(["aaa", "bbb"])
+        expect(subject.map(&:display_name).sort).to eq(["aaa", "bbb", "fff"])
       end
     end
   end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -1,50 +1,108 @@
 require "rails_helper"
 
-RSpec.describe "DELETE /supervisor_volunteers/:id", type: :request do
-  context "when the logged in user is an admin" do
-    it "destroys the assignment of a volunteer to a supervisor" do
-      admin = create(:casa_admin)
-      supervisor = create(:supervisor)
-      volunteer = create(:volunteer)
-      create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+RSpec.describe "/supervisor_volunteers", type: :request do
 
-      sign_in admin
+  context "DELETE :id" do
+    context "when the logged in user is an admin" do
+      it "destroys the assignment of a volunteer to a supervisor" do
+        admin = create(:casa_admin)
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
 
-      expect {
-        delete supervisor_volunteer_path(volunteer)
-      }.to change(supervisor.volunteers, :count).by(-1)
+        sign_in admin
 
-      expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect {
+          delete supervisor_volunteer_path(volunteer)
+        }.to change(supervisor.volunteers, :count).by(-1)
+
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
+      end
+    end
+
+    context "when the logged in user is a supervisor" do
+      it "destroys the assignment of a volunteer to a supervisor" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+        sign_in supervisor
+
+        expect {
+          delete supervisor_volunteer_path(volunteer)
+        }.to change(supervisor.volunteers, :count).by(-1)
+
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
+      end
+    end
+
+    context "when the logged in user is not an admin or supervisor" do
+      it "does not destroy the assignment" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+        sign_in volunteer
+
+        expect {
+          delete supervisor_volunteer_path(assignment)
+        }.to change(supervisor.volunteers, :count).by(0)
+      end
     end
   end
 
-  context "when the logged in user is a supervisor" do
-    it "destroys the assignment of a volunteer to a supervisor" do
-      supervisor = create(:supervisor)
-      volunteer = create(:volunteer)
+  context "PATCH /unassign" do
+    let!(:admin) { create(:casa_admin) }
+    let!(:supervisor) { create(:supervisor) }
+    let!(:volunteer) { create(:volunteer) }
+    let!(:association) do
       create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
-
-      sign_in supervisor
-
-      expect {
-        delete supervisor_volunteer_path(volunteer)
-      }.to change(supervisor.volunteers, :count).by(-1)
-
-      expect(response).to redirect_to edit_supervisor_path(supervisor)
     end
-  end
 
-  context "when the logged in user is not an admin or supervisor" do
-    it "does not destroy the assignment" do
-      supervisor = create(:supervisor)
-      volunteer = create(:volunteer)
-      assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+    context "when the logged in user is an admin" do
+      it "sets the is_active flag for assignment of a volunteer to a supervisor to false" do
+        sign_in admin
 
-      sign_in volunteer
+        expect {
+          patch unassign_supervisor_volunteer_path(volunteer)
+        }.not_to change(supervisor.volunteers, :count)
 
-      expect {
-        delete supervisor_volunteer_path(assignment)
-      }.to change(supervisor.volunteers, :count).by(0)
+        association.reload
+        expect(association.is_active).to be(false)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
+      end
+    end
+
+    context "when the logged in user is a supervisor" do
+      it "sets the is_active flag for assignment of a volunteer to a supervisor to false" do
+        sign_in supervisor
+
+        expect {
+          patch unassign_supervisor_volunteer_path(volunteer)
+        }.not_to change(supervisor.volunteers, :count)
+
+        association.reload
+        expect(association.is_active).to be(false)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
+      end
+    end
+
+    context "when the logged in user is not an admin or supervisor" do
+      it "does not set the is_active flag on the association to false" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+
+        sign_in volunteer
+
+        expect {
+          patch unassign_supervisor_volunteer_path(volunteer)
+        }.not_to change(supervisor.volunteers, :count)
+
+        assignment.reload
+
+        expect(assignment.is_active).to be(true)
+      end
     end
   end
 end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -1,56 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "/supervisor_volunteers", type: :request do
-
-  context "DELETE :id" do
-    context "when the logged in user is an admin" do
-      it "destroys the assignment of a volunteer to a supervisor" do
-        admin = create(:casa_admin)
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
-
-        sign_in admin
-
-        expect {
-          delete supervisor_volunteer_path(volunteer)
-        }.to change(supervisor.volunteers, :count).by(-1)
-
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
-      end
-    end
-
-    context "when the logged in user is a supervisor" do
-      it "destroys the assignment of a volunteer to a supervisor" do
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
-
-        sign_in supervisor
-
-        expect {
-          delete supervisor_volunteer_path(volunteer)
-        }.to change(supervisor.volunteers, :count).by(-1)
-
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
-      end
-    end
-
-    context "when the logged in user is not an admin or supervisor" do
-      it "does not destroy the assignment" do
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        assignment = create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
-
-        sign_in volunteer
-
-        expect {
-          delete supervisor_volunteer_path(assignment)
-        }.to change(supervisor.volunteers, :count).by(0)
-      end
-    end
-  end
-
   context "PATCH /unassign" do
     let!(:admin) { create(:casa_admin) }
     let!(:supervisor) { create(:supervisor) }

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -14,11 +14,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         }
         sign_in(admin)
 
-        expect { post supervisor_volunteers_url, params: valid_parameters }
-            .to change(
-                    SupervisorVolunteer,
-                    :count
-                ).by(1)
+        expect do
+          post supervisor_volunteers_url, params: valid_parameters
+        end.to change(SupervisorVolunteer, :count).by(1)
       end
     end
 
@@ -55,8 +53,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
             supervisor: other_supervisor,
             volunteer: volunteer,
             is_active: false
-        )
+          )
       end
+
       it "replaces that association" do
         valid_parameters = {
             supervisor_volunteer: { volunteer_id: volunteer.id },
@@ -83,9 +82,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
       it "sets the is_active flag for assignment of a volunteer to a supervisor to false" do
         sign_in admin
 
-        expect {
+        expect do
           patch unassign_supervisor_volunteer_path(volunteer)
-        }.not_to change(supervisor.volunteers, :count)
+        end.not_to change(supervisor.volunteers, :count)
 
         association.reload
 
@@ -98,9 +97,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
       it "sets the is_active flag for assignment of a volunteer to a supervisor to false" do
         sign_in supervisor
 
-        expect {
+        expect do
           patch unassign_supervisor_volunteer_path(volunteer)
-        }.not_to change(supervisor.volunteers, :count)
+        end.not_to change(supervisor.volunteers, :count)
 
         association.reload
 
@@ -116,9 +115,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
       it "does not set the is_active flag on the association to false" do
         sign_in volunteer
 
-        expect {
+        expect do
           patch unassign_supervisor_volunteer_path(volunteer)
-        }.not_to change(supervisor.volunteers, :count)
+        end.not_to change(supervisor.volunteers, :count)
 
         association.reload
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #449

### What changed, and why?
Introduced the ability to define a supervisor_volunteer relationship as not active so that volunteers who were unassigned can appear in the list of volunteers for a supervisor.

When the volunteer is assigned to a new supervisor, this inactive relationship is removed in favor of the new active relationship.


### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor permissions: no change
- Admin permissions: no change

### How is this tested? (please write tests!)
Tests written

### Screenshots please

#### A volunteer is unassigned and then re-assigned to the same supervisor
Reva Marquardt originally assigned to Gloria O'Malley
![before-unassigning-reva-marquardt](https://user-images.githubusercontent.com/3824492/90685848-ff224e00-e22f-11ea-8237-6e25e1c0afea.png)

Reva Marquardt unassigned from Gloria O'Malley
![after-unassigning-reva-marquardt](https://user-images.githubusercontent.com/3824492/90685847-ff224e00-e22f-11ea-80a8-c0514bbb2932.png)

Reva Marquardt re-assigned to Gloria O'Malley
![after-re-assigning-reva-marquardt](https://user-images.githubusercontent.com/3824492/90685843-fe89b780-e22f-11ea-9438-08b6bbd5612e.png)

Database records for this relationship
```sql
-- after unassigning Reva Marquardt (user #2)
casa_development=# select * from supervisor_volunteers where volunteer_id = 2;
 id | supervisor_id | volunteer_id |         created_at         |         updated_at         | is_active 
----+---------------+--------------+----------------------------+----------------------------+-----------
  1 |           104 |            2 | 2020-08-19 19:23:41.941016 | 2020-08-19 19:25:48.311013 | f
(1 row)

-- after re-assigning Reva Marquardt (user #2)
casa_development=# select * from supervisor_volunteers where volunteer_id = 2;
 id | supervisor_id | volunteer_id |         created_at         |         updated_at         | is_active 
----+---------------+--------------+----------------------------+----------------------------+-----------
  1 |           104 |            2 | 2020-08-19 19:23:41.941016 | 2020-08-19 19:27:10.391131 | t
(1 row)
```

#### A volunteer is unassigned from one supervisor and then assigned to another one

Raymundo Stark is unassigned from Gloria O'Malley
![raymundo-stark-unassigned-from-gloria-omalley](https://user-images.githubusercontent.com/3824492/90685842-fe89b780-e22f-11ea-9bc6-6d038767479d.png)

Raymundo Stark is assigned to Latosha Emmrich
![raymundo-stark-assigned-to-latosha-emmereich](https://user-images.githubusercontent.com/3824492/90685841-fdf12100-e22f-11ea-9088-53a334823970.png)



Database records for this relationship
```sql
-- moving Raymundo Stark from one supervisor to another
casa_development=# select * from supervisor_volunteers where volunteer_id = 20;
 id  | supervisor_id | volunteer_id |         created_at         |         updated_at         | is_active 
-----+---------------+--------------+----------------------------+----------------------------+-----------
 108 |           104 |           20 | 2020-08-19 20:15:47.047636 | 2020-08-19 20:15:47.047636 | t
(1 row)

casa_development=# select * from supervisor_volunteers where volunteer_id = 20;
 id  | supervisor_id | volunteer_id |         created_at         |         updated_at         | is_active 
-----+---------------+--------------+----------------------------+----------------------------+-----------
 108 |           104 |           20 | 2020-08-19 20:15:47.047636 | 2020-08-19 20:16:14.042868 | f
(1 row)

casa_development=# select * from supervisor_volunteers where volunteer_id = 20;
 id  | supervisor_id | volunteer_id |         created_at         |         updated_at         | is_active 
-----+---------------+--------------+----------------------------+----------------------------+-----------
 109 |           105 |           20 | 2020-08-19 20:17:06.721558 | 2020-08-19 20:17:06.721558 | t
```