### PR TITLE
Create unassigned volunteer filter

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -2,7 +2,11 @@
 $('document').ready(() => {
   $.fn.dataTable.ext.search.push(
     function (settings, data, dataIndex) {
-      var supervisorArray = ['']
+      if ($('#unassigned-vol-filter').is(':checked')) {
+        var supervisorArray = ['']
+      } else {
+        var supervisorArray = []
+      }
       var statusArray = []
       var assignedToTransitionYouthArray = []
 
@@ -33,7 +37,6 @@ $('document').ready(() => {
         assignedToTransitionYouthArray.includes(assignedToTransitionYouth)) {
         return true
       }
-
       return false
     }
   )
@@ -69,7 +72,22 @@ $('document').ready(() => {
   $('table#casa_cases').DataTable({ searching: false })
   $('table#case_contacts').DataTable({ searching: false, order: [[0, 'desc']] })
 
-  $('.volunteer-filters input[type="checkbox"]').on('click', function () {
+  function filterOutUnassignedVolunteers (checked) {
+    $('.supervisor-options').find('input[type="checkbox"]').not('#unassigned-vol-filter').each(function () {
+      this.checked = checked
+    })
+  }
+
+  $('#unassigned-vol-filter').on('click', function () {
+    if ($('#unassigned-vol-filter').is(':checked')) {
+      filterOutUnassignedVolunteers(false)
+    } else {
+      filterOutUnassignedVolunteers(true)
+    }
+    volunteersTable.draw()
+  })
+
+  $('.volunteer-filters input[type="checkbox"]').not('#unassigned-vol-filter').on('click', function () {
     volunteersTable.draw()
   })
 

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -19,6 +19,16 @@
         Supervisor
       </button>
         <ul class="dropdown-menu supervisor-options" style="min-width: 15rem;">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1">
+              <input
+                id="unassigned-vol-filter"
+                type="checkbox"
+                data-value="No supervisor assignment"
+                unchecked>
+              No supervisor assignment
+            </a>
+          </li>
           <% Supervisor.decorate.each do |supervisor| %>
             <li>
               <a class="small" data-value="option1" tabIndex="-1">

--- a/spec/factories/volunteer.rb
+++ b/spec/factories/volunteer.rb
@@ -10,5 +10,17 @@ FactoryBot.define do
         create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), volunteer: user)
       end
     end
+
+    trait :with_assigned_supervisor do
+      after(:create) do |user, _|
+        create(:supervisor_volunteer, volunteer: user)
+      end
+    end
+
+    trait :with_inactive_supervisor do
+      after(:create) do |user, _|
+        create(:supervisor_volunteer, :inactive, volunteer: user)
+      end
+    end
   end
 end

--- a/spec/system/admin_views_volunteers_page_spec.rb
+++ b/spec/system/admin_views_volunteers_page_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe "admin views Volunteers page", type: :system do
     # by default, only active users are shown
     expect(page.all("table#volunteers tbody tr").count).to eq assigned_volunteers.count
 
+    click_on "Supervisor"
+    find(:css, "#unassigned-vol-filter").set(true)
+
+    expect(page.all("table#volunteers tbody tr").count).to eq unassigned_volunteers.count
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').set(false)

--- a/spec/system/admin_views_volunteers_page_spec.rb
+++ b/spec/system/admin_views_volunteers_page_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "admin views Volunteers page", type: :system do
   end
 
   it "can go to the volunteer edit page from the volunteer list" do
-    create(:volunteer, casa_org: organization)
+    create(:volunteer, :with_assigned_supervisor, casa_org: organization)
     sign_in admin
 
     visit volunteers_path
@@ -109,6 +109,8 @@ RSpec.describe "admin views Volunteers page", type: :system do
       sign_in admin
 
       visit volunteers_path
+      click_on "Supervisor"
+      find(:css, "#unassigned-vol-filter").set(true)
       supervisor_cell = page.find(".supervisor-column")
 
       expect(supervisor_cell.text).to eq ""
@@ -126,12 +128,13 @@ RSpec.describe "admin views Volunteers page", type: :system do
       expect(supervisor_cell.text).to eq name
     end
 
-    it "is blank when volunteer has been unassigned from supervisor" do
-      volunteer = create(:volunteer, casa_org: organization)
-      create(:supervisor_volunteer, volunteer: volunteer, is_active: false)
+    it "is blank when volunteer's supervisor is inactive" do
+      volunteer = create(:volunteer, :with_inactive_supervisor, casa_org: organization)
       sign_in admin
 
       visit volunteers_path
+      click_on "Supervisor"
+      find(:css, "#unassigned-vol-filter").set(true)
       supervisor_cell = page.find(".supervisor-column")
 
       expect(supervisor_cell.text).to eq ""

--- a/spec/system/supervisor_views_volunteers_page_spec.rb
+++ b/spec/system/supervisor_views_volunteers_page_spec.rb
@@ -5,16 +5,15 @@ RSpec.describe "supervisor views Volunteers page", type: :system do
   let(:supervisor) { create(:supervisor, casa_org: organization) }
 
   it "can filter volunteers" do
-    create_list(:volunteer, 3, casa_org: organization)
-    create_list(:volunteer, 2, :inactive, casa_org: organization)
+    active_volunteers = create_list(:volunteer, 3, :with_assigned_supervisor, casa_org: organization)
+    inactive_volunteers = create_list(:volunteer, 2, :with_assigned_supervisor, :inactive, casa_org: organization)
 
     sign_in supervisor
 
     visit volunteers_path
     expect(page).to have_selector(".volunteer-filters")
 
-    # by default, only active users are shown, so result should be 3 here
-    expect(page.all("table#volunteers tbody tr").count).to eq 3
+    expect(page.all("table#volunteers tbody tr").count).to eq active_volunteers.count
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').set(false)
@@ -24,7 +23,7 @@ RSpec.describe "supervisor views Volunteers page", type: :system do
 
     find(:css, 'input[data-value="Inactive"]').set(true)
 
-    expect(page.all("table#volunteers tbody tr").count).to eq 2
+    expect(page.all("table#volunteers tbody tr").count).to eq inactive_volunteers.count
   end
 
   it "can show/hide columns on volunteers table" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
~~If this looks good, please don't merge yet, I will rebase and update tests after PR #965 is good/merged~~

Resolves #934 

### What changed, and why?
Created filter to view unassigned volunteers

Unassigned volunteers no longer show up with assigned volunteers by default

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
~~I need to use the changes in PR #965 to update the tests for the filters- Once that PR is merged - I will update this PR.~~

Added test that checks result count when the `No supervisor` filter is applied
This was added to the admin view test page. Adding it to the supervisor test page seems redundant.

### Screenshots please :)
![vol_filter](https://user-images.githubusercontent.com/19519317/95082942-c9411680-0756-11eb-988b-255a5add1c92.gif)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
