### PR TITLE
493 changed logical conditions for dropdown

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,1 +1,15 @@
-class ApplicationPolicy; end
+class ApplicationPolicy
+  attr_reader :user
+
+  def initialize(user, _application)
+    @user = user
+  end
+
+  def see_reports_page?
+    user.supervisor? || user.casa_admin?
+  end
+
+  def see_import_page?
+    user.casa_admin?
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,8 +12,10 @@
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
             <%= link_to "Edit Profile", edit_users_path, class: "dropdown-item" %>
-            <% if current_user.is_a?(CasaAdmin) %>
+            <% if current_user.is_a?(CasaAdmin) || current_user.is_a?(Supervisor) %>
               <%= link_to "Generate Reports", reports_path, class: "dropdown-item" %>
+            <% end %>
+            <% if current_user.is_a?(CasaAdmin) %>
               <%= link_to "System Imports", imports_path, class: "dropdown-item" %>
             <% end %>
           </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,10 +12,10 @@
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
             <%= link_to "Edit Profile", edit_users_path, class: "dropdown-item" %>
-            <% if current_user.is_a?(CasaAdmin) || current_user.is_a?(Supervisor) %>
+            <% if policy(:application).see_reports_page? %>
               <%= link_to "Generate Reports", reports_path, class: "dropdown-item" %>
             <% end %>
-            <% if current_user.is_a?(CasaAdmin) %>
+            <% if policy(:application).see_import_page? %>
               <%= link_to "System Imports", imports_path, class: "dropdown-item" %>
             <% end %>
           </div>

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe ApplicationPolicy do
+  subject { described_class }
+
+  permissions :see_reports_page? do
+    it "allows casa_admins" do
+      expect(subject).to permit(create(:casa_admin))
+    end
+
+    it "allows supervisors" do
+      expect(subject).to permit(create(:supervisor))
+    end
+
+    it "does not allow volunteers" do
+      expect(subject).not_to permit(create(:volunteer))
+    end
+  end
+
+  permissions :see_import_page? do
+    it "allows casa_admins" do
+      expect(subject).to permit(create(:casa_admin))
+    end
+
+    it "does not allow supervisors" do
+      expect(subject).not_to permit(create(:supervisor))
+    end
+
+    it "does not allow volunteers" do
+      expect(subject).not_to permit(create(:volunteer))
+    end
+  end
+end


### PR DESCRIPTION
added an additional if statement so that the admin and supervisor roles can see the reports in the dropdown

### What github issue is this PR for, if any?
Resolves #493 

### What changed, and why?
The supervisor needs access to the reports, but not the system imports.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
view only: can now see the report in the nav dropdown.
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
no
![Screen Shot 2020-09-06 at 11 05 06 AM](https://user-images.githubusercontent.com/7873934/92328771-0cfa1080-f031-11ea-8562-b50d6d97f625.png)


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
