### PR TITLE
#539 Meta tags to link preview

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,8 @@ module ApplicationHelper
     when "alert" then "alert alert-warning"
     end
   end
+
+  def og_tag(type, options = {})
+    tag.meta(property: "og:#{type}", **options)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title><%= translate('page.meta.title') %></title>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <meta name="description" content="<%= translate('page.meta.description') %>">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= render 'shared/favicons' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,11 @@
 
     <meta name="description" content="<%= translate('page.meta.description') %>">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <%= og_tag :title, content: translate('page.meta.title') %>
+    <%= og_tag :url, content: root_url %>
+    <%= og_tag :image, content: asset_pack_url('media/src/images/login.jpg') %>
+
     <%= render 'shared/favicons' %>
     <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%= og_tag :title, content: translate('page.meta.title') %>
+    <%= og_tag :description, content: translate('page.meta.description') %>
     <%= og_tag :url, content: root_url %>
     <%= og_tag :image, content: asset_pack_url('media/src/images/login.jpg') %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,3 +48,4 @@ en:
   page:
     meta:
       title: CASA Volunteer Tracking
+      description: Volunteer activity tracking for CASA volunteers, supervisors, and administrators.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,3 +45,6 @@ en:
       notes_placeholder: "Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth."
     volunteer:
       mark_inactive_warning: "WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?"
+  page:
+    meta:
+      title: CASA Volunteer Tracking

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,4 +35,10 @@ describe ApplicationHelper, type: :helper do
       expect(helper.session_link).to match(new_user_session_path)
     end
   end
+
+  describe "#og_tag" do
+    subject { helper.og_tag(:title, content: 'Website Title') }
+
+    it { is_expected.to eql('<meta property="og:title" content="Website Title">') }
+  end
 end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe "layouts/application", type: :view do
+  subject { rendered }
+
+  let(:title) { 'CASA Volunteer Tracking' }
+  let(:description) { 'Volunteer activity tracking for CASA volunteers, supervisors, and administrators.' }
+
+  it "renders correct title" do
+    render
+    expect(subject).to match "<title>#{title}</title>"
+  end
+
+  it "renders correct description" do
+    render
+    expect(subject).to match "<meta name=\"description\" content=\"#{description}\">"
+  end
+
+  it "renders correct og meta tags" do
+    render
+
+    expect(rendered.scan(/\<meta property="og:.*>/).count).to be(4)
+    expect(subject).to match("og:title\" content=\"#{title}\"")
+    expect(subject).to match('og:url" content="http://test.host/"')
+    expect(subject).to match('og:image" content="http://test.host/packs-test/media/src/images/.*.jpg"')
+    expect(subject).to match(
+      'og:description" content="Volunteer activity tracking for CASA volunteers, supervisors, and administrators."'
+    )
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #539

### What changed, and why?
Add meta tags:
- title and description: for browser context
- og tags: for embed previews, used by external services to collect the data that will be shown

### How will this affect user permissions?
No permission changes

### How is this tested? (please write tests!) 💖💪
Copy and paste a public URL for this application into the slack to see the link preview
Or you can use this website to see it working https://metatags.io/

### Screenshots please :)
Slack | Facebook | Twitter
------- | ------------- | ----------
![Screenshot_20201002_173109](https://user-images.githubusercontent.com/6165892/94967260-1ada6e80-04d5-11eb-8f00-64c807bc1bad.png) | ![Screenshot_20201002_173447](https://user-images.githubusercontent.com/6165892/94967556-aeac3a80-04d5-11eb-96c7-ca340b0d875a.png) | ![Screenshot_20201002_173513](https://user-images.githubusercontent.com/6165892/94967560-b10e9480-04d5-11eb-9889-44fd23b5ae8b.png)


### Feelings gif
![Really happy](https://media.giphy.com/media/LZElUsjl1Bu6c/giphy.gif)
