### PR TITLE
Add tests for user redirection on authz error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,21 +14,21 @@ class ApplicationController < ActionController::Base
   def must_be_admin
     return if current_user&.casa_admin?
 
-    flash[:notice] = "You do not have permission to view that page."
+    flash[:notice] = t("default", scope: "pundit")
     redirect_to root_url
   end
 
   def must_be_admin_or_supervisor
     return if current_user&.casa_admin? || current_user&.supervisor?
 
-    flash[:notice] = "You do not have permission to view that page."
+    flash[:notice] = t("default", scope: "pundit")
     redirect_to root_url
   end
 
   def not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
 
-    flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
+    flash[:error] = t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)
     redirect_to(request.referrer || root_url)
   end
 

--- a/spec/system/user_attempts_to_load_an_unauthorized_page_spec.rb
+++ b/spec/system/user_attempts_to_load_an_unauthorized_page_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "user attempts to load an unauthorized page", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+
+  context "as a volunteer" do
+    before { sign_in volunteer }
+
+    describe "new supervisor page" do
+      it "redirects the user with an error message" do
+        visit new_supervisor_path
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
+      end
+    end
+
+    describe "imports page" do
+      it "redirects the user with an error message" do
+        visit imports_path
+
+        expect(page).to have_current_path("/")
+        expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #536

### What changed, and why?
Adds a couple of high level tests that users see friendly error message when they encounter an authz error. More scenarios can be added if there are unique situations or coverage is desired.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Via system tests