### PR TITLE
687 allcasaadmin can create orgs

### DIFF
--- a/app/controllers/all_casa_admins/casa_orgs_controller.rb
+++ b/app/controllers/all_casa_admins/casa_orgs_controller.rb
@@ -2,4 +2,26 @@ class AllCasaAdmins::CasaOrgsController < AllCasaAdminsController
   def show
     @casa_org = CasaOrg.find(params[:id])
   end
+
+  def new
+    @casa_org = CasaOrg.new
+  end
+
+  def create
+    @casa_org = CasaOrg.new(casa_org_params)
+
+    respond_to do |format|
+      if @casa_org.save
+        format.html { redirect_to all_casa_admins_casa_org_path(@casa_org), notice: "CASA Organization was successfully created." }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+  private
+
+  def casa_org_params
+    params.require(:casa_org).permit(:name, :display_name, :address)
+  end
 end

--- a/app/javascript/src/stylesheets/pages/dashboard.scss
+++ b/app/javascript/src/stylesheets/pages/dashboard.scss
@@ -1,4 +1,4 @@
-body.dashboard {
+.dashboard, .all_casa_admins-dashboard  {
 
   .container {
     @media (max-width: 1200px) {

--- a/app/views/all_casa_admins/casa_orgs/new.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/new.html.erb
@@ -1,0 +1,30 @@
+<%= link_to "Back", root_path %>
+<h1>Create a new CASA Organization</h1>
+
+<div class="row">
+  <div class="col-md-6">
+    <%= form_with model: @casa_org, url: all_casa_admins_casa_orgs_path, method: :post, local: true do |form| %>
+      <%= render "/shared/error_messages", resource: @casa_org %>
+
+      <div class="field form-group">
+        <%= form.label :name %>
+        <%= form.text_field :name, class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= form.label :display_name %>
+        <%= form.text_field :display_name, class: "form-control" %>
+      </div>
+
+      <div class="field form-group">
+        <%= form.label :address %>
+        <%= form.text_field :address, class: "form-control" %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "Create CASA Organization", class: "btn btn-primary" %>
+        <%= return_to_dashboard_button %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/all_casa_admins/dashboard/show.html.erb
+++ b/app/views/all_casa_admins/dashboard/show.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header">
     <h1>All CASA Admin</h1>
+    <a class="btn btn-primary" href="<%= new_all_casa_admins_casa_org_path %>" >New CASA Organization</a>
   </div>
 </div>
 <h2>CASA Organizations</h2>

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -4,47 +4,68 @@ describe "all casa admins with casa orgs", type: :system do
   let(:all_casa_admin) { create(:all_casa_admin) }
   let!(:casa_org) { create(:casa_org) }
 
-  before { sign_in all_casa_admin }
+  context "as an all casa admin" do
+    before { sign_in all_casa_admin }
 
-  it "lets admin navigate to an organization and see casa_admins" do
-    ca1 = create(:casa_admin, casa_org: casa_org)
-    ca2 = create(:casa_admin, casa_org: casa_org)
-    vol = create(:volunteer, casa_org: casa_org)
-    sup = create(:supervisor, casa_org: casa_org)
+    it "lets admin navigate to an organization and see casa_admins" do
+      ca1 = create(:casa_admin, casa_org: casa_org)
+      ca2 = create(:casa_admin, casa_org: casa_org)
+      vol = create(:volunteer, casa_org: casa_org)
+      sup = create(:supervisor, casa_org: casa_org)
 
-    visit "/"
+      visit "/"
 
-    expect(page).to have_text "All CASA Admin"
-    expect(page).to have_text casa_org.name
+      expect(page).to have_text "All CASA Admin"
+      expect(page).to have_text casa_org.name
 
-    click_on casa_org.name
+      click_on casa_org.name
 
-    expect(page).to have_text "Administrators"
-    expect(page).to have_text "Back to dashboard"
-    expect(page).to_not have_text vol.email
-    expect(page).to_not have_text sup.email
-    expect(page).to have_text ca1.email
-    expect(page).to have_text ca2.email
+      expect(page).to have_text "Administrators"
+      expect(page).to have_text "Back to dashboard"
+      expect(page).to_not have_text vol.email
+      expect(page).to_not have_text sup.email
+      expect(page).to have_text ca1.email
+      expect(page).to have_text ca2.email
+    end
+
+    it "lets admin create a casa org" do
+      visit "/"
+      expect(page).to have_text "All CASA Admin"
+
+      click_on "New CASA Organization"
+      expect(page).to have_text "Create a new CASA Organization"
+
+      fill_in "Name", with: "A new org"
+      fill_in "Display name", with: "A new org"
+      fill_in "Address", with: "123 Whole St"
+
+      click_on "Create CASA Organization"
+
+      expect(page).to have_text "CASA Organization was successfully created."
+
+      new_org = CasaOrg.last
+      expect(new_org.name).to eq "A new org"
+      expect(new_org.display_name).to eq "A new org"
+      expect(new_org.address).to eq "123 Whole St"
+    end
   end
 
-  it "lets admin create a casa org" do
-    visit "/"
-    expect(page).to have_text "All CASA Admin"
+  context "as any other user" do
+    let(:casa_admin) { create(:casa_admin, casa_org: casa_org) }
 
-    click_on "New CASA Organization"
-    expect(page).to have_text "Create a new CASA Organization"
+    before { sign_in casa_admin }
 
-    fill_in "Name", with: "A new org"
-    fill_in "Display name", with: "A new org"
-    fill_in "Address", with: "123 Whole St"
+    it "redirects to root" do
+      visit new_all_casa_admins_casa_org_path
+      expect(page).to have_text "Volunteers"
+      expect(page).to_not have_text "Create a new CASA Organization"
+    end
+  end
 
-    click_on "Create CASA Organization"
-
-    expect(page).to have_text "CASA Organization was successfully created."
-
-    new_org = CasaOrg.last
-    expect(new_org.name).to eq "A new org"
-    expect(new_org.display_name).to eq "A new org"
-    expect(new_org.address).to eq "123 Whole St"
+  context "as anonymous user" do
+    it "redirects sign in page with warning" do
+      visit new_all_casa_admins_casa_org_path
+      expect(page).to have_text "You need to sign in before continuing."
+    end
   end
 end

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -39,14 +39,34 @@ describe "all casa admins with casa orgs", type: :system do
       fill_in "Display name", with: "A new org"
       fill_in "Address", with: "123 Whole St"
 
-      click_on "Create CASA Organization"
-
-      expect(page).to have_text "CASA Organization was successfully created."
+      expect {
+        click_on "Create CASA Organization"
+        expect(page).to have_text "CASA Organization was successfully created."
+      }.to change(
+        CasaOrg,
+        :count
+      ).by(1)
 
       new_org = CasaOrg.last
       expect(new_org.name).to eq "A new org"
       expect(new_org.display_name).to eq "A new org"
       expect(new_org.address).to eq "123 Whole St"
+    end
+
+    it "requires name" do
+      visit "/"
+      expect(page).to have_text "All CASA Admin"
+
+      click_on "New CASA Organization"
+      expect(page).to have_text "Create a new CASA Organization"
+
+      expect {
+        click_on "Create CASA Organization"
+        expect(page).to have_text "Name can't be blank"
+      }.to change(
+        CasaOrg,
+        :count
+      ).by(0)
     end
   end
 

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "all casa admins with casa orgs", type: :system do
+describe "all casa admins with casa orgs", type: :system do
   let(:all_casa_admin) { create(:all_casa_admin) }
   let!(:casa_org) { create(:casa_org) }
 
@@ -25,5 +25,26 @@ RSpec.describe "all casa admins with casa orgs", type: :system do
     expect(page).to_not have_text sup.email
     expect(page).to have_text ca1.email
     expect(page).to have_text ca2.email
+  end
+
+  it "lets admin create a casa org" do
+    visit "/"
+    expect(page).to have_text "All CASA Admin"
+
+    click_on "New CASA Organization"
+    expect(page).to have_text "Create a new CASA Organization"
+
+    fill_in "Name", with: "A new org"
+    fill_in "Display name", with: "A new org"
+    fill_in "Address", with: "123 Whole St"
+
+    click_on "Create CASA Organization"
+
+    expect(page).to have_text "CASA Organization was successfully created."
+
+    new_org = CasaOrg.last
+    expect(new_org.name).to eq "A new org"
+    expect(new_org.display_name).to eq "A new org"
+    expect(new_org.address).to eq "123 Whole St"
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #687


### What changed, and why?

Added a simple "Create CASA Organization" form to the all casa admin section of the site.


### How is this tested? (please write tests!) 💖💪

System tests on the new `new` and `create` actions.


### Screenshots please :)

It's bootstrap defaults 🤷 
