### PR TITLE
Ensure contact types for a case contact can be edited

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -68,7 +68,7 @@ class CaseContactsController < ApplicationController
     @selected_cases = @casa_cases
 
     respond_to do |format|
-      if @case_contact.update(update_case_contact_params)
+      if @case_contact.update_cleaning_contact_types(update_case_contact_params)
         format.html { redirect_to casa_case_path(@case_contact.casa_case), notice: "Case contact was successfully updated." }
         format.json { render :show, status: :ok, location: @case_contact }
       else

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -53,6 +53,13 @@ class CaseContact < ApplicationRecord
   LETTER = "letter".freeze
   CONTACT_MEDIUMS = [IN_PERSON, TEXT_EMAIL, VIDEO, VOICE_ONLY, LETTER].freeze
 
+  def update_cleaning_contact_types(args)
+    transaction do
+      case_contact_contact_type.destroy_all
+      update(args)
+    end
+  end
+
   def occurred_at_not_in_future
     return unless occurred_at && occurred_at >= Date.tomorrow
 

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -76,4 +76,22 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact).to_not be_valid
     expect(case_contact.errors[:base]).to eq(["cannot edit past case contacts outside of quarter"])
   end
+
+  context "#update_cleaning_contact_types" do
+    it "cleans up contact types before saving" do
+      group = create(:contact_type_group)
+      type1 = create(:contact_type, contact_type_group: group)
+      type2 = create(:contact_type, contact_type_group: group)
+
+      case_contact = create(:case_contact, db_contact_types: [type1])
+
+      expect(case_contact.case_contact_contact_type.count).to eql 1
+      expect(case_contact.db_contact_types).to match_array([type1])
+
+      case_contact.update_cleaning_contact_types({case_contact_contact_type_attributes: [{ contact_type_id: type2.id }]})
+
+      expect(case_contact.case_contact_contact_type.count).to eql 1
+      expect(case_contact.db_contact_types.reload).to match_array([type2])
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/869

### What changed, and why?
Ideally, this should be fixed with a better nested association
between contact types and case contacts, but since this is a
bug I'm going with the quick and dirty solution to unblock
deployments to stagging and prod

### How will this affect user permissions?
It won't

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
![](https://media.giphy.com/media/Y6AOEbX5WtDNK/giphy.gif)
