### PR TITLE
Set Skylight environments using environment variables

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,6 @@ module Casa
   class Application < Rails::Application
     config.load_defaults 6.0
     config.serve_static_assets = true
-    config.skylight.environments << "staging"
     config.action_mailer.preview_path = "#{Rails.root}/lib/mailers/previews"
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
   end

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,3 +1,0 @@
----
-# The authentication token for the application.
-authentication: QA1OKxp4SPmHTUWVtgDo3xyYHswM-bhbEvvxy8sRxCQ


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #916

### What changed, and why?
* Removed auth token from repo since repo is public
* Set the following environment variables (see [Skylight documentation](https://www.skylight.io/support/environments#for-rails-using-environment-variables)):

**staging**
```
SKYLIGHT_AUTHENTICATION:  QA1OKxp4SPmHTUWVtgDo3xyYHswM-bhbEvvxy8sRxCQ
SKYLIGHT_ENABLED:         true
SKYLIGHT_ENV:             staging
```

**qa**
```
SKYLIGHT_AUTHENTICATION:  QA1OKxp4SPmHTUWVtgDo3xyYHswM-bhbEvvxy8sRxCQ
SKYLIGHT_ENABLED:         true
SKYLIGHT_ENV:             qa
```

**production**
```
SKYLIGHT_AUTHENTICATION: QA1OKxp4SPmHTUWVtgDo3xyYHswM-bhbEvvxy8sRxCQ
SKYLIGHT_ENABLED:        true
```
(will default to "production" environment on Skylight).

### TODO

For someone who has access to Skylight, please change the access token and set the new token on the Heroku environments:
```
heroku config:set SKYLIGHT_AUTHENTICATION=new-secret-token -a casa-r4g-staging
```
- [ ] Update staging
- [ ] Update QA
- [ ] Update production
