### PR TITLE
760/Admin can enter Casa Case's birth month and year

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -78,7 +78,7 @@ class CasaCasesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def casa_case_params
-    params.require(:casa_case).permit(:case_number, :transition_aged_youth)
+    params.require(:casa_case).permit(:case_number, :transition_aged_youth, :birth_month_year_youth)
   end
 
   # Separate params so only admins can update the case_number

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -14,4 +14,9 @@ body.casa_cases {
   .case-contact-list {
       margin-bottom: 20px;
   }
+
+  .datetime-year-month select.date-input {
+    width: 130px;
+    padding-bottom: 15px;
+  }
 }

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -37,12 +37,13 @@ end
 #
 # Table name: casa_cases
 #
-#  id                    :bigint           not null, primary key
-#  case_number           :string           not null
-#  transition_aged_youth :boolean          default(FALSE), not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  casa_org_id           :bigint           not null
+#  id                     :bigint           not null, primary key
+#  birth_month_year_youth :datetime
+#  case_number            :string           not null
+#  transition_aged_youth  :boolean          default(FALSE), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  casa_org_id            :bigint           not null
 #
 # Indexes
 #

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -37,7 +37,7 @@ class CasaCasePolicy
   def permitted_attributes
     case @user
     when CasaAdmin
-      %i[case_number transition_aged_youth]
+      %i[case_number transition_aged_youth birth_month_year_youth]
     else
       %i[transition_aged_youth]
     end

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -18,11 +18,6 @@
         <% end %>
       </div>
 
-      <div class="field form-group">
-        <%= form.label :transition_aged_youth %>
-        <%= form.check_box :transition_aged_youth %>
-      </div>
-
       <% if current_user.casa_admin? %>
         <div class="field form-group">
           <%= form.label :transition_aged_youth, "Youth's Birth Month & Year" %>
@@ -30,6 +25,11 @@
           <span class="datetime-year-month"> <%= form.date_select :birth_month_year_youth, {order: [:month, :year], start_year: Date.current.year, end_year: 1989, prompt: {month: 'Month', year: 'Year'}, discard_day: true }, class: "select2 date-input"%></span>
         </div>
       <% end %>
+
+      <div class="field form-group">
+        <%= form.label :transition_aged_youth %>
+        <%= form.check_box :transition_aged_youth %>
+      </div>
 
       <br>
 

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -18,10 +18,18 @@
         <% end %>
       </div>
 
-      <div class="field">
+      <div class="field form-group">
         <%= form.label :transition_aged_youth %>
         <%= form.check_box :transition_aged_youth %>
       </div>
+
+      <% if current_user.casa_admin? %>
+        <div class="field form-group">
+          <%= form.label :transition_aged_youth, "Youth's Birth Month & Year" %>
+          <br>
+          <%= form.date_field :birth_month_year_youth %>
+        </div>
+      <% end %>
 
       <br>
 

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -27,7 +27,7 @@
         <div class="field form-group">
           <%= form.label :transition_aged_youth, "Youth's Birth Month & Year" %>
           <br>
-          <%= form.date_field :birth_month_year_youth %>
+          <span class="datetime-year-month"> <%= form.date_select :birth_month_year_youth, {order: [:month, :year], start_year: Date.current.year, end_year: 1989, prompt: {month: 'Month', year: 'Year'}, discard_day: true }, class: "select2 date-input"%></span>
         </div>
       <% end %>
 

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -12,7 +12,15 @@
         <%= form.text_field :case_number, class: "form-control" %>
       </div>
 
-      <div class="field">
+      <% if current_user.casa_admin? %>
+        <div class="field form-group">
+          <%= form.label :transition_aged_youth, "Youth's Birth Month & Year" %>
+          <br>
+          <span class="datetime-year-month"> <%= form.date_select :birth_month_year_youth, {order: [:month, :year], start_year: Date.current.year, end_year: 1989, prompt: {month: 'Month', year: 'Year'}, discard_day: true }, class: "select2 date-input"%></span>
+        </div>
+      <% end %>
+
+      <div class="field form-group">
         <%= form.label :transition_aged_youth %>
         <%= form.check_box :transition_aged_youth %>
       </div>

--- a/db/migrate/20200922144730_add_birth_month_year_youth_to_casa_cases.rb
+++ b/db/migrate/20200922144730_add_birth_month_year_youth_to_casa_cases.rb
@@ -1,0 +1,5 @@
+class AddBirthMonthYearYouthToCasaCases < ActiveRecord::Migration[6.0]
+  def change
+    add_column :casa_cases, :birth_month_year_youth, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_115741) do
+ActiveRecord::Schema.define(version: 2020_09_22_144730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2020_09_18_115741) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "casa_org_id", null: false
+    t.datetime "birth_month_year_youth"
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number"], name: "index_casa_cases_on_case_number", unique: true
   end

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :casa_case do
     sequence(:case_number) { |n| n }
     transition_aged_youth { false }
+    birth_month_year_youth { 16.years.ago }
     casa_org
 
     trait :with_case_assignments do

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -7,6 +7,10 @@ module SessionHelper
     sign_in(Volunteer.first || create(:volunteer))
   end
 
+  def sign_in_as_supervisor
+    sign_in(Supervisor.first || create(:supervisor))
+  end
+
   def sign_in_as_all_casa_admin
     sign_in(AllCasaAdmin.first || create(:all_casa_admin))
   end

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -13,6 +13,7 @@ describe "casa_cases/edit" do
       render template: "casa_cases/edit"
 
       expect(rendered).not_to include("Assign a New Volunteer")
+      expect(rendered).not_to include(CGI.escapeHTML("Youth's Birth Month & Year"))
     end
   end
 
@@ -26,6 +27,7 @@ describe "casa_cases/edit" do
       render template: "casa_cases/edit"
 
       expect(rendered).to include("Assign a New Volunteer")
+      expect(rendered).to include(CGI.escapeHTML("Youth's Birth Month & Year"))
     end
   end
 end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -13,5 +13,14 @@ describe "casa_cases/new" do
     end
 
     it { is_expected.to have_selector("a", text: "Return to Dashboard") }
+    it { is_expected.to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
+  end
+
+  context "while signed in as supervisor" do
+    before do
+      sign_in_as_supervisor
+    end
+
+    it { is_expected.not_to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #760

### What changed, and why?
Adds a `birth_month_year_youth` datetime attribute to `casa cases` model and allow admins to select a month and year. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions: Only admins can add/edit `birth_month_year_youth`

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
<img width="962" alt="Screen Shot 2020-09-22 at 4 00 34 PM" src="https://user-images.githubusercontent.com/6829115/93932048-9bd38200-fced-11ea-9161-d35acca5a6fb.png">
<img width="878" alt="Screen Shot 2020-09-22 at 4 00 47 PM" src="https://user-images.githubusercontent.com/6829115/93932051-9d04af00-fced-11ea-9205-43513a5248ae.png">
<img width="820" alt="Screen Shot 2020-09-22 at 4 01 00 PM" src="https://user-images.githubusercontent.com/6829115/93932054-9d9d4580-fced-11ea-9fa0-2ed0fbc9fa64.png">
<img width="903" alt="Screen Shot 2020-09-22 at 4 01 14 PM" src="https://user-images.githubusercontent.com/6829115/93932058-9e35dc00-fced-11ea-81f4-e62e1163f536.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/QLtO7Hs5FXtJe/giphy.gif)
