### PR TITLE
Use letter_opener instead of mailcatcher

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -67,10 +67,6 @@ $ docker-compose exec database psql -h database -Upostgres casa_development
 $ docker-compose exec web rails c
 ```
 
-## Mailcatcher
-We use [Mailcatcher](https://mailcatcher.me/) to receive mail in development.
-All mail sent in the development environment can be viewed at http://localhost:1080.
-
 ## Testing Suite
 Run the testing suite from within the container:
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,6 @@ Bullet points `formatted like this` are commands you can run on your machine
   - If you're on Ubuntu/WSL, use `sudo apt-get install libpq-dev` so the gem can install. [Use the Postgres repo for Ubuntu or WSL to get the server and client tools](https://www.postgresql.org/download/linux/ubuntu/).
   - If you're using Docker, do what you need to do.
 
-**Mailcatcher**
-
-1. Install the [Mailcatcher](https://mailcatcher.me) gem: `gem install mailcatcher`
-2. Start mailcatcher on the command line: `mailcatcher`
-3. All mail sent in development can be viewed at http://localhost:1080
-
 **Chromedriver**
 
 1. Install the current stable release of [chromedriver](https://chromedriver.chromium.org/) for your operating system so the browser-based Ruby feature/integration tests can run. Installing `chromium-browser` is enough, even in WSL.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Test coverage is run by simplecov on all builds and aggregated by CodeClimate
 
 If you have any troubles running tests, check out `.travis.yml` which is what makes the CI build run.
 
+**Mail**
+
+We are using [Letter Opener](https://github.com/ryanb/letter_opener) in
+development to receive mail. All emails sent in development should open in a
+new tab in the browser.
+
 ### Documentation
 
 There is a `doc` directory at the top level that includes [Architectural Decision Records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) and entity relationship diagrams of various models.

--- a/config/docker.env
+++ b/config/docker.env
@@ -1,6 +1,5 @@
 DOCKER=true
 DATABASE_HOST=database
-MAILCATCHER_HOST=mailcatcher
 
 POSTGRES_USER=postgres
 POSTGRES_HOST_AUTH_METHOD=trust

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,16 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.action_mailer.default_url_options = {host: "localhost", port: 3000} # for devise authentication
-
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: ENV["MAILCATCHER_HOST"] || "127.0.0.1",
-    port: 1025,
-    domain: "127.0.0.1"
-  }
-
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -46,6 +36,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,6 @@ services:
     ports:
       - '5435:5432'
 
-  mailcatcher:
-    image: schickling/mailcatcher:latest
-    ports:
-      - '1080:1080'
-      - '1025:1025'
-
   selenium_chrome:
     image: selenium/standalone-chrome-debug
     logging:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #754 

### What changed, and why?
The `letter_opener` gem had been set up in April, but then the `mailcatcher` gem also got added in July. However, the mail configuration was still set up for `letter_opener` so Mailcatcher was never actually working at all. Removed all references to mailcatcher.

