### PR TITLE
Issue 831: add tasks to update transition_aged_youth when 14

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -30,6 +30,11 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   }
 
+  scope :should_transition, -> {
+    where(transition_aged_youth: false)
+      .where('birth_month_year_youth <= ?', 14.years.ago)
+  }
+
   def self.available_for_volunteer(volunteer)
     ids = connection.select_values(%{
       SELECT casa_cases.id

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,6 @@
+desc "Transition youth who are now 14, run by heroku scheduler"
+task transition_youth: :environment do
+  puts "Updating casa cases..."
+  CasaCase.should_transition.update_all(transition_aged_youth: true)
+  puts "done."
+end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe CasaCase do
     end
   end
 
+  describe "#should_transition" do
+    it "returns only youth who should have transitioned but have not" do
+      not_transitioned_13_yo = create(:casa_case,
+        birth_month_year_youth: Date.current - 13.years,
+        transition_aged_youth: false)
+      transitioned_14_yo = create(:casa_case,
+        birth_month_year_youth: Date.current - 14.years,
+        transition_aged_youth: true)
+      not_transitioned_14_yo = create(:casa_case,
+        birth_month_year_youth: Date.current - 14.years,
+        transition_aged_youth: false)
+      cases = CasaCase.should_transition
+      aggregate_failures do
+        expect(cases.length).to eq 1
+        expect(cases.include?(not_transitioned_14_yo)).to eq true
+        expect(cases.include?(not_transitioned_13_yo)).to eq false
+        expect(cases.include?(transitioned_14_yo)).to eq false
+      end
+    end
+  end
+
   describe ".actively_assigned_to" do
     it "only returns cases actively assigned to a volunteer" do
       current_user = create(:volunteer)

--- a/spec/policies/case_contact_policy/scope_spec.rb
+++ b/spec/policies/case_contact_policy/scope_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe CaseContactPolicy::Scope do
         create_irrelevant_contacts(current_user, other_user)
 
         scope = described_class.new(current_user, CaseContact)
-        expect(scope.resolve).to eq relevant_contacts
+        aggregate_failures do
+          expect(scope.resolve.include?(relevant_contacts[0])).to eq true
+          expect(scope.resolve.include?(relevant_contacts[1])).to eq true
+          expect(scope.resolve.length).to eq 2
+        end
       end
     end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7363,9 +7363,9 @@ postcss-attribute-case-insensitive@^4.0.1:
     postcss-selector-parser "^6.0.2"
 
 postcss-calc@^7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.4.tgz#5e177ddb417341e6d4a193c5d9fd8ada79094f8b"
-  integrity sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.5.tgz#f8a6e99f12e619c2ebc23cf6c486fdc15860933e"
+  integrity sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==
   dependencies:
     postcss "^7.0.27"
     postcss-selector-parser "^6.0.2"
@@ -9378,12 +9378,12 @@ strip-json-comments@^3.0.1:
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 style-loader@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
-  integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
+  integrity sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==
   dependencies:
     loader-utils "^2.0.0"
-    schema-utils "^2.6.6"
+    schema-utils "^2.7.0"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #831 

### What changed, and why?
Added a scope to check if youth is 14 and not marked as transitioned and a task to update all youth who match that criteria.

### How will this affect user permissions?
Not a user-facing change.

### How is this tested? (please write tests!) 💖💪
Added a test for the scope change.

