### PR TITLE
Fix error while saving profile with invalid values as an admin 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
       flash[:success] = "Profile was successfully updated."
       redirect_to edit_users_path
     else
+      @active_casa_admins = CasaAdmin.in_organization(current_organization).active
       render :edit
     end
   end

--- a/spec/system/edit_user_system_spec.rb
+++ b/spec/system/edit_user_system_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe "Editing Profile", type: :system do
     expect(page).to have_field("Email", disabled: true)
   end
 
+  it "should not be able to update the profile without display name as an admin" do
+    sign_in admin
+    visit edit_users_path
+
+    fill_in "Display name", with: ""
+    click_on "Update Profile"
+
+    expect(page).to have_text("Display name can't be blank")
+  end
+
   # Add back when Travis CI correctly handles large screen size
   xit "should be able to update the email if user is a admin" do
     sign_in admin


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #902

### What changed, and why?
Load Active CASA admins on update with error

### How is this tested?
Have tested manually
Added a test
