### PR TITLE
Ideas for multitenancy [work in progress]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+.DS_Store
 
 # Ignore uploaded files in development.
 /storage/*

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,12 @@
 class ApplicationController < ActionController::Base
   include Pundit
+  include Organizational
+
   protect_from_forgery
   before_action :set_paper_trail_whodunnit
 
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
+  rescue_from Organizational::UnknownOrganization, with: :not_authorized
 
   private
 

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -1,11 +1,12 @@
 class CasaCasesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_casa_case, only: %i[show edit update destroy]
+  before_action :require_organization!
 
   # GET /casa_cases
   # GET /casa_cases.json
   def index
-    @casa_cases = policy_scope(CasaCase.all)
+    @casa_cases = policy_scope(current_organization.casa_cases)
   end
 
   # GET /casa_cases/1
@@ -16,7 +17,7 @@ class CasaCasesController < ApplicationController
 
   # GET /casa_cases/new
   def new
-    @casa_case = CasaCase.new
+    @casa_case = CasaCase.new(casa_org: current_organization)
     authorize @casa_case
   end
 
@@ -28,7 +29,7 @@ class CasaCasesController < ApplicationController
   # POST /casa_cases
   # POST /casa_cases.json
   def create
-    @casa_case = CasaCase.new(casa_case_params)
+    @casa_case = CasaCase.new(casa_case_params.merge(casa_org: current_organization))
 
     respond_to do |format|
       if @casa_case.save
@@ -69,12 +70,14 @@ class CasaCasesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_casa_case
-    @casa_case = CasaCase.find(params[:id])
+    @casa_case = current_organization.casa_cases.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
   end
 
   # Only allow a list of trusted parameters through.
   def casa_case_params
-    params.require(:casa_case).permit(:case_number, :transition_aged_youth, :casa_org_id)
+    params.require(:casa_case).permit(:case_number, :transition_aged_youth)
   end
 
   # Separate params so only admins can update the case_number

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -2,19 +2,21 @@
 class CaseContactsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_case_contact, only: %i[edit update destroy]
+  before_action :require_organization!
 
   # GET /case_contacts
   # GET /case_contacts.json
   def index
-    @case_contacts = policy_scope(CaseContact).decorate
+    @case_contacts = policy_scope(current_organization.case_contacts).decorate
   end
 
   # GET /case_contacts/new
   def new
-    @casa_cases = policy_scope(CasaCase)
+    @casa_cases = policy_scope(current_organization.casa_cases)
+
     # Admins and supervisors who are navigating to this page from a specific
     # case detail page will only see that case as an option
-    @casa_cases.where!(id: params.dig(:case_contact, :casa_case_id)) if params.dig(:case_contact, :casa_case_id).present?
+    @casa_cases = @casa_cases.where(id: params.dig(:case_contact, :casa_case_id)) if params.dig(:case_contact, :casa_case_id).present?
 
     @case_contact = CaseContact.new
   end
@@ -23,7 +25,7 @@ class CaseContactsController < ApplicationController
     # These variables are used to re-render the form (render :new) if there are
     # validation errors so that the user does not lose inputs to fields that
     # they did previously enter.
-    @casa_cases = policy_scope(CasaCase)
+    @casa_cases = policy_scope(current_organization.casa_cases)
     @case_contact = CaseContact.new(create_case_contact_params)
 
     selected_cases = @casa_cases.where(id: params.dig(:case_contact, :casa_case_id))
@@ -83,7 +85,7 @@ class CaseContactsController < ApplicationController
   private
 
   def set_case_contact
-    @case_contact = authorize(CaseContact.find(params[:id]))
+    @case_contact = authorize(current_organization.case_contacts.find(params[:id]))
   end
 
   def create_case_contact_params

--- a/app/controllers/concerns/organizational.rb
+++ b/app/controllers/concerns/organizational.rb
@@ -9,6 +9,10 @@ module Organizational
   end
 
   def current_organization
-    current_user&.casa_org
+    @current_organization ||= current_user&.casa_org
+  end
+
+  included do
+    helper_method :current_organization
   end
 end

--- a/app/controllers/concerns/organizational.rb
+++ b/app/controllers/concerns/organizational.rb
@@ -1,0 +1,14 @@
+module Organizational
+  extend ActiveSupport::Concern
+
+  class UnknownOrganization < StandardError
+  end
+
+  def require_organization!
+    raise UnknownOrganization.new if current_organization.nil?
+  end
+
+  def current_organization
+    current_user&.casa_org
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,15 +6,15 @@ class DashboardController < ApplicationController
 
     # Return all active/inactive volunteers, inactive will be filtered by default
     @volunteers = policy_scope(
-      Volunteer.includes(:supervisor, :case_assignments, :case_contacts, :casa_cases, versions: [:item])
+      current_organization.volunteers.includes(:supervisor, :case_assignments, :case_contacts, :casa_cases, versions: [:item])
     ).decorate
 
-    @casa_cases = policy_scope(CasaCase.includes(:case_assignments, :volunteers))
+    @casa_cases = policy_scope(current_organization.casa_cases.includes(:case_assignments, :volunteers, :case_contacts))
 
-    @case_contacts = policy_scope(
-      CaseContact.all
-    ).order(occurred_at: :desc).decorate
+    @case_contacts = policy_scope(CaseContact.where(
+      casa_case_id: @casa_cases.map(&:id)
+    )).order(occurred_at: :desc).decorate
 
-    @supervisors = policy_scope(Supervisor.includes(:supervisor_volunteers, :volunteers))
+    @supervisors = policy_scope(current_organization.supervisors.includes(:supervisor_volunteers, :volunteers))
   end
 end

--- a/app/helpers/casa_cases_helper.rb
+++ b/app/helpers/casa_cases_helper.rb
@@ -1,1 +1,0 @@
-module CasaCasesHelper; end

--- a/app/helpers/case_assignments_helper.rb
+++ b/app/helpers/case_assignments_helper.rb
@@ -1,1 +1,0 @@
-module CaseAssignmentsHelper; end

--- a/app/helpers/policy_helper.rb
+++ b/app/helpers/policy_helper.rb
@@ -1,5 +1,0 @@
-module PolicyHelper
-  def casa_admin_of_org?(user, record)
-    user.is_instance?(CasaAdmin) && (record.casa_org == user.casa_org)
-  end
-end

--- a/app/helpers/supervisor_volunteers_helper.rb
+++ b/app/helpers/supervisor_volunteers_helper.rb
@@ -1,1 +1,0 @@
-module SupervisorVolunteersHelper; end

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -11,6 +11,12 @@ class CasaOrg < ApplicationRecord
   def volunteers
     users.where(type: "Volunteer")
   end
+
+  def case_contacts
+    CaseContact.where(
+      casa_case_id: CasaCase.where(casa_org_id: self.id)
+    )
+  end
 end
 
 # == Schema Information

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -1,5 +1,16 @@
 class CasaOrg < ApplicationRecord
   validates :name, presence: true
+
+  has_many :users
+  has_many :casa_cases
+
+  def supervisors
+    users.where(type: "Supervisor")
+  end
+
+  def volunteers
+    users.where(type: "Volunteer")
+  end
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,9 +21,15 @@ class User < ApplicationRecord
     joins("left join supervisor_volunteers "\
           "on supervisor_volunteers.volunteer_id = users.id "\
           "and supervisor_volunteers.is_active")
-      .where(active: true)
-      .where(casa_org_id: org.id)
-      .where(supervisor_volunteers: {id: nil})
+      .active
+      .in_organization(org)
+      .where(supervisor_volunteers: { id: nil })
+  }
+
+  scope :active, -> { where(active: true) }
+
+  scope :in_organization, lambda { |org|
+    where(casa_org_id: org.id)
   }
 
   def casa_admin?

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,8 +1,6 @@
 # not a database model -- used for display in tables
 # volunteer is a user role and is controlled by User model
 class Volunteer < User
-  scope :active, -> { where(active: true) }
-
   TABLE_COLUMNS = %w[
     name
     email

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -1,5 +1,4 @@
 class CasaCasePolicy
-  include PolicyHelper
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -16,12 +16,10 @@ class CasaCasePolicy
 
     def resolve
       case @user
-      when CasaAdmin # scope.in_casa_administered_by(@user)
-        scope.ordered
+      when CasaAdmin, Supervisor
+        scope
       when Volunteer
-        scope.ordered.actively_assigned_to(user)
-      when Supervisor
-        scope.ordered
+        scope.actively_assigned_to(user)
       else
         raise "unrecognized user type #{@user.type}"
       end

--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -1,5 +1,4 @@
 class CaseContactPolicy
-  include PolicyHelper
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -1,5 +1,4 @@
 class DashboardPolicy
-  include PolicyHelper
   attr_reader :user, :dashboard
 
   def initialize(user, dashboard)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,5 +1,4 @@
 class UserPolicy
-  include PolicyHelper
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -1,5 +1,4 @@
 class VolunteerPolicy < UserPolicy
-  include PolicyHelper
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,6 @@ CasaOrg.delete_all
 AllCasaAdmin.delete_all
 
 pg_casa = CasaOrg.create(name: "Prince George CASA")
-other_casa = CasaOrg.create(name: "Other CASA org")
 
 # number of volunteer users and casa cases to generate
 VOLUNTEER_USER_COUNT = 100
@@ -110,13 +109,6 @@ CasaAdmin.create(
   password: SEED_PASSWORD,
   password_confirmation: SEED_PASSWORD
 )
-CasaAdmin.create(
-  casa_org_id: other_casa.id,
-  display_name: "Other Casa Admin 1",
-  email: "other_casa_admin@example.com",
-  password: SEED_PASSWORD,
-  password_confirmation: SEED_PASSWORD
-)
 
 # inactive users
 Volunteer.create(
@@ -205,3 +197,32 @@ vols.map do |vol|
     }
   }
 end
+
+###########################
+# Other CASA Organization #
+###########################
+other_casa = CasaOrg.create(name: "Other CASA org")
+
+CasaAdmin.create(
+  casa_org: other_casa,
+  display_name: "Other Admin",
+  email: "other_casa_admin@example.com",
+  password: SEED_PASSWORD,
+  password_confirmation: SEED_PASSWORD
+)
+
+Supervisor.create(
+  casa_org: other_casa,
+  display_name: "Other Supervisor",
+  email: "other.supervisor@example.com",
+  password: SEED_PASSWORD,
+  password_confirmation: SEED_PASSWORD
+)
+
+Volunteer.create(
+  casa_org: other_casa,
+  display_name: "Other Volunteer",
+  email: "other.volunteer@example.com",
+  password: SEED_PASSWORD,
+  password_confirmation: SEED_PASSWORD
+)

--- a/spec/factories/volunteer.rb
+++ b/spec/factories/volunteer.rb
@@ -6,7 +6,8 @@ FactoryBot.define do
 
     trait :with_casa_cases do
       after(:create) do |user, _|
-        create_list(:case_assignment, 2, volunteer: user)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), volunteer: user)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), volunteer: user)
       end
     end
   end

--- a/spec/policies/casa_case_policy/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy/casa_case_policy_spec.rb
@@ -3,16 +3,23 @@ require "rails_helper"
 RSpec.describe CasaCasePolicy do
   subject { described_class }
 
+  let(:organization) { create(:casa_org) }
+
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+
   permissions :update_case_number? do
     context "when user is an admin" do
       it "does allow update case number" do
-        expect(subject).to permit(create(:casa_admin), create(:casa_case))
+        expect(subject).to permit(casa_admin, casa_case)
       end
     end
 
     context "when user is a volunteer" do
       it "does not allow update case number" do
-        expect(subject).not_to permit(create(:volunteer), create(:casa_case))
+        expect(subject).not_to permit(volunteer, casa_case)
       end
     end
   end
@@ -20,26 +27,26 @@ RSpec.describe CasaCasePolicy do
   permissions :assign_volunteers? do
     context "when user is an admin" do
       it "does allow volunteer assignment" do
-        expect(subject).to permit(create(:casa_admin), create(:casa_case))
+        expect(subject).to permit(casa_admin, casa_case)
       end
     end
 
     context "when user is a volunteer" do
       it "does not allow volunteer assignment" do
-        expect(subject).not_to permit(create(:volunteer), create(:casa_case))
+        expect(subject).not_to permit(volunteer, casa_case)
       end
     end
   end
 
   permissions :show? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin), create(:casa_case))
+      expect(subject).to permit(casa_admin, casa_case)
     end
 
     context "when volunteer is assigned" do
       it "allows the volunteer" do
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
+        volunteer = create(:volunteer, casa_org: organization)
+        casa_case = create(:casa_case, casa_org: organization)
         volunteer.casa_cases << casa_case
         expect(subject).to permit(volunteer, casa_case)
       end
@@ -47,20 +54,20 @@ RSpec.describe CasaCasePolicy do
 
     context "when volunteer is not assigned" do
       it "does not allow the volunteer" do
-        expect(subject).not_to permit(create(:volunteer), create(:casa_case))
+        expect(subject).not_to permit(volunteer, casa_case)
       end
     end
   end
 
   permissions :edit? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin), create(:casa_case))
+      expect(subject).to permit(casa_admin, casa_case)
     end
 
     context "when volunteer is assigned" do
       it "allows the volunteer" do
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
+        volunteer = create(:volunteer, casa_org: organization)
+        casa_case = create(:casa_case, casa_org: organization)
         volunteer.casa_cases << casa_case
         expect(subject).to permit(volunteer, casa_case)
       end
@@ -68,57 +75,57 @@ RSpec.describe CasaCasePolicy do
 
     context "when volunteer is not assigned" do
       it "does not allow the volunteer" do
-        expect(subject).not_to permit(create(:volunteer), create(:casa_case))
+        expect(subject).not_to permit(volunteer, casa_case)
       end
     end
   end
 
   permissions :new? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin))
+      expect(subject).to permit(casa_admin)
     end
 
     it "does not allow volunteers" do
-      expect(subject).not_to permit(create(:volunteer))
+      expect(subject).not_to permit(volunteer)
     end
   end
 
   permissions :update? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin))
+      expect(subject).to permit(casa_admin)
     end
 
     context "when volunteer is assigned" do
       it "allows the volunteer" do
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
+        volunteer = create(:volunteer, casa_org: organization)
+        casa_case = create(:casa_case, casa_org: organization)
         volunteer.casa_cases << casa_case
         expect(subject).to permit(volunteer, casa_case)
       end
     end
 
     it "does not allow volunteers who are unassigned" do
-      expect(subject).not_to permit(create(:volunteer), create(:casa_case))
+      expect(subject).not_to permit(volunteer, casa_case)
     end
   end
 
   permissions :create? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin))
+      expect(subject).to permit(casa_admin)
     end
 
     it "does not allow volunteers" do
-      expect(subject).not_to permit(create(:volunteer))
+      expect(subject).not_to permit(volunteer)
     end
   end
 
   permissions :destroy? do
     it "allows casa_admins" do
-      expect(subject).to permit(create(:casa_admin))
+      expect(subject).to permit(casa_admin)
     end
 
     it "does not allow volunteers" do
-      expect(subject).not_to permit(create(:volunteer))
+      expect(subject).not_to permit(volunteer)
     end
   end
 end

--- a/spec/policies/casa_case_policy/scope_spec.rb
+++ b/spec/policies/casa_case_policy/scope_spec.rb
@@ -1,23 +1,34 @@
 require "rails_helper"
 
 RSpec.describe CasaCasePolicy::Scope do
+  let(:organization) { create(:casa_org) }
+
   describe "#resolve" do
     it "returns all CasaCases when user is admin" do
-      user = create(:casa_admin)
-      all_casa_cases = create_list(:casa_case, 2)
+      user = create(:casa_admin, casa_org: organization)
+      all_casa_cases = create_list(:casa_case, 2, casa_org: organization)
+      other_casa_cases = create_list(:casa_case, 2)
 
-      scope = described_class.new(user, CasaCase)
+      scope = described_class.new(user, organization.casa_cases)
 
       expect(scope.resolve).to contain_exactly(*all_casa_cases)
     end
 
     it "returns active cases of the volunteer when user is volunteer" do
-      user = create(:volunteer)
-      create_list(:casa_case, 2)
-      casa_cases = create_list(:casa_case, 2, volunteers: [user])
+      user = create(:volunteer, casa_org: organization)
+      casa_cases = create_list(:casa_case, 2, volunteers: [user], casa_org: organization)
 
-      scope = described_class.new(user, CasaCase)
+      more_user = create(:volunteer, casa_org: organization)
+      more_casa_cases = create_list(:casa_case, 2, volunteers: [more_user], casa_org: organization)
 
+      other_org = create(:casa_org)
+      other_user = create(:volunteer, casa_org: other_org)
+      other_casa_cases = create_list(:casa_case, 2, volunteers: [other_user], casa_org: other_org)
+
+      scope = described_class.new(user, organization.casa_cases)
+
+      expect(CasaCase.count).to eq 6
+      expect(scope.resolve.count).to eq 2
       expect(scope.resolve).to eq casa_cases
     end
   end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -1,39 +1,138 @@
 require "rails_helper"
 
 RSpec.describe "/casa_cases", type: :request do
-  let(:casa_org) { create(:casa_org) }
-
-  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true, casa_org_id: casa_org.id} }
-
+  let(:organization) { create(:casa_org) }
+  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true, casa_org_id: organization.id} }
   let(:invalid_attributes) { {case_number: nil} }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
 
-  before { sign_in create(:casa_admin) }
+  describe "as an admin" do
+    before { sign_in create(:casa_admin, casa_org: organization) }
 
-  describe "GET /index" do
-    it "renders a successful response" do
-      create(:casa_case)
-      get casa_cases_url
-      expect(response).to be_successful
+    describe "GET /index" do
+      it "renders a successful response" do
+        create(:casa_case)
+        get casa_cases_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /show" do
+      it "renders a successful response" do
+        get casa_case_url(casa_case)
+        expect(response).to be_successful
+      end
+
+      it "fails across organizations" do
+        other_org = create(:casa_org)
+        other_case = create(:casa_admin, casa_org: other_org)
+
+        get casa_case_url(other_case)
+        expect(response).to be_not_found
+      end
+    end
+
+    describe "GET /new" do
+      it "renders a successful response" do
+        get new_casa_case_url
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET /edit" do
+      it "render a successful response" do
+        get edit_casa_case_url(casa_case)
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST /create" do
+      context "with valid parameters" do
+        it "creates a new CasaCase" do
+          expect { post casa_cases_url, params: {casa_case: valid_attributes} }.to change(
+            CasaCase,
+            :count
+          ).by(1)
+        end
+
+        it "redirects to the created casa_case" do
+          post casa_cases_url, params: {casa_case: valid_attributes}
+          expect(response).to redirect_to(casa_case_url(CasaCase.last))
+        end
+      end
+
+      context "with invalid parameters" do
+        it "does not create a new CasaCase" do
+          expect { post casa_cases_url, params: {casa_case: invalid_attributes} }.to change(
+            CasaCase,
+            :count
+          ).by(0)
+        end
+
+        it "renders a successful response (i.e. to display the 'new' template)" do
+          post casa_cases_url, params: {casa_case: invalid_attributes}
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    describe "PATCH /update" do
+      context "with valid parameters" do
+        let(:new_attributes) { {case_number: "12345", transition_aged_youth: false} }
+
+        it "does not update case_number for volunteers" do
+          sign_in create(:volunteer, casa_org: organization)
+          casa_case = create(:casa_case, case_number: "1234", casa_org: organization)
+          patch casa_case_url(casa_case), params: {casa_case: new_attributes}
+          casa_case.reload
+          expect(casa_case.case_number).to eq "1234"
+          expect(casa_case.transition_aged_youth).to eq false
+        end
+
+        it "updates the requested casa_case" do
+          patch casa_case_url(casa_case), params: {casa_case: new_attributes}
+          casa_case.reload
+          expect(casa_case.case_number).to eq "12345"
+          expect(casa_case.transition_aged_youth).to eq false
+        end
+
+        it "redirects to the casa_case" do
+          patch casa_case_url(casa_case), params: {casa_case: new_attributes}
+          casa_case.reload
+          expect(response).to redirect_to(edit_casa_case_path)
+        end
+      end
+
+      context "with invalid parameters" do
+        it "renders a successful response displaying the edit template" do
+          patch casa_case_url(casa_case), params: {casa_case: invalid_attributes}
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    describe "DELETE /destroy" do
+      it "destroys the requested casa_case" do
+        another_case = create(:casa_case, casa_org: organization)
+        expect {
+          delete casa_case_url(another_case)
+          expect(response).to redirect_to(casa_cases_url)
+        }.to change(CasaCase, :count).by(-1)
+      end
+
+      it "redirects to the casa_cases list" do
+        delete casa_case_url(casa_case)
+        expect(response).to redirect_to(casa_cases_url)
+      end
     end
   end
 
-  describe "GET /show" do
-    it "renders a successful response" do
-      casa_case = create(:casa_case)
-      get casa_case_url(casa_case)
-      expect(response).to be_successful
-    end
-  end
+  context "as a volunteer" do
+    let(:volunteer) { create(:volunteer, casa_org: organization) }
 
-  describe "GET /new" do
-    it "renders a successful response" do
-      get new_casa_case_url
-      expect(response).to be_successful
-    end
+    before { sign_in volunteer }
 
-    context "as a volunteer" do
-      before { sign_in create(:volunteer) }
-
+    describe "GET /new" do
       it "denies access and redirects elsewhere" do
         get new_casa_case_url
 
@@ -41,95 +140,20 @@ RSpec.describe "/casa_cases", type: :request do
         expect(flash[:error]).to match(/you are not authorized/)
       end
     end
-  end
 
-  describe "GET /edit" do
-    it "render a successful response" do
-      casa_case = create(:casa_case)
-      get edit_casa_case_url(casa_case)
-      expect(response).to be_successful
-    end
-  end
+    describe "GET index" do
+      it "shows only cases assigned to user" do
+        mine = create(:casa_case, casa_org: organization, case_number: SecureRandom.hex(32))
+        other = create(:casa_case, casa_org: organization, case_number: SecureRandom.hex(32))
 
-  describe "POST /create" do
-    context "with valid parameters" do
-      it "creates a new CasaCase" do
-        expect { post casa_cases_url, params: {casa_case: valid_attributes} }.to change(
-          CasaCase,
-          :count
-        ).by(1)
-      end
+        volunteer.casa_cases << mine
 
-      it "redirects to the created casa_case" do
-        post casa_cases_url, params: {casa_case: valid_attributes}
-        expect(response).to redirect_to(casa_case_url(CasaCase.last))
-      end
-    end
+        get casa_cases_url
 
-    context "with invalid parameters" do
-      it "does not create a new CasaCase" do
-        expect { post casa_cases_url, params: {casa_case: invalid_attributes} }.to change(
-          CasaCase,
-          :count
-        ).by(0)
-      end
-
-      it "renders a successful response (i.e. to display the 'new' template)" do
-        post casa_cases_url, params: {casa_case: invalid_attributes}
         expect(response).to be_successful
+        expect(response.body).to include(mine.case_number)
+        expect(response.body).not_to include(other.case_number)
       end
-    end
-  end
-
-  describe "PATCH /update" do
-    context "with valid parameters" do
-      let(:new_attributes) { {case_number: "12345", transition_aged_youth: false} }
-
-      it "does not update case_number for volunteers" do
-        sign_in create(:volunteer)
-
-        casa_case = create(:casa_case, case_number: "1234")
-        patch casa_case_url(casa_case), params: {casa_case: new_attributes}
-        casa_case.reload
-        expect(casa_case.case_number).to eq "1234"
-        expect(casa_case.transition_aged_youth).to eq false
-      end
-
-      it "updates the requested casa_case" do
-        casa_case = create(:casa_case)
-        patch casa_case_url(casa_case), params: {casa_case: new_attributes}
-        casa_case.reload
-        expect(casa_case.case_number).to eq "12345"
-        expect(casa_case.transition_aged_youth).to eq false
-      end
-
-      it "redirects to the casa_case" do
-        casa_case = create(:casa_case)
-        patch casa_case_url(casa_case), params: {casa_case: new_attributes}
-        casa_case.reload
-        expect(response).to redirect_to(edit_casa_case_path)
-      end
-    end
-
-    context "with invalid parameters" do
-      it "renders a successful response (i.e. to display the 'edit' template)" do
-        casa_case = create(:casa_case)
-        patch casa_case_url(casa_case), params: {casa_case: invalid_attributes}
-        expect(response).to be_successful
-      end
-    end
-  end
-
-  describe "DELETE /destroy" do
-    it "destroys the requested casa_case" do
-      casa_case = create(:casa_case)
-      expect { delete casa_case_url(casa_case) }.to change(CasaCase, :count).by(-1)
-    end
-
-    it "redirects to the casa_cases list" do
-      casa_case = create(:casa_case)
-      delete casa_case_url(casa_case)
-      expect(response).to redirect_to(casa_cases_url)
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,13 +1,42 @@
 require "rails_helper"
 
-RSpec.describe "/dashboard", type: :request do
-  describe "GET /show" do
-    it "renders a successful response" do
-      sign_in create(:volunteer)
+describe "/dashboard", type: :request do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
 
-      get root_url
+  context "as a volunteer" do
+    before do
+      sign_in volunteer
+    end
 
-      expect(response).to be_successful
+    describe "GET /show" do
+      it "renders a successful response" do
+        get root_url
+
+        expect(response).to be_successful
+      end
+
+      it "shows my cases"
+      it "doesn't show other volunteers' cases"
+      it "doesn't show other organizations' cases"
+    end
+  end
+
+  context "as an admin" do
+    before do
+      sign_in admin
+    end
+
+    describe "GET /show" do
+      it "renders a successful response" do
+        get root_url
+
+        expect(response).to be_successful
+      end
+
+      it "shows all my organization's cases"
+      it "doesn't show other organizations' cases"
     end
   end
 end

--- a/spec/requests/imports_request_spec.rb
+++ b/spec/requests/imports_request_spec.rb
@@ -28,12 +28,11 @@ RSpec.describe "/imports", type: :request do
       expect(Volunteer.count).to eq(0)
 
       expect {
-        post imports_url, {
+        post imports_url,
           params: {
             import_type: "volunteer",
             file: fixture_file_upload(volunteer_file)
           }
-        }
       }.to change(Volunteer, :count).by(3)
 
       expect(response).to redirect_to(imports_url(import_type: "volunteer"))
@@ -48,12 +47,11 @@ RSpec.describe "/imports", type: :request do
       expect(Supervisor.count).to eq(0)
 
       expect {
-        post imports_url, {
+        post imports_url,
           params: {
             import_type: "supervisor",
             file: fixture_file_upload(supervisor_file)
           }
-        }
       }.to change(Supervisor, :count).by(3)
 
       expect(Supervisor.find_by(email: "supervisor1@example.net").volunteers.size).to eq(1)

--- a/spec/system/admin_adds_a_case_contact_spec.rb
+++ b/spec/system/admin_adds_a_case_contact_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "admin or supervisor adds a case contact", type: :system do
-  let(:admin) { create(:casa_admin) }
-  let(:casa_case) { create(:casa_case) }
+
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
 
   before do
     sign_in admin

--- a/spec/system/admin_assign_a_volunteer_to_case_spec.rb
+++ b/spec/system/admin_assign_a_volunteer_to_case_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "admin or supervisor assign and unassign a volunteer to case", type: :system do
-  let(:casa_case) { create(:casa_case) }
-  let(:supervisor1) { create(:supervisor) }
-  let!(:volunteer) { create(:volunteer, supervisor: supervisor1) }
+  let(:organization) { create(:casa_org) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let(:supervisor1) { create(:supervisor, casa_org: organization) }
+  let!(:volunteer) {  create(:volunteer, supervisor: supervisor1, casa_org: organization) }
 
   before do
     travel_to Time.zone.local(2020, 8, 29, 4, 5, 6)
@@ -70,8 +71,8 @@ RSpec.describe "admin or supervisor assign and unassign a volunteer to case", ty
   end
 
   it "when can assign only active volunteer to a case" do
-    volunteer1 = create(:volunteer)
-    volunteer2 = create(:volunteer, :inactive)
+    volunteer1 = create(:volunteer, casa_org: organization)
+    volunteer2 = create(:volunteer, :inactive, casa_org: organization)
 
     expect(find("select[name='case_assignment[volunteer_id]']").all("option").count).to eq 1
   end

--- a/spec/system/admin_edits_a_case_contact_spec.rb
+++ b/spec/system/admin_edits_a_case_contact_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "admin or supervisor edits a case contact", type: :system do
-  let(:casa_case) { create(:casa_case) }
+  let(:organization) { create(:casa_org) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
   let!(:case_contact) { create(:case_contact, duration_minutes: 105, casa_case: casa_case) }
 
   it "is successful" do
-    admin = create(:casa_admin)
+    admin = create(:casa_admin, casa_org: organization)
     sign_in admin
 
     visit edit_case_contact_path(case_contact)
@@ -21,4 +22,6 @@ RSpec.describe "admin or supervisor edits a case contact", type: :system do
     expect(case_contact.medium_type).to eq "letter"
     expect(case_contact.contact_made).to eq true
   end
+
+  it "fails across organizations"
 end

--- a/spec/system/case_assigned_to_multiple_volunteers_spec.rb
+++ b/spec/system/case_assigned_to_multiple_volunteers_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "case assigned to multiple volunteers", type: :system do
-  let!(:supervisor) { create(:casa_admin) }
-  let!(:volunteer_1) { create(:volunteer, display_name: "AAA") }
-  let!(:volunteer_2) { create(:volunteer, display_name: "BBB") }
-  let!(:casa_case) { create(:casa_case) }
+  let(:organization) { create(:casa_org) }
+  let!(:supervisor) { create(:casa_admin, casa_org: organization) }
+  let!(:volunteer_1) { create(:volunteer, display_name: 'AAA', casa_org: organization) }
+  let!(:volunteer_2) { create(:volunteer, display_name: 'BBB', casa_org: organization) }
+  let!(:casa_case) { create(:casa_case, casa_org: organization) }
 
   it "supervisor assigns multiple volunteers to the same case" do
     sign_in supervisor

--- a/spec/system/volunteer_views_dashboard_spec.rb
+++ b/spec/system/volunteer_views_dashboard_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "volunteer views dashboard", type: :system do
   it "sees all case contacts for their case" do
     volunteer = create(:volunteer)
-    case_assignment = create(:case_assignment, volunteer: volunteer)
+    casa_case = create(:casa_case, casa_org: volunteer.casa_org)
+    case_assignment = create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
     case_contact = create(:case_contact, casa_case: case_assignment.casa_case, miles_driven: 98)
     case_contact_for_other_case = create(:case_contact, miles_driven: 777)
 

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 describe "casa_cases/edit" do
+  let(:organization) { create(:casa_org) }
+
   context "when accessed by a volunteer" do
     it "does not include volunteer assignment" do
-      assign :casa_case, create(:casa_case)
+      assign :casa_case, create(:casa_case, casa_org: organization)
 
-      user = build_stubbed(:volunteer)
+      user = build_stubbed(:volunteer, casa_org: organization)
       allow(view).to receive(:current_user).and_return(user)
 
       render template: "casa_cases/edit"
@@ -16,9 +18,9 @@ describe "casa_cases/edit" do
 
   context "when accessed by an admin" do
     it "includes volunteer assignment" do
-      assign :casa_case, create(:casa_case)
+      assign :casa_case, create(:casa_case, casa_org: organization)
 
-      user = build_stubbed(:casa_admin)
+      user = build_stubbed(:casa_admin, casa_org: organization)
       allow(view).to receive(:current_user).and_return(user)
 
       render template: "casa_cases/edit"


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #606 and probably #597


### What changed, and why?

Makes sure that all data access accounts for the organization (CasaOrg) to which the user and resource belong.

**NOTE:** only User and CasaCase have a `belong_to` relationship with CasaOrg. CaseContact records do not, but I rewrote all the CaseContact lookups to be scoped to cases or users, which both makes more sense and is simpler at the time of record creation.


### How is this tested? (please write tests!) 💖💪
 
This update required edits to a _bunch_ of tests to make sure that the `create` statements in the test suite associated records with a specific organization.


### Other notes

This is a fairly complete _logical_ implementation of multi-tenancy, but it's mostly about making sure existing logic doesn't cross the streams w.r.t. organizations. There's a lot of polish needed before the app is properly multi-tenant. 

I also left some pending tests as TODOs / possible future stories. 
