### PR TITLE
Allow all_casa_admin user to edit email/password

### DIFF
--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -16,9 +16,24 @@ class AllCasaAdminsController < ApplicationController
     end
   end
 
+  def update_password
+    @user = current_all_casa_admin
+    if @user.update(password_params)
+      bypass_sign_in(@user)
+      flash[:success] = "Password was successfully updated."
+      redirect_to edit_all_casa_admins_path
+    else
+      render "edit"
+    end
+  end
+
   private
 
   def all_casa_admin_params
     params.require(:all_casa_admin).permit(:email)
+  end
+
+  def password_params
+    params.require(:all_casa_admin).permit(:password, :password_confirmation)
   end
 end

--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -1,3 +1,21 @@
 class AllCasaAdminsController < ApplicationController
   before_action :authenticate_all_casa_admin!
-end
+  def edit
+    @user = current_all_casa_admin
+  end
+
+    def update
+      @user = current_all_casa_admin
+
+      if @user.update(all_casa_admin_params)
+        flash[:success] = "Profile was successfully updated."
+        redirect_to edit_all_casa_admins_path
+      else
+        render :edit
+      end
+  end
+  private
+  def all_casa_admin_params
+    params.require(:all_casa_admin).permit(:email)
+  end
+  end

--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -1,21 +1,24 @@
 class AllCasaAdminsController < ApplicationController
   before_action :authenticate_all_casa_admin!
+
   def edit
     @user = current_all_casa_admin
   end
 
-    def update
-      @user = current_all_casa_admin
+  def update
+    @user = current_all_casa_admin
 
-      if @user.update(all_casa_admin_params)
-        flash[:success] = "Profile was successfully updated."
-        redirect_to edit_all_casa_admins_path
-      else
-        render :edit
-      end
+    if @user.update(all_casa_admin_params)
+      flash[:success] = "Profile was successfully updated."
+      redirect_to edit_all_casa_admins_path
+    else
+      render :edit
+    end
   end
+
   private
+
   def all_casa_admin_params
     params.require(:all_casa_admin).permit(:email)
   end
-  end
+end

--- a/app/views/all_casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/edit.html.erb
@@ -20,11 +20,11 @@
       </div>
       <% end %>
       <br>
-      <!-- <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
-        <%= form_for(@user, as: :user, :url => { :action => "update_password" } ) do |f| %>
+      <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+        <%= form_for(@user, as: :all_casa_admin, url: { action: "update_password" } ) do |f| %>
           <div class="field form-group">
             <%= f.label :password, "Password" %><br>
-            <%= f.password_field :password, :autocomplete => "off", class: "form-control" %>
+            <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
           </div>
           <div class="field form-group">
             <%= f.label :password_confirmation, "Password Confirmation" %><br>
@@ -34,7 +34,7 @@
             <%= f.submit "Update Password", class: "btn btn-danger" %>
           </div>
         <% end %>
-      </div> -->
+      </div>
       <br>
   </div>
 </div>

--- a/app/views/all_casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/edit.html.erb
@@ -1,0 +1,40 @@
+<%= errors_for(@user) %>
+
+<h1>Edit Profile</h1>
+
+<div class="row">
+  <div class="col-sm-6">
+    <%= form_for @user, as: :all_casa_admin, url: all_casa_admins_path do |form| %>
+
+      <div class="field form-group">
+        <%= form.label :email %>
+        <p class="form-control"><%= @user.email %></p>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "Update Profile", class: "btn btn-primary" %>
+        <%= link_to "Back", authenticated_all_casa_admin_root_path, class: "btn btn-primary" %>
+        <button class="btn btn-warning accordion" id="accordionExample" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+          Change Password
+        </button>
+      </div>
+      <% end %>
+      <br>
+      <!-- <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+        <%= form_for(@user, as: :user, :url => { :action => "update_password" } ) do |f| %>
+          <div class="field form-group">
+            <%= f.label :password, "Password" %><br>
+            <%= f.password_field :password, :autocomplete => "off", class: "form-control" %>
+          </div>
+          <div class="field form-group">
+            <%= f.label :password_confirmation, "Password Confirmation" %><br>
+            <%= f.password_field :password_confirmation, class: "form-control" %>
+          </div>
+          <div class="action_container">
+            <%= f.submit "Update Password", class: "btn btn-danger" %>
+          </div>
+        <% end %>
+      </div> -->
+      <br>
+  </div>
+</div>

