### PR TITLE
Fixed the error treatment to emails send fail

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -41,6 +41,8 @@ class CasaAdminsController < ApplicationController
     else
       render :edit
     end
+  rescue Errno::ECONNREFUSED => error
+    redirect_to_casa_admin_edition_page(error)
   end
 
   def deactivate
@@ -52,12 +54,16 @@ class CasaAdminsController < ApplicationController
       render :edit
     end
   rescue Errno::ECONNREFUSED => error
+    redirect_to_casa_admin_edition_page(error)
+  end
+
+  private
+
+  def redirect_to_casa_admin_edition_page(error)
     Bugsnag.notify(error)
 
     redirect_to edit_casa_admin_path(@casa_admin), alert: "Email not sent."
   end
-
-  private
 
   def set_admin
     @casa_admin = CasaAdmin.find(params[:id])

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -51,6 +51,10 @@ class CasaAdminsController < ApplicationController
     else
       render :edit
     end
+  rescue Errno::ECONNREFUSED => error
+    Bugsnag.notify(error)
+
+    redirect_to edit_casa_admin_path(@casa_admin), alert: "Email not sent."
   end
 
   private

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -105,6 +105,28 @@ RSpec.describe "/casa_admins", type: :request do
         patch activate_casa_admin_path(casa_admin)
       }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    context 'when occurs send errors' do
+      it 'redirects to admin edition page' do
+        sign_in_as_admin
+
+        allow(CasaAdminMailer).to receive_message_chain(:account_setup, :deliver) { raise Errno::ECONNREFUSED }
+
+        patch activate_casa_admin_path(casa_admin)
+
+        expect(response).to redirect_to(edit_casa_admin_path(casa_admin))
+      end
+
+      it 'shows error message' do
+        sign_in_as_admin
+
+        allow(CasaAdminMailer).to receive_message_chain(:account_setup, :deliver) { raise Errno::ECONNREFUSED }
+
+        patch activate_casa_admin_path(casa_admin)
+
+        expect(flash[:alert]).to eq('Email not sent.')
+      end
+    end
   end
 
   describe "PATCH /casa_admins/:id/deactivate" do
@@ -130,7 +152,7 @@ RSpec.describe "/casa_admins", type: :request do
       end
 
       context 'when occurs send errors' do
-        it 'redirects to admin edition page when occurs errors' do
+        it 'redirects to admin edition page' do
           sign_in_as_admin
 
           allow(CasaAdminMailer).to receive_message_chain(:deactivation, :deliver) { raise Errno::ECONNREFUSED }
@@ -140,7 +162,7 @@ RSpec.describe "/casa_admins", type: :request do
           expect(response).to redirect_to(edit_casa_admin_path(casa_admin))
         end
 
-        it 'shows error message when occurs errors' do
+        it 'shows error message' do
           sign_in_as_admin
 
           allow(CasaAdminMailer).to receive_message_chain(:deactivation, :deliver) { raise Errno::ECONNREFUSED }

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -128,6 +128,28 @@ RSpec.describe "/casa_admins", type: :request do
           patch deactivate_casa_admin_path(casa_admin)
         }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
+
+      context 'when occurs send errors' do
+        it 'redirects to admin edition page when occurs errors' do
+          sign_in_as_admin
+
+          allow(CasaAdminMailer).to receive_message_chain(:deactivation, :deliver) { raise Errno::ECONNREFUSED }
+
+          patch deactivate_casa_admin_path(casa_admin)
+
+          expect(response).to redirect_to(edit_casa_admin_path(casa_admin))
+        end
+
+        it 'shows error message when occurs errors' do
+          sign_in_as_admin
+
+          allow(CasaAdminMailer).to receive_message_chain(:deactivation, :deliver) { raise Errno::ECONNREFUSED }
+
+          patch deactivate_casa_admin_path(casa_admin)
+
+          expect(flash[:alert]).to eq('Email not sent.')
+        end
+      end
     end
 
     context "logged in as a non-admin user" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/952

### What changed, and why?

I created a error treatment (Errno::ECONNREFUSED) in the methods that active/deactive Admins.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions:N/A

### How is this tested? (please write tests!) 💖💪
I created tests in requests spec files forcing the error using Mock.

### Feelings gif (optional)

![alt text](https://media.giphy.com/media/5iXTLFjce2qcw/giphy.gif)
