### PR TITLE
Fix search volunteers by current name

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -116,7 +116,7 @@
       <tbody>
       <% @volunteers.each do |volunteer| %>
         <tr>
-          <td data-search="<%= volunteer.past_names %>">
+          <td data-search="<%= volunteer.past_names %>|<%= volunteer.display_name %>>
               <%= link_to(volunteer.decorate.name, edit_volunteer_path(volunteer)) %>
               <% if !volunteer.made_contact_with_all_cases_in_days? %>
                 🕐


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #953

### What changed, and why?
Previously, the ability to search for volunteers by the old version of the name was added, because of this, the ability to search by the current one was lost. This has now been fixed.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


<img width="1589" alt="CASA Volunteer Tracking 2020-10-05 09-36-53" src="https://user-images.githubusercontent.com/1007159/95054517-ac76f580-06fa-11eb-8af8-017cdd5710fb.png">

