### PR TITLE
662 add filters to case contact report

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -16,7 +16,9 @@ class CaseContactsController < ApplicationController
 
     # Admins and supervisors who are navigating to this page from a specific
     # case detail page will only see that case as an option
-    @casa_cases = @casa_cases.where(id: params.dig(:case_contact, :casa_case_id)) if params.dig(:case_contact, :casa_case_id).present?
+    if params.dig(:case_contact, :casa_case_id).present?
+      @casa_cases = @casa_cases.where(id: params.dig(:case_contact, :casa_case_id))
+    end
 
     @case_contact = CaseContact.new
 
@@ -39,9 +41,9 @@ class CaseContactsController < ApplicationController
     end
 
     # Create a case contact for every case that was checked
-    case_contacts = @selected_cases.map { |casa_case|
+    case_contacts = @selected_cases.map do |casa_case|
       casa_case.case_contacts.create(create_case_contact_params)
-    }
+    end
 
     if case_contacts.all?(&:persisted?)
       redirect_to casa_case_path(CaseContact.last.casa_case), notice: "Case contact was successfully created."

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -41,9 +41,9 @@ class CaseContactsController < ApplicationController
     end
 
     # Create a case contact for every case that was checked
-    case_contacts = @selected_cases.map do |casa_case|
+    case_contacts = @selected_cases.map { |casa_case|
       casa_case.case_contacts.create(create_case_contact_params)
-    end
+    }
 
     if case_contacts.all?(&:persisted?)
       redirect_to casa_case_path(CaseContact.last.casa_case), notice: "Case contact was successfully created."

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -18,9 +18,9 @@ class SupervisorVolunteersController < ApplicationController
   def unassign
     volunteer = Volunteer.find(params[:id])
     supervisor_volunteer = volunteer.supervisor_volunteer
+    supervisor = volunteer.supervisor
     supervisor_volunteer.is_active = false
     supervisor_volunteer.save!
-    supervisor = volunteer.supervisor
     flash_message = "#{volunteer.decorate.name} was unassigned from #{supervisor.decorate.name}."
 
     redirect_to after_action_path(supervisor), notice: flash_message

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -20,6 +20,10 @@ class CasaCase < ApplicationRecord
       order(:case_number)
     end
   end
+
+  def has_transitioned?
+    transition_aged_youth
+  end
 end
 
 # == Schema Information

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -13,6 +13,9 @@ class CaseContact < ApplicationRecord
   validate :check_if_allow_edit, on: :update
 
   belongs_to :creator, class_name: "User"
+  has_many :supervisor_volunteers, primary_key: :creator_id, foreign_key: :volunteer_id
+  has_many :supervisors, through: :supervisor_volunteers
+
   belongs_to :casa_case
 
   CONTACT_TYPES = %w[
@@ -31,11 +34,11 @@ class CaseContact < ApplicationRecord
     youth
   ].freeze
 
-  IN_PERSON = "in-person"
-  TEXT_EMAIL = "text/email"
-  VIDEO = "video"
-  VOICE_ONLY = "voice-only"
-  LETTER = "letter"
+  IN_PERSON = "in-person".freeze
+  TEXT_EMAIL = "text/email".freeze
+  VIDEO = "video".freeze
+  VOICE_ONLY = "voice-only".freeze
+  LETTER = "letter".freeze
   CONTACT_MEDIUMS = [IN_PERSON, TEXT_EMAIL, VIDEO, VOICE_ONLY, LETTER].freeze
 
   def contact_types_included
@@ -76,6 +79,14 @@ class CaseContact < ApplicationRecord
     return if allowed_edit?
 
     errors[:base] << "cannot edit past case contacts outside of quarter"
