### PR TITLE
add route "Generate Court Report" to sidebar

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -3,6 +3,6 @@ class CaseCourtReportsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @assigned_cases = current_user.casa_cases
+    @assigned_cases = CasaCase.actively_assigned_to(current_user)
   end
 end

--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class CaseCourtReportsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @assigned_cases = current_user.casa_cases
+  end
+end

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -4,7 +4,7 @@
   <div class="card-body">
     <h5 class="card-title"><strong>Generate Court Report</strong></h5>
     <p class="card-text">
-      Download a Court Report with pre-filled information for your cases. This document is in Word format (.docx).
+      The Court Report is pre-filled with information of your case. You can select among currently active cases assigned to you. The document is in Microsoft Word format (.dox).
     </p>
 
     <hr>

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -4,41 +4,41 @@
   <div class="card-body">
     <h5 class="card-title"><strong>Generate Court Report</strong></h5>
     <p class="card-text">
-      The Court Report is pre-filled with information of your case. You can select among currently active cases assigned to you. The document is in Microsoft Word format (.dox).
+      The Court Report is pre-filled with information for your case. You can select among currently active cases assigned to you. The document is in Microsoft Word format (.docx).
     </p>
 
     <hr>
 
     <%= form_with do |form| %>
       <div class="field form-group">
-      <%= label_tag :case_number, "Case Number:" %>
-      <%= select_tag :case_number,
-                    options_from_collection_for_select(@assigned_cases, :case_number, :case_number, 0),
-                    prompt: "Select a case to generate report",
-                    include_blank: false,
-                    id: "case-selection", 
-                    class: "custom-select" %>
+        <%= label_tag :case_number, "Case Number:" %>
+        <%= select_tag :case_number,
+                      options_from_collection_for_select(@assigned_cases, :case_number, :case_number, 0),
+                      prompt: "Select a case to generate report",
+                      include_blank: false,
+                      id: "case-selection",
+                      class: "custom-select" %>
       </div>
 
       <div class="form-group">
-      <%= button_tag "Generate Report", type: :submit,
-          data: { 
-            button_name: "Generate Report",
-            disable_with: "Court report generating. Do not refresh or leave this page...",
-            ready_with: "Your report is ready"
-          },
-          id: "btnGenerateReport",
-          class: "btn btn-primary" %>
-    <!--
-      Link to report is set to empty by default.
-      Download link will be created once the report is generated.
-    -->
-    <%= link_to "Download Court Report",
-        "#",
-        id: "btnDownloadReport",
-        class: "btn btn-outline-primary" %>
+        <%= button_tag "Generate Report",type: :submit,
+            data: {
+              button_name: "Generate Report",
+              disable_with: "Court report generating. Do not refresh or leave this page...",
+              ready_with: "Your report is ready"
+            },
+            id: "btnGenerateReport",
+            class: "btn btn-primary" %>
+        <!--
+          Link to report is set to empty by default.
+          Download link will be created once the report is generated.
+        -->
+        <%= link_to "Download Court Report",
+            "#",
+            id: "btnDownloadReport",
+            class: "btn btn-outline-primary" %>
       </div>
-    <% end%>
+    <% end %>
 
   </div>
 </div>

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -1,0 +1,44 @@
+<h1>Report Categories</h1>
+
+<div class="card card-container">
+  <div class="card-body">
+    <h5 class="card-title"><strong>Generate Court Report</strong></h5>
+    <p class="card-text">
+      Download a Court Report with pre-filled information for your cases. This document is in Word format (.docx).
+    </p>
+
+    <hr>
+
+    <%= form_with do |form| %>
+      <div class="field form-group">
+      <%= label_tag :case_number, "Case Number:" %>
+      <%= select_tag :case_number,
+                    options_from_collection_for_select(@assigned_cases, :case_number, :case_number, 0),
+                    prompt: "Select a case to generate report",
+                    include_blank: false,
+                    id: "case-selection", 
+                    class: "custom-select" %>
+      </div>
+
+      <div class="form-group">
+      <%= button_tag "Generate Report", type: :submit,
+          data: { 
+            button_name: "Generate Report",
+            disable_with: "Court report generating. Do not refresh or leave this page...",
+            ready_with: "Your report is ready"
+          },
+          id: "btnGenerateReport",
+          class: "btn btn-primary" %>
+    <!--
+      Link to report is set to empty by default.
+      Download link will be created once the report is generated.
+    -->
+    <%= link_to "Download Court Report",
+        "#",
+        id: "btnDownloadReport",
+        class: "btn btn-outline-primary" %>
+      </div>
+    <% end%>
+
+  </div>
+</div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -36,7 +36,7 @@
       <div class="list-group list-group-flush footer-nav">
         <% if user_signed_in? %>
           <%= link_to "Edit Profile", edit_users_path, class: "list-group-item" %>
-
+          <%= link_to  "Generate Court Reports", case_court_reports_path, class: "list-group-item" %>
           <% if policy(:application).see_reports_page? %>
             <%= link_to "Generate Reports", reports_path, class: "list-group-item" %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
   resources :case_contacts, except: %i[show]
   resources :reports, only: %i[index]
+  resources :case_court_reports, only: %i[index]
   resources :imports, only: %i[index create] do
     collection do
       get :download_failed

--- a/spec/views/case_court_reports/index.html.erb_spec.rb
+++ b/spec/views/case_court_reports/index.html.erb_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe 'case_court_reports/index', type: :view do
+
+  context "Volunteer views 'Generate Court Report' form" do
+
+    let(:user) { create(:volunteer, :with_casa_cases) }
+    let(:active_assigned_cases) { CasaCase.actively_assigned_to(user) }
+
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+      assign :assigned_cases, active_assigned_cases
+      render
+    end
+
+    it "renders the index page" do
+      expect(controller.request.fullpath).to eq case_court_reports_path
+    end
+
+    it "has a Bootstrap card with card title 'Generate Court Report'" do
+      expect(rendered).to have_selector("div", class: "card", count: 1)
+      expect(rendered).to have_selector("h5", class: "card-title", text: "Generate Court Report", count: 1)
+    end
+
+    it "displays a form" do
+      expect(rendered).to have_selector("form", count: 1)
+    end
+
+    it "has a dropdown select with shows 2 options" do
+      expect(rendered).to have_selector("select#case-selection option", count: 3)
+    end
+
+    it "has a drowndown select element for CASA case" do
+      expect(rendered).to have_selector("select#case-selection")
+    end
+
+    it "has a 'Generate Report' button" do
+      expect(rendered).to have_selector("button[@type='submit']", text: "Generate Report", id: "btnGenerateReport")
+    end
+
+    it "has a 'Download Court Report' button" do
+      expect(rendered).to have_link("Download Court Report", id: "btnDownloadReport", href: "#")
+    end
+
+  end
+
+end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -53,6 +53,7 @@ describe "layout/sidebar", type: :view do
 
       expect(rendered).to have_link("My Cases", href: "/casa_cases")
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to have_link("Generate Court Report", href: "/case_court_reports")
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #923 

### What changed, and why?
- Added a route to "Generate Court Report": `<domain_name>/case_court_reports/`, and placed it to the sidebar.
- When visit "Generate Court Report" link, users can see a form with a select element showing their actively assigned cases.
- The form also has 2 buttons: "Generate Report" & "Download Court Report" as specified in #922 acceptance criteria.
  - The buttons do nothing for now. The functionalities are to be developed in #922. 

### How will this affect user permissions?
N/A
Currently, all users can see visit the link and see the form.

### How is this tested? (please write tests!) 💖💪
- 1 test to check if link 'Generate Court Report' on sidebar is generated
  - `spec/views/layouts/sidebar.html.erb_spec.rb`
- Tests to check if the page loads and the form elements (case selection & buttons) are present
  - `app/views/case_court_reports/index.html.erb`

### Screenshots please :)
![image](https://user-images.githubusercontent.com/44339322/95172782-8c7f2900-0803-11eb-9c33-bcc0771de297.png)
![image](https://user-images.githubusercontent.com/44339322/95172623-50e45f00-0803-11eb-95df-e00b3f6b6be2.png)
![image](https://user-images.githubusercontent.com/44339322/95172850-a28ce980-0803-11eb-9c9e-9c8a5976b589.png)
