### PR TITLE
Add active flag to contact types and groups

### DIFF
--- a/app/controllers/contact_type_groups_controller.rb
+++ b/app/controllers/contact_type_groups_controller.rb
@@ -29,7 +29,7 @@ class ContactTypeGroupsController < ApplicationController
 private
 
     def contact_type_group_params
-      params.require(:contact_type_group).permit(:name)
+      params.require(:contact_type_group).permit(:name, :active)
     end
 
     def set_contact_type_group

--- a/app/controllers/contact_types_controller.rb
+++ b/app/controllers/contact_types_controller.rb
@@ -40,6 +40,6 @@ private
   end
 
   def contact_type_params
-    params.require(:contact_type).permit(:name, :contact_type_group_id)
+    params.require(:contact_type).permit(:name, :contact_type_group_id, :active)
   end
 end

--- a/app/models/contact_type.rb
+++ b/app/models/contact_type.rb
@@ -14,6 +14,7 @@ end
 # Table name: contact_types
 #
 #  id                    :bigint           not null, primary key
+#  active                :boolean          default(TRUE)
 #  name                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/app/models/contact_type_group.rb
+++ b/app/models/contact_type_group.rb
@@ -12,6 +12,7 @@ end
 # Table name: contact_type_groups
 #
 #  id          :bigint           not null, primary key
+#  active      :boolean          default(TRUE)
 #  name        :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/views/casa_orgs/_contact_type_groups.html.erb
+++ b/app/views/casa_orgs/_contact_type_groups.html.erb
@@ -9,6 +9,7 @@
   <thead>
     <tr>
       <th>Name</th>
+      <th>Active?</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -16,9 +17,12 @@
   <tbody>
     <% @contact_type_groups.each do |group| %>
       <tr id="group-<%= group.id %>">
-        <th scope="row">
+        <td scope="row">
           <%= group.name %>
-        </th>
+        </td>
+        <td scope="row">
+          <%= group.active? ? "Yes" : "No" %>
+        </td>
         <td>
           <%= link_to "Edit", edit_contact_type_group_path(group) %>
         </td>

--- a/app/views/casa_orgs/_contact_types.html.erb
+++ b/app/views/casa_orgs/_contact_types.html.erb
@@ -10,6 +10,7 @@
     <tr>
       <th>Name</th>
       <th>Group</th>
+      <th>Active?</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -17,12 +18,14 @@
   <tbody>
     <% @contact_types.each do |contact_type| %>
       <tr id="contact_type-<%= contact_type.id %>">
-        <th scope="row">
+        <td scope="row">
           <%= contact_type.name %>
-        </th>
-        <th scope="row">
+        </td>
+        <td scope="row">
           <%= contact_type.contact_type_group.name %>
-        </th>
+        </td>
+        <td scope="row">
+          <%= contact_type.active? ? "Yes" : "No" %>
         <td>
           <%= link_to "Edit", edit_contact_type_path(contact_type) %>
         </td>

--- a/app/views/contact_type_groups/_form.html.erb
+++ b/app/views/contact_type_groups/_form.html.erb
@@ -8,10 +8,15 @@
   <div class="col-sm-6">
     <%= form_with(model: contact_type_group, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: contact_type_group %>
-        <div class="field form-group">
-            <%= form.label :name %>
-            <%= form.text_field :name, class: "form-control" %>
-        </div>
+      <div class="field form-group">
+          <%= form.label :name %>
+          <%= form.text_field :name, class: "form-control" %>
+      </div>
+      <div class="field form-group">
+        <%= form.check_box :active %>
+        <%= form.label :active %>
+      </div>
+
       <br>
 
       <div class="actions">

--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -8,17 +8,18 @@
   <div class="col-sm-6">
     <%= form_with(model: contact_type, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: contact_type %>
-
       <div class="field form-group">
-          <%= form.label :name %>
-          <%= form.text_field :name, class: "form-control" %>
+        <%= form.label :name %>
+        <%= form.text_field :name, class: "form-control" %>
       </div>
-
       <div class="field form-group">
-          <%= form.label :contact_type_group %>
-          <%= form.select :contact_type_group_id, group_options, class: "form-control" %>
+        <%= form.label :contact_type_group %>
+        <%= form.select :contact_type_group_id, group_options, class: "form-control" %>
       </div>
-
+      <div class="field form-group">
+        <%= form.check_box :active %>
+        <%= form.label :active %>
+      </div>
       <br>
 
       <div class="actions">

--- a/db/migrate/20200925180941_add_active_to_contact_type_groups.rb
+++ b/db/migrate/20200925180941_add_active_to_contact_type_groups.rb
@@ -1,0 +1,5 @@
+class AddActiveToContactTypeGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :contact_type_groups, :active, :boolean, default: true
+  end
+end

--- a/db/migrate/20200925181042_add_active_to_contact_types.rb
+++ b/db/migrate/20200925181042_add_active_to_contact_types.rb
@@ -1,0 +1,5 @@
+class AddActiveToContactTypes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :contact_types, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_170308) do
+ActiveRecord::Schema.define(version: 2020_09_25_181042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_170308) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "active", default: true
     t.index ["casa_org_id"], name: "index_contact_type_groups_on_casa_org_id"
   end
 
@@ -108,6 +109,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_170308) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "active", default: true
     t.index ["contact_type_group_id"], name: "index_contact_types_on_contact_type_group_id"
   end
 

