### PR TITLE
Create separate root paths for authenticated, unauthenticated users

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,13 @@ Rails.application.routes.draw do
   devise_for :all_casa_admins
   devise_for :users
 
-  root to: "dashboard#show"
+  authenticated :user do
+    root to: "dashboard#show"
+  end
+
+  devise_scope :user do
+    root to: "devise/sessions#new", as: :unauthenticated_root
+  end
 
   resources :casa_cases
   resources :case_contacts, except: %i[show]

--- a/spec/requests/security_meta_spec.rb
+++ b/spec/requests/security_meta_spec.rb
@@ -42,10 +42,17 @@ RSpec.describe "All Endpoints", type: :request do
         p route
       end
 
-      it "Redirects to the sign_in page with #{route.name}" do
-        send(route.verb.downcase.to_sym, route.path)
-        expect(response.status).to eq(302)
-        expect(response.header["Location"]).to be_end_with("sign_in")
+      if route.path == "/"
+        it "Renders the sign in page for root path" do
+          send(route.verb.downcase.to_sym, route.path)
+          expect(response.status).to eq(200)
+        end
+      else
+        it "Redirects to the sign_in page with #{route.name}" do
+          send(route.verb.downcase.to_sym, route.path)
+          expect(response.status).to eq(302)
+          expect(response.header["Location"]).to be_end_with("sign_in")
+        end
       end
     end
   end

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Authentication", type: :system do
+  context "when guest" do
+    it "renders sign in page with no flash messages" do
+      visit "/"
+      expect(page).to have_text "Log in"
+      expect(page).to_not have_text "sign in before continuing"
+    end
+  end
+
+  context "when authenticated user" do
+    let(:user) { create(:casa_admin) }
+    before { sign_in user }
+
+    it "renders dashboard page and shows correct flash message upon sign out" do
+      visit "/"
+      expect(page).to have_text "Volunteers"
+      click_link "Log out"
+      expect(page).to_not have_text "sign in before continuing"
+      expect(page).to have_text "Signed out successfully"
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #581 

### What changed, and why?
* For authenticated users, set root path to be the `dashboard#show` page.
* For unauthenticated users, set root path to be the sign in page.
* When guest visits root path: "/", and when user signs out, it no longer has the "you need to sign in or sign up message" displayed.

### How is this tested? (please write tests!) 💖💪
* Added a system spec that checks root path for guest and authenticated user, verifies incorrect flash messages aren't displayed

### Screenshots please :)
<img width="500" alt="Screen Shot 2020-08-29 at 10 04 10 AM" src="https://user-images.githubusercontent.com/1938665/91642322-469e9c00-e9df-11ea-986c-5063ba3affd3.png">
