### PR TITLE
Require webdrivers conditionally #621

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,7 @@ group :test do
   gem "rake"
   gem "selenium-webdriver"
   gem "simplecov", "~> 0.19.0", require: false # pinned as a workaround for https://github.com/codeclimate/test-reporter/issues/418
-  unless ENV["DOCKER"]
-    gem "webdrivers" # Easy installation and use of web drivers to run system tests with browsers
-  end
+  gem "webdrivers", require: false # Easy installation and use of web drivers to run system tests with browsers; do not initially require as causes conflict with Docker setup
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__) # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+require "webdrivers" unless ENV["DOCKER"]
 
 # Require all support folder files
 Dir[File.expand_path(File.join(File.dirname(__FILE__), "support", "**", "*.rb"))].sort.each { |f| require f }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #621 

### What changed, and why?
Removed conditional installing of webdrivers gem since it caused discrepancies in Gemfile.lock (🤦‍♀️ ). Instead, require it conditionally in the spec helper file.

### How is this tested? (please write tests!) 💖💪
Tests should pass as normal.