--- a/app/views/all_casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/edit.html.erb
@@ -8,7 +8,7 @@
 
       <div class="field form-group">
         <%= form.label :email %>
-        <p class="form-control"><%= @user.email %></p>
+        <%= form.email_field :email, class: "form-control" %>
       </div>
 
       <div class="actions">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,6 +30,7 @@
             <%= current_all_casa_admin.email %>
           </button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+          <%= link_to "Edit Profile", edit_all_casa_admins_path, class: "dropdown-item" %>
           </div>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,13 @@ Rails.application.routes.draw do
   namespace :all_casa_admins do
     resources :casa_orgs, only: [:new, :create, :show]
   end
-
+  resources :all_casa_admins, only: [] do
+    collection do
+      get :edit
+      patch :update
+      patch "update_password"
+    end
+  end
   # TODO: Remove, if possible. Prefer to use specific role routes.
   resources :users, only: [] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
   namespace :all_casa_admins do
     resources :casa_orgs, only: [:new, :create, :show]
   end
+
   resources :all_casa_admins, only: [] do
     collection do
       get :edit
@@ -55,6 +56,7 @@ Rails.application.routes.draw do
       patch "update_password"
     end
   end
+
   # TODO: Remove, if possible. Prefer to use specific role routes.
   resources :users, only: [] do
     collection do

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "/all_casa_admins", type: :request do
+  describe "GET /edit" do
+    context "with a all_casa_admin signed in" do
+      it "renders a successful response" do
+        sign_in create(:all_casa_admin)
+
+        get edit_all_casa_admins_path
+
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+        it "updates the all_casa_admin" do
+        admin = create(:all_casa_admin)
+        sign_in admin
+
+        patch all_casa_admins_path, params: {all_casa_admin: {email: "newemail@example.com"}}
+
+        expect(admin.email).to eq "newemail@example.com"
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+    context "with invalid parameters" do
+        it "does not update the all_casa_admin" do
+        admin = create(:all_casa_admin)
+        sign_in admin
+        other_admin = create(:all_casa_admin)
+        patch all_casa_admins_path, params: {all_casa_admin: {email: other_admin.email}}
+
+        expect(admin.email).to_not eq "newemail@example.com"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -38,4 +38,44 @@ RSpec.describe "/all_casa_admins", type: :request do
       end
     end
   end
+
+  describe "PATCH /update_password" do
+    let(:admin) { create(:all_casa_admin) }
+
+    before { sign_in admin }
+
+    context "with valid parameters" do
+      let(:params) {
+        {
+          all_casa_admin: {
+            password: "newpassword",
+            password_confirmation: "newpassword",
+          }
+        }
+      }
+
+      it "updates the all_casa_admin password" do
+        patch update_password_all_casa_admins_path, params: params
+        expect(response).to have_http_status(:redirect)
+        expect(admin.valid_password?("newpassword")).to be true
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:params) {
+        {
+          all_casa_admin: {
+            password: "newpassword",
+            password_confirmation: "badmatch",
+          }
+        }
+      }
+
+      it "does not update the all_casa_admin password" do
+        patch update_password_all_casa_admins_path, params: params
+        expect(response).to have_http_status(:ok)
+        expect(admin.reload.valid_password?("newpassword")).to be false
+      end
+    end
+  end
 end

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -15,25 +15,26 @@ RSpec.describe "/all_casa_admins", type: :request do
 
   describe "PATCH /update" do
     context "with valid parameters" do
-        it "updates the all_casa_admin" do
+      it "updates the all_casa_admin" do
         admin = create(:all_casa_admin)
         sign_in admin
 
         patch all_casa_admins_path, params: {all_casa_admin: {email: "newemail@example.com"}}
+        expect(response).to have_http_status(:redirect)
 
         expect(admin.email).to eq "newemail@example.com"
-        expect(response).to have_http_status(:redirect)
       end
     end
+
     context "with invalid parameters" do
-        it "does not update the all_casa_admin" do
+      it "does not update the all_casa_admin" do
         admin = create(:all_casa_admin)
         sign_in admin
         other_admin = create(:all_casa_admin)
         patch all_casa_admins_path, params: {all_casa_admin: {email: other_admin.email}}
