### PR TITLE
Add bin/login script to automate application launching and logging in

### DIFF
--- a/bin/login
+++ b/bin/login
@@ -1,16 +1,6 @@
 #!/usr/bin/env ruby
 
-# This script simplifies login for experimentation with the users added to the application when it is seeded
-# in development mode.
-#
-# It outputs the available users and accepts a numbered choice. It then logs in as that choice,
-# at the URL appropriate for that user.
-#
-# The browser window remains open as long as the script has not yet terminated (using Ctrl-C).
-# You can either keep a terminal with this script open, or you can send it to the background with Ctrl-Z.
-# If the latter, when you are finished using the browser, you can bring the script back to the foreground with `fg[Enter]`.
-#
-# Usage: `bin/login` from the project root
+# See HELP_TEXT below for description.
 
 require 'webdrivers'
 require 'capybara/dsl'
@@ -36,6 +26,24 @@ class LoginExecutor
       User.new('allcasaadmin@example.com',     ALL_CASA_ADMIN_LOGIN_URL),
   ]
 
+  HELP_TEXT = <<~HEREDOC
+    
+    Usage: bin/login [user_number]
+
+    This script automates login for experimentation with the users added to the application when it is seeded
+    in development mode.
+                        
+    If executed without any arguments, it outputs the available users and accepts a numbered choice.
+    It then logs in as that choice, at the URL appropriate for that user.
+                                    
+    It can also be executed with the user list element number passed as an argument, to bypass interactive mode.
+
+    The browser window remains open as long as the script has not yet terminated (using Ctrl-C).
+    You can either keep a terminal with this script open, or you can send it to the background with Ctrl-Z.
+    If the latter, when you are finished using the browser, you can bring the script back to the foreground with `fg[Enter]`.
+
+  HEREDOC
+
 
   def self.login
     self.new.call
@@ -43,16 +51,16 @@ class LoginExecutor
 
 
   def call
+
+    if ARGV.first == '-h'
+      puts HELP_TEXT
+      exit 0
+    end
+
     user = ARGV.empty? ? get_user_from_input : get_user_from_arg
     puts "\nLogging in to #{user.url} as #{user.email}...\n\n"
     visit_and_log_in(user)
-
-    loop do
-      puts "\n\nPress Ctrl-C to exit and close browser.\n\n"
-      puts "You can also press Ctrl-Z to send this to the background to continue using your terminal."
-      puts "When you are done, type fg[Enter] and then Ctrl-C."
-      $stdin.gets
-    end
+    print_post_open_message_and_wait
   end
 
 
@@ -89,6 +97,23 @@ class LoginExecutor
     exit unless (1..(USERS.size)).include?(choice)
 
     USERS[choice - 1]
+  end
+
+
+  def print_post_open_message_and_wait
+    loop do
+      puts <<~HEREDOC
+
+      --------------------------------------------------------------------------------
+      Press Ctrl-C to exit and close browser.
+
+      You can also press Ctrl-Z to send this to the background to continue using your terminal.
+      When you are done, type fg[Enter] and then Ctrl-C.
+
+      Next time you can pass the user number on the command line if you like.
+      HEREDOC
+      $stdin.gets
+    end
   end
 end
 

--- a/bin/login
+++ b/bin/login
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+
+# This script simplifies login for experimentation with the users added to the application when it is seeded
+# in development mode.
+#
+# It outputs the available users and accepts a numbered choice. It then logs in as that choice,
+# at the URL appropriate for that user.
+#
+# The browser window remains open as long as the script has not yet terminated (using Ctrl-C).
+# You can either keep a terminal with this script open, or you can send it to the background with Ctrl-Z.
+# If the latter, when you are finished using the browser, you can bring the script back to the foreground with `fg[Enter]`.
+#
+# Usage: `bin/login` from the project root
+
+require 'webdrivers'
+require 'capybara/dsl'
+
+class LoginExecutor
+
+  include Capybara::DSL
+
+  Capybara.default_driver = :selenium
+
+  DEFAULT_LOGIN_URL        = ENV['CASA_DEFAULT_LOGIN_URL'] || 'http://localhost:3000'
+  ALL_CASA_ADMIN_LOGIN_URL = ENV['ALL_CASA_ADMIN_LOGIN_URL'] || 'http://localhost:3000/all_casa_admins/sign_in'
+
+  User = Struct.new(:email, :url)
+
+  USERS = [
+      User.new('volunteer1@example.com',       DEFAULT_LOGIN_URL),
+      User.new('supervisor1@example.com',      DEFAULT_LOGIN_URL),
+      User.new('casa_admin1@example.com',      DEFAULT_LOGIN_URL),
+      User.new('other_casa_admin@example.com', DEFAULT_LOGIN_URL),
+      User.new('other.supervisor@example.com', DEFAULT_LOGIN_URL),
+      User.new('other.volunteer@example.com',  DEFAULT_LOGIN_URL),
+      User.new('allcasaadmin@example.com',     ALL_CASA_ADMIN_LOGIN_URL),
+  ]
+
+
+  def self.login
+    self.new.call
+  end
+
+
+  def call
+    user = ARGV.empty? ? get_user_from_input : get_user_from_arg
+    puts "\nLogging in to #{user.url} as #{user.email}...\n\n"
+    visit_and_log_in(user)
+
+    loop do
+      puts "\n\nPress Ctrl-C to exit and close browser.\n\n"
+      puts "You can also press Ctrl-Z to send this to the background to continue using your terminal."
+      puts "When you are done, type fg[Enter] and then Ctrl-C."
+      $stdin.gets
+    end
+  end
+
+
+  private  # ----------------------------- all methods below are private ----------------
+
+  def visit_and_log_in(user)
+    visit user.url
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "123456"
+    click_on "Log in"
+  end
+
+
+  def get_user_from_arg
+    arg = ARGV.first.strip
+    user = USERS[arg.to_i - 1]
+    unless user
+      puts "\nInvalid option: #{arg}. Must be a number between 1 and #{USERS.size}"
+      exit -1
+    end
+    user
+  end
+
+
+  def get_user_from_input
+    puts "With which user would you like to log in to CASA?\n\n"
+    USERS.each_with_index do |user, index|
+      puts "#{index + 1}) #{user.email}"
+    end
+    puts "\nInput a number, then [Enter]. An invalid entry will exit."
+
+    choice = $stdin.gets.chomp.to_i
+
+    exit unless (1..(USERS.size)).include?(choice)
+
+    USERS[choice - 1]
+  end
+end
+
+
+LoginExecutor.login

--- a/bin/login
+++ b/bin/login
@@ -107,11 +107,14 @@ class LoginExecutor
       --------------------------------------------------------------------------------
       Press Ctrl-C to exit and close browser.
 
-      You can also press Ctrl-Z to send this to the background to continue using your terminal.
-      When you are done, type fg[Enter] and then Ctrl-C.
-
-      Next time you can pass the user number on the command line if you like.
+      To move this script to the background so you can continue using your terminal:
+        Press Ctrl-Z.
+        When you are done, type fg[Enter] and then Ctrl-C.
       HEREDOC
+
+      if ARGV.empty?
+        puts "\nNext time you can pass the user number on the command line if you like.\n\n"
+      end
       $stdin.gets
     end
   end


### PR DESCRIPTION
Resolves #812

A `bin/login` script is added that automates the launching and logging in of users seeded in development mode.

This can make the developer workflow faster, eliminating the need for manual browser input of URL, user id, and password.
