### PR TITLE
Restrict permissions to edit case contacts

### DIFF
--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -64,15 +64,15 @@ class CaseContactPolicy
   end
 
   def _is_creator_or_supervisor_or_casa_admin?
-    _is_admin? || _is_supervisor? || _is_creator?
+    _is_admin? || _is_creator? || _is_creator_supervisor?
   end
 
   def _is_admin?
     user.casa_admin?
   end
 
-  def _is_supervisor?
-    user.supervisor?
+  def _is_creator_supervisor?
+    record.creator&.supervisor == user
   end
 
   def _is_creator?

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -25,9 +25,9 @@
   <td>
     <%# TODO What text for tooltip? %>
     <% if Pundit.policy(current_user, contact).update? %>
-    <div class="add-disallow-edit-tooltip" data-toggle="tooltip" title="Disallow edit contact after end of quarter">
-      <%= link_to_if contact.allowed_edit?, 'Edit', edit_case_contact_path(contact) %>
+      <div class="add-disallow-edit-tooltip" data-toggle="tooltip" title="Disallow edit contact after end of quarter">
+        <%= link_to_if contact.allowed_edit?, 'Edit', edit_case_contact_path(contact) %>
+      </div>
     <% end %>
-    </div>
   </td>
 </tr>

--- a/spec/policies/case_contact_policy/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy/case_contact_policy_spec.rb
@@ -28,8 +28,25 @@ RSpec.describe CaseContactPolicy do
       expect(subject).to permit(create(:casa_admin), create(:case_contact))
     end
 
-    it "allows supervisors" do
-      expect(subject).to permit(create(:supervisor), create(:case_contact))
+    context "when supervisor" do
+      it "allows if is creator" do
+        supervisor = create(:supervisor)
+        expect(subject).to permit(supervisor, create(:case_contact, creator: supervisor))
+      end
+
+      it "does not allow if is not the creator" do
+        expect(subject).to_not permit(create(:supervisor), create(:case_contact, creator: create(:supervisor)))
+      end
+
+      it "allows if is supervisor of the creator" do
+        supervisor = create(:supervisor)
+        expect(subject).to permit(supervisor, create(:case_contact, creator: create(:volunteer, supervisor: supervisor)))
+      end
+
+      it "does not allow if is not supervisor of the creator" do
+        expect(subject).to_not permit(create(:supervisor),
+                                      create(:case_contact, creator: create(:volunteer, supervisor: create(:supervisor))))
+      end
     end
 
     context "when volunteer is assigned" do
@@ -66,8 +83,25 @@ RSpec.describe CaseContactPolicy do
       expect(subject).not_to permit(create(:volunteer), create(:case_contact))
     end
 
-    it "allows supervisors" do
-      expect(subject).to permit(create(:supervisor), create(:case_contact))
+    context "when supervisor" do
+      it "allows if is creator" do
+        supervisor = create(:supervisor)
+        expect(subject).to permit(supervisor, create(:case_contact, creator: supervisor))
+      end
+
+      it "does not allow if is not the creator" do
+        expect(subject).to_not permit(create(:supervisor), create(:case_contact, creator: create(:supervisor)))
+      end
+
+      it "allows if is supervisor of the creator" do
+        supervisor = create(:supervisor)
+        expect(subject).to permit(supervisor, create(:case_contact, creator: create(:volunteer, supervisor: supervisor)))
+      end
+
+      it "does not allow if is not supervisor of the creator" do
+        expect(subject).to_not permit(create(:supervisor),
+                                      create(:case_contact, creator: create(:volunteer, supervisor: create(:supervisor))))
+      end
     end
   end
 

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -6,7 +6,7 @@ describe "case_contacts/case_contact" do
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
 
-    user = build_stubbed(:supervisor)
+    user = build_stubbed(:casa_admin)
     allow(view).to receive(:current_user).and_return(user)
 
     render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
@@ -18,7 +18,7 @@ describe "case_contacts/case_contact" do
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
 
-    user = build_stubbed(:supervisor)
+    user = build_stubbed(:casa_admin)
     allow(view).to receive(:current_user).and_return(user)
 
     render(partial: "case_contacts/case_contact", locals: {contact: case_contact})


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #776.

### What changed, and why?

Changed the rules to edit or update a case contact according to the task description.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: supervisors now can only see case contacts created by themselves or by creators who are supervised by them.
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪

Added [specs](https://github.com/rubyforgood/casa/blob/2bac2d6a76140fbc2602fea21515c7de5d6f1135/spec/policies/case_contact_policy/case_contact_policy_spec.rb)

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
