### PR TITLE
Admins can view admins on dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,5 +16,6 @@ class DashboardController < ApplicationController
     )).order(occurred_at: :desc).decorate
 
     @supervisors = policy_scope(current_organization.supervisors)
+    @admins = policy_scope(current_organization.casa_admins)
   end
 end

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -8,15 +8,15 @@ class CasaOrg < ApplicationRecord
   delegate :url, :alt_text, :size, to: :casa_org_logo, prefix: :logo, allow_nil: true
 
   def casa_admins
-    users.where(type: "CasaAdmin")
+    CasaAdmin.in_organization(self)
   end
 
   def supervisors
-    users.where(type: "Supervisor")
+    Supervisor.in_organization(self)
   end
 
   def volunteers
-    users.where(type: "Volunteer")
+    Volunteer.in_organization(self)
   end
 
   def case_contacts

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -25,4 +25,8 @@ class DashboardPolicy
   def see_supervisors_section?
     user.casa_admin?
   end
+
+  def see_admins_section?
+    user.casa_admin?
+  end
 end

--- a/app/views/dashboard/_admin_dashboard.html.erb
+++ b/app/views/dashboard/_admin_dashboard.html.erb
@@ -18,3 +18,6 @@
 <br>
 <%= render "supervisors_table" %>
 <br>
+<%= render "admins_table" %>
+<br>
+

--- a/app/views/dashboard/_admins_table.html.erb
+++ b/app/views/dashboard/_admins_table.html.erb
@@ -1,0 +1,29 @@
+<% if policy(:dashboard).see_admins_section? %>
+  <div class="row">
+    <div class="col-sm-12 dashboard-table-header">
+      <h1>Admins</h1>
+    </div>
+  </div>
+
+  <table class="table table-striped table-bordered" id="admins">
+    <thead>
+    <tr>
+      <th>Admin Email</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% @admins.each do |admin| %>
+      <tr id="admin-<%= admin.id %>">
+        <th scope="row">
+          <%= admin.email %>
+        </th>
+        <td>
+          <a href="#">TBA!</a>a
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -65,4 +65,18 @@ RSpec.describe DashboardPolicy do
       expect(subject).not_to permit(create(:volunteer))
     end
   end
+
+  permissions :see_admins_section? do
+    it "allows casa_admins" do
+      expect(subject).to permit(create(:casa_admin))
+    end
+
+    it "does not allow supervisors" do
+      expect(subject).not_to permit(create(:supervisor))
+    end
+
+    it "does not allow volunteers" do
+      expect(subject).not_to permit(create(:volunteer))
+    end
+  end
 end

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -195,4 +195,19 @@ RSpec.describe "admin views dashboard", type: :system do
 
     expect(page).to have_text("There are no active, unassigned volunteers available")
   end
+
+  it "displays other admins within the same CASA organization" do
+    admin2 = create(:casa_admin, email: "Jon@org.com", casa_org: organization)
+    admin3 = create(:casa_admin, email: "Bon@org.com", casa_org: organization)
+    different_org_admin = create(:casa_admin, email: "Jovi@something.else", casa_org: create(:casa_org))
+
+    sign_in admin
+    visit root_path
+
+    within "#admins" do
+      expect(page).to have_content(admin2.name)
+      expect(page).to have_content(admin3.name)
+      expect(page).to have_no_content(different_org_admin.name)
+    end
+  end
 end

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -200,14 +200,18 @@ RSpec.describe "admin views dashboard", type: :system do
     admin2 = create(:casa_admin, email: "Jon@org.com", casa_org: organization)
     admin3 = create(:casa_admin, email: "Bon@org.com", casa_org: organization)
     different_org_admin = create(:casa_admin, email: "Jovi@something.else", casa_org: create(:casa_org))
+    supervisor = create(:supervisor, email: "super@visor.com", casa_org: organization)
+    volunteer = create(:volunteer, email: "volun@tear.com", casa_org: organization)
 
     sign_in admin
     visit root_path
 
     within "#admins" do
-      expect(page).to have_content(admin2.name)
-      expect(page).to have_content(admin3.name)
-      expect(page).to have_no_content(different_org_admin.name)
+      expect(page).to have_content(admin2.email)
+      expect(page).to have_content(admin3.email)
+      expect(page).to have_no_content(different_org_admin.email)
+      expect(page).to have_no_content(supervisor.email)
+      expect(page).to have_no_content(volunteer.email)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #714

### What changed, and why?
Adds a small table at the bottom of the dashboard, only viewable by Admins, that lists other admins for the org.

### How will this affect user permissions?
- Volunteer permissions: n/c
- Supervisor permissions: n/c
- Admin permissions: Admins have access to view this

### How is this tested? (please write tests!) 💖💪
Added system spec and policy spec to vet it. The test checks to ensure that other-org-admins are not displayed as well as non-admin users.
