### PR TITLE
Added style to enlarge checkbox and removed inline.

### DIFF
--- a/app/javascript/src/stylesheets/shared/dashboard.scss
+++ b/app/javascript/src/stylesheets/shared/dashboard.scss
@@ -9,3 +9,12 @@
     display: inline-block;
   }
 }
+
+.dropdown-menu {
+  li {
+    input[type="checkbox"] {
+      transform: scale(1.5);
+      margin: 0 8px;
+    }
+  }
+}

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -23,7 +23,6 @@
             <li>
               <a class="small" data-value="option1" tabIndex="-1">
                 <input
-                  style="margin:0 8px;"
                   type="checkbox"
                   data-value="<%= supervisor.name %>"
                   checked>
@@ -39,11 +38,11 @@
       </button>
       <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
         <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="Active" checked>
+          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Active" checked>
           Active</a>
         </li>
         <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="Inactive">
+          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Inactive">
           Inactive</a>
         </li>
       </div>
@@ -53,8 +52,8 @@
         Assigned to Transition Aged Youth
       </button>
       <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="Yes 🐛🦋" checked>Yes</a></li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input style="margin:0 8px;" type="checkbox" data-value="No" checked>No</a></li>
+        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🐛🦋" checked>Yes</a></li>
+        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a></li>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #924

### What changed, and why?
Provides a new style for checkboxes on drop down menus to enlarges the box, and includes the previously used inline margin style.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Manually (if you have tests of the SCSS I can try to add something for this.

### Screenshots please :)
<img width="317" alt="checkbox-revised" src="https://user-images.githubusercontent.com/2972053/95002152-f6e35f80-059e-11eb-929f-35522a3ace9e.png">
