### PR TITLE
Fix spec admin can_filter_volunteers

### DIFF
--- a/spec/system/admin_views_volunteers_page_spec.rb
+++ b/spec/system/admin_views_volunteers_page_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "admin views Volunteers page", type: :system do
   end
 
   # Add back when Travis CI correctly handles large screen size
-  xit "can filter volunteers" do
+  it "can filter volunteers" do
     create_list(:volunteer, 3, casa_org: organization)
     create_list(:volunteer, 2, :inactive, casa_org: organization)
 
@@ -68,17 +68,17 @@ RSpec.describe "admin views Volunteers page", type: :system do
     expect(page).to have_selector(".volunteer-filters")
 
     # by default, only active users are shown, so result should be 4 here
-    expect(page.all("table#volunteers tr").count).to eq 4
+    expect(page.all("table#volunteers tbody tr").count).to eq 3
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').set(false)
 
     # when all users are hidden, the tr count will be 2 for header and "no results" row
-    expect(page.all("table#volunteers tr").count).to eq 2
+    expect(page.all("table#volunteers tbody tr").count).to eq 1
 
     find(:css, 'input[data-value="Inactive"]').set(true)
 
-    expect(page.all("table#volunteers tr").count).to eq 3
+    expect(page.all("table#volunteers tbody tr").count).to eq 2
   end
 
   it "can go to the volunteer edit page from the volunteer list" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #965 

### What changed, and why?
The previous version of the spec passes in Docker but fell in my local environment. At the moment, the local environment is not configured to work with js (judging by the screenshots from some other tasks, this problem is not only mine). Specifically in this case, the test does not see the table header(thead), so it has one tr less everywhere. If we count only the tr in the tbody of the table, it can help unify the tests.


### Screenshots please :)

![locale_env_spec](https://user-images.githubusercontent.com/1007159/95075273-99731e00-0718-11eb-8869-1baa2441ef44.png)

