### PR TITLE
filter by current supervisor for volunteers view by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,4 @@ If you are wondering how to keep your fork in sync with the main [repo], follow 
 [code of conduct]: https://github.com/rubyforgood/code-of-conduct
 [issues]: https://github.com/rubyforgood/casa/issues?q=is%3Aopen+is%3Aissue+label%3A%22Status%3A+Available%22
 [repo]: https://github.com/rubyforgood/casa
-[setup]: https://github.com/rubyforgood/casa#setup-to-develop 
+[setup]: https://github.com/rubyforgood/casa#setting-up-your-development-environment

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -22,11 +22,17 @@
           <% Supervisor.decorate.each do |supervisor| %>
             <li>
               <a class="small" data-value="option1" tabIndex="-1">
+              <% if !current_user.supervisor? or supervisor.id == current_user.id %>
                 <input
                   type="checkbox"
                   data-value="<%= supervisor.name %>"
                   checked>
-                <%= supervisor.name %>
+              <% else %>
+                <input
+                  type="checkbox"
+                  data-value="<%= supervisor.name %>">
+              <% end %>
+              <%= supervisor.name %>
               </a>
             </li>
           <% end %>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -22,7 +22,7 @@
           <% Supervisor.decorate.each do |supervisor| %>
             <li>
               <a class="small" data-value="option1" tabIndex="-1">
-              <% if !current_user.supervisor? or supervisor.id == current_user.id %>
+              <% if !current_user.supervisor? || supervisor == current_user %>
                 <input
                   type="checkbox"
                   data-value="<%= supervisor.name %>"

--- a/spec/system/supervisor_views_volunteers_page_spec.rb
+++ b/spec/system/supervisor_views_volunteers_page_spec.rb
@@ -51,4 +51,17 @@ RSpec.describe "supervisor views Volunteers page", type: :system do
     expect(page).not_to have_text("Contact Made In Past 60 Days")
     expect(page).not_to have_text("Last Contact Made")
   end
+
+  describe "filters" do
+    let(:supervisor) { create(:supervisor, :with_volunteers) }
+
+    it "by default only shows volunteers filtered by signed in supervisor" do
+      sign_in supervisor
+
+      visit volunteers_path
+      expect(page).to have_selector(".volunteer-filters")
+      
+      expect(page.all("table#volunteers tr").count).to eq(supervisor.volunteers.count + 1)
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
For Hacktoberfest, resolves https://github.com/rubyforgood/casa/issues/933


### What changed, and why?
* Added a default filter by current supervisor when viewing `/volunteers` page
* also updated a link in the contribute markdown file

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Added a test to `spec/system/supervisor_views_volunteers_page_spec.rb`

### Screenshots please :)
On visiting `/volunteers` only the current supervisor is selected in the supervisor "filter by":
![image](https://user-images.githubusercontent.com/25035236/95024628-1fb83300-0639-11eb-9dba-b6b98d171280.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