--- a/spec/requests/contact_type_groups_spec.rb
+++ b/spec/requests/contact_type_groups_spec.rb
@@ -33,23 +33,22 @@ RSpec.describe "/contact_type_groups", type: :request do
   end
 
   describe "POST /contact_type_groups" do
+    let(:params) { { contact_type_group: { name: "New Group", active: true } } }
+
     context "logged in as admin user" do
       it "can successfully create a contact type group" do
         casa_org = create(:casa_org)
         sign_in create(:casa_admin, casa_org: casa_org)
 
         expect {
-          post contact_type_groups_path params: {
-            contact_type_group: {
-              name: "New Group"
-            }
-          }
+          post contact_type_groups_path, params: params
         }.to change(ContactTypeGroup, :count).by(1)
 
         group = ContactTypeGroup.last
 
         expect(group.name).to eql "New Group"
         expect(group.casa_org).to eql casa_org
+        expect(group.active).to be_truthy
         expect(response).to redirect_to edit_casa_org_path(casa_org)
         expect(response.request.flash[:notice]).to eq "Contact Type Group was successfully created."
       end
@@ -59,11 +58,7 @@ RSpec.describe "/contact_type_groups", type: :request do
       it "cannot create a contact type group" do
         sign_in_as_volunteer
 
-        post contact_type_groups_path params: {
-          contact_type_group: {
-            name: "New Group"
-          }
-        }
+        post contact_type_groups_path, params: params
 
         expect(response).to redirect_to root_path
         expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
@@ -72,11 +67,7 @@ RSpec.describe "/contact_type_groups", type: :request do
 
     context "unauthenticated request" do
       it "cannot create a contact type group" do
-        post contact_type_groups_path params: {
-          contact_type_group: {
-            name: "New Group"
-          }
-        }
+        post contact_type_groups_path, params: params
 
         expect(response).to redirect_to new_user_session_path
       end
@@ -115,23 +106,20 @@ RSpec.describe "/contact_type_groups", type: :request do
   end
 
   describe "PUT /contact_type_groups/:id" do
+    let(:params) { { contact_type_group: { name: "New Group Name", active: false } } }
     context "logged in as admin user" do
       it "can successfully update a contact type group" do
         casa_org = create(:casa_org)
         sign_in create(:casa_admin, casa_org: casa_org)
 
-        group = create(:contact_type_group, casa_org: casa_org)
-        expected_name = "New Group"
+        group = create(:contact_type_group, casa_org: casa_org, active: true)
 
-        put contact_type_group_path(group), params: {
-          contact_type_group: {
-            name: expected_name
-          }
-        }
+        put contact_type_group_path(group), params: params
 
         group.reload
-        expect(group.name).to eq expected_name
+        expect(group.name).to eq "New Group Name"
         expect(group.casa_org).to eq casa_org
+        expect(group.active).to be_falsey
 
         expect(response).to redirect_to edit_casa_org_path(casa_org)
         expect(response.request.flash[:notice]).to eq "Contact Type Group was successfully updated."
@@ -142,11 +130,7 @@ RSpec.describe "/contact_type_groups", type: :request do
       it "cannot update a update a contact type group" do
         sign_in_as_volunteer
 
-        put contact_type_group_path(create(:contact_type_group)), params: {
-          contact_type_group: {
-            name: "New Group"
-          }
-        }
+        put contact_type_group_path(create(:contact_type_group)), params: params
 
         expect(response).to redirect_to root_path
         expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
@@ -155,11 +139,7 @@ RSpec.describe "/contact_type_groups", type: :request do
 
     context "unauthenticated request" do
       it "cannot update a update a contact type group" do
-        put contact_type_group_path(create(:contact_type_group)), params: {
-          contact_type_group: {
-            name: "New Group"
-          }
-        }
+        put contact_type_group_path(create(:contact_type_group)), params: params
 
         expect(response).to redirect_to new_user_session_path
       end

