### PR TITLE
Allow supervisors/ admin to update court report due date

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -79,7 +79,13 @@ class CasaCasesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def casa_case_params
-    params.require(:casa_case).permit(:case_number, :transition_aged_youth, :birth_month_year_youth, :court_date)
+    params.require(:casa_case).permit(
+      :case_number,
+      :transition_aged_youth,
+      :birth_month_year_youth,
+      :court_date,
+      :court_report_due_date
+    )
   end
 
   # Separate params so only admins can update the case_number

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -46,9 +46,9 @@ class CasaCasePolicy
 
     case @user
     when CasaAdmin
-      common_attrs.concat(%i[case_number birth_month_year_youth court_date])
+      common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date])
     when Supervisor
-      common_attrs.concat(%i[court_date])
+      common_attrs.concat(%i[court_date court_report_due_date])
     else
       common_attrs
     end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -13,13 +13,25 @@
       </div>
 
       <div class="field form-group">
-        <% if current_user.casa_admin? || current_user.supervisor?  %>
+        <% if current_user.casa_admin? || current_user.supervisor? %>
           <%= form.label :court_date, "Next Court Date" %>
           <br>
           <span class="datetime-year-month"> <%= form.date_select :court_date, {order: [:day, :month, :year], start_year: Date.current.year + 3, end_year: 2000, prompt: {day: 'Day', month: 'Month', year: 'Year'} }, class: "select2 date-input" %></span>
         <% else %>
           <label for="court_date">
             Next Court Date: <%= l @casa_case.court_date, format: :day_and_date, default: '' %>
+          </label>
+        <% end %>
+      </div>
+
+      <div class="field form-group">
+        <% if current_user.casa_admin? || current_user.supervisor? %>
+          <%= form.label :court_report_due_date, "Court Report Due Date" %>
+          <br>
+          <span class="datetime-year-month"> <%= form.date_select :court_report_due_date, {order: [:day, :month, :year], start_year: Date.current.year + 3, end_year: 2000, prompt: {day: 'Day', month: 'Month', year: 'Year'} }, class: "select2 date-input" %></span>
+        <% else %>
+          <label for="court_report_due_date">
+            Court Report Due Date: <%= l @casa_case.court_report_due_date, format: :day_and_date, default: '' %>
           </label>
         <% end %>
       </div>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -27,6 +27,10 @@
     </p>
 
     <p>
+      <h6><strong>Court Report Due Date:</strong> <%= l @casa_case.court_report_due_date, format: :day_and_date, default: '' %></h6>
+    </p>
+
+    <p>
       <h6><strong>Court Report Submission:</strong> <%= @casa_case.decorate.court_report_submission %>
     </p>
 

--- a/db/migrate/20201004165322_add_court_report_due_date_to_casa_cases.rb
+++ b/db/migrate/20201004165322_add_court_report_due_date_to_casa_cases.rb
@@ -1,0 +1,5 @@
+class AddCourtReportDueDateToCasaCases < ActiveRecord::Migration[6.0]
+  def change
+    add_column :casa_cases, :court_report_due_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_192636) do
+ActiveRecord::Schema.define(version: 2020_10_04_165322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_10_02_192636) do
     t.datetime "birth_month_year_youth"
     t.boolean "court_report_submitted", default: false, null: false
     t.datetime "court_date"
+    t.datetime "court_report_due_date"
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number"], name: "index_casa_cases_on_case_number", unique: true
   end

--- a/spec/system/admin_adds_new_case_spec.rb
+++ b/spec/system/admin_adds_new_case_spec.rb
@@ -1,66 +1,73 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'admin adds a new case', type: :system do
+RSpec.describe "admin adds a new case", type: :system do
   let(:admin) { create(:casa_admin) }
-  let(:case_number) { '12345' }
+  let(:case_number) { "12345" }
+  let!(:next_year) { (Date.today.year + 1).to_s }
 
   before do
     sign_in admin
     visit root_path
-    click_on 'Cases'
+    click_on "Cases"
 
-    click_on 'New Case'
+    click_on "New Case"
   end
 
-  context 'when all fields are filled' do
-    it 'is successful' do
-      fill_in 'Case number', with: case_number 
-      select '3', from: 'casa_case_court_date_3i'
-      select 'March', from: 'casa_case_court_date_2i'
-      select '2020', from: 'casa_case_court_date_1i'
-  
-      check 'Transition aged youth'
-      has_checked_field? 'Transition aged youth'
-  
-      click_on 'Create CASA Case'
+  context "when all fields are filled" do
+    it "is successful" do
+      fill_in "Case number", with: case_number
+      select "3", from: "casa_case_court_date_3i"
+      select "March", from: "casa_case_court_date_2i"
+      select next_year, from: "casa_case_court_date_1i"
+
+      select "1", from: "casa_case_court_report_due_date_3i"
+      select "April", from: "casa_case_court_report_due_date_2i"
+      select next_year, from: "casa_case_court_report_due_date_1i"
+
+      check "Transition aged youth"
+      has_checked_field? "Transition aged youth"
+
+      click_on "Create CASA Case"
 
       expect(page.body).to have_content(case_number)
-      expect(page).to have_content('CASA case was successfully created.')
-      expect(page).to have_content('Next Court Date: Tuesday, 3-MAR-2020')
-      expect(page).to have_content('Transition Aged Youth: Yes')
+      expect(page).to have_content("CASA case was successfully created.")
+      expect(page).to have_content("Next Court Date: Wednesday, 3-MAR-2021")
+      expect(page).to have_content("Court Report Due Date: Thursday, 1-APR-2021")
+      expect(page).to have_content("Transition Aged Youth: Yes")
     end
   end
 
-  context 'when non-mandatory fields are not filled' do
-    it 'is successful' do
-      fill_in 'Case number', with: case_number
-      click_on 'Create CASA Case'
+  context "when non-mandatory fields are not filled" do
+    it "is successful" do
+      fill_in "Case number", with: case_number
+      click_on "Create CASA Case"
 
       expect(page.body).to have_content(case_number)
-      expect(page).to have_content('CASA case was successfully created.')
-      expect(page).to have_content('Next Court Date:')
-      expect(page).to have_content('Transition Aged Youth: No')
+      expect(page).to have_content("CASA case was successfully created.")
+      expect(page).to have_content("Next Court Date:")
+      expect(page).to have_content("Court Report Due Date:")
+      expect(page).to have_content("Transition Aged Youth: No")
     end
   end
 
-  context 'when the case number field is not filled' do
-    it 'does not create a new case' do
-      click_on 'Create CASA Case'
+  context "when the case number field is not filled" do
+    it "does not create a new case" do
+      click_on "Create CASA Case"
 
       expect(current_path).to eq(casa_cases_path)
-      expect(page).to have_content('Case number can\'t be blank')
+      expect(page).to have_content("Case number can't be blank")
     end
   end
 
-  context 'when the case number already exists' do
+  context "when the case number already exists" do
     let!(:casa_case) { create(:casa_case, case_number: case_number) }
-    
-    it 'does not create a new case' do
-      fill_in 'Case number', with: case_number
-      click_on 'Create CASA Case'
+
+    it "does not create a new case" do
+      fill_in "Case number", with: case_number
+      click_on "Create CASA Case"
 
       expect(current_path).to eq(casa_cases_path)
-      expect(page).to have_content('Case number has already been taken')
+      expect(page).to have_content("Case number has already been taken")
     end
   end
 end

--- a/spec/system/admin_edits_a_case_spec.rb
+++ b/spec/system/admin_edits_a_case_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "admin edits case", type: :system do
 
     has_checked_field? :court_report_submitted
     expect(page).to have_text("Court Date")
+    expect(page).to have_text("Court Report Due Date")
     expect(page).to have_text("Day")
     expect(page).to have_text("Month")
     expect(page).to have_text("Year")

--- a/spec/system/supervisor_edits_case_spec.rb
+++ b/spec/system/supervisor_edits_case_spec.rb
@@ -23,39 +23,63 @@ RSpec.describe "supervisor edits case", type: :system do
     select "4", from: "casa_case_court_date_3i"
     select "November", from: "casa_case_court_date_2i"
     select next_year, from: "casa_case_court_date_1i"
