### PR TITLE
Fix error message for bad court date for casa cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :test do
   gem "brakeman" # security inspection
   gem "capybara", ">= 2.15"
+  gem "capybara-screenshot"
   gem "rake"
   gem "selenium-webdriver"
   gem "simplecov", "~> 0.19.0", require: false # pinned as a workaround for https://github.com/codeclimate/test-reporter/issues/418

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.24)
+      capybara (>= 1.0, < 4)
+      launchy
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -332,6 +335,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  capybara-screenshot
   cypress-on-rails (~> 1.0)
   devise
   devise_invitable

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -54,10 +54,29 @@ class CasaCase < ApplicationRecord
   end
 
   def update_cleaning_contact_types(args)
+    begin
+      args = parse_court_date(args)
+    rescue Date::Error
+      errors.messages[:court_date] << "was not a valid date."
+      return false
+    end
     transaction do
       casa_case_contact_types.destroy_all
       update(args)
     end
+  end
+
+  private
+
+  def parse_court_date(args)
+    day = args.delete("court_date(3i)")
+    month = args.delete("court_date(2i)")
+    year = args.delete("court_date(1i)")
+    return args if day.blank? && month.blank? && year.blank?
+    raise Date::Error if day.blank? || month.blank? || year.blank?
+    court_date = Date.parse("#{day}-#{month}-#{year}")
+    args["court_date"] = court_date
+    args
   end
 end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,6 @@
 require "capybara/rails"
+require "capybara/rspec"
+require "capybara-screenshot/rspec"
 require "selenium/webdriver"
 
 Capybara.register_driver :selenium_chrome_in_container do |app|


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #954 

### What changed, and why?
- Add capybara-screenshot gem to help debug capybara specs
- Add error message for incorrectly added court date for casa cases
- Checks for both an invalid date and a partial date

### How is this tested? (please write tests!) 💖💪
Added two additional tests for when a supervisor edits a casa case

### Screenshots please :)
<img width="604" alt="Screen Shot 2020-10-05 at 10 27 55 AM" src="https://user-images.githubusercontent.com/1082370/95107823-69bc1a00-0708-11eb-9bc4-bea2983180cc.png">