### PR TITLE
Fix admin link on admin-created case contact

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -8,7 +8,13 @@
   <td><%= contact.decorate.reimbursement %></td>
   <td>
     <% if current_user&.casa_admin? || current_user&.supervisor? %>
-      <%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %>
+      <% if contact.creator&.supervisor? %>
+        <%= link_to "#{contact.creator&.display_name} ", edit_supervisor_path(current_user) %>
+      <% elsif contact.creator&.casa_admin? %>
+        <%= link_to "#{contact.creator&.display_name} ", edit_users_path %>
+      <% else %>
+        <%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %>
+      <%end%>
     <% else %>
       <%= contact.creator&.display_name %>
     <% end %>

--- a/spec/system/link_admin_creator_case_contact_spec.rb
+++ b/spec/system/link_admin_creator_case_contact_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "admin or supervisor see link to own edit page after create case contact", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+
+  it "admin see link to index admin page" do
+    sign_in admin
+    case_contact = create(:case_contact, creator: admin, casa_case_id: casa_case.id)
+    visit casa_case_path(casa_case.id)
+
+    expect(page).to have_link(href: '/users/edit')
+  end
+
+  it "supervisor see link to own edit page" do
+    sign_in supervisor
+    case_contact = create(:case_contact, creator: supervisor, casa_case_id: casa_case.id)
+    visit casa_case_path(casa_case.id)
+
+    expect(page).to have_link(href: "/supervisors/#{supervisor.id}/edit")
+  end
+end


### PR DESCRIPTION
or supervisor-created.

### What github issue is this PR for, if any?
Resolves #491 

### What changed, and why?
When admin-created case contact - it's linked to admin page
when supervisor-created case contact - it's linked to their own personal edit supervisor page

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added tests

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
