### PR TITLE
558 Group cases in "Assign a New Case" dropdown on the edit volunteer page

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -2,4 +2,21 @@ module UiHelper
   def return_to_dashboard_button
     link_to "Return to Dashboard", root_path, {class: "btn btn-info pull-right"}
   end
+
+  def grouped_options_for_assigning_case(volunteer)
+    [
+      [
+        "Not Assigned",
+        CasaCase
+          .not_assigned(@volunteer.casa_org)
+          .map{ |casa_case| [casa_case.case_number, casa_case.id] }
+      ],
+      [
+        "Assigned",
+        CasaCase
+          .actively_assigned_excluding_volunteer(@volunteer)
+          .map{ |casa_case| [casa_case.case_number, casa_case.id] }
+      ]
+    ]
+  end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -13,6 +13,18 @@ class CasaCase < ApplicationRecord
       case_assignments: {volunteer: volunteer, is_active: true}
     )
   }
+  scope :actively_assigned_excluding_volunteer, -> (volunteer) {
+    joins(:case_assignments)
+      .where(case_assignments: { is_active: true })
+      .where.not(case_assignments: { volunteer: volunteer })
+      .order(:case_number)
+  }
+  scope :not_assigned, -> (casa_org) {
+    where(casa_org_id: casa_org.id)
+      .left_outer_joins(:case_assignments)
+      .where(case_assignments: { id: nil })
+      .order(:case_number)
+  }
 
   def self.available_for_volunteer(volunteer)
     ids = connection.select_values(%{

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -123,11 +123,7 @@
 
         <div class='form-group'>
           <label for='case_assignment_casa_case_id'>Select a Case</label>
-          <select id="case_assignment_casa_case_id" name='case_assignment[casa_case_id]' class='form-control select2'>
-            <% CasaCase.available_for_volunteer(@volunteer).find_each do |casa_case| %>
-              <option value="<%= casa_case.id %>"><%= casa_case.case_number %></option>
-            <% end %>
-          </select>
+          <%= form.select :casa_case_id, grouped_options_for_assigning_case(@volunteer), {}, { class: "form-control select2" } %>
         </div>
 
         <%= form.submit 'Assign Case', class: 'btn btn-primary' %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
https://github.com/rubyforgood/casa/issues/558

### What changed, and why?
- added 2 new scopes to `CasaCase` for actively_assigned_excluding_volunteer and not_assigned
- use these 2 new scopes to build `<optgroup>`s to group cases by “Not Assigned” and “Assigned” in the “Assign a New Case” dropdown on the edit volunteer page

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
TODO: need to write tests for new scopes

### Screenshots please :)
![image](https://user-images.githubusercontent.com/151394/94204480-2c3cce80-fe76-11ea-9964-33ab28ca4fdc.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/MYyfBsZl05r2bkyxMn/giphy.gif)