--- a/spec/requests/contact_type_spec.rb
+++ b/spec/requests/contact_type_spec.rb
@@ -34,24 +34,21 @@ RSpec.describe "/contact_types", type: :request do
   end
 
   describe "POST /contact_types" do
+    let(:params) { { contact_type: { name: "New Contact", contact_type_group_id: group.id, active: true } } }
     context "logged in as admin user" do
       it "can successfully create a contact type" do
         casa_org = create(:casa_org)
         sign_in create(:casa_admin, casa_org: casa_org)
 
         expect {
-          post contact_types_path params: {
-            contact_type: {
-              name: "New Contact",
-              contact_type_group_id: group.id
-            }
-          }
+          post contact_types_path, params: params
         }.to change(ContactType, :count).by(1)
 
         contact_type = ContactType.last
 
         expect(contact_type.name).to eql "New Contact"
         expect(contact_type.contact_type_group).to eql group
+        expect(contact_type.active).to be_truthy
         expect(response).to redirect_to edit_casa_org_path(casa_org)
         expect(response.request.flash[:notice]).to eq "Contact Type was successfully created."
       end
@@ -61,12 +58,7 @@ RSpec.describe "/contact_types", type: :request do
       it "cannot create a contact type" do
         sign_in_as_volunteer
 
-        post contact_types_path params: {
-          contact_type: {
-            name: "New Contact",
-            contact_type_group_id: group.id
-          }
-        }
+        post contact_types_path, params: params
 
         expect(response).to redirect_to root_path
         expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
@@ -75,12 +67,7 @@ RSpec.describe "/contact_types", type: :request do
 
     context "unauthenticated request" do
       it "cannot create a contact type" do
-        post contact_types_path params: {
-          contact_type: {
-            name: "New Contact",
-            contact_type_group_id: group.id
-          }
-        }
+        post contact_types_path, params: params
 
         expect(response).to redirect_to new_user_session_path
       end
@@ -119,25 +106,21 @@ RSpec.describe "/contact_types", type: :request do
   end
 
   describe "PUT /contact_types/:id" do
+    let(:casa_org) { create(:casa_org) }
+    let(:new_group) { create(:contact_type_group, casa_org: casa_org) }
+    let(:params) { { contact_type: { name: "New Name", contact_type_group_id: new_group.id, active: false } } }
     context "logged in as admin user" do
       it "can successfully update a contact type" do
-        casa_org = create(:casa_org)
         sign_in create(:casa_admin, casa_org: casa_org)
 
         contact_type = create(:contact_type, contact_type_group: group)
-        expected_name = "New Contact Type"
-        expected_group = create(:contact_type_group, casa_org: casa_org)
 
-        put contact_type_path(contact_type), params: {
-          contact_type: {
-            name: expected_name,
-            contact_type_group_id: expected_group.id
-          }
-        }
+        put contact_type_path(contact_type), params: params
 
         contact_type.reload
-        expect(contact_type.name).to eq expected_name
-        expect(contact_type.contact_type_group).to eq expected_group
+        expect(contact_type.name).to eq "New Name"
+        expect(contact_type.contact_type_group).to eq new_group
+        expect(contact_type.active).to be_falsey
 
         expect(response).to redirect_to edit_casa_org_path(casa_org)
         expect(response.request.flash[:notice]).to eq "Contact Type was successfully updated."
@@ -148,12 +131,7 @@ RSpec.describe "/contact_types", type: :request do
       it "cannot update a update a contact type" do
         sign_in_as_volunteer
 
-        put contact_type_path(create(:contact_type)), params: {
-          contact_type: {
-            name: "New Name",
-            contact_type_group_id: group.id
-          }
-        }
+        put contact_type_path(create(:contact_type)), params: params
 
         expect(response).to redirect_to root_path
         expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
@@ -162,12 +140,7 @@ RSpec.describe "/contact_types", type: :request do
 
     context "unauthenticated request" do
       it "cannot update a update a contact type" do
-        put contact_type_path(create(:contact_type)), params: {
-          contact_type: {
-            name: "New Name",
-            contact_type_group_id: group.id
-          }
-        }
+        put contact_type_path(create(:contact_type)), params: params
 
         expect(response).to redirect_to new_user_session_path
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #869 

### What changed, and why?


### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪

Ensure it is possible to toggle the active flag of `Contact Type Groups` and `Contact Types` (covered by integration tests).

### Screenshots please :)

![image](https://user-images.githubusercontent.com/938522/94305130-19de9580-ff47-11ea-845e-80474d0a8f19.png)
![image](https://user-images.githubusercontent.com/938522/94305175-2bc03880-ff47-11ea-89d4-f7be43113dcc.png)
![image](https://user-images.githubusercontent.com/938522/94305214-367acd80-ff47-11ea-818e-11a7b5309a0e.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
