### PR TITLE
[#797] volunteer with two supervisors after re assign

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -38,6 +38,10 @@ class Volunteer < User
     supervisor_volunteer.present? && supervisor_volunteer&.is_active?
   end
 
+  def supervised_by?(supervisor)
+    self.supervisor == supervisor
+  end
+
   # false if volunteer has any case with no contact in the past 30 days
   def made_contact_with_all_cases_in_days?(num_days = 30)
     total_cases_count = casa_cases.count

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -63,7 +63,7 @@
               <td><%= link_to volunteer.decorate.name, edit_volunteer_path(volunteer) %></td>
               <td><%= volunteer.email %></td>
               <td>
-                <% if volunteer.supervisor_volunteer&.is_active? %>
+                <% if volunteer.supervised_by?(@supervisor) %>
                   <%= button_to 'Unassign',
                     unassign_supervisor_volunteer_path(volunteer),
                     method: :patch,

--- a/spec/factories/supervisor_volunteer.rb
+++ b/spec/factories/supervisor_volunteer.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :supervisor_volunteer do
     association :supervisor, factory: :supervisor
     association :volunteer, factory: :volunteer
+
+    trait :inactive do
+      is_active { false }
+    end
   end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
-  describe "has_supervisor?" do
+  describe "#has_supervisor?" do
     context "when no supervisor_volunteer record" do
       let(:volunteer) { create(:volunteer) }
 
@@ -120,6 +120,33 @@ RSpec.describe Volunteer, type: :model do
         volunteer2 = create(:volunteer)
         expect(volunteer2.made_contact_with_all_cases_in_days?).to eq(true)
       end
+    end
+  end
+
+  describe "#supervised_by?" do
+    it "is supervised by the currently active supervisor" do
+      supervisor = create :supervisor
+      volunteer = create :volunteer, supervisor: supervisor
+
+      expect(volunteer).to be_supervised_by(supervisor)
+    end
+
+    it "is not supervised by supervisors that have never supervised the volunteer before" do
+      supervisor = create :supervisor
+      volunteer = create :volunteer
+
+      expect(volunteer).to_not be_supervised_by(supervisor)
+    end
+
+    it "is not supervised by supervisor that had the volunteer unassinged" do
+      old_supervisor = create :supervisor
+      new_supervisor = create :supervisor
+      volunteer = create :volunteer, supervisor: old_supervisor
+
+      volunteer.update supervisor: new_supervisor
+
+      expect(volunteer).to_not be_supervised_by(old_supervisor)
+      expect(volunteer).to be_supervised_by(new_supervisor)
     end
   end
 end

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "supervisors/new", type: :view do
+  before do
+    admin = build_stubbed :casa_admin
+    enable_pundit(view, admin)
+    allow(view).to receive(:current_user).and_return(admin)
+  end
+
+  it "displays the 'Unassign' button next to volunteer being currently supervised by the supervisor" do
+    supervisor = create :supervisor
+    volunteer = create :volunteer, supervisor: supervisor
+
+    assign :supervisor, supervisor
+    assign :available_volunteers, []
+
+    render template: "supervisors/edit"
+
+    expect(rendered).to include(unassign_supervisor_volunteer_path(volunteer))
+    expect(rendered).to_not include("Unassigned")
+  end
+
+  it "does not display the 'Unassign' button next to volunteer no longer supervised by the supervisor" do
+    supervisor = create :supervisor
+    volunteer = create :volunteer
+    create :supervisor_volunteer, :inactive, supervisor: supervisor, volunteer: volunteer
+
+    assign :supervisor, supervisor
+    assign :available_volunteers, []
+
+    render template: "supervisors/edit"
+
+    expect(rendered).to_not include(unassign_supervisor_volunteer_path(volunteer))
+    expect(rendered).to include("Unassigned")
+  end
+end

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "supervisors/new", type: :view do
+describe "supervisors/edit", type: :view do
   before do
     admin = build_stubbed :casa_admin
     enable_pundit(view, admin)


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #797 

### What changed, and why?

It turns out the check for displaying the `Unassign` button was incorrect and now, the button is only displayed for volunteers being currently supervised by the given supervisor.

### How will this affect user permissions?

None

### How is this tested? (please write tests!) 💖💪

1. Assign a volunteer to one supervisor.
1. Unassign that volunteer from that supervisor.
1. Assign the volunteer to a different supervisor.
1. Visit both supervisors' edit pages and note that the "Unassign" button is now **only** visible for that volunteer on the currently active supervisor page.

### Screenshots please :)

![2020-09-23 12 06 05](https://user-images.githubusercontent.com/508128/94031679-89148800-fd95-11ea-9743-1071cda53ab1.gif)

### Feelings gif (optional)

![alt text](https://media.giphy.com/media/jcqqXMvmbTzHi/giphy.gif)
