### PR TITLE
779 Show new admins in alphabetical order on admin dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,6 +16,6 @@ class DashboardController < ApplicationController
     )).order(occurred_at: :desc).decorate
 
     @supervisors = policy_scope(current_organization.supervisors)
-    @admins = policy_scope(current_organization.casa_admins)
+    @admins = policy_scope(current_organization.casa_admins).sort_by(&:email)
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -37,6 +37,12 @@ describe "/dashboard", type: :request do
 
       it "shows all my organization's cases"
       it "doesn't show other organizations' cases"
+
+      it "shows all my organization's admins in alphabetical order" do
+        new_admin = create(:casa_admin, casa_org: organization, email: "admin_a@example.com")
+        admins = CasaAdmin.where(casa_org_id: organization.id).sort_by(&:email)
+        expect(new_admin.email).to eq "admin_a@example.com"
+      end
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
https://github.com/rubyforgood/casa/issues/779

### What changed, and why?
Added `.sort_by(&:email)` to the @admins

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added a test to spec/requests/dashboard_spec.rb

### Screenshots please :)
![image](https://user-images.githubusercontent.com/151394/93815068-44101a80-fc0a-11ea-8eab-004eef144001.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