+  end
+
+  def supervisor_id
+    supervisors.first&.id
+  end
+
+  def has_casa_case_transitioned
+    casa_case.has_transitioned?
   end
 end
 

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -29,13 +29,13 @@ class CaseContact < ApplicationRecord
     where("occurred_at BETWEEN ? AND ?", start_date, end_date) if start_date.present? && end_date.present?
   }
   scope :contact_made, ->(contact_made = nil) {
-    where(contact_made: contact_made) if (contact_made == true || contact_made == false)
+    where(contact_made: contact_made) if contact_made == true || contact_made == false
   }
   scope :has_transitioned, ->(has_transitioned = nil) {
-    joins(:casa_case).where(casa_cases: {transition_aged_youth: has_transitioned}) if (has_transitioned == true || has_transitioned == false)
+    joins(:casa_case).where(casa_cases: {transition_aged_youth: has_transitioned}) if has_transitioned == true || has_transitioned == false
   }
   scope :want_driving_reimbursement, ->(want_driving_reimbursement = nil) {
-    where(want_driving_reimbursement: want_driving_reimbursement) if (want_driving_reimbursement == true || want_driving_reimbursement == false)
+    where(want_driving_reimbursement: want_driving_reimbursement) if want_driving_reimbursement == true || want_driving_reimbursement == false
   }
   scope :contact_type, ->(contact_type = nil) {
     where("? = ANY (contact_types)", contact_type) if contact_type.present?

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -1,4 +1,3 @@
-# CaseContact Model
 class CaseContact < ApplicationRecord
   attr_accessor :duration_hours
 
@@ -13,11 +12,34 @@ class CaseContact < ApplicationRecord
   validate :check_if_allow_edit, on: :update
 
   belongs_to :creator, class_name: "User"
-  has_many :supervisor_volunteers, primary_key: :creator_id, foreign_key: :volunteer_id
-  has_many :supervisors, through: :supervisor_volunteers
+  has_one :supervisor_volunteer, -> {
+    where(is_active: true)
+  }, primary_key: :creator_id, foreign_key: :volunteer_id
+  has_one :supervisor, through: :creator
 
   belongs_to :casa_case
 
+  scope :supervisors, ->(supervisor_ids = nil) {
+    joins(:supervisor_volunteer).where(supervisor_volunteers: {supervisor_id: supervisor_ids}) if supervisor_ids.present?
+  }
+  scope :creators, ->(creator_ids = nil) {
+    where(creator_id: creator_ids) if creator_ids.present?
+  }
+  scope :occurred_between, ->(start_date = nil, end_date = nil) {
+    where("occurred_at BETWEEN ? AND ?", start_date, end_date) if start_date.present? && end_date.present?
+  }
+  scope :contact_made, ->(contact_made = nil) {
+    where(contact_made: contact_made) if (contact_made == true || contact_made == false)
+  }
+  scope :has_transitioned, ->(has_transitioned = nil) {
+    joins(:casa_case).where(casa_cases: {transition_aged_youth: has_transitioned}) if (has_transitioned == true || has_transitioned == false)
+  }
+  scope :want_driving_reimbursement, ->(want_driving_reimbursement = nil) {
+    where(want_driving_reimbursement: want_driving_reimbursement) if (want_driving_reimbursement == true || want_driving_reimbursement == false)
+  }
+  scope :contact_type, ->(contact_type = nil) {
+    where("? = ANY (contact_types)", contact_type) if contact_type.present?
+  }
   CONTACT_TYPES = %w[
     attorney
     bio_parent
@@ -61,10 +83,6 @@ class CaseContact < ApplicationRecord
     errors[:base] << "Must enter miles driven to receive driving reimbursement."
   end
 
-  def self.occurred_between(start_date, end_date)
-    where("occurred_at BETWEEN ? AND ?", start_date, end_date)
-  end
-
   def contact_made_chosen
     errors[:base] << "Must enter whether the contact was made." if contact_made.nil?
     !contact_made.nil?
@@ -82,7 +100,7 @@ class CaseContact < ApplicationRecord
   end
 
   def supervisor_id
-    supervisors.first&.id
+    supervisor.id
   end
 
   def has_casa_case_transitioned

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -2,11 +2,19 @@ class CaseContactReport
   attr_reader :case_contacts
 
   def initialize(args = {})
-    @case_contacts = if args[:start_date] && args[:end_date]
-      CaseContact.occurred_between(args[:start_date], args[:end_date])
-    else
-      CaseContact.all
+    @case_contacts = filtered_case_contacts(args)
+  end
+
+  def filtered_case_contacts(args)
+    return CaseContact.all if args.empty?
+    contact = CaseContact
+    if args[:start_date] && args[:end_date]
+      contact = contact.occurred_between(args[:start_date], args[:end_date])
     end
+    if args[:creator_id]
+      contact = contact.where(creator_id: args[:creator_id])
+    end
+    contact
   end
 
   def to_csv

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -9,27 +9,18 @@ class CaseContactReport
     return CaseContact.all if args.empty?
 
     contact = CaseContact
-    if args.has_key?(:start_date) && args[:end_date] # contact date range
-      contact = contact.occurred_between(args[:start_date], args[:end_date])
-    end
+    contact = contact.where(supervisors: args[:supervisor_ids]) if args.has_key?(:supervisor_ids) # supervisor, as an array
     contact = contact.where(creator_id: args[:creator_id]) if args.has_key?(:creator_id) # volunteer
-    if args.has_key?(:supervisor_ids) # supervisor, as an array
-      contact = contact.where(supervisors: args[:supervisor_ids])
-    end
+    contact = contact.occurred_between(args[:start_date], args[:end_date]) if  args.has_key?(:start_date) && args.has_key?(:end_date)
     contact = contact.where(contact_made: args[:contact_made]) if args.has_key?(:contact_made) # contact made, boolean
-    if args.has_key?(:has_transitioned) # boolean, but also in the casa cases table
-      contact = contact.joins(:casa_case).where("casa_cases.transition_aged_youth in (?)", args[:has_transitioned])
-    end
-    if args.has_key?(:want_driving_reimbursement)
-      contact = contact.where(want_driving_reimbursement: args[:want_driving_reimbursement])
-    end
+    contact = contact.joins(:casa_case).where("casa_cases.transition_aged_youth in (?)", args[:has_transitioned]) if args.has_key?(:has_transitioned) # boolean, but also in the casa cases table
+    contact = contact.where(want_driving_reimbursement: args[:want_driving_reimbursement]) if args.has_key?(:want_driving_reimbursement)
     # This filter is not working properly, commenting it out for now
     # if args[:contact_types]
     #   args[:contact_types].each do |contact_type|
     #     contact = contact.where "contact_types @> ARRAY[?]::varchar[]", [contact_type]
     #   end
     # end
-
     contact
   end
 

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -7,13 +7,29 @@ class CaseContactReport
 
   def filtered_case_contacts(args)
     return CaseContact.all if args.empty?
+
     contact = CaseContact
-    if args[:start_date] && args[:end_date]
+    if args.has_key?(:start_date) && args[:end_date] # contact date range
       contact = contact.occurred_between(args[:start_date], args[:end_date])
     end
-    if args[:creator_id]
-      contact = contact.where(creator_id: args[:creator_id])
+    contact = contact.where(creator_id: args[:creator_id]) if args.has_key?(:creator_id) # volunteer
+    if args.has_key?(:supervisor_ids) # supervisor, as an array
+      contact = contact.where(supervisors: args[:supervisor_ids])
     end
+    contact = contact.where(contact_made: args[:contact_made]) if args.has_key?(:contact_made) # contact made, boolean
+    if args.has_key?(:has_transitioned) # boolean, but also in the casa cases table
+      contact = contact.joins(:casa_case).where("casa_cases.transition_aged_youth in (?)", args[:has_transitioned])
+    end
+    if args.has_key?(:want_driving_reimbursement)
+      contact = contact.where(want_driving_reimbursement: args[:want_driving_reimbursement])
+    end
+    # This filter is not working properly, commenting it out for now
+    # if args[:contact_types]
+    #   args[:contact_types].each do |contact_type|
+    #     contact = contact.where "contact_types @> ARRAY[?]::varchar[]", [contact_type]
+    #   end
+    # end
+
     contact
   end
 

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -6,22 +6,14 @@ class CaseContactReport
   end
 
   def filtered_case_contacts(args)
-    return CaseContact.all if args.empty?
-
-    contact = CaseContact
-    contact = contact.where(supervisors: args[:supervisor_ids]) if args.has_key?(:supervisor_ids) # supervisor, as an array
-    contact = contact.where(creator_id: args[:creator_id]) if args.has_key?(:creator_id) # volunteer
-    contact = contact.occurred_between(args[:start_date], args[:end_date]) if args.has_key?(:start_date) && args.has_key?(:end_date)
-    contact = contact.where(contact_made: args[:contact_made]) if args.has_key?(:contact_made) # contact made, boolean
-    contact = contact.joins(:casa_case).where("casa_cases.transition_aged_youth in (?)", args[:has_transitioned]) if args.has_key?(:has_transitioned) # boolean, but also in the casa cases table
-    contact = contact.where(want_driving_reimbursement: args[:want_driving_reimbursement]) if args.has_key?(:want_driving_reimbursement)
-    # This filter is not working properly, commenting it out for now
-    # if args[:contact_types]
-    #   args[:contact_types].each do |contact_type|
-    #     contact = contact.where "contact_types @> ARRAY[?]::varchar[]", [contact_type]
-    #   end
-    # end
-    contact
+    CaseContact
+                .supervisors(args[:supervisor_ids])
+                .creators(args[:creator_ids])
+                .occurred_between(args[:start_date], args[:end_date])
+                .contact_made(args[:contact_made])
+                .has_transitioned(args[:has_transitioned])
+                .want_driving_reimbursement(args[:want_driving_reimbursement])
+                .contact_type(args[:contact_type])
   end
 
   def to_csv

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -7,13 +7,13 @@ class CaseContactReport
 
   def filtered_case_contacts(args)
     CaseContact
-                .supervisors(args[:supervisor_ids])
-                .creators(args[:creator_ids])
-                .occurred_between(args[:start_date], args[:end_date])
-                .contact_made(args[:contact_made])
-                .has_transitioned(args[:has_transitioned])
-                .want_driving_reimbursement(args[:want_driving_reimbursement])
-                .contact_type(args[:contact_type])
+      .supervisors(args[:supervisor_ids])
+      .creators(args[:creator_ids])
+      .occurred_between(args[:start_date], args[:end_date])
+      .contact_made(args[:contact_made])
+      .has_transitioned(args[:has_transitioned])
+      .want_driving_reimbursement(args[:want_driving_reimbursement])
+      .contact_type(args[:contact_type])
   end
 
   def to_csv

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -11,7 +11,7 @@ class CaseContactReport
     contact = CaseContact
     contact = contact.where(supervisors: args[:supervisor_ids]) if args.has_key?(:supervisor_ids) # supervisor, as an array
     contact = contact.where(creator_id: args[:creator_id]) if args.has_key?(:creator_id) # volunteer
-    contact = contact.occurred_between(args[:start_date], args[:end_date]) if  args.has_key?(:start_date) && args.has_key?(:end_date)
+    contact = contact.occurred_between(args[:start_date], args[:end_date]) if args.has_key?(:start_date) && args.has_key?(:end_date)
     contact = contact.where(contact_made: args[:contact_made]) if args.has_key?(:contact_made) # contact made, boolean
     contact = contact.joins(:casa_case).where("casa_cases.transition_aged_youth in (?)", args[:has_transitioned]) if args.has_key?(:has_transitioned) # boolean, but also in the casa cases table
     contact = contact.where(want_driving_reimbursement: args[:want_driving_reimbursement]) if args.has_key?(:want_driving_reimbursement)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,9 @@ class User < ApplicationRecord
   has_many :supervisor_volunteers, foreign_key: "supervisor_id"
   has_many :volunteers, -> { order(:display_name) }, through: :supervisor_volunteers
 
-  has_one :supervisor_volunteer, foreign_key: "volunteer_id"
+  has_one :supervisor_volunteer, -> {
+      where(is_active: true)
+  }, foreign_key: "volunteer_id"
   has_one :supervisor, through: :supervisor_volunteer
 
   scope :volunteers_with_no_supervisor, lambda { |org|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   has_many :volunteers, -> { order(:display_name) }, through: :supervisor_volunteers
 
   has_one :supervisor_volunteer, -> {
-      where(is_active: true)
+    where(is_active: true)
   }, foreign_key: "volunteer_id"
   has_one :supervisor, through: :supervisor_volunteer
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -29,4 +29,41 @@ RSpec.describe CaseContactReport, type: :model do
       expect(case_contact_data[1]).to eq("60")
     end
   end
+  describe "filter behavior" do
+    describe "occured at range filter" do
+      
+      it "uses date range if provided" do
+        create(:case_contact, {occurred_at: 20.days.ago})
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+      it "returns all date ranges if not provided" do
+        create(:case_contact, {occurred_at: 20.days.ago})
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(2)
+      end
+      it "returns only the volunteer" do
+        volunteer = create(:volunteer)
+        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({creator_id: volunteer.id})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+      it "returns only the volunteer with date range" do
+        volunteer = create(:volunteer)
+        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer.id})
+       
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_id: volunteer.id})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe CaseContactReport, type: :model do
         volunteer = create(:volunteer)
         create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
         create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({creator_id: volunteer.id})
