### PR TITLE
fix bug where error message not showing for supervisor imports

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   devise_for :all_casa_admins, path: "all_casa_admins", controllers: {sessions: "all_casa_admins/sessions"}
-  devise_for :users, controllers: { sessions: "users/sessions" }
+  devise_for :users, controllers: {sessions: "users/sessions"}
 
   authenticated :all_casa_admin do
     root to: "all_casa_admins/dashboard#show", as: :authenticated_all_casa_admin_root

--- a/spec/models/file_importer_spec.rb
+++ b/spec/models/file_importer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FileImporter, type: :concern do
 
       alert = FileImporter.new(import_file_path, import_user.casa_org.id).import_volunteers
       expect(alert[:type]).to eq(:error)
-      expect(alert[:message]).to include("You successfully imported 0 volunteers, the following volunteers were not")
+      expect(alert[:message]).to include("You successfully imported 0 volunteers. The following volunteers were not")
     end
   end
 
@@ -97,17 +97,17 @@ RSpec.describe FileImporter, type: :concern do
 
       alert = FileImporter.new(import_file_path, import_user.casa_org.id).import_supervisors
       expect(alert[:type]).to eq(:error)
-      expect(alert[:message]).to include("You successfully imported 0 supervisors, the following supervisors were not")
+      expect(alert[:message]).to include("You successfully imported 0 supervisors. The following supervisors were not")
     end
 
     it "returns an error message when there are volunteers not imported" do
       import_user = create(:casa_admin)
-      create(:volunteer, email: "volunteer1@example.com")
+      create(:volunteer, email: "volunteer1@example.net")
       import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisor_volunteers.csv")
       alert = FileImporter.new(import_supervisor_path, import_user.casa_org.id).import_supervisors
 
       expect(alert[:type]).to eq(:error)
-      expect(alert[:message]).to include("You successfully imported 0 supervisors, the following supervisors were not")
+      expect(alert[:message]).to include("You successfully imported 2 supervisors. The following volunteers were not imported: volunteer1@example.net was not assigned to supervisor s6@example.com on row #2")
     end
   end
 
@@ -115,7 +115,7 @@ RSpec.describe FileImporter, type: :concern do
     it "returns list of users given string of user emails" do
       volunteer1 = create(:volunteer, email: "volunteer1@example.com")
       volunteer2 = create(:volunteer, email: "volunteer2@example.com")
-      expect(FileImporter.new("", 1).get_list_volunteers('volunteer1@example.com,volunteer2@example.com')).to eq([volunteer1, volunteer2])
+      expect(FileImporter.new("", 1).get_list_volunteers("volunteer1@example.com,volunteer2@example.com")).to eq([volunteer1, volunteer2])
     end
   end
 
@@ -177,7 +177,7 @@ RSpec.describe FileImporter, type: :concern do
 
       alert = FileImporter.new(import_case_path, import_user.casa_org.id).import_cases
       expect(alert[:type]).to eq(:error)
-      expect(alert[:message]).to include("You successfully imported 0 casa_cases, the following casa_cases were not")
+      expect(alert[:message]).to include("You successfully imported 0 casa_cases. The following casa_cases were not")
     end
   end
 end

--- a/spec/models/file_importer_spec.rb
+++ b/spec/models/file_importer_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe FileImporter, type: :concern do
       expect(alert[:type]).to eq(:error)
       expect(alert[:message]).to include("You successfully imported 0 supervisors, the following supervisors were not")
     end
+
+    it "returns an error message when there are volunteers not imported" do
+      import_user = create(:casa_admin)
+      create(:volunteer, email: "volunteer1@example.com")
+      import_supervisor_path = Rails.root.join("spec", "fixtures", "supervisor_volunteers.csv")
+      alert = FileImporter.new(import_supervisor_path, import_user.casa_org.id).import_supervisors
+
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to include("You successfully imported 0 supervisors, the following supervisors were not")
+    end
+  end
+
+  describe "#get_list_volunteers" do
+    it "returns list of users given string of user emails" do
+      volunteer1 = create(:volunteer, email: "volunteer1@example.com")
+      volunteer2 = create(:volunteer, email: "volunteer2@example.com")
+      expect(FileImporter.new("", 1).get_list_volunteers('volunteer1@example.com,volunteer2@example.com')).to eq([volunteer1, volunteer2])
+    end
   end
 
   describe "#import_cases" do

--- a/spec/system/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/system/volunteer_adds_a_case_contact_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "volunteer adds a case contact", type: :system do
     end
   end
 
-   context "with contact made not checked" do
+  context "with contact made not checked" do
     it "does not re-render form, preserves all previously entered selections" do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
@@ -116,5 +116,4 @@ RSpec.describe "volunteer adds a case contact", type: :system do
       expect(page).to have_field("Notes", with: "Hello world")
     end
   end
-
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #565

### What changed, and why?
Error message was not displaying volunteer already assigned to a supervisor. Created a list of volunteers not updated to show in message to user.

### How is this tested? (please write tests!) 💖💪
We added tests for this use case

### Screenshots please :)
![message1](https://user-images.githubusercontent.com/56096225/92334288-594d4c80-f041-11ea-8824-49572e665c3e.PNG)
![message2](https://user-images.githubusercontent.com/56096225/92334294-6702d200-f041-11ea-9a4f-8132af8cf146.PNG)


### Feelings gif
![alt text](https://media.giphy.com/media/fVo7TCflc5TDA6S93l/giphy.gif)
