### PR TITLE
Deactivate casa admins

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -1,6 +1,6 @@
 class CasaAdminsController < ApplicationController
   before_action :authenticate_user!, :must_be_admin
-  before_action :set_admin, only: [:edit, :update]
+  before_action :set_admin, except: [:new, :create]
   before_action :require_organization!
 
   def edit; end
@@ -25,6 +25,14 @@ class CasaAdminsController < ApplicationController
       redirect_to root_path, notice: "New Admin created."
     else
       render new_casa_admin_path
+    end
+  end
+
+  def deactivate
+    if @casa_admin.deactivate
+      redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was deactivated."
+    else
+      render :edit
     end
   end
 

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -1,4 +1,7 @@
 class CasaAdmin < User
+  def deactivate
+    update(active: false)
+  end
 end
 
 # == Schema Information

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -15,6 +15,23 @@
         <%= form.text_field :display_name, class: "form-control" %>
       </div>
 
+      <% if casa_admin.persisted? %>
+        <div class="field form-group">
+          <% if casa_admin.active? %>
+            Admin is <span class="badge badge-success text-uppercase display-1">Active</span>
+            <%= link_to "Deactivate",
+              deactivate_casa_admin_path(casa_admin),
+              method: :patch,
+              class: "btn btn-outline-danger",
+              data: { confirm: t("forms.casa_admin.mark_inactive_warning") } %>
+          <% else %>
+            <div class="alert alert-danger">
+              Admin was deactivated on: <%= casa_admin.updated_at.strftime("%m-%d-%Y") %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
       <div class="actions">
         <%= form.submit "Submit", class: "btn btn-primary" %>
         <%= return_to_dashboard_button %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,8 @@ en:
       edit?: "Sorry, you can only edit case contacts that you have logged."
       update?: "Sorry, you can only edit case contacts that you have logged."
   forms:
+    casa_admin:
+      mark_inactive_warning: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"
     case_contact:
       notes_placeholder: "Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth."
     volunteer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,11 @@ Rails.application.routes.draw do
   end
 
   resources :casa_cases
-  resources :casa_admins, only: %i[new create]
+  resources :casa_admins, only: %i[new create] do
+    member do
+      patch :deactivate
+    end
+  end
   resources :case_contacts, except: %i[index show]
   resources :reports, only: %i[index]
   resources :imports, only: %i[index create]

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe CasaAdmin, type: :model do
+  describe "#deactivate" do
+    let(:casa_admin) { create(:casa_admin) }
+
+    it "deactivates the volunteer" do
+      casa_admin.deactivate
+
+      casa_admin.reload
+      expect(casa_admin.active).to eq(false)
+    end
+  end
+end

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -85,4 +85,41 @@ RSpec.describe "/casa_admins", type: :request do
       end
     end
   end
+
+  describe "PATCH /casa_admins/:id/deactivate" do
+    context "logged in as admin user" do
+      it "can successfully deactivate a casa admin user" do
+        sign_in_as_admin
+        casa_admin = create(:casa_admin)
+        expected_display_name = "Admin 2"
+        expected_email = "admin2@casa.com"
+
+        patch deactivate_casa_admin_path(casa_admin)
+        casa_admin.reload
+        expect(casa_admin.active).to be_falsey
+
+        expect(response).to redirect_to edit_casa_admin_path(casa_admin)
+        expect(response.request.flash[:notice]).to eq "Admin was deactivated."
+      end
+    end
+
+    context "logged in as a non-admin user" do
+      it "cannot update a casa admin user" do
+        sign_in_as_volunteer
+
+        patch deactivate_casa_admin_path(create(:casa_admin))
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+
+    context "unauthenticated request" do
+      it "cannot update a casa admin user" do
+        patch deactivate_casa_admin_path(create(:casa_admin))
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
 end

--- a/spec/system/admin_edits_another_admin_spec.rb
+++ b/spec/system/admin_edits_another_admin_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe "admin editing admin users", type: :system do
       click_on "Deactivate"
     end
 
-    expect(page).not_to have_text "Admin was deactivated."
+    expect(page).not_to have_text("Admin was deactivated.")
 
     accept_confirm do
       click_on "Deactivate"
     end
 
-    expect(page).to have_text "Admin was deactivated."
+    expect(page).to have_text("Admin was deactivated.")
     expect(another.reload.active).to be_falsey
   end
 end

--- a/spec/system/admin_edits_another_admin_spec.rb
+++ b/spec/system/admin_edits_another_admin_spec.rb
@@ -38,4 +38,22 @@ RSpec.describe "admin editing admin users", type: :system do
       expect(page).to have_text "Display name can't be blank"
     end
   end
+
+  it "can successfully deactivate" do
+    another = create(:casa_admin)
+    visit edit_casa_admin_path(another)
+
+    dismiss_confirm do
+      click_on "Deactivate"
+    end
+
+    expect(page).not_to have_text "Admin was deactivated."
+
+    accept_confirm do
+      click_on "Deactivate"
+    end
+
+    expect(page).to have_text "Admin was deactivated."
+    expect(another.reload.active).to be_falsey
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #772  

### What changed, and why?

Allow the deactivation of casa admin users. I've followed the same idea of the activation/deactivation of Volunteers to offer the same UX experience and keep a visual integrity.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: now the admins have permission to deactivate other admins.

### How is this tested? (please write tests!) 💖💪

1. Ensure that a admin can deactivate other admins accounts;
2. Ensure that non-admin cannot deactivate admins accounts;

Automatized tests covering these cases were also added.

### Screenshots please :)

![image](https://user-images.githubusercontent.com/938522/93934138-0fc75780-fcf9-11ea-9de6-ce4b7d1f41a5.png)
![image](https://user-images.githubusercontent.com/938522/93934149-1524a200-fcf9-11ea-80a6-3147204ff990.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
