### PR TITLE
[#866] Display user role on the sidebar based off of current logged in user

### DIFF
--- a/app/controllers/concerns/organizational.rb
+++ b/app/controllers/concerns/organizational.rb
@@ -12,7 +12,16 @@ module Organizational
     @current_organization ||= current_user&.casa_org
   end
 
+  def current_role
+    @current_role ||= if user_signed_in?
+      current_user.role
+    elsif all_casa_admin_signed_in?
+      current_all_casa_admin.role
+    end
+  end
+
   included do
     helper_method :current_organization
+    helper_method :current_role
   end
 end

--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -1,4 +1,6 @@
 class AllCasaAdmin < ApplicationRecord
+  include Roles
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :recoverable, :validatable, :timeoutable

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -1,0 +1,7 @@
+module Roles
+  extend ActiveSupport::Concern
+
+  def role
+    model_name.human.titleize
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 # model for all user roles: volunteer supervisor casa_admin inactive
 class User < ApplicationRecord
+  include Roles
+
   has_paper_trail
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -30,7 +30,7 @@
         </li>
         <li class="list-group-item">
           <span class="label">Role</span>
-          <span class="value">Supervisor</span>
+          <span class="value"><%= current_role %></span>
         </li>
       </div>
       <div class="list-group list-group-flush footer-nav">

--- a/spec/models/all_casa_admin_spec.rb
+++ b/spec/models/all_casa_admin_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe AllCasaAdmin, type: :model do
+  describe "#role" do
+    subject(:all_casa_admin) { create :all_casa_admin }
+    it { expect(all_casa_admin.role).to eq "All Casa Admin" }
+  end
+end

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -20,4 +20,9 @@ RSpec.describe CasaAdmin, type: :model do
       expect(casa_admin.active).to eq(true)
     end
   end
+
+  describe "#role" do
+    subject(:admin) { create :casa_admin }
+    it { expect(admin.role).to eq "Casa Admin" }
+  end
 end

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Supervisor, type: :model do
+  describe "#role" do
+    subject(:supervisor) { create :supervisor }
+    it { expect(supervisor.role).to eq "Supervisor" }
+  end
+end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -149,4 +149,9 @@ RSpec.describe Volunteer, type: :model do
       expect(volunteer).to be_supervised_by(new_supervisor)
     end
   end
+
+  describe "#role" do
+    subject(:volunteer) { create :volunteer }
+    it { expect(volunteer.role).to eq "Volunteer" }
+  end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -5,45 +5,81 @@ describe "layout/sidebar", type: :view do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:user_signed_in?).and_return(true)
+    allow(view).to receive(:current_role).and_return(user.role)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
-    allow(view).to receive(:user_signed_in?).and_return(true)
 
     assign :casa_org, user.casa_org
-  end
-
-  context "when logged in as an admin" do
-    let(:user) { build_stubbed :casa_admin }
-
-    it "renders the 'Supervisors' menu item" do
-      sign_in user
-
-      render partial: "layouts/sidebar"
-
-      expect(rendered).to have_link("Supervisors", href: "/supervisors")
-    end
   end
 
   context "when logged in as a supervisor" do
     let(:user) { build_stubbed :supervisor }
 
-    it "renders the 'Supervisors' menu item" do
+    it "renders the correct Role name on the sidebar" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match '<span class="value">Supervisor</span>'
+    end
+
+    it "renders only menu items visible by supervisors" do
       sign_in user
 
       render partial: "layouts/sidebar"
 
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
+      expect(rendered).to have_link("Volunteers", href: "/volunteers")
+      expect(rendered).to have_link("Cases", href: "/casa_cases")
+      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to_not have_link("Admins", href: "/casa_admins")
     end
   end
 
   context "when logged in as a volunteer" do
     let(:user) { build_stubbed :volunteer }
 
-    it "does not render the 'Supervisors' menu item" do
+    it "renders the correct Role name on the sidebar" do
       sign_in user
 
       render partial: "layouts/sidebar"
 
+      expect(rendered).to match '<span class="value">Volunteer</span>'
+    end
+
+    it "renders only menu items visible by volunteers" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to have_link("My Cases", href: "/casa_cases")
+      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
+      expect(rendered).to_not have_link("Admins", href: "/casa_admins")
+    end
+  end
+
+  context "when logged in as a casa admin" do
+    let(:user) { build_stubbed :casa_admin }
+
+    it "renders the correct Role name on the sidebar" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match '<span class="value">Casa Admin</span>'
+    end
+
+    it "renders only menu items visible by admins" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to have_link("Volunteers", href: "/volunteers")
+      expect(rendered).to have_link("Cases", href: "/casa_cases")
+      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to have_link("Supervisors", href: "/supervisors")
+      expect(rendered).to have_link("Admins", href: "/casa_admins")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #866 

### What changed, and why?

The **Role** information on the sidebar will be computed based on the current logged in user's role rather than being staticly set to `Supervisor`.

### How will this affect user permissions?

No.

### How is this tested? (please write tests!) 💖💪

1. Log into Casa as all user types;
2. Verify that the Role section of the sidebar reflects the expected role of the currently logged in user.

### Screenshots please :)

Logged in as `All Casa Admin` user:

<img width="319" alt="all-casa-admin" src="https://user-images.githubusercontent.com/508128/94319879-00971280-ff62-11ea-9314-aefd16481b29.png">

Logged in as `Volunteer` user:

<img width="317" alt="volunteer" src="https://user-images.githubusercontent.com/508128/94319898-042a9980-ff62-11ea-9484-0f208ed6d3bd.png">

Logged in as `Casa Admin` user:

<img width="317" alt="casa-admin" src="https://user-images.githubusercontent.com/508128/94319901-05f45d00-ff62-11ea-9533-38adbf526a89.png">

Logged in as `Supervisor` user:

<img width="318" alt="supervisor" src="https://user-images.githubusercontent.com/508128/94320081-74391f80-ff62-11ea-841e-58d0d5b22be6.png">

### Feelings gif (optional)

![success](https://media.giphy.com/media/l2SqgT1Iv6EFL44OA/giphy.gif)
