### PR TITLE
Add after_party:run to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bundle exec rake db:migrate
+release: bundle exec rake db:migrate && bundle exec rake after_party:run
 web: bundle exec puma
 assets: bin/webpack-dev-server


### PR DESCRIPTION
### What changed, and why?

Add `after_party:run` rake task to Procfile so it will run automatically on Heroku.

But @compwron if you are not a fan of After Party for other reasons, happy to move away from it.  I just feel like it is safer than having brittle migrations down the line.