### PR TITLE
[issue-706] Adds "pick displayed columns" in admin and supervisor das…

### DIFF
--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -1,18 +1,6 @@
-<div class="row">
-  <div class="col-sm-12 dashboard-table-header">
-    <h1>Volunteers</h1>
-    <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">
-      Pick displayed columns
-    </button>
-  </div>
-</div>
-<hr>
-
+<%= render "volunteers_display_columns" %>
 <%= render "volunteer_filters", logged_in_supervisor: nil %>
-
 <%= render "volunteers_table" %>
-
 <br>
 <%= render "casa_cases" %>
 <br>

--- a/app/views/dashboard/_supervisor_dashboard.html.erb
+++ b/app/views/dashboard/_supervisor_dashboard.html.erb
@@ -1,9 +1,4 @@
-<div class="row">
-  <div class="col-sm-12 dashboard-table-header">
-    <h1>Volunteers</h1>
-  </div>
-</div>
-<hr>
+<%= render "volunteers_display_columns" %>
 <%= render "volunteer_filters", logged_in_supervisor: logged_in_supervisor %>
 <%= render "volunteers_table" %>
 <br>

--- a/app/views/dashboard/_volunteers_display_columns.html.erb
+++ b/app/views/dashboard/_volunteers_display_columns.html.erb
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-sm-12 dashboard-table-header">
+    <h1>Volunteers</h1>
+    <% if current_user.casa_admin? %>
+      <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
+    <% end %>
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">
+      Pick displayed columns
+    </button>
+  </div>
+</div>
+<hr>

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -152,6 +152,29 @@ RSpec.describe "admin views dashboard", type: :system do
     expect(page.all("table#volunteers tr").count).to eq 3
   end
 
+  it "can show/hide columns on volunteers table" do
+    sign_in admin
+
+    visit root_path
+    expect(page).to have_text("Pick displayed columns")
+    expected_columns = [
+        'Name', 'Email', 'Supervisor', 'Status', 'Assigned To Transition Aged Youth',
+        'Case Number', 'Last Contact Made','Contact Made In Past 60 Days','Actions'
+    ]
+    expected_columns.each do |column_name|
+      click_on "Pick displayed columns"
+      expect(page).to have_text(column_name)
+      check column_name
+      click_on "Close"
+      expect(page).to have_text(column_name)
+
+      click_on "Pick displayed columns"
+      uncheck column_name
+      click_on "Close"
+      expect(page).not_to have_text(column_name)
+    end
+  end
+
   it "can go to the supervisor edit page from the supervisor list" do
     supervisor_name = "Leslie Knope"
     create(:supervisor, display_name: supervisor_name, casa_org: organization)

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -157,22 +157,24 @@ RSpec.describe "admin views dashboard", type: :system do
 
     visit root_path
     expect(page).to have_text("Pick displayed columns")
-    expected_columns = [
-        'Name', 'Email', 'Supervisor', 'Status', 'Assigned To Transition Aged Youth',
-        'Case Number', 'Last Contact Made','Contact Made In Past 60 Days','Actions'
-    ]
-    expected_columns.each do |column_name|
-      click_on "Pick displayed columns"
-      expect(page).to have_text(column_name)
-      check column_name
-      click_on "Close"
-      expect(page).to have_text(column_name)
 
-      click_on "Pick displayed columns"
-      uncheck column_name
-      click_on "Close"
-      expect(page).not_to have_text(column_name)
+    click_on "Pick displayed columns"
+    expect(page).to have_text('Name')
+    expect(page).to have_text('Status')
+    expect(page).to have_text('Contact Made In Past 60 Days')
+    expect(page).to have_text('Last Contact Made')
+    check 'Name'
+    check 'Status'
+    uncheck 'Contact Made In Past 60 Days'
+    uncheck 'Last Contact Made'
+    within(".modal-dialog") do
+      click_button "Close"
     end
+
+    expect(page).to have_text('Name')
+    expect(page).to have_text('Status')
+    expect(page).not_to have_text('Contact Made In Past 60 Days')
+    expect(page).not_to have_text('Last Contact Made')
   end
 
   it "can go to the supervisor edit page from the supervisor list" do

--- a/spec/system/supervisor_views_dashboard_spec.rb
+++ b/spec/system/supervisor_views_dashboard_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe "supervisor views dashboard", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+  it "can filter volunteers" do
+    create_list(:volunteer, 3, casa_org: organization)
+    create_list(:volunteer, 2, :inactive, casa_org: organization)
+
+    sign_in supervisor
+
+    visit root_path
+    expect(page).to have_selector(".volunteer-filters")
+
+    # by default, only active users are shown, so result should be 4 here
+    expect(page.all("table#volunteers tr").count).to eq 4
+
+    click_on "Status"
+    find(:css, 'input[data-value="Active"]').set(false)
+
+    # when all users are hidden, the tr count will be 2 for header and "no results" row
+    expect(page.all("table#volunteers tr").count).to eq 2
+
+    find(:css, 'input[data-value="Inactive"]').set(true)
+
+    expect(page.all("table#volunteers tr").count).to eq 3
+  end
+
+  it "can show/hide columns on volunteers table" do
+    sign_in supervisor
+
+    visit root_path
+    expect(page).to have_text("Pick displayed columns")
+
+    click_on "Pick displayed columns"
+    expect(page).to have_text('Name')
+    expect(page).to have_text('Status')
+    expect(page).to have_text('Contact Made In Past 60 Days')
+    expect(page).to have_text('Last Contact Made')
+    check 'Name'
+    check 'Status'
+    uncheck 'Contact Made In Past 60 Days'
+    uncheck 'Last Contact Made'
+    within(".modal-dialog") do
+      click_button "Close"
+    end
+
+    expect(page).to have_text('Name')
+    expect(page).to have_text('Status')
+    expect(page).not_to have_text('Contact Made In Past 60 Days')
+    expect(page).not_to have_text('Last Contact Made')
+  end
+end


### PR DESCRIPTION
…hboard.

### What github issue is this PR for, if any?
Resolves #706 


### What changed, and why?
Adds "pick displayed columns" for volunteers table exists in admin dashboard. It was requested to be added also in supervisor dashboard.

### How will this affect user permissions?
No permissions are affected

### How is this tested? (please write tests!) 💖💪
WIP

### Screenshots please :)

<img width="1179" alt="Screen Shot 2020-09-12 at 12 15 11 PM" src="https://user-images.githubusercontent.com/2204448/92999786-b89fd680-f4f1-11ea-99b5-9033fdfb6bb1.png">
<img width="1149" alt="Screen Shot 2020-09-12 at 12 15 23 PM" src="https://user-images.githubusercontent.com/2204448/92999787-b9386d00-f4f1-11ea-9277-be5993381659.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
