### PR TITLE
Issue 600 - Adds notes field to CaseContact and displays field on the create case contact form

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -77,6 +77,7 @@ end
 #  duration_minutes           :integer          not null
 #  medium_type                :string
 #  miles_driven               :integer
+#  notes                      :string
 #  occurred_at                :datetime         not null
 #  other_type_text            :string
 #  want_driving_reimbursement :boolean          default(FALSE)

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -10,6 +10,7 @@ class CaseContactParameters < SimpleDelegator
         :medium_type,
         :miles_driven,
         :want_driving_reimbursement,
+        :notes,
         contact_types: []
       )
 

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -116,6 +116,11 @@
     <%= form.select :want_driving_reimbursement, options_for_select([['Yes', true], ['No', false]], case_contact.want_driving_reimbursement), {}, class: "custom-select" %>
   </div>
 
+  <div class="field notes form-group">
+    <h2><%= form.label :Notes %></h2>
+    <%= form.text_area :notes, :rows=>5, placeholder: t("forms.case_contact.notes_placeholder"), class: "form-control" %>
+  </div>
+
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary", id: "case-contact-submit" %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,3 +38,6 @@ en:
     case_contact_policy:
       edit?: "Sorry, you can only edit case contacts that you have logged."
       update?: "Sorry, you can only edit case contacts that you have logged."
+  forms:
+    case_contact:
+      notes_placeholder: "Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth."

--- a/db/migrate/20200830011647_add_notes_to_case_contacts.rb
+++ b/db/migrate/20200830011647_add_notes_to_case_contacts.rb
@@ -1,0 +1,5 @@
+class AddNotesToCaseContacts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :case_contacts, :notes, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_220659) do
+ActiveRecord::Schema.define(version: 2020_08_30_011647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_220659) do
     t.string "contact_types", array: true
     t.integer "miles_driven"
     t.boolean "want_driving_reimbursement", default: false
+    t.string "notes"
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
     t.index ["contact_types"], name: "index_case_contacts_on_contact_types", using: :gin
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -12,4 +12,16 @@ describe "case_contacts/new" do
     render template: "case_contacts/new"
     expect(rendered).to include(Time.zone.now.strftime("%Y-%m-%d"))
   end
+
+  it "displays the notes text area field" do
+    case_contact = create(:case_contact)
+    assign :case_contact, case_contact
+    assign :casa_cases, [case_contact.casa_case]
+
+    user = build_stubbed(:volunteer)
+    allow(view).to receive(:current_user).and_return(user)
+
+    render template: "case_contacts/new"
+    expect(rendered).to have_selector("textarea", :id => "case_contact_notes")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #600 

### What changed, and why?
A new field `notes` is added to the CaseContact ActiveRecord and displays this field as a `textarea` input in the create case contact form. The placeholder text specified in the issue is added in `locales/en.yml`.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Adds a test to check that the `textarea` input for the `notes` field is display in the create case contact form.

### Screenshots please :)
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/18248767/91650206-be55e080-ea4a-11ea-9adc-b9ec9ac55f41.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
