### PR TITLE
[issue-748] Allows admin to edit his or her email from Edit Profile.

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,7 +8,7 @@
 
       <div class="field form-group">
         <%= form.label :email %>
-        <p class="form-control"><%= @user.email %></p>
+        <%= form.text_field :email, class: "form-control", disabled: !current_user.casa_admin? %>
       </div>
 
       <div class="field form-group">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #748

### What changed, and why?
Admin user will be able to change his or her email form 'Edit Profile'.

### How will this affect user permissions?
No permissions were affected

### How is this tested? (please write tests!) 💖💪
Tests were added

### Screenshots please :)
<img width="875" alt="Screen Shot 2020-09-15 at 8 51 23 AM" src="https://user-images.githubusercontent.com/2204448/93212632-d313c300-f730-11ea-9008-c0f35a55b430.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
