### PR TITLE
Adds "Return to dashboard" button

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -1,0 +1,5 @@
+module UiHelper
+  def return_to_dashboard_button
+    link_to 'Return to Dashboard', root_path, { class: "btn btn-info pull-right" }
+  end
+end

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -23,7 +23,7 @@
 
       <div class="actions">
         <%= form.submit "Create CASA Case", class: "btn btn-primary" %>
-        <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
+        <%= return_to_dashboard_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -23,9 +23,10 @@
 
       <div class="actions">
         <%= form.submit "Create CASA Case", class: "btn btn-primary" %>
+        <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
       </div>
     <% end %>
   </div>
 </div>
 <br>
-<%= link_to 'Back', :back %>
+

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -123,6 +123,6 @@
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary", id: "case-contact-submit" %>
-    <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
+    <%= return_to_dashboard_button %>
   </div>
 <% end %>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -123,5 +123,6 @@
 
   <div class="actions">
     <%= form.submit "Submit", class: "btn btn-primary", id: "case-contact-submit" %>
+    <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
   </div>
 <% end %>

--- a/app/views/case_contacts/new.html.erb
+++ b/app/views/case_contacts/new.html.erb
@@ -1,14 +1,8 @@
 <h1 class="text-center">New Case Contact</h1>
 
-<br>
-
 <div class="row">
 
   <div class="col-sm-12">
     <%= render 'form', case_contact: @case_contact, casa_cases: @casa_cases %>
   </div>
 </div>
-
-<br>
-
-<%= link_to 'Back', :back %>

--- a/app/views/supervisors/new.html.erb
+++ b/app/views/supervisors/new.html.erb
@@ -17,7 +17,7 @@
 
       <div class="actions">
         <%= form.submit "Create Supervisor", class: "btn btn-primary" %>
-        <%= link_to 'Return to Dashboard', root_path, class: 'btn btn-info pull-right' %>
+        <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/supervisors/new.html.erb
+++ b/app/views/supervisors/new.html.erb
@@ -17,7 +17,7 @@
 
       <div class="actions">
         <%= form.submit "Create Supervisor", class: "btn btn-primary" %>
-        <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
+        <%= return_to_dashboard_button %>
       </div>
     <% end %>
   </div>

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -25,6 +25,6 @@
 
   <div class="actions">
     <%= form.submit "Create User", class: "btn btn-primary" %>
-    <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
+    <%= return_to_dashboard_button %>
   </div>
 <% end %>

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -25,5 +25,6 @@
 
   <div class="actions">
     <%= form.submit "Create User", class: "btn btn-primary" %>
+    <%= link_to 'Return to Dashboard', { controller: "dashboard", action: :show}, { class: "btn btn-info pull-right" } %>
   </div>
 <% end %>

--- a/app/views/volunteers/new.html.erb
+++ b/app/views/volunteers/new.html.erb
@@ -6,4 +6,3 @@
   </div>
 </div>
 <br>
-<%= link_to 'Back', root_path %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include Warden::Test::Helpers
   config.after do
     Warden.test_reset!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Warden::Test::Helpers
+  config.include SessionHelper, type: :view
   config.after do
     Warden.test_reset!
   end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,0 +1,9 @@
+module SessionHelper
+  def sign_in_as_admin
+    sign_in(CasaAdmin.first || create(:casa_admin))
+  end
+
+  def sign_in_as_volunteer
+    sign_in(Volunteer.first || create(:volunteer))
+  end
+end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 describe "casa_cases/new" do
+  subject { render template: "casa_cases/new" }
+
+  before do
+    assign :casa_case, CasaCase.new
+  end
 
   context "while signed in as admin" do
     before do
-      user = create(:casa_admin)
-      sign_in(user)
-      assign :casa_case, Supervisor.new
+      sign_in_as_admin
     end
 
-    fit "has a button to Return to Dashboard" do
-      render template: "casa_cases/new"
-      expect(rendered).to have_selector("a", text: "Return to Dashboard")
-    end
+    it { is_expected.to have_selector("a", text: "Return to Dashboard") }
   end
 end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "casa_cases/new" do
+  include Devise::TestHelpers
+
+  context "while signed in as admin" do
+    before do
+      user = create(:casa_admin)
+      sign_in(user)
+      assign :casa_case, Supervisor.new
+    end
+
+    fit "has a button to Return to Dashboard" do
+      render template: "casa_cases/new"
+      expect(rendered).to have_selector("a", text: "Return to Dashboard")
+    end
+  end
+end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "casa_cases/new" do
-  include Devise::TestHelpers
 
   context "while signed in as admin" do
     before do

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe "case_contacts/new" do
+
   it "displays current time in the occurred at form field" do
     case_contact = create(:case_contact)
     assign :case_contact, case_contact

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -1,40 +1,25 @@
 require "rails_helper"
 
 describe "case_contacts/new" do
+  subject { render template: "case_contacts/new" }
 
-  it "displays current time in the occurred at form field" do
+  before do
     case_contact = create(:case_contact)
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
-
-    user = build_stubbed(:volunteer)
-    allow(view).to receive(:current_user).and_return(user)
-
-    render template: "case_contacts/new"
-    expect(rendered).to include(Time.zone.now.strftime("%Y-%m-%d"))
   end
 
-  it "displays the notes text area field" do
-    case_contact = create(:case_contact)
-    assign :case_contact, case_contact
-    assign :casa_cases, [case_contact.casa_case]
+  context "while signed-in as a volunteer" do
+    before do
+      sign_in_as_volunteer
+    end
 
