### PR TITLE
Do not remove old supervisor-volunteer relationships

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -7,11 +7,6 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.is_active = true unless supervisor_volunteer.is_active?
     supervisor_volunteer.save
 
-    SupervisorVolunteer
-      .where(volunteer_id: supervisor_volunteer.volunteer, is_active: false)
-      .where.not(supervisor_id: supervisor_volunteer.supervisor.id)
-      .destroy_all
-
     redirect_to after_action_path(supervisor_volunteer_parent)
   end
 

--- a/spec/policies/casa_case_policy/scope_spec.rb
+++ b/spec/policies/casa_case_policy/scope_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CasaCasePolicy::Scope do
 
       expect(CasaCase.count).to eq 6
       expect(scope.resolve.count).to eq 2
-      expect(scope.resolve).to eq casa_cases
+      expect(scope.resolve).to match_array casa_cases
     end
   end
 end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         expect {
           post supervisor_volunteers_url, params: valid_parameters
         }.to change(SupervisorVolunteer, :count).by(1)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
       end
     end
 
@@ -39,6 +40,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         expect {
           post supervisor_volunteers_url, params: valid_parameters
         }.not_to change(SupervisorVolunteer, :count)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
 
         association.reload
         expect(association.is_active?).to be(true)
@@ -56,7 +58,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         )
       end
 
-      it "replaces that association" do
+      it "does not remove association" do
         valid_parameters = {
           supervisor_volunteer: {volunteer_id: volunteer.id},
           supervisor_id: supervisor.id
@@ -65,9 +67,10 @@ RSpec.describe "/supervisor_volunteers", type: :request do
 
         expect {
           post supervisor_volunteers_url, params: valid_parameters
-        }.not_to change(SupervisorVolunteer, :count)
+        }.to change(SupervisorVolunteer, :count).by(1)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
 
-        expect(SupervisorVolunteer.exists?(previous_association.id)).to be(false)
+        expect(previous_association.reload.is_active?).to be(false)
         expect(SupervisorVolunteer.where(supervisor: supervisor, volunteer: volunteer).exists?).to be(true)
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #449 

### What changed, and why?
Do not delete old supervisor-volunteer relationships when creating new ones.

### How is this tested? (please write tests!) 💖💪
Modified a spec

### Notes
Only change I'm going to make on this as other related changes are getting handled in #756 