### PR TITLE
Prohibit changing of transition_aged_youth

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -40,7 +40,6 @@ class CasaCasePolicy
 
   def permitted_attributes
     common_attrs = [
-      :transition_aged_youth,
       :court_report_submitted,
       casa_case_contact_types_attributes: [:contact_type_id],
     ]

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -20,7 +20,7 @@
         </div>
       <% end %>
 
-      <% if !casa_case.persisted? %>
+      <% if casa_case.new_record? %>
         <%# Only show the field when creating, but not when updating %>
         <div class="field form-group">
           <%= form.label :transition_aged_youth %>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -20,10 +20,13 @@
         </div>
       <% end %>
 
-      <div class="field form-group">
-        <%= form.label :transition_aged_youth %>
-        <%= form.check_box :transition_aged_youth %>
-      </div>
+      <% if !casa_case.persisted? %>
+        <%# Only show the field when creating, but not when updating %>
+        <div class="field form-group">
+          <%= form.label :transition_aged_youth %>
+          <%= form.check_box :transition_aged_youth %>
+        </div>
+      <% end %>
       <div class="field form-group">
         <%= form.label :court_report_submitted %>
         <%= form.check_box :court_report_submitted %>

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -80,13 +80,12 @@ RSpec.describe "/casa_cases", type: :request do
 
     describe "PATCH /update" do
       context "with valid parameters" do
-        let(:new_attributes) { {case_number: "12345", transition_aged_youth: true} }
+        let(:new_attributes) { {case_number: "12345"} }
 
         it "updates the requested casa_case" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           casa_case.reload
           expect(casa_case.case_number).to eq "12345"
-          expect(casa_case.transition_aged_youth).to be true
         end
 
         it "redirects to the casa_case" do
@@ -142,13 +141,12 @@ RSpec.describe "/casa_cases", type: :request do
 
     describe "PATCH /update" do
       context "with valid parameters" do
-        let(:new_attributes) { { case_number: "12345", transition_aged_youth: true, court_report_submitted: true } }
+        let(:new_attributes) { { case_number: "12345", court_report_submitted: true } }
 
         it "updates fields (except case_number)" do
           patch casa_case_url(casa_case), params: { casa_case: new_attributes }
           casa_case.reload
           expect(casa_case.case_number).to eq "111"
-          expect(casa_case.transition_aged_youth).to be true
           expect(casa_case.court_report_submitted).to be true
         end
 
@@ -194,13 +192,12 @@ RSpec.describe "/casa_cases", type: :request do
 
     describe "PATCH /update" do
       context "with valid parameters" do
-        let(:new_attributes) { { case_number: "12345", transition_aged_youth: true, court_report_submitted: true } }
+        let(:new_attributes) { { case_number: "12345", court_report_submitted: true } }
 
         it "updates fields (except case_number)" do
           patch casa_case_url(casa_case), params: { casa_case: new_attributes }
           casa_case.reload
           expect(casa_case.case_number).to eq "111"
-          expect(casa_case.transition_aged_youth).to be true
           expect(casa_case.court_report_submitted).to be true
         end
 

--- a/spec/system/admin_edits_a_case_spec.rb
+++ b/spec/system/admin_edits_a_case_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "admin edits case", type: :system do
     check "Court report submitted"
     click_on "Update CASA Case"
 
-    has_checked_field? :transition_aged_youth
     has_checked_field? :court_report_submitted
 
     click_on "Back"

--- a/spec/system/admin_edits_a_case_spec.rb
+++ b/spec/system/admin_edits_a_case_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "admin edits case", type: :system do
 
     visit edit_casa_case_path(casa_case)
 
-    check "Transition aged youth"
     check "Court report submitted"
     click_on "Update CASA Case"
 

--- a/spec/system/supervisor_edits_case_spec.rb
+++ b/spec/system/supervisor_edits_case_spec.rb
@@ -14,13 +14,10 @@ RSpec.describe "supervisor edits case", type: :system do
   end
 
   it "edits case" do
-    has_no_checked_field? :transition_aged_youth
     has_no_checked_field? :court_report_submitted
-    check "Transition aged youth"
     check "Court report submitted"
     check "Youth"
     click_on "Update CASA Case"
-    has_checked_field? :transition_aged_youth
     has_checked_field? :court_report_submitted
     has_checked_field? "Youth"
     has_no_checked_field? "Supervisor"

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "volunteer edits case", type: :system do
     check "Transition aged youth"
     click_on "Update CASA Case"
 
-    has_checked_field? :transition_aged_youth
+    has_no_checked_field? :court_report_submitted
 
     click_on "Back"
 
@@ -22,12 +22,9 @@ RSpec.describe "volunteer edits case", type: :system do
   end
 
   it "edits case" do
-    has_no_checked_field? :transition_aged_youth
     has_no_checked_field? :court_report_submitted
-    check "Transition aged youth"
     check "Court report submitted"
     click_on "Update CASA Case"
-    has_checked_field? :transition_aged_youth
     has_checked_field? :court_report_submitted
   end
 end

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "volunteer edits case", type: :system do
   end
 
   it "clicks back button after editing case" do
-    check "Transition aged youth"
+    check "Court report submitted"
     click_on "Update CASA Case"
 
     has_no_checked_field? :court_report_submitted


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #896 

### What changed, and why?
Removed the ability to change the `transition_aged_youth` flag. I still allowed the field to be used when creating the case.