-    user = build_stubbed(:volunteer)
-    allow(view).to receive(:current_user).and_return(user)
+    let(:current_time) { Time.zone.now.strftime("%Y-%m-%d") }
 
-    render template: "case_contacts/new"
-    expect(rendered).to have_selector("textarea", id: "case_contact_notes")
+    it { is_expected.to have_field('Occurred at', with: current_time) }
+    it { is_expected.to have_selector("textarea", id: "case_contact_notes") }
+    it { is_expected.to have_selector("a", text: "Return to Dashboard") }
   end
 
-  fit "has a button to Return to Dashboard" do
-    case_contact = create(:case_contact)
-    assign :case_contact, case_contact
-    assign :casa_cases, [case_contact.casa_case]
-
-    user = build_stubbed(:volunteer)
-    allow(view).to receive(:current_user).and_return(user)
-
-    render template: "case_contacts/new"
-    expect(rendered).to have_selector("a", text: "Return to Dashboard")
-  end
+  
 end

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -24,4 +24,16 @@ describe "case_contacts/new" do
     render template: "case_contacts/new"
     expect(rendered).to have_selector("textarea", id: "case_contact_notes")
   end
+
+  fit "has a button to Return to Dashboard" do
+    case_contact = create(:case_contact)
+    assign :case_contact, case_contact
+    assign :casa_cases, [case_contact.casa_case]
+
+    user = build_stubbed(:volunteer)
+    allow(view).to receive(:current_user).and_return(user)
+
+    render template: "case_contacts/new"
+    expect(rendered).to have_selector("a", text: "Return to Dashboard")
+  end
 end

--- a/spec/views/supervisors/new.html.erb_spec.rb
+++ b/spec/views/supervisors/new.html.erb_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 describe "supervisors/new" do
+  subject { render template: "supervisors/new" }
+
+  before do
+    assign :supervisor, Supervisor.new
+  end
 
   context "while signed in as admin" do
     before do
-      user = build_stubbed(:casa_admin)
-      sign_in(user)
-      assign :supervisor, Supervisor.new
+      sign_in_as_admin
     end
-
-    fit "has a button to Return to Dashboard" do
-      render template: "supervisors/new"
-      expect(rendered).to have_selector("a", text: "Return to Dashboard")
-    end
+    
+    it { is_expected.to have_selector("a", text: "Return to Dashboard") }
   end
 end

--- a/spec/views/supervisors/new.html.erb_spec.rb
+++ b/spec/views/supervisors/new.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "supervisors/new" do
-  include Devise::TestHelpers
 
   context "while signed in as admin" do
     before do

--- a/spec/views/supervisors/new.html.erb_spec.rb
+++ b/spec/views/supervisors/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "supervisors/new" do
+  include Devise::TestHelpers
+
+  context "while signed in as admin" do
+    before do
+      user = build_stubbed(:casa_admin)
+      sign_in(user)
+      assign :supervisor, Supervisor.new
+    end
+
+    fit "has a button to Return to Dashboard" do
+      render template: "supervisors/new"
+      expect(rendered).to have_selector("a", text: "Return to Dashboard")
+    end
+  end
+end

--- a/spec/views/volunteers/new.html.erb_spec.rb
+++ b/spec/views/volunteers/new.html.erb_spec.rb
@@ -1,17 +1,16 @@
 require "rails_helper"
 
 describe "volunteers/new" do
+  subject { render template: "volunteers/new" }
+  before do
+    assign :volunteer, Volunteer.new
+  end
 
   context "while signed in as admin" do
     before do
-      user = create(:casa_admin)
-      sign_in(user)
-      assign :volunteer, Volunteer.new
+      sign_in_as_admin
     end
 
-    fit "has a button to Return to Dashboard" do
-      render template: "volunteers/new"
-      expect(rendered).to have_selector("a", text: "Return to Dashboard")
-    end
+    it { is_expected.to have_selector("a", text: "Return to Dashboard") }
   end
 end

--- a/spec/views/volunteers/new.html.erb_spec.rb
+++ b/spec/views/volunteers/new.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe "volunteers/new" do
+  include Devise::TestHelpers
+
+  context "while signed in as admin" do
+    before do
+      user = create(:casa_admin)
+      sign_in(user)
+      assign :volunteer, Volunteer.new
+    end
+
+    fit "has a button to Return to Dashboard" do
+      render template: "volunteers/new"
+      expect(rendered).to have_selector("a", text: "Return to Dashboard")
+    end
+  end
+end

--- a/spec/views/volunteers/new.html.erb_spec.rb
+++ b/spec/views/volunteers/new.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 describe "volunteers/new" do
-  include Devise::TestHelpers
 
   context "while signed in as admin" do
     before do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #635 

### What changed, and why?
This satisfies the request of the issue to add "Return to Dashboard" button in place of the "Back" links.

Additionally, it:
 - Creates a new helper file (`UiHelper`) that defines a `return_to_dashboard_button` helper. (This will reduce future editing should the behavior or classes need to change)
 - Creates a new SessionHelper for RSpec to mediate sign-ins, and applies those to the affected specs
 - Creates some new View specs to test this feature

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Tests are written!

We used View specs because there were already view specs created, and TBH it would be overkill to test it with a full system test.

I also tested it manually

### Screenshots please :)
spin up your server and click these links:
 - http://localhost:3000/casa_cases/new
 - http://localhost:3000/case_contacts/new
 - http://localhost:3000/volunteers/new
 - http://localhost:3000/supervisors/new

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
