### PR TITLE
update all casa admin sessions/new to match main login

### DIFF
--- a/app/views/all_casa_admins/sessions/new.html.erb
+++ b/app/views/all_casa_admins/sessions/new.html.erb
@@ -1,26 +1,43 @@
-<h2>Log in</h2>
+<div class="row">
+  <div class="col-md-12 vertically-center">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-6">
+          <h2>All CASA Log In</h2>
+          <br>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+          <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+            <div class="field form-group">
+              <%= f.label :email %><br>
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+            </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+            <div class="field form-group">
+              <%= f.label :password %><br>
+              <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+            </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+            <% if devise_mapping.rememberable? %>
+              <div class="field">
+                <%= f.check_box :remember_me %>
+                <%= f.label :remember_me %>
+              </div>
+            <% end %>
+
+            <div class="actions">
+              <%= f.submit "Log in", class: "btn btn-outline-primary" %>
+            </div>
+          <% end %>
+
+          <%= render "all_casa_admins/shared/links" %>
+
+          <br/>
+          <p>
+            <strong>Not able to sign in?</strong>
+            You might be looking for the <a href="/">CASA user sign in page</a>.
+          </p>
+        </div>
+      </div>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "all_casa_admins/shared/links" %>
+</div>

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -7,6 +7,42 @@ RSpec.describe "Authentication", type: :system do
       expect(page).to have_text "Log in"
       expect(page).to_not have_text "sign in before continuing"
     end
+
+    %w[volunteer supervisor casa_admin].each do |user_type|
+      it "allows #{user_type} to sign in" do
+        user = create(user_type.to_sym)
+
+        visit "/"
+        expect(page).to have_text "Log in"
+        expect(page).to_not have_text "sign in before continuing"
+
+        fill_in "Email", with: user.email
+        fill_in "Password", with: "123456"
+        within ".actions" do
+          click_on "Log in"
+        end
+
+        within ".navbar-nav" do
+          expect(page).to have_text user.email
+        end
+      end
+    end
+
+    it "does not allow AllCasaAdmin to sign in" do
+      user = create(:all_casa_admin)
+
+      visit "/"
+      expect(page).to have_text "Log in"
+      expect(page).to_not have_text "sign in before continuing"
+
+      fill_in "Email", with: user.email
+      fill_in "Password", with: "123456"
+      within ".actions" do
+        click_on "Log in"
+      end
+
+      expect(page).to have_text "Invalid Email or password"
+    end
   end
 
   context "when authenticated user" do

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 describe "AllCasaAdmin auth", type: :system do
+  let(:all_casa_admin) { create(:all_casa_admin) }
+  let(:volunteer) { create(:volunteer) }
+
   context "when authenticated user" do
-    let(:all_casa_admin) { create(:all_casa_admin) }
     before { sign_in all_casa_admin }
 
     it "renders AllCasaAdmin dashboard page" do
@@ -15,6 +17,37 @@ describe "AllCasaAdmin auth", type: :system do
       click_link "Log out"
       expect(page).to_not have_text "sign in before continuing"
       expect(page).to have_text "Signed out successfully"
+    end
+  end
+
+  context "when unauthenticated" do
+    it "shows sign in page" do
+      visit "/all_casa_admins/sign_in"
+      expect(page).to have_text "All CASA Log In"
+    end
+
+    it "allows sign in" do
+      visit "/all_casa_admins/sign_in"
+
+      fill_in "Email", with: all_casa_admin.email
+      fill_in "Password", with: "123456"
+      within ".actions" do
+        click_on "Log in"
+      end
+
+      expect(page).to have_text "Welcome Super Admin!"
+    end
+
+    it "prevents User sign in" do
+      visit "/all_casa_admins/sign_in"
+
+      fill_in "Email", with: volunteer.email
+      fill_in "Password", with: "123456"
+      within ".actions" do
+        click_on "Log in"
+      end
+
+      expect(page).to have_text "Invalid Email or password"
     end
   end
 end


### PR DESCRIPTION
Reused devise/sessions/new erb on the all_casa_admins/sessions/new page. 

Fixes #683

### How is this tested? (please write tests!) 💖💪

Added positive and negative sign in tests (can sign in as, can't sign in as) for all three `User` derived and the `AllCasaAdmin` user types. 