### PR TITLE
Implement all CASA admin dashboard page with list of organizations.

### DIFF
--- a/app/controllers/all_casa_admins/dashboard_controller.rb
+++ b/app/controllers/all_casa_admins/dashboard_controller.rb
@@ -1,4 +1,5 @@
 class AllCasaAdmins::DashboardController < ApplicationController
   def show
+    @casa_orgs = CasaOrg.all
   end
 end

--- a/app/views/all_casa_admins/dashboard/show.html.erb
+++ b/app/views/all_casa_admins/dashboard/show.html.erb
@@ -1,1 +1,27 @@
-<h1>Welcome Super Admin!</h1>
+<div class="row">
+  <div class="col-sm-12 dashboard-table-header">
+    <h1>All CASA Admin</h1>
+  </div>
+</div>
+
+<h2>CASA Organizations</h2>
+
+<table class="table case-list">
+  <thead>
+  <tr>
+    <th>Name</th>
+    <th>Created At</th>
+    <th>Link</th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @casa_orgs.each do |casa_org| %>
+    <tr>
+      <td><%= casa_org.name %></td>
+      <td><%= casa_org.created_at.strftime('%B %e, %Y') %></td>
+      <td>(Not Yet Implemented)</td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/spec/system/all_casa_admins/all_casa_admin_dashboard_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admin_dashboard_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "all_casa_admin_dashboard_spec", type: :system do
+
+  let(:all_casa_admin) { create(:all_casa_admin) }
+  let(:volunteer) { create(:volunteer) }
+  let!(:casa_org) { create(:casa_org) }
+
+  context "when authenticated user" do
+    before { sign_in all_casa_admin }
+
+    it "renders AllCasaAdmin dashboard page" do
+      visit "/"
+      expect(page).to have_text "All CASA Admin"
+      expect(page).to have_text casa_org.name
+    end
+  end
+end

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -9,7 +9,7 @@ describe "AllCasaAdmin auth", type: :system do
 
     it "renders AllCasaAdmin dashboard page" do
       visit "/"
-      expect(page).to have_text "Welcome Super Admin!"
+      expect(page).to have_text "All CASA Admin"
     end
 
     it "allows sign out" do

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -35,7 +35,7 @@ describe "AllCasaAdmin auth", type: :system do
         click_on "Log in"
       end
 
-      expect(page).to have_text "Welcome Super Admin!"
+      expect(page).to have_text "All CASA Admin"
     end
 
     it "prevents User sign in" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #628 

### What changed, and why?
For all CASA admins, a dashboard with the list of organizations is displayed on login.

### How is this tested? (please write tests!) 💖💪
Test added. 