+
+    select "8", from: "casa_case_court_report_due_date_3i"
+    select "September", from: "casa_case_court_report_due_date_2i"
+    select next_year, from: "casa_case_court_report_due_date_1i"
+
     click_on "Update CASA Case"
     has_checked_field? :court_report_submitted
     has_checked_field? "Youth"
     has_no_checked_field? "Supervisor"
+
     expect(page).to have_text("Court Date")
+    expect(page).to have_text("Court Report Due Date")
     expect(page).to have_text("Day")
     expect(page).to have_text("Month")
     expect(page).to have_text("Year")
     expect(page).to have_text("November")
+    expect(page).to have_text("September")
+
     visit casa_case_path(casa_case)
+
     expect(page).to have_text("Court Report Submission: Submitted")
     expect(page).to have_text("4-NOV-#{next_year}")
+    expect(page).to have_text("8-SEP-#{next_year}")
   end
 
-  it "will return error message if date is not fully selected" do
+  it "will return error message if date fields are not fully selected" do
     visit casa_case_path(casa_case)
     expect(page).to have_text("Court Report Submission: Not Submitted")
     visit edit_casa_case_path(casa_case)
     has_no_checked_field? :court_report_submitted
+
     select "November", from: "casa_case_court_date_2i"
+    select "April", from: "casa_case_court_report_due_date_2i"
+
     click_on "Update CASA Case"
+
     expect(page).to have_text("Court date was not a valid date.")
+    expect(page).to have_text("Court report due date was not a valid date.")
   end
 
-  it "will return error message if date is not valid" do
+  it "will return error message if date fields are not valid" do
     visit casa_case_path(casa_case)
     expect(page).to have_text("Court Report Submission: Not Submitted")
     visit edit_casa_case_path(casa_case)
     has_no_checked_field? :court_report_submitted
+
     select "31", from: "casa_case_court_date_3i"
     select "April", from: "casa_case_court_date_2i"
     select next_year, from: "casa_case_court_date_1i"
+
+    select "31", from: "casa_case_court_report_due_date_3i"
+    select "April", from: "casa_case_court_report_due_date_2i"
+    select next_year, from: "casa_case_court_report_due_date_1i"
+
     click_on "Update CASA Case"
+
     expect(page).to have_text("Court date was not a valid date.")
+    expect(page).to have_text("Court report due date was not a valid date.")
   end
 end

--- a/spec/system/user_views_supervisor_edit_spec.rb
+++ b/spec/system/user_views_supervisor_edit_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "view supervisor edit", type: :system do
           click_on "Submit"
           page.find ".header-flash > div"
           supervisor.reload
-        }.to change {supervisor.email}.to "new" + supervisor.email
+        }.to change { supervisor.email }.to "new" + supervisor.email
       end
     end
 

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "volunteer edits case", type: :system do
     has_checked_field? :court_report_submitted
 
     expect(page).to have_text("Court Date")
+    expect(page).to have_text("Court Report Due Date")
     expect(page).not_to have_text("Day")
     expect(page).not_to have_text("Month")
     expect(page).not_to have_text("Year")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #808

### What changed, and why?
- Adds a  `court_report_due_date` column to the `CasaCase` table.
- Adds a `court_report_due_date` date field in the details view that
admins and supervisors can edit. Volunteers will see a non-editable
date.
- Minor refactor of date parse method in `CasaCase` to allow court report
due date validation.

### How will this affect user permissions?
- Volunteer permissions: View court report due date.
- Supervisor permissions: View/Edit court report due date.
- Admin permissions: View/Edit court report due date.

### How is this tested? (please write tests!)
- Test that the court report due date field is editable in
`supervisor_edits_case_spec` and `admin_edits_case_spec`.
- Test the the court report due date field is visible in
`volunteer_edits_case_spec`.
- Test that an invalid court report due date throws an error in
`supervisor_edits_case_spec`.

### Screenshots

![Screen Shot 2020-10-07 at 8 36 45 AM](https://user-images.githubusercontent.com/16447748/95353627-5760ee00-0878-11eb-8e51-8fe8db2f7f77.png)
![Screen Shot 2020-10-07 at 8 36 27 AM](https://user-images.githubusercontent.com/16447748/95353634-58921b00-0878-11eb-871d-914933d14f28.png)
