### PR TITLE
751 Use DeviseInvitable for volunteer invites

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -12,7 +12,7 @@ class VolunteersController < ApplicationController
     @volunteer = Volunteer.new(create_volunteer_params)
 
     if @volunteer.save
-      VolunteerMailer.account_setup(@volunteer).deliver
+      @volunteer.invite!
       redirect_to root_path
     else
       render :new


### PR DESCRIPTION
### What github issue is this PR for, if any?
https://github.com/rubyforgood/casa/issues/751

### What changed, and why?
When creating a new volunteer, use DeviseInvitable instead of VolunteerMailer to send the invitation email. This will consolidate how users are sent invitation emails.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
This was tested locally in development by configuring ActionMailer to send emails via smtp through Gmail; an email was received after calling `invite!` on the volunteer object.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/151394/94029649-ded73900-fd71-11ea-8cab-832fee8b9b69.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/UFN6Uw2nLttok/giphy.gif)
