### PR TITLE
fixes bug that defaults contact made to false

### DIFF
--- a/app/helpers/case_contacts_helper.rb
+++ b/app/helpers/case_contacts_helper.rb
@@ -8,6 +8,10 @@ module CaseContactsHelper
     case_contact.duration_minutes.to_i.remainder(60)
   end
 
+  def set_contact_made_false(case_contact)
+    case_contact.persisted? && case_contact.contact_made == false
+  end
+
   def render_back_link(casa_case)
     return send_home if !current_user || current_user&.volunteer?
 

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -56,7 +56,7 @@
     <%= form.radio_button(:contact_made, true, checked: case_contact.contact_made, required: true) %>
     <%= form.label "Yes", for: "case_contact_contact_made_true" %>
     <br>
-    <%= form.radio_button(:contact_made, false, checked: !case_contact.contact_made, required: true) %>
+    <%= form.radio_button(:contact_made, false, checked: set_contact_made_false(case_contact), required: true) %>
     <%= form.label "No", for: "case_contact_contact_made_false" %>
   </div>
 

--- a/spec/helpers/case_contacts_helper_spec.rb
+++ b/spec/helpers/case_contacts_helper_spec.rb
@@ -67,4 +67,21 @@ describe CaseContactsHelper do
       expect(helper.duration_hours(case_contact)).to eq(0)
     end
   end
+
+  describe "#set_contact_made_false" do
+    it "returns false if contact_made is true" do
+      case_contact = create(:case_contact, contact_made: true)
+      expect(helper.set_contact_made_false(case_contact)).to eq(false)
+    end
+
+    it "returns true if contact_made is false" do
+      case_contact = create(:case_contact, contact_made: false)
+      expect(helper.set_contact_made_false(case_contact)).to eq(true)
+    end
+
+    it "returns false if contact_made is nil" do
+      case_contact = build(:case_contact, contact_made: nil)
+      expect(helper.set_contact_made_false(case_contact)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #673

### What changed, and why?
a change was previously made that checked "No" for contact made if `!case_contact.contact_made`. This returns true if `contact_made` is `nil`, so it was effectively defaulting to false. Added back in code and tests that checks if the value is actually set to false. We could potentially simplify this and remove the helper, but that makes it harder to test, so I'm in favor of keeping the helper.

### How will this affect user permissions?
No

### How is this tested? (please write tests!) 💖💪
Added a system spec that validates that, if it's not selected, it doesn't get automatically selected on submit.