+        report = CaseContactReport.new({creator_ids: [volunteer.id]})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
@@ -59,7 +59,7 @@ RSpec.describe CaseContactReport, type: :model do
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer.id})
 
         create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_id: volunteer.id})
+        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_ids: [volunteer.id]})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
@@ -122,16 +122,8 @@ RSpec.describe CaseContactReport, type: :model do
           contacts = report.case_contacts
           expect(contacts.length).to eq(1)
         end
-        it "returns only case contacts the youth has transitioned" do
-          case_case_1 = create(:casa_case, transition_aged_youth: false)
-          case_case_2 = create(:casa_case, transition_aged_youth: true)
-          create(:case_contact, {casa_case: case_case_1})
-          create(:case_contact, {casa_case: case_case_2})
-          report = CaseContactReport.new({has_transitioned: [true, false]})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(2)
-        end
       end
+
       describe "wanting driving reimbursement functionality" do
         it "returns only contacts that want reimbursement" do
           # want_driving_reimbursement
@@ -151,53 +143,48 @@ RSpec.describe CaseContactReport, type: :model do
           contacts = report.case_contacts
           expect(contacts.length).to eq(1)
         end
-        it "returns all contacts that specify whether they want reimbursement or not" do
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+      end
 
-          report = CaseContactReport.new({want_driving_reimbursement: [true, false]})
+      describe "contact type filter functionality" do
+        it "returns only the case contacts that include the case contact" do
+          supervisor = create(:supervisor)
+          volunteer = create(:volunteer)
+          volunteer2 = create(:volunteer)
+          supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+
+          create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
+          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: ["school"]})
+
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({contact_type: "court"})
           contacts = report.case_contacts
-          expect(contacts.length).to eq(2)
+          expect(contacts.length).to eq(1)
         end
       end
-      # describe "contact type filter functionality" do
-      #   it "returns only the case contacts that include the case contact" do
-      #     supervisor = create(:supervisor)
-      #     volunteer = create(:volunteer)
-      #     volunteer2 = create(:volunteer)
-      #     supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
-
-      #     create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
-      #     create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: ["school"]})
-
-      #     create(:case_contact, {occurred_at: 100.days.ago})
-      #     report = CaseContactReport.new({contact_types: ["court"]})
-      #     contacts = report.case_contacts
-      #     expect(contacts.length).to eq(1)
-      #   end
-      # end
       describe "multiple filter behavior" do
         it "only returns records that occured less than 30 days ago, the youth has transitioned, and the contact type was either court or therapist" do
           untransitioned_casa_case = create(:casa_case, transition_aged_youth: false)
           transitioned_casa_case = create(:casa_case, transition_aged_youth: true)
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
-          create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: ["court"])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["school"])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court", "school"])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["therapist"])
+          contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
+          contact2 = create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
+          contact3 = create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: ["court"])
+          contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["school"])
+          contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court", "school"])
+          contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["therapist"])
 
-          report_20_days_ago_court_transitioned = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_types: ["court"]})
-          contacts = report_20_days_ago_court_transitioned.case_contacts
-          expect(contacts.length).to eq(4)
+          aggregate_failures do
+          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "court"})
+          expect(report_1.case_contacts.length).to eq(2)
+          expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
 
-          report_20_days_ago_court_school_transitioned = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_types: ["court", "school"]})
-          contacts = report_20_days_ago_court_transitioned.case_contacts
-          expect(contacts.length).to eq(5)
+          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "school"})
+          expect(report_2.case_contacts.length).to eq(2)
+          expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
 
-          report_20_days_ago_school_therapist_transitioned = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_types: ["school", "therapist"]})
-          contacts = report_20_days_ago_court_transitioned.case_contacts
-          expect(contacts.length).to eq(2)
+          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "therapist"})
+          expect(report_3.case_contacts.length).to eq(1)
+          expect(report_3.case_contacts.include?(contact6)).to eq(true)
+          end
         end
       end
     end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -64,6 +64,147 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+      it "returns only the volunteer with the specified supervisors" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        volunteer2 = create(:volunteer)
+        supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+        
+        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id})
+       
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
+        contacts = report.case_contacts
+        # expect(contacts.length).to eq(1)
+      end
+      it "returns only the volunteer with the specified supervisors" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        volunteer2 = create(:volunteer)
+        supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+        
+        create(:case_contact, {creator_id: volunteer.id})
+        create(:case_contact, {creator_id: volunteer2.id})
+       
+        report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+      describe "case contact behavior" do
+        it "returns only the case contacts with where contact was made" do
+          create(:case_contact, {contact_made: true})
+          create(:case_contact, {contact_made: false})
+
+          report = CaseContactReport.new({contact_made: true})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns only the case contacts with where contact was NOT made" do
+          create(:case_contact, {contact_made: true})
+          create(:case_contact, {contact_made: false})
+
+          report = CaseContactReport.new({contact_made: false})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns only the case contacts with where contact was made or NOT made" do
+          create(:case_contact, {contact_made: true})
+          create(:case_contact, {contact_made: false})
+
+          report = CaseContactReport.new({contact_made: [true, false]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(2)
+        end
+      end
+      describe "has transitioned behavior" do
+        it "returns only case contacts the youth has transitioned" do
+          case_case_1 = create(:casa_case, transition_aged_youth: false)
+          case_case_2 = create(:casa_case, transition_aged_youth: true)
+          create(:case_contact, {casa_case: case_case_1})
+          create(:case_contact, {casa_case: case_case_2})
+          report = CaseContactReport.new({has_transitioned: false})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns only case contacts the youth has transitioned" do
+          case_case_1 = create(:casa_case, transition_aged_youth: false)
+          case_case_2 = create(:casa_case, transition_aged_youth: true)
+          create(:case_contact, {casa_case: case_case_1})
+          create(:case_contact, {casa_case: case_case_2})
+          report = CaseContactReport.new({has_transitioned: true})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns only case contacts the youth has transitioned" do
+          case_case_1 = create(:casa_case, transition_aged_youth: false)
+          case_case_2 = create(:casa_case, transition_aged_youth: true)
+          create(:case_contact, {casa_case: case_case_1})
+          create(:case_contact, {casa_case: case_case_2})
+          report = CaseContactReport.new({has_transitioned: [true, false]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(2)
+        end
+      end
+      describe "wanting driving reimbursement functionality" do
+        it "returns only contacts that want reimbursement" do
+          # want_driving_reimbursement
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+
+          report = CaseContactReport.new({want_driving_reimbursement: true})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns only contacts that DO NOT want reimbursement" do
+          # want_driving_reimbursement
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+
+          report = CaseContactReport.new({want_driving_reimbursement: false})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
+        it "returns all contacts that specify whether they want reimbursement or not" do
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+
+          report = CaseContactReport.new({want_driving_reimbursement: [true, false]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(2)
+        end
+      end
+      # describe "contact type filter functionality" do
+      #   it "returns only the case contacts that include the case contact" do
+      #     supervisor = create(:supervisor)
+      #     volunteer = create(:volunteer)
+      #     volunteer2 = create(:volunteer)
+      #     supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+          
+      #     create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
+      #     create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: ["school"]})
+        
+      #     create(:case_contact, {occurred_at: 100.days.ago})
+      #     report = CaseContactReport.new({contact_types: ["court"]})
+      #     contacts = report.case_contacts
+      #     expect(contacts.length).to eq(1)
+      #   end
+      # end
+      describe "multiple filter behavior" do
+        it "only returns records that occured less than 30 days ago, the youth has transitioned, and the contact type was either court or therapist" do
+          create(:case_contact, occurred_at: 20.days.ago, has_transitioned: true, contact_types: ["court"])
+          create(:case_contact, occurred_at: 40.days.ago, has_transitioned: true, contact_types: ["court"])
+          create(:case_contact, occurred_at: 20.days.ago, has_transitioned: false, contact_types: ["court"])
+          create(:case_contact, occurred_at: 20.days.ago, has_transitioned: true, contact_types: ["school"])
+          create(:case_contact, occurred_at: 20.days.ago, has_transitioned: true, contact_types: ["court", "school"])
+          create(:case_contact, occurred_at: 20.days.ago, has_transitioned: true, contact_types: ["therapist"])
+
+          20_days_ago_court_transitioned_report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_types: ["court"] })
+          contacts = 20_days_ago_court_transitioned_report.case_contacts
+          expect(contacts.length).to eq(1)
+
+        end
+      end
     end
   end
 end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe CaseContactReport, type: :model do
   end
   describe "filter behavior" do
     describe "occured at range filter" do
-      
       it "uses date range if provided" do
         create(:case_contact, {occurred_at: 20.days.ago})
         create(:case_contact, {occurred_at: 100.days.ago})
@@ -58,7 +57,7 @@ RSpec.describe CaseContactReport, type: :model do
         volunteer = create(:volunteer)
         create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer.id})
-       
+
         create(:case_contact, {occurred_at: 100.days.ago})
         report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_id: volunteer.id})
         contacts = report.case_contacts
@@ -69,10 +68,10 @@ RSpec.describe CaseContactReport, type: :model do
         volunteer = create(:volunteer)
         volunteer2 = create(:volunteer)
         supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
-        
+
         create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id})
-       
+
         create(:case_contact, {occurred_at: 100.days.ago})
         report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
         contacts = report.case_contacts
@@ -167,10 +166,10 @@ RSpec.describe CaseContactReport, type: :model do
       #     volunteer = create(:volunteer)
       #     volunteer2 = create(:volunteer)
       #     supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
-          
+
       #     create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
       #     create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: ["school"]})
-        
+
       #     create(:case_contact, {occurred_at: 100.days.ago})
       #     report = CaseContactReport.new({contact_types: ["court"]})
       #     contacts = report.case_contacts
@@ -199,7 +198,6 @@ RSpec.describe CaseContactReport, type: :model do
           report_20_days_ago_school_therapist_transitioned = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_types: ["school", "therapist"]})
           contacts = report_20_days_ago_court_transitioned.case_contacts
           expect(contacts.length).to eq(2)
-
         end
       end
     end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -67,15 +67,16 @@ RSpec.describe CaseContactReport, type: :model do
         supervisor = create(:supervisor)
         volunteer = create(:volunteer)
         volunteer2 = create(:volunteer)
-        supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+        create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
-        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+        contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id})
 
         create(:case_contact, {occurred_at: 100.days.ago})
         report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
         contacts = report.case_contacts
-        # expect(contacts.length).to eq(1)
+        expect(contacts.length).to eq(1)
+        expect(contacts).to eq([contact])
       end
       describe "case contact behavior" do
         it "returns only the case contacts with where contact was made" do
@@ -150,15 +151,16 @@ RSpec.describe CaseContactReport, type: :model do
           supervisor = create(:supervisor)
           volunteer = create(:volunteer)
           volunteer2 = create(:volunteer)
-          supervisor_volunteer = create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+          create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
-          create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
+          contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: ["court"]})
           create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: ["school"]})
 
           create(:case_contact, {occurred_at: 100.days.ago})
           report = CaseContactReport.new({contact_type: "court"})
           contacts = report.case_contacts
           expect(contacts.length).to eq(1)
+          expect(contacts).to eq([contact])
         end
       end
       describe "multiple filter behavior" do
@@ -166,24 +168,24 @@ RSpec.describe CaseContactReport, type: :model do
           untransitioned_casa_case = create(:casa_case, transition_aged_youth: false)
           transitioned_casa_case = create(:casa_case, transition_aged_youth: true)
           contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
-          contact2 = create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
-          contact3 = create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: ["court"])
+          create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: ["court"])
+          create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: ["court"])
           contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["school"])
           contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["court", "school"])
           contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: ["therapist"])
 
           aggregate_failures do
-          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "court"})
-          expect(report_1.case_contacts.length).to eq(2)
-          expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
+            report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "court"})
+            expect(report_1.case_contacts.length).to eq(2)
+            expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
 
-          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "school"})
-          expect(report_2.case_contacts.length).to eq(2)
-          expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
+            report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "school"})
+            expect(report_2.case_contacts.length).to eq(2)
+            expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
 
-          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "therapist"})
-          expect(report_3.case_contacts.length).to eq(1)
-          expect(report_3.case_contacts.include?(contact6)).to eq(true)
+            report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "therapist"})
+            expect(report_3.case_contacts.length).to eq(1)
+            expect(report_3.case_contacts.include?(contact6)).to eq(true)
           end
         end
       end

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -21,7 +21,7 @@ describe "case_contacts/case_contact" do
     user = build_stubbed(:supervisor)
     allow(view).to receive(:current_user).and_return(user)
 
-    render(partial: "case_contacts/case_contact", locals: { contact: case_contact})
+    render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
     expect(rendered).to have_no_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
   end
 end

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe "case_contacts/case_contact" do
     user = build_stubbed(:supervisor)
     allow(view).to receive(:current_user).and_return(user)
 
-    render(partial: "case_contacts/case_contact", locals: { contact: case_contact})
+    render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
     expect(rendered).to have_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
   end
 


### PR DESCRIPTION
abstracted the filter logic in the case contact report model to make it easier to test. then added tests to the case contact report spec. successfully added one new creator filter

### What github issue is this PR for, if any?
Resolves [#662](https://github.com/rubyforgood/casa/issues/662)

### What changed, and why?


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
