### PR TITLE
update view to only show volunteers assigned to supervisor by default

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -32,10 +32,16 @@
           <% Supervisor.decorate.each do |supervisor| %>
             <li>
               <a class="small" data-value="option1" tabIndex="-1">
+              <% if !current_user.supervisor? || supervisor == current_user %>
                 <input
                   type="checkbox"
                   data-value="<%= supervisor.name %>"
-                  checked>
+                  checked />
+                <% else %>
+                <input
+                  type="checkbox"
+                  data-value="<%= supervisor.name %>" />
+                <% end %>
                 <%= supervisor.name %>
               </a>
             </li>

--- a/spec/system/supervisor_views_volunteers_page_spec.rb
+++ b/spec/system/supervisor_views_volunteers_page_spec.rb
@@ -3,17 +3,21 @@ require "rails_helper"
 RSpec.describe "supervisor views Volunteers page", type: :system do
   let(:organization) { create(:casa_org) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
-
+  
   it "can filter volunteers" do
     active_volunteers = create_list(:volunteer, 3, :with_assigned_supervisor, casa_org: organization)
+    active_volunteers[2].supervisor = supervisor
+
     inactive_volunteers = create_list(:volunteer, 2, :with_assigned_supervisor, :inactive, casa_org: organization)
+    inactive_volunteers[0].supervisor = supervisor
+    inactive_volunteers[1].supervisor = supervisor
 
     sign_in supervisor
 
     visit volunteers_path
     expect(page).to have_selector(".volunteer-filters")
 
-    expect(page.all("table#volunteers tbody tr").count).to eq active_volunteers.count
+    expect(page.all("table#volunteers tbody tr").count).to eq 1
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').set(false)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #933

### What changed, and why?
View updated to select logged in supervisor on filter by default. This way, when a supervisor accesses the Volunteers page they will initially only see volunteers assigned to them.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
In the existing tests, 3 active and 2 inactive volunteers are created. I assigned the mocked supervisor to 1 active and 2 inactive volunteers, and changed the expectation for active volunteers displayed to only select those assigned to the mocked supervisor. If there's a more elegant way to do this (such as mocking it or adding it to factories), please let me know and I will update the tests. I tried `active_volunteers = create_list(:volunteer, 3, :with_assigned_supervisor, casa_org: organization, supervisor: supervisor)` but that didn't work.

Two unrelated tests are failing, as shown below. I've gotten these in a previous PR too, so they've been hanging around for a while.

<img width="862" alt="Screenshot 2020-10-06 at 08 55 24" src="https://user-images.githubusercontent.com/22390758/95175510-85c8c580-07b3-11eb-8a47-fa920959c4dc.png">

### Screenshots please :)

<img width="1334" alt="Screenshot 2020-10-06 at 08 57 40" src="https://user-images.githubusercontent.com/22390758/95175533-8bbea680-07b3-11eb-81b2-a4c621fab836.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![kinda like...](https://24.media.tumblr.com/ee2a7c7500b3dd3c9dce0754575bfd7a/tumblr_mg45giYm9g1r8t4b8o5_250.gif)
