### PR TITLE
fixes capybara window size issue

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -18,3 +18,11 @@ Capybara.register_driver :selenium_chrome_headless_in_container do |app|
       chromeOptions: {args: %w[headless disable-gpu --window-size=1280,900]}
     )
 end
+
+Capybara.register_driver :selenium_chrome_headless do |app|
+  Capybara::Selenium::Driver.new app,
+    browser: :chrome,
+    options: Selenium::WebDriver::Chrome::Options.new(
+      args:  %w[--headless --disable-gpu --disable-site-isolation-trials --window-size=1280,900]
+    )
+end

--- a/spec/system/admin_views_volunteers_page_spec.rb
+++ b/spec/system/admin_views_volunteers_page_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "admin views Volunteers page", type: :system do
   after { travel_back }
 
   context "when no logo_url" do
-    # Add back when Travis CI correctly handles large screen size
-    xit "can see volunteers and navigate to their cases" do
+    it "can see volunteers and navigate to their cases" do
       volunteer = create(:volunteer, display_name: "User 1", email: "casa@example.com", casa_org: organization)
       volunteer.casa_cases << create(:casa_case, casa_org: organization)
       volunteer.casa_cases << create(:casa_case, casa_org: organization)
@@ -57,7 +56,6 @@ RSpec.describe "admin views Volunteers page", type: :system do
     expect(page).not_to have_text("Last Contact Made")
   end
 
-  # Add back when Travis CI correctly handles large screen size
   it "can filter volunteers" do
     create_list(:volunteer, 3, casa_org: organization)
     create_list(:volunteer, 2, :inactive, casa_org: organization)

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -89,8 +89,8 @@ describe "all casa admins with casa orgs", type: :system do
     let(:casa_admin) { create(:casa_admin, casa_org: current_organization) }
 
     before { sign_in casa_admin }
-    # Add back when Travis CI correctly handles large screen size
-    xit "redirects to root" do
+
+    it "redirects to root" do
       visit new_all_casa_admins_casa_org_path
       expect(page).to have_text "Volunteers"
       expect(page).to_not have_text "Create a new CASA Organization"

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe "Authentication", type: :system do
     end
 
     %w[volunteer supervisor casa_admin].each do |user_type|
-      # Add back when Travis CI correctly handles large screen size
-      xit "allows #{user_type} to sign in" do
+      it "allows #{user_type} to sign in" do
         user = create(user_type.to_sym)
 
         visit "/"
@@ -48,8 +47,7 @@ RSpec.describe "Authentication", type: :system do
     let(:user) { create(:casa_admin) }
     before { sign_in user }
 
-    # Add back when Travis CI correctly handles large screen size
-    xit "renders dashboard page and shows correct flash message upon sign out" do
+    it "renders dashboard page and shows correct flash message upon sign out" do
       visit "/"
       expect(page).to have_text "Volunteers"
       # click_link "Log out"

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -11,8 +11,8 @@ describe "AllCasaAdmin auth", type: :system do
       visit "/"
       expect(page).to have_text "All CASA Admin"
     end
-    # Add back when Travis CI correctly handles large screen size
-    xit "allows sign out" do
+
+    it "allows sign out" do
       visit "/"
       click_link "Log out"
       expect(page).to_not have_text "sign in before continuing"

--- a/spec/system/edit_user_system_spec.rb
+++ b/spec/system/edit_user_system_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe "Editing Profile", type: :system do
     expect(page).to have_text("Display name can't be blank")
   end
 
-  # Add back when Travis CI correctly handles large screen size
-  xit "should be able to update the email if user is a admin" do
+  it "should be able to update the email if user is a admin" do
     sign_in admin
     visit edit_users_path
     expect(page).to have_field("Email", disabled: false)

--- a/spec/system/supervisor_views_volunteers_page_spec.rb
+++ b/spec/system/supervisor_views_volunteers_page_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "supervisor views Volunteers page", type: :system do
   let(:organization) { create(:casa_org) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
-  # Add back when Travis CI correctly handles large screen size
+
   it "can filter volunteers" do
     create_list(:volunteer, 3, casa_org: organization)
     create_list(:volunteer, 2, :inactive, casa_org: organization)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #967 #966 #964 #960 #959

### What changed, and why?
Travis runs with [selenium_chrome_headless](https://github.com/rubyforgood/casa/blob/9da2c4497b41fd026b6a758808ee5d443491bc0e/spec/spec_helper.rb#L34) that is configured with [default values from capybara](https://github.com/teamcapybara/capybara/blob/b154720822bd5b182b4071f1ec624406030ec27b/lib/capybara/registrations/drivers.rb#L27-L36). So, I registered our own [selenium_chrome_headless](https://github.com/rubyforgood/casa/pull/979/files#diff-1b366f44043971d2660c6cd2050cdf5bR22-R28) with window size setting

I removed skipping from this tests:
- spec/system/admin_views_volunteers_page_spec.rb 
- spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb 
- spec/system/authentication_spec.rb 
- spec/system/can_sign_in_as_all_casa_admin_spec.rb 
- spec/system/edit_user_system_spec.rb 
- spec/system/supervisor_views_volunteers_page_spec.rb 

### How will this affect user permissions?
- This not affect user permissions

### How is this tested? (please write tests!) 💖💪
- This is a fix in the CI test suite, check the travis link to see it's working

### Feelings gif
![Happy Capybara](https://media.giphy.com/media/hbB8efOHAezRK/giphy.gif)
