### PR TITLE
Fix page errors caused when volunteer form re-renders due to update error

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -20,8 +20,6 @@ class VolunteersController < ApplicationController
   end
 
   def edit
-    @case_assignments = @volunteer.case_assignments.includes(:casa_case)
-    @available_casa_cases = _get_available_casa_cases
   end
 
   def update

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -31,7 +31,6 @@ class VolunteersController < ApplicationController
   end
 
   def activate
-    @available_casa_cases = _get_available_casa_cases
     if @volunteer.activate
       VolunteerMailer.account_setup(@volunteer).deliver
 
@@ -46,7 +45,6 @@ class VolunteersController < ApplicationController
   end
 
   def deactivate
-    @available_casa_cases = _get_available_casa_cases
     if @volunteer.deactivate
       VolunteerMailer.deactivation(@volunteer).deliver
 
@@ -57,10 +55,6 @@ class VolunteersController < ApplicationController
   end
 
   private
-
-  def _get_available_casa_cases
-    CasaCase.all.order(:case_number) || []
-  end
 
   def set_volunteer
     # @volunteer = authorize User.find(params[:id]) # TODO fix this

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -14,6 +14,12 @@ class CasaCase < ApplicationRecord
         case_assignments: {volunteer: volunteer, is_active: true}
       )
     }
+
+  class << self
+    def available
+      order(:case_number)
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -30,6 +30,10 @@ class Volunteer < User
     end
   end
 
+  def case_assignments_with_cases
+    case_assignments.includes(:casa_case)
+  end
+
   def has_supervisor?
     supervisor_volunteer.present? && supervisor_volunteer.is_active?
   end

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -81,7 +81,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @case_assignments.each do |assignment| %>
+          <% @volunteer.case_assignments_with_cases.each do |assignment| %>
             <tr>
               <td><%= link_to assignment.casa_case.case_number, casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.decorate.transition_aged_youth_icon %></td>
@@ -124,7 +124,7 @@
         <div class='form-group'>
           <label for='case_assignment_casa_case_id'>Select a Case</label>
           <select id="case_assignment_casa_case_id" name='case_assignment[casa_case_id]' class='form-control'>
-            <% @available_casa_cases.each do |casa_case| %>
+            <% CasaCase.available.find_each do |casa_case| %>
               <option value="<%= casa_case.id %>"><%= casa_case.case_number %></option>
             <% end %>
           </select>

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -5,6 +5,31 @@ RSpec.describe "Admin: Editing Volunteers", type: :system do
   let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
   let(:volunteer) { create(:volunteer, casa_org_id: organization.id) }
 
+  describe "updating volunteer personal data" do
+    before do
+      sign_in admin
+      visit edit_volunteer_path(volunteer)
+    end
+
+    context "with valid data" do
+      it "updates successfully" do
+        fill_in "volunteer_email", with: "newemail@example.com"
+        fill_in "volunteer_display_name", with: "Mickey Mouse"
+        click_on "Submit"
+        expect(page).to have_text "Volunteer was successfully updated."
+      end
+    end
+
+    context "with invalid data" do
+      it "shows error message" do
+        fill_in "volunteer_email", with: admin.email
+        fill_in "volunteer_display_name", with: "Mickey Mouse"
+        click_on "Submit"
+        expect(page).to have_text "already been taken"
+      end
+    end
+  end
+
   it "saves the user as inactive, but only if the admin confirms" do
     sign_in admin
     visit edit_volunteer_path(volunteer)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #708 

### What changed, and why?
When the volunteer form had to re-render due to an update error, the instance variables defined in the `edit` method were not available, causing errors. Instead of re-defining the instance variables in the `update` method, I moved the instance variables to methods.

### How is this tested? (please write tests!) 💖💪
Added request and system specs to test the case when a non-unique email address is used to update the form.

### Screenshots please :)

<img width="778" alt="Screen Shot 2020-09-11 at 1 18 27 PM" src="https://user-images.githubusercontent.com/1938665/92969180-57183300-f431-11ea-94c2-a2a84aec3d0f.png">

### Notes
Will create follow-up task to prettify the error message.