### PR TITLE
Bugsnag environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # Do not send emails in staging or qa
   config.action_mailer.perform_deliveries = ENV["APP_ENVIRONMENT"] == "production"
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { # WARNING do not let standardrb linter change this block, it breaks
+  config.action_mailer.smtp_settings = {
     address: 'smtp-relay.sendinblue.com',
     port: 587,
     user_name: ENV["SENDINBLUE_EMAIL"],

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,4 +1,5 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"]
   config.ignore_classes << ActiveRecord::RecordNotFound
+  config.release_stage = ENV["APP_ENVIRONMENT"]
 end


### PR DESCRIPTION
### What changed, and why?
Since all environments are using the production config file now, specifically set the release environment on Bugsnag.

https://docs.bugsnag.com/platforms/ruby/rails/configuration-options/#release_stage