+        expect(response).to have_http_status(:ok)
 
         expect(admin.email).to_not eq "newemail@example.com"
-        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "all_casa_admin_edit_spec", type: :system do
+let(:admin) {create(:all_casa_admin)}
+before do
+    sign_in admin
+end
+describe"with valid parameters" do
+    it "updates email" do
+    end
+end
+
+end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -1,14 +1,29 @@
 require "rails_helper"
 
 RSpec.describe "all_casa_admin_edit_spec", type: :system do
-  let(:admin) {create(:all_casa_admin)}
+  let(:admin) { create(:all_casa_admin) }
 
   before do
     sign_in admin
+    visit edit_all_casa_admins_path
   end
 
-  describe"with valid parameters" do
+  describe "with valid parameters" do
     it "updates email" do
+      fill_in "all_casa_admin_email", with: "newemail@example.com"
+      click_on "Update Profile"
+      expect(page).to have_text "successfully updated"
+    end
+  end
+
+  describe "with invalid parameters" do
+    let!(:other_admin) { create(:all_casa_admin) }
+
+    it "updates email" do
+      visit edit_all_casa_admins_path
+      fill_in "all_casa_admin_email", with: other_admin.email
+      click_on "Update Profile"
+      expect(page).to have_text "already been taken"
     end
   end
 end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "all_casa_admin_edit_spec", type: :system do
-let(:admin) {create(:all_casa_admin)}
-before do
+  let(:admin) {create(:all_casa_admin)}
+
+  before do
     sign_in admin
-end
-describe"with valid parameters" do
+  end
+
+  describe"with valid parameters" do
     it "updates email" do
     end
-end
-
+  end
 end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe "all_casa_admin_edit_spec", type: :system do
       click_on "Update Profile"
       expect(page).to have_text "successfully updated"
     end
+
+    it "updates password" do
+      click_on "Change Password"
+      fill_in "all_casa_admin_password", with: "newpassword"
+      fill_in "all_casa_admin_password_confirmation", with: "newpassword"
+      click_on "Update Password"
+      expect(page).to have_text "successfully updated"
+    end
   end
 
   describe "with invalid parameters" do
@@ -24,6 +32,14 @@ RSpec.describe "all_casa_admin_edit_spec", type: :system do
       fill_in "all_casa_admin_email", with: other_admin.email
       click_on "Update Profile"
       expect(page).to have_text "already been taken"
+    end
+
+    it "does not update password" do
+      click_on "Change Password"
+      fill_in "all_casa_admin_password", with: "newpassword"
+      fill_in "all_casa_admin_password_confirmation", with: "badmatch"
+      click_on "Update Password"
+      expect(page).to have_text "confirmation doesn't match"
     end
   end
 end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "all_casa_admin_edit_spec", type: :system do
   describe "with invalid parameters" do
     let!(:other_admin) { create(:all_casa_admin) }
 
-    it "updates email" do
+    it "does not update email" do
       visit edit_all_casa_admins_path
       fill_in "all_casa_admin_email", with: other_admin.email
       click_on "Update Profile"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #630

### What changed, and why?
* Added Edit Profile link 
* Added edit email and password view

### How is this tested? (please write tests!) 💖💪
* Added system and request specs

### Screenshots please :)

<img width="1246" alt="Screen Shot 2020-09-12 at 11 46 03 AM" src="https://user-images.githubusercontent.com/1938665/93002708-b0de3300-f4ed-11ea-860d-b517de23f067.png">

<img width="719" alt="Screen Shot 2020-09-12 at 11 46 16 AM" src="https://user-images.githubusercontent.com/1938665/93002712-b5a2e700-f4ed-11ea-8236-52d015213a8c.png">

<img width="695" alt="Screen Shot 2020-09-12 at 11 46 27 AM" src="https://user-images.githubusercontent.com/1938665/93002711-b5a2e700-f4ed-11ea-84a5-fc620cff3ae2.png">

<img width="749" alt="Screen Shot 2020-09-12 at 11 46 55 AM" src="https://user-images.githubusercontent.com/1938665/93002710-b471ba00-f4ed-11ea-9f51-43b93177c71e.png">


