### PR TITLE
[issue-618] Adds modal to confirm that the content of the note does not include specifics about the youth.

### DIFF
--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -69,23 +69,37 @@ window.onload = function () {
     }
   }
 
-  function validateNoteContent () {
+  function validateNoteContent (e) {
     const note_content = document.getElementById('case_contact_notes').value;
-    if (note_content == '') {
-      $('#casa-contact-form').submit();
-    }else{
+    if (note_content != '') {
+      e.preventDefault();
       $('#confirm-submit').modal('show');
-      var text_note = document.createTextNode(note_content);
-      document.getElementById('note-content').appendChild(text_note);
+      document.getElementById('note-content').innerHTML = note_content;
     }
   }
 
-  caseContactSubmit.onclick = function () {
+  $('#casa-contact-form').submit(function(e) {
+    validateNoteContent(e)
+  });
+
+  $("#confirm-submit").on("focus", function () {
+    document.getElementById('modal-case-contact-submit').disabled = false;
+  });
+
+  $("#confirm-submit").on("hide.bs.modal", function () {
+    caseContactSubmit.disabled = false
+  });
+
+  const caseContactSubmitFromModal = document.getElementById('modal-case-contact-submit')
+  caseContactSubmitFromModal.onclick = function () {
+    $('#casa-contact-form').unbind("submit");
+  }
+
+  caseContactSubmit.onclick = function (e) {
     validateAtLeastOneChecked(document.querySelectorAll('.casa-case-id'))
     validateAtLeastOneChecked(document.querySelectorAll('.case-contact-contact-type'))
 
     validateDuration()
-    validateNoteContent()
   }
 }
 $('document').ready(() => {

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -69,11 +69,23 @@ window.onload = function () {
     }
   }
 
+  function validateNoteContent () {
+    const note_content = document.getElementById('case_contact_notes').value;
+    if (note_content == '') {
+      $('#casa-contact-form').submit();
+    }else{
+      $('#confirm-submit').modal('show');
+      var text_note = document.createTextNode(note_content);
+      document.getElementById('note-content').appendChild(text_note);
+    }
+  }
+
   caseContactSubmit.onclick = function () {
     validateAtLeastOneChecked(document.querySelectorAll('.casa-case-id'))
     validateAtLeastOneChecked(document.querySelectorAll('.case-contact-contact-type'))
 
     validateDuration()
+    validateNoteContent()
   }
 }
 $('document').ready(() => {

--- a/app/views/case_contacts/_confirm_note_content_dialog.html.erb
+++ b/app/views/case_contacts/_confirm_note_content_dialog.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Go Back to Form</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal" id=modal-case-contact-cancel">Go Back to Form</button>
         <%= form.submit "Continue Submitting", class: "btn btn-primary", id: "modal-case-contact-submit" %>
       </div>
     </div>

--- a/app/views/case_contacts/_confirm_note_content_dialog.html.erb
+++ b/app/views/case_contacts/_confirm_note_content_dialog.html.erb
@@ -1,0 +1,21 @@
+<div class="modal fade" id="confirm-submit" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        Confirm Note Content
+      </div>
+      <div class="modal-body">
+        Please double check your notes to ensure they don't contain any identifying details about your youth or anyone else.
+        <p>
+          <h6>Note</h6>
+          <div id="note-content"></div>
+        </p>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Go Back to Form</button>
+        <%= form.submit "Continue Submitting", class: "btn btn-primary", id: "modal-case-contact-submit" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: case_contact, local: true) do |form| %>
+<%= form_with(model: case_contact, local: true, id: "casa-contact-form") do |form| %>
   <% if case_contact.errors.any? %>
     <div id="error_explanation" class="alert alert-danger">
       <h6><%= pluralize(case_contact.errors.count, "error") %> prohibited this Case Contact from being saved:</h6>
@@ -135,7 +135,12 @@
   </div>
 
   <div class="actions">
-    <%= form.submit "Submit", class: "btn btn-primary", id: "case-contact-submit" %>
+    <button type="button" id="case-contact-submit" class="btn btn-primary" data-target="#confirm-submit">
+      Submit
+    </button>
     <%= return_to_dashboard_button %>
   </div>
+  <%= render 'confirm_note_content_dialog', form: form %>
 <% end %>
+
+

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -135,9 +135,7 @@
   </div>
 
   <div class="actions">
-    <button type="button" id="case-contact-submit" class="btn btn-primary" data-target="#confirm-submit">
-      Submit
-    </button>
+    <%= form.submit "Submit", class: "btn btn-primary", id: "case-contact-submit", "data-target": "#confirm-submit" %>
     <%= return_to_dashboard_button %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>

--- a/app/views/case_contacts/edit.html.erb
+++ b/app/views/case_contacts/edit.html.erb
@@ -1,13 +1,11 @@
 <h1>Editing Case Contact</h1>
-
 <br>
-
 <div class="row">
-  <div class="col-sm-6">
+  <div class="col-sm-12">
     <%= render 'form', case_contact: @case_contact, casa_cases: @casa_cases %>
   </div>
 </div>
-
 <br>
-
-<%= link_to 'Back', render_back_link(@case_contact.casa_case) %>
+<div class="row">
+  <%= link_to 'Back', render_back_link(@case_contact.casa_case) %>
+</div>

--- a/app/views/case_contacts/new.html.erb
+++ b/app/views/case_contacts/new.html.erb
@@ -1,8 +1,11 @@
-<h1 class="text-center">New Case Contact</h1>
-
+<h1>New Case Contact</h1>
+<br>
 <div class="row">
-
   <div class="col-sm-12">
     <%= render 'form', case_contact: @case_contact, casa_cases: @casa_cases %>
   </div>
+</div>
+<br>
+<div class="row">
+  <%= link_to 'Back', :back %>
 </div>


### PR DESCRIPTION
…urate when creating and editing a case contact.

### What github issue is this PR for, if any?
Resolves #618 

### What changed, and why?
The behavior is added when creating or editing a casa case.
When the user with permissions to add or edit a casa case clicks on 'Submit' button, if the notes field has content, we are going to ask to review that content before submitting the form. If the note field is empty, the form will be submitted.

### How will this affect user permissions?
No permissions were affected

### How is this tested? (please write tests!) 💖💪
HAVING a user login as a admin or supervisor
WHEN user go to create or edit a case contact
AND the user create or edit a case contact WITHOUT content in the note field
THEN the user should be able to create or edit the form

HAVING a user login as a admin or supervisor
WHEN user go to create or edit a case contact
AND the user create or edit a case contact WITH content in the note field
THEN the user should see a modal to ask for confirmation in the note content
AND if user clicks on Continue
THEN the form will be submitted
AND if user clicks on 'go back to form'
THEN the user will have the opportunity to make changes in the notes and submit again.

HAVING a user login as a admin or supervisor
WHEN user go to create or edit a case contact
AND the user create or edit a case contact with content in the note field
AND the form does not have all the required fields completed
THEN the user should see the javascript errors coming from the validation of the required fields.
AND the modal will not be displayed until there is no validation errors.

### Screenshots please :)

<img width="979" alt="Screen Shot 2020-09-13 at 11 18 45 AM" src="https://user-images.githubusercontent.com/2204448/93021810-e6991f80-f5b2-11ea-99b5-fc368097e742.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
