### PR TITLE
Feature/miles driven should not be negative

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -3,6 +3,7 @@ class CaseContact < ApplicationRecord
 
   validate :contact_made_chosen
   validates :duration_minutes, numericality: {greater_than_or_equal_to: 15, message: "Minimum case contact duration should be 15 minutes."}
+  validates :miles_driven, numericality: { greater_than_or_equal_to: 0, message: 'should not be negative.' }
   validates :medium_type, presence: true
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -116,7 +116,7 @@
 
   <div class="field miles-driven form-group">
     <h2><%= form.label :miles_driven %></h2>
-    <%= form.number_field :miles_driven, class: "form-control" %>
+    <%= form.number_field :miles_driven, class: "form-control", required: true, min: "0" %>
   </div>
 
   <div class="field want-driving-reimbursement form-group">

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact.miles_driven).to eq 0
   end
 
+  it "validates miles_driven should not be negative" do
+    case_contact = build(:case_contact, miles_driven: -1)
+    expect(case_contact).to_not be_valid
+    expect(case_contact.errors[:miles_driven]).to eq(['should not be negative'])
+  end
+
   it "validates presence of occurred_at" do
     case_contact = build(:case_contact, occurred_at: nil)
     expect(case_contact).to_not be_valid

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CaseContact, type: :model do
   it "validates miles_driven should not be negative" do
     case_contact = build(:case_contact, miles_driven: -1)
     expect(case_contact).to_not be_valid
-    expect(case_contact.errors[:miles_driven]).to eq(['should not be negative'])
+    expect(case_contact.errors[:miles_driven]).to eq(['should not be negative.'])
   end
 
   it "validates presence of occurred_at" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #956

### What changed, and why?
- I've added in the form an input validation when create/edit a case_contact for permit only positive numbers(include the 0)
- I've added a new validation in the model case_contact for permit only positive number(include the 0)

### How will this affect user permissions?- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪

I wrote a unit test to validate a miles driven permit only positive numbers `./spec/models/case_contact_spec.rb:21`

### Screenshots please :)

![Screen Shot 2020-10-06 at 00 10 59](https://user-images.githubusercontent.com/7256891/95161314-6b1d2f00-0768-11eb-841e-da6c8fa78b21.png)
![Screen Shot 2020-10-06 at 00 11 37](https://user-images.githubusercontent.com/7256891/95161340-81c38600-0768-11eb-813f-2631f57bb6f4.png)
![Screen Shot 2020-10-06 at 00 11 10](https://user-images.githubusercontent.com/7256891/95161320-72dcd380-0768-11eb-8cfe-c2932d6f168b.png)
