### PR TITLE
fix 'can filter volunteers' example in supervisor_views_volunteers

### DIFF
--- a/spec/system/supervisor_views_volunteers_page_spec.rb
+++ b/spec/system/supervisor_views_volunteers_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "supervisor views Volunteers page", type: :system do
   let(:organization) { create(:casa_org) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
   # Add back when Travis CI correctly handles large screen size
-  xit "can filter volunteers" do
+  it "can filter volunteers" do
     create_list(:volunteer, 3, casa_org: organization)
     create_list(:volunteer, 2, :inactive, casa_org: organization)
 
@@ -13,18 +13,18 @@ RSpec.describe "supervisor views Volunteers page", type: :system do
     visit volunteers_path
     expect(page).to have_selector(".volunteer-filters")
 
-    # by default, only active users are shown, so result should be 4 here
-    expect(page.all("table#volunteers tr").count).to eq 4
+    # by default, only active users are shown, so result should be 3 here
+    expect(page.all("table#volunteers tr").count).to eq 3
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').set(false)
 
-    # when all users are hidden, the tr count will be 2 for header and "no results" row
-    expect(page.all("table#volunteers tr").count).to eq 2
+    # when all users are hidden, the tr count will be 1 for "no results" row
+    expect(page.all("table#volunteers tr").count).to eq 1
 
     find(:css, 'input[data-value="Inactive"]').set(true)
 
-    expect(page.all("table#volunteers tr").count).to eq 3
+    expect(page.all("table#volunteers tr").count).to eq 2
   end
 
   it "can show/hide columns on volunteers table" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #968 

### What changed, and why?
Example on line 7 was failing (and ignored) due to UI rewrite: was looking for 4 active users but only created 3; 3 inactive users but only created 2; and 2 <tr> but only one is created when all users hidden.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
I have 2 unrelated tests failing. These are be failing on my `master` branch too, so not sure where they're coming from.

![Screenshot 2020-10-05 at 08 18 24](https://user-images.githubusercontent.com/22390758/95050418-6b271b80-06e3-11eb-945d-2cf723cae7d7.png)

### Screenshots please :)
![Screenshot 2020-10-05 at 08 24 44](https://user-images.githubusercontent.com/22390758/95050903-3ff0fc00-06e4-11eb-969d-513108fe3778.png)

### Feelings gif (optional)
`![It works, I guess... ?](https://iruntheinternet.com/lulzdump/images/gifs/red-and-green-power-rangers-shrug-who-cares-so-what-1381971694L.gif?id=)`
