### PR TITLE
Issue 575 - Directs users to details casa case page instead of edit page when clicking on casa case number

### DIFF
--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -86,7 +86,7 @@
         <tbody>
           <% @volunteer.case_assignments.each do |assignment| %>
             <tr>
-              <td><%= link_to assignment.casa_case.case_number, edit_casa_case_path(assignment.casa_case) %></td>
+              <td><%= link_to assignment.casa_case.case_number, casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.decorate.transition_aged_youth_icon %></td>
               <td>
                 <% if @volunteer.active? %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #575 

### What changed, and why?
Directs users to the casa case details page instead of the edit page when the user clicks on a casa case number anywhere on the platform. The casa case number links in the "Assigned Cases" table in the volunteer edit page was the only place I found where this was happening 👀 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
