### PR TITLE
Add font-family fallback for option elements

### DIFF
--- a/app/javascript/src/stylesheets/shared/typography.scss
+++ b/app/javascript/src/stylesheets/shared/typography.scss
@@ -3,3 +3,7 @@
 body {
   font-family: "Montserrat";
 }
+
+option {
+  font-family: Helvetica, Arial, sans-serif;
+}


### PR DESCRIPTION
Add font-family fallback values to `option` elements.

### What github issue is this PR for, if any?

Resolves #886 

### What changed, and why?

Option elements now have a fallback `font-family` to work around a Firefox bug that prevents web fonts from being applied correctly.

For more details, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1536148#c19

### How will this affect user permissions?

None

### How is this tested? (please write tests!) 💖💪

In Firefox, navigate to the contact types creation form and verify that the dropdown uses the fallback font values since `Montserrat`, being a web-font, won't work.

### Screenshots please :)

On Firefox:

![2020-10-02 16 11 25](https://user-images.githubusercontent.com/508128/94961946-06de3f00-04cc-11eb-8635-56ef7b0a8a01.gif)

On Chrome:

![2020-10-02 16 11 07](https://user-images.githubusercontent.com/508128/94961921-fb8b1380-04cb-11eb-9fcc-4c2563487a58.gif)

### Alternatives

I haven't tried "vendorizing" the `Montserrat` font, perhaps that could work? Worth trying?

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
