### PR TITLE
Fixes the Back link on case contact edit view

### DIFF
--- a/app/helpers/case_contacts_helper.rb
+++ b/app/helpers/case_contacts_helper.rb
@@ -59,6 +59,12 @@ module CaseContactsHelper
     end
   end
 
+  def render_back_link(casa_case)
+    return send_home if !current_user || current_user&.volunteer?
+
+    send_to_case(casa_case)
+  end
+
   private
 
   def build_minute_options
@@ -83,5 +89,13 @@ module CaseContactsHelper
     end
 
     durations
+  end
+
+  def send_home
+    root_path
+  end
+
+  def send_to_case(casa_case)
+    casa_case_path(casa_case)
   end
 end

--- a/app/views/case_contacts/edit.html.erb
+++ b/app/views/case_contacts/edit.html.erb
@@ -10,5 +10,4 @@
 
 <br>
 
-<%= link_to 'Show', @case_contact %> |
-<%= link_to 'Back', :back %>
+<%= link_to 'Back', render_back_link(@case_contact.casa_case) %>

--- a/spec/helpers/case_contacts_helper_spec.rb
+++ b/spec/helpers/case_contacts_helper_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe CaseContactsHelper do
+  describe "#render_back_link" do
+    it "renders back link to home page when user is a volunteer" do
+      current_user = create(:volunteer)
+      casa_case = create(:casa_case)
+      allow(helper).to receive(:current_user).and_return(current_user)
+
+      expect(helper.render_back_link(casa_case)).to eq(root_path)
+    end
+
+    it "renders back link to home page when user does not exist" do
+      casa_case = create(:casa_case)
+      allow(helper).to receive(:current_user).and_return(nil)
+
+      expect(helper.render_back_link(casa_case)).to eq(root_path)
+    end
+
+    it "renders back link to home page when user is a supervisor" do
+      current_user = create(:supervisor)
+      casa_case = create(:casa_case)
+      allow(helper).to receive(:current_user).and_return(current_user)
+
+      expect(helper.render_back_link(casa_case)).to eq(casa_case_path(casa_case))
+    end
+
+    it "renders back link to home page when user is a administrator" do
+      current_user = create(:casa_admin)
+      casa_case = create(:casa_case)
+      allow(helper).to receive(:current_user).and_return(current_user)
+
+      expect(helper.render_back_link(casa_case)).to eq(casa_case_path(casa_case))
+    end
+  end
+end

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 describe "case_contacts/edit" do
+  before do
+    user = build_stubbed(:volunteer)
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
   it "is listing all the contact methods from the model" do
     case_contact = create(:case_contact)
     assign :case_contact, case_contact
@@ -17,9 +22,6 @@ describe "case_contacts/edit" do
     case_contact.occurred_at = Time.zone.now - (3600 * 24)
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
-
-    user = build_stubbed(:volunteer)
-    allow(view).to receive(:current_user).and_return(user)
 
     render template: "case_contacts/edit"
     expect(rendered).to include(case_contact.occurred_at.strftime("%Y-%m-%d"))


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #638 

### What changed, and why?
The Back link was previously trying to go to a non existent show page for case contacts if you are trying to submit changes unsuccessfully.
We have removed the Show link from the Edit view.
Depending on the users role:
  - if volunteer, Back link will redirect to the home page of the user.
  - otherwise, Back link will redirect to case show page.

### How will this affect user permissions?
This will not affect user permissions.

### How is this tested? (please write tests!) 💖💪
Added a test for the case contact helper

### Screenshots please :)
Visually it looks the same, the error is handled now.

### Feelings gif (optional)

