### PR TITLE
Feature/remove state in datatable

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -41,7 +41,7 @@ $('document').ready(() => {
   // Enable all data tables on dashboard but only filter on volunteers table
   var volunteersTable = $('table#volunteers').DataTable({
     autoWidth: false,
-    stateSave: true,
+    stateSave: false,
     columnDefs: [
       {
         targets: [1],

--- a/spec/system/search_history_clean_after_navigate_away_volunteer_table_spec.rb
+++ b/spec/system/search_history_clean_after_navigate_away_volunteer_table_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "Search history should clean after I navigate away from volunteers view", type: :system do
+  let (:supervisor) { create(:supervisor, :with_volunteers)}
+  let (:input_field ) { "div#volunteers_filter input" }
+
+  it do
+    sign_in supervisor 
+    visit volunteers_path
+    
+    page.find(input_field).set('Test')
+
+    visit supervisors_path
+    visit volunteers_path
+    input_search = page.find(input_field)
+    expect(input_search.value).to eq('')
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #932 

### What changed, and why?

I've changed the config of datatable for volunteers view, I change the stateSave parameter to false because this parameter saves not only information about search input even information other parts of data table.

### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: None
- Admin permissions: None

### How is this tested? (please write tests!) 💖💪
I write a system test called `spec/system/search_history_clean_after_navigate_away_volunteer_table_spec.rb`

### Screenshots please :)

I think a video is more useful
[Video](https://drive.google.com/file/d/19o9v4jsUQDSpXugpXr3qxFa3KIe6zRtt/view?usp=sharing)
