### PR TITLE
Send emails when volunteers are activated and deactivated

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -33,7 +33,7 @@ class VolunteersController < ApplicationController
   end
 
   def activate
-    if @volunteer.update(active: true)
+    if @volunteer.activate
       VolunteerMailer.account_setup(@volunteer).deliver
 
       if params[:redirect_to_path] == "casa_case" && casa_case = CasaCase.find(params[:casa_case_id])
@@ -47,9 +47,9 @@ class VolunteersController < ApplicationController
   end
 
   def deactivate
-    if @volunteer.update(active: false)
-      @volunteer.case_assignments.update_all(is_active: false)
+    if @volunteer.deactivate
       VolunteerMailer.deactivation(@volunteer).deliver
+
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else
       render :edit

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -20,7 +20,6 @@ class VolunteersController < ApplicationController
   end
 
   def edit
-    @volunteer_active = @volunteer.active_volunteer
     @available_casa_cases = CasaCase.all.order(:case_number)
   end
 

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -9,7 +9,7 @@ class CaseAssignment < ApplicationRecord
   validate :assignee_must_be_volunteer
 
   def assignee_must_be_volunteer
-    errors.add(:volunteer, "Case assignee must be a volunteer") unless volunteer.active_volunteer
+    errors.add(:volunteer, "Case assignee must be a volunteer") unless volunteer.is_a?(Volunteer) && volunteer.active?
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,10 +42,6 @@ class User < ApplicationRecord
     end
   end
 
-  def active_volunteer
-    active && type == "Volunteer"
-  end
-
   # all contacts this user has with this casa case
   def case_contacts_for(casa_case_id)
     found_casa_case = casa_cases.find { |cc| cc.id == casa_case_id }

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -14,6 +14,23 @@ class Volunteer < User
     contact_made_in_past_60_days
     actions
   ].freeze
+
+  # Activates this volunteer.
+  def activate
+    update(active: true)
+  end
+
+  # Deactivates this volunteer and all of their case assignments.
+  def deactivate
+    transaction do
+      updated = update(active: false)
+      if updated
+        case_assignments.update_all(is_active: false)
+      end
+
+      updated
+    end
+  end
 end
 
 # == Schema Information

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -23,7 +23,7 @@
                 <% if assignment.is_active? %>
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
-                  <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active_volunteer ? "Unassigned" : "Deactivated volunteer" %></span>
+                  <span class="badge badge-danger text-uppercase"><%= assignment.volunteer.active? ? "Unassigned" : "Deactivated volunteer" %></span>
                 <% end %>
               </td>
               <td data-test="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
@@ -35,7 +35,7 @@
               <td data-test="action">
                 <% if assignment.is_active? && (current_user.supervisor? || current_user.casa_admin?) %>
                   <%= button_to 'Unassign Volunteer', unassign_case_assignment_path(assignment), method: :patch, class: "btn btn-outline-danger" %>
-                <% elsif !assignment.volunteer.active_volunteer && policy(assignment.volunteer).activate? %>
+                <% elsif !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
                   <%= link_to "Activate Volunteer",
                         activate_volunteer_path(assignment.volunteer, redirect_to_path: 'casa_case', casa_case_id: @casa_case.id),
                         method: :patch,

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -38,7 +38,7 @@
 
 
       <div class="field form-group">
-        <% if @volunteer_active %>
+        <% if @volunteer.active? %>
           Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
           <% if policy(@volunteer).deactivate? %>
             <%= link_to "Deactivate volunteer",
@@ -90,14 +90,14 @@
               <td><%= link_to assignment.casa_case.case_number, edit_casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.decorate.transition_aged_youth_icon %></td>
               <td>
-                <% if @volunteer_active %>
+                <% if @volunteer.active? %>
                   Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
                 <% else %>
                   Deactivated
                 <% end %>
               </td>
               <td>
-                <% if @volunteer_active %>
+                <% if @volunteer.active? %>
                   <%= button_to 'Unassign Case', case_assignment_path(assignment, volunteer_id: @volunteer.id), method: :delete, class: "btn btn-danger" if Pundit.policy(current_user, @volunteer).unassign_case? %>
                 <% else %>
                   None
@@ -111,7 +111,7 @@
   </div>
 <% end %>
 
-<% if @volunteer_active %>
+<% if @volunteer.active? %>
   <br>
 
   <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
   resources :volunteers, only: %i[new edit create update] do
     member do
       patch :activate
-      get :deactivate
       patch :deactivate
     end
   end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Volunteer, type: :model do
+  describe "#activate" do
+    let(:volunteer) { create(:volunteer, :inactive) }
+
+    it "activates the volunteer" do
+      volunteer.activate
+
+      volunteer.reload
+      expect(volunteer.active).to eq(true)
+    end
+  end
+
+  describe "#deactivate" do
+    let(:volunteer) { create(:volunteer) }
+
+    it "deactivates the volunteer" do
+      volunteer.deactivate
+
+      volunteer.reload
+      expect(volunteer.active).to eq(false)
+    end
+
+    it "sets all of a volunteer's case assignments to inactive" do
+      case_contacts = create_list(:case_assignment, 3, volunteer: volunteer)
+
+      volunteer.deactivate
+
+      case_contacts.each { |c| c.reload }
+      expect(case_contacts).to all(satisfy { |c| !c.is_active })
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #550

### What changed, and why?
* Send volunteer activation and deactivation emails
* Push logic down into model
* Rely on autogenerated methods where possible

### How will this affect user permissions?
- Volunteer permissions: No changes
- Supervisor permissions: No changes
- Admin permissions: No changes

### How is this tested? (please write tests!) 💖💪
Tests added