### PR TITLE
704 volunteer unassigned bug

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -29,6 +29,10 @@ class Volunteer < User
       updated
     end
   end
+
+  def has_supervisor?
+    supervisor_volunteer.present? && supervisor_volunteer.is_active?
+  end
 end
 
 # == Schema Information

--- a/app/views/dashboard/_volunteers_table.html.erb
+++ b/app/views/dashboard/_volunteers_table.html.erb
@@ -19,7 +19,7 @@
       <td data-search="<%= volunteer.past_names %>"><%= link_to(volunteer.decorate.name, edit_volunteer_path(volunteer)) %></td>
       <td><%= volunteer.email %></td>
       <td id="supervisor-column">
-        <%- unless volunteer.supervisor.nil? %>
+        <%- if volunteer.has_supervisor? %>
           <%= link_to(volunteer.supervisor.decorate.name, edit_supervisor_path(volunteer.supervisor)) %>
         <%- end %>
       </td>

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -43,4 +43,32 @@ RSpec.describe Volunteer, type: :model do
       end
     end
   end
+
+  describe "has_supervisor?" do
+    context "when no supervisor_volunteer record" do
+      let(:volunteer) { create(:volunteer) }
+
+      it "returns false" do
+        expect(volunteer.has_supervisor?).to be false
+      end
+    end
+
+    context "when active supervisor_volunteer record" do
+      let(:sv) { create(:supervisor_volunteer, is_active: true) }
+      let(:volunteer) { sv.volunteer }
+
+      it "returns true" do
+        expect(volunteer.has_supervisor?).to be true
+      end
+    end
+
+    context "when inactive supervisor_volunteer record" do
+      let(:sv) { create(:supervisor_volunteer, is_active: false) }
+      let(:volunteer) { sv.volunteer }
+
+      it "returns false" do
+        expect(volunteer.has_supervisor?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe "admin views dashboard", type: :system do
 
       expect(supervisor_cell.text).to eq name
     end
+
+    it "is blank when volunteer has been unassigned from supervisor" do
+      volunteer = create(:volunteer, casa_org: organization)
+      sv = create(:supervisor_volunteer, volunteer: volunteer, is_active: false)
+      sign_in admin
+
+      visit root_path
+      supervisor_cell = page.find("#supervisor-column")
+
+      expect(supervisor_cell.text).to eq ""
+    end
   end
 
   it "can see the last case contact and navigate to it", js: false do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #704 

### What changed, and why?
* Added `has_supervisor?` method to volunteer that will return true if volunteer has active supervisor
* Only display email for active supervisors in Volunteers table

### How is this tested? (please write tests!) 💖💪
* Added unit tests for the new volunteer method
* Added system spec to check that unassigned supervisor email does not display

### Screenshots please :)

<img width="1243" alt="Screen Shot 2020-09-08 at 8 08 57 PM" src="https://user-images.githubusercontent.com/1938665/92549873-28227700-f20f-11ea-9383-ff5c71829b71.png">
<img width="1290" alt="Screen Shot 2020-09-08 at 8 08 47 PM" src="https://user-images.githubusercontent.com/1938665/92549878-2c4e9480-f20f-11ea-94e2-791ef5a7244b.png">


