### PR TITLE
Issue 572 - Enables users to remain on the same page after editing a casa case

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -46,7 +46,7 @@ class CasaCasesController < ApplicationController
   def update
     respond_to do |format|
       if @casa_case.update(casa_case_update_params)
-        format.html { redirect_to root_path, notice: "CASA case was successfully updated." }
+        format.html { redirect_to edit_casa_case_path, notice: "CASA case was successfully updated."}
         format.json { render :show, status: :ok, location: @casa_case }
       else
         format.html { render :edit }

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "/casa_cases", type: :request do
         casa_case = CasaCase.create! valid_attributes
         patch casa_case_url(casa_case), params: {casa_case: new_attributes}
         casa_case.reload
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(edit_casa_case_path)
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #572 

### What changed, and why?
This PR lets users to stay on the same page after making an edit to a casa case and still be able to see the success message. The issue stated that users should remain on the same page instead of being redirected to the homepage after making an edit to the casa case.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Adds a test to check that users will remain in the edit casa case page after making an edit to a casa case.

### Screenshots please :)
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/18248767/91385178-4b582a00-e7fe-11ea-8006-e162202bfa77.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
