### PR TITLE
Move user permission logic from erb into pundit policy files 

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -46,6 +46,7 @@ class CasaAdminsController < ApplicationController
   end
 
   def deactivate
+    authorize @casa_admin, :deactivate?
     if @casa_admin.deactivate
       CasaAdminMailer.deactivation(@casa_admin).deliver
 

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -35,6 +35,7 @@ class CaseAssignmentsController < ApplicationController
 
   def unassign
     case_assignment = CaseAssignment.find(params[:id])
+    authorize case_assignment, :unassign?
     casa_case = case_assignment.casa_case
     volunteer = case_assignment.volunteer
     flash_message = "Volunteer was unassigned from Case #{casa_case.case_number}."

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -12,6 +12,7 @@ class VolunteersController < ApplicationController
   end
 
   def new
+    authorize :volunteer
     @volunteer = Volunteer.new
   end
 

--- a/app/policies/casa_admin_policy.rb
+++ b/app/policies/casa_admin_policy.rb
@@ -2,4 +2,18 @@ class CasaAdminPolicy < UserPolicy
   def index?
     user.casa_admin?
   end
+
+  def deactivate?
+    show_deactivate_option? && CasaAdmin.in_organization(current_organization).active.size > 1
+  end
+
+  def see_deactivate_option?
+    user.casa_admin? && user.active?
+  end
+
+  private
+
+  def current_organization
+    current_user&.casa_org
+  end
 end

--- a/app/policies/casa_admin_policy.rb
+++ b/app/policies/casa_admin_policy.rb
@@ -4,7 +4,7 @@ class CasaAdminPolicy < UserPolicy
   end
 
   def deactivate?
-    show_deactivate_option? && CasaAdmin.in_organization(current_organization).active.size > 1
+    see_deactivate_option? && CasaAdmin.in_organization(current_organization).active.size > 1
   end
 
   def see_deactivate_option?
@@ -14,6 +14,6 @@ class CasaAdminPolicy < UserPolicy
   private
 
   def current_organization
-    current_user&.casa_org
+    user&.casa_org
   end
 end

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -34,6 +34,14 @@ class CasaCasePolicy
     user.is_a?(Supervisor)
   end
 
+  def update_court_date?
+    user.casa_admin? || user.supervisor?
+  end
+
+  def update_birth_month_year_youth?
+    user.casa_admin?
+  end
+
   def assign_volunteers?
     is_in_same_org? && is_supervisor_or_casa_admin?
   end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -1,0 +1,25 @@
+class CaseAssignmentPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all 
+    end
+  end
+
+  def unassing?
+    record.is_active? && (user.supervisor? || user.casa_admin?) 
+  end
+end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -19,7 +19,7 @@ class CaseAssignmentPolicy
     end
   end
 
-  def unassing?
+  def unassign?
     record.is_active? && (user.supervisor? || user.casa_admin?) 
   end
 end

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -5,6 +5,14 @@ class VolunteerPolicy < UserPolicy
     user.casa_admin? || user.supervisor?
   end
 
+  def new?
+    create?
+  end
+
+  def create?
+    user.casa_admin?
+  end
+
   def initialize(user, record)
     @user = user
     @record = record

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <div class="field form-group">
-        <% if current_user.casa_admin? || current_user.supervisor?  %>
+        <% if policy(casa_case).update_court_date? %>
           <%= form.label :court_date, "Next Court Date" %>
           <br>
           <span class="datetime-year-month"> <%= form.date_select :court_date, {order: [:day, :month, :year], start_year: Date.current.year + 3, end_year: 2000, prompt: {day: 'Day', month: 'Month', year: 'Year'} }, class: "select2 date-input" %></span>
@@ -24,7 +24,7 @@
         <% end %>
       </div>
 
-      <% if current_user.casa_admin? %>
+      <% if policy(casa_case).update_birth_month_year_youth? %>
         <div class="field form-group">
           <%= form.label :birth_month_year_youth, "Youth's Birth Month & Year" %>
           <br>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -39,7 +39,7 @@
                 <% end %>
               </td>
               <td data-test="action">
-                <% if assignment.is_active? && (current_user.supervisor? || current_user.casa_admin?) %>
+                <% if policy(assignment).unassing? %>
                   <%= button_to 'Unassign Volunteer',
                     unassign_case_assignment_path(assignment),
                     method: :patch,

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -39,7 +39,7 @@
                 <% end %>
               </td>
               <td data-test="action">
-                <% if policy(assignment).unassing? %>
+                <% if policy(assignment).unassign? %>
                   <%= button_to 'Unassign Volunteer',
                     unassign_case_assignment_path(assignment),
                     method: :patch,

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -30,7 +30,7 @@
   </td>
   <td>
     <span class="mobile-label">Creator</span>
-    <% if current_user&.casa_admin? || current_user&.supervisor? %>
+    <% if policy(contact).edit? %>
       <% if contact.creator&.supervisor? %>
         <%= link_to "#{contact.creator&.display_name} ", edit_supervisor_path(current_user) %>
       <% elsif contact.creator&.casa_admin? %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,7 +23,7 @@
         Change Password
       </button>
 
-      <% if current_user.casa_admin? && current_user.active? %>
+      <% if policy(CasaAdmin).see_deactivate_option? %>
         <% if @active_casa_admins.length > 1 %>
           <%= link_to "Deactivate",
             deactivate_casa_admin_path(current_user),

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header">
     <h1>Volunteers</h1>
-    <% if policy(Volunteer).create? %>
+    <% if policy(Volunteer).new? %>
       <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
     <% end %>
     <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header">
     <h1>Volunteers</h1>
-    <% if current_user.casa_admin? %>
+    <% if policy(Volunteer).create? %>
       <%= link_to "New Volunteer", new_volunteer_path, class: "btn btn-primary" %>
     <% end %>
     <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">

--- a/spec/policies/casa_admin_policy/casa_admin_policy_spec.rb
+++ b/spec/policies/casa_admin_policy/casa_admin_policy_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe CasaAdminPolicy do
   subject { described_class }
 
-  let(:organization) { create(:casa_org) }
-  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
-  let(:volunteer) { create(:volunteer, casa_org: organization) }
-  let(:supervisor) { create(:supervisor, casa_org: organization) }
-
   permissions :index? do
+    let(:organization) { create(:casa_org) }
+    let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+    let(:volunteer) { create(:volunteer, casa_org: organization) }
+    let(:supervisor) { create(:supervisor, casa_org: organization) }
+
     it "allows casa_admins" do
       expect(subject).to permit(casa_admin)
     end
@@ -19,6 +19,34 @@ RSpec.describe CasaAdminPolicy do
 
     it "allows supervisor" do
       expect(subject).to_not permit(volunteer)
+    end
+  end
+
+  permissions :deactivate? do
+    context "when user is a casa admin" do
+      let(:admin) { create(:casa_admin, active: true) }
+      let(:admin_inactive) { create(:casa_admin, active: false)}
+      it 'permit if is a active user' do
+        expect(subject).to permit(admin, :casa_admin)
+      end
+
+      it 'does permit if is a inactive user' do
+        expect(subject).not_to permit(admin_inactive, :casa_admin)
+      end
+    end
+
+    context "when user is a supervisor" do
+      let(:supervisor) { create(:supervisor) }
+      it 'does not permit' do
+        expect(subject).not_to permit(supervisor, :casa_admin)
+      end
+    end
+
+    context "when user is a volunteer" do
+      let(:volunteer) { create(:volunteer) }
+      it 'does not permit' do
+        expect(subject).not_to permit(volunteer)
+      end
     end
   end
 end

--- a/spec/policies/casa_admin_policy/casa_admin_policy_spec.rb
+++ b/spec/policies/casa_admin_policy/casa_admin_policy_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe CasaAdminPolicy do
   subject { described_class }
 
-  permissions :index? do
-    let(:organization) { create(:casa_org) }
-    let(:casa_admin) { create(:casa_admin, casa_org: organization) }
-    let(:volunteer) { create(:volunteer, casa_org: organization) }
-    let(:supervisor) { create(:supervisor, casa_org: organization) }
+  let(:organization) { create(:casa_org) }
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
 
+  permissions :index? do
     it "allows casa_admins" do
       expect(subject).to permit(casa_admin)
     end
@@ -24,26 +24,30 @@ RSpec.describe CasaAdminPolicy do
 
   permissions :deactivate? do
     context "when user is a casa admin" do
-      let(:admin) { create(:casa_admin, active: true) }
-      let(:admin_inactive) { create(:casa_admin, active: false)}
-      it 'permit if is a active user' do
-        expect(subject).to permit(admin, :casa_admin)
-      end
+      let(:admin_inactive) { create(:casa_admin, active: false, casa_org: organization)}
 
       it 'does permit if is a inactive user' do
         expect(subject).not_to permit(admin_inactive, :casa_admin)
       end
+
+      it 'does permit if is the only admin' do
+        expect(subject).not_to permit(casa_admin, :casa_admin)
+      end
+
+      it 'permit if is a active user and exist other casa admins' do
+        create(:casa_admin, casa_org: organization)
+        expect(subject).to permit(casa_admin, :casa_admin)
+      end
+
     end
 
     context "when user is a supervisor" do
-      let(:supervisor) { create(:supervisor) }
       it 'does not permit' do
         expect(subject).not_to permit(supervisor, :casa_admin)
       end
     end
 
     context "when user is a volunteer" do
-      let(:volunteer) { create(:volunteer) }
       it 'does not permit' do
         expect(subject).not_to permit(volunteer)
       end

--- a/spec/policies/casa_case_policy/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy/casa_case_policy_spec.rb
@@ -25,6 +25,46 @@ RSpec.describe CasaCasePolicy do
     end
   end
 
+  permissions :update_court_date? do
+    context "when user is an admin" do
+      it "allow update" do
+        expect(subject).to permit(casa_admin, casa_case)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it "allow update" do
+        expect(subject).to permit(supervisor, casa_case)
+      end
+    end
+
+    context "when user is a volunteer" do
+      it "does not allow update" do
+        expect(subject).not_to permit(volunteer, casa_case)
+      end
+    end
+  end
+
+  permissions :update_birth_month_year_youth? do
+    context "when user is an admin" do
+      it "allow update" do
+        expect(subject).to permit(casa_admin, casa_case)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it "doest not allow update" do
+        expect(subject).not_to permit(supervisor, casa_case)
+      end
+    end
+
+    context "when user is a volunteer" do
+      it "does not allow update" do
+        expect(subject).not_to permit(volunteer, casa_case)
+      end
+    end
+  end
+
   permissions :assign_volunteers? do
     context "when user is an admin" do
       it "does allow volunteer assignment" do

--- a/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
+++ b/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe CaseAssignmentPolicy do
+  subject { described_class }
+
+  let(:organization) { create(:casa_org) }
+
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+  let(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
+  let(:case_assignment_inactive) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+
+  permissions :unassing? do
+    it "does not allow unassign if case_assignment is inactive" do
+      expect(subject).not_to permit(casa_admin, case_assignment_inactive)
+    end
+    context "when user is an admin" do
+      it "allow update when case_assignment is active" do
+        expect(subject).to permit(casa_admin, case_assignment)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it "allow update when case_assignment is active" do
+        expect(subject).to permit(supervisor, case_assignment)
+      end
+    end
+
+    context "when user is a volunteer" do
+      it "does not allow unassign" do
+        expect(subject).not_to permit(volunteer, case_assignment)
+      end
+    end
+  end
+end

--- a/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
+++ b/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CaseAssignmentPolicy do
   let(:supervisor) { create(:supervisor, casa_org: organization) }
   let(:casa_admin) { create(:casa_admin, casa_org: organization) }
 
-  permissions :unassing? do
+  permissions :unassign? do
     it "does not allow unassign if case_assignment is inactive" do
       expect(subject).not_to permit(casa_admin, case_assignment_inactive)
     end

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -19,27 +19,26 @@ RSpec.describe VolunteerPolicy do
     end
   end
 
-  permissions :create? do
+  permissions :create?, :new? do
     context "when user is a casa admin" do
-      it 'permits create a volunteer' do
-        admin = create(:casa_admin)
+      let(:admin) { create(:casa_admin) }
+      it 'allows' do
         expect(subject).to permit(admin, :volunteer)
       end
     end
 
     context "when user is a supervisor" do
-      it 'does not permit create' do
-        supervisor = create(:supervisor)
+      let(:supervisor) { create(:supervisor) }
+      it 'does not permit' do
         expect(subject).not_to permit(supervisor, :volunteer)
       end
     end
 
     context "when user is a volunteer" do
-      it 'does not permit create' do
-        volunteer = create(:volunteer)
+      let(:volunteer) { create(:volunteer) }
+      it 'does not permit' do
         expect(subject).not_to permit(volunteer, :volunteer)
       end
     end
-
   end
 end

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -18,4 +18,28 @@ RSpec.describe VolunteerPolicy do
       end
     end
   end
+
+  permissions :create? do
+    context "when user is a casa admin" do
+      it 'permits create a volunteer' do
+        admin = create(:casa_admin)
+        expect(subject).to permit(admin, :volunteer)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it 'does not permit create' do
+        supervisor = create(:supervisor)
+        expect(subject).not_to permit(supervisor, :volunteer)
+      end
+    end
+
+    context "when user is a volunteer" do
+      it 'does not permit create' do
+        volunteer = create(:volunteer)
+        expect(subject).not_to permit(volunteer, :volunteer)
+      end
+    end
+
+  end
 end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "/volunteers", type: :request do
     end
   end
 
+  describe "GET /new" do
+    it "renders a successful response only for admin user" do
+      sign_in admin
+
+      get new_volunteer_path
+      expect(response).to be_successful
+    end
+  end
+
   describe "GET /edit" do
     it "render a successful response" do
       sign_in admin

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 describe "casa_cases/edit" do
   let(:organization) { create(:casa_org) }
 
+  before do
+    enable_pundit(view, user)
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
   context "when accessed by a volunteer" do
+    let(:user) { build_stubbed(:volunteer, casa_org: organization) }
     it "does not include volunteer assignment" do
       assign :casa_case, create(:casa_case, casa_org: organization)
-
-      user = build_stubbed(:volunteer, casa_org: organization)
-      allow(view).to receive(:current_user).and_return(user)
 
       render template: "casa_cases/edit"
 
@@ -18,11 +21,10 @@ describe "casa_cases/edit" do
   end
 
   context "when accessed by an admin" do
+    let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+
     it "includes volunteer assignment" do
       assign :casa_case, create(:casa_case, casa_org: organization)
-
-      user = build_stubbed(:casa_admin, casa_org: organization)
-      allow(view).to receive(:current_user).and_return(user)
 
       render template: "casa_cases/edit"
 

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -6,11 +6,15 @@ describe "casa_cases/new" do
   before do
     assign :casa_case, CasaCase.new
     assign :contact_types, []
+
+    enable_pundit(view, user)
+    allow(view).to receive(:current_user).and_return(user)
   end
 
   context "while signed in as admin" do
+    let(:user) { build_stubbed(:casa_admin)}
     before do
-      sign_in_as_admin
+      sign_in user 
     end
 
     it { is_expected.to have_selector("a", text: "Back") }
@@ -18,8 +22,9 @@ describe "casa_cases/new" do
   end
 
   context "while signed in as supervisor" do
+    let(:user) { build_stubbed(:supervisor) }
     before do
-      sign_in_as_supervisor
+      sign_in user
     end
 
     it { is_expected.to have_selector("a", text: "Back") }

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -1,13 +1,16 @@
 require "rails_helper"
 
 describe "case_contacts/case_contact" do
+  let(:user) { build_stubbed(:casa_admin) }
+  before do
+    enable_pundit(view, user)
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
   it "shows edit button when occured_at is before the last day of the month in the quarter that the case contact was created" do
     case_contact = create(:case_contact)
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
-
-    user = build_stubbed(:casa_admin)
-    allow(view).to receive(:current_user).and_return(user)
 
     render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
     expect(rendered).to have_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
@@ -17,9 +20,6 @@ describe "case_contacts/case_contact" do
     case_contact = create(:case_contact, occurred_at: Time.zone.now - 1.year)
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
-
-    user = build_stubbed(:casa_admin)
-    allow(view).to receive(:current_user).and_return(user)
 
     render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
     expect(rendered).to have_no_link(nil, href: "/case_contacts/#{case_contact.id}/edit")

--- a/spec/views/case_contacts/index.html.erb_spec.rb
+++ b/spec/views/case_contacts/index.html.erb_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe "case_contacts/index" do
+  let(:user) { build_stubbed(:volunteer) }
   before do
-    user = build_stubbed(:volunteer)
+    enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
     case_contact = create(:case_contact)
     assign :case_contact, case_contact

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -4,10 +4,17 @@ describe "volunteers" do
   subject { render template: "volunteers/index" }
 
   context "while signed in as other user diferent to admin" do
-    before do
-      sign_in_as_volunteer
-    end
+    let(:user) { build_stubbed :volunteer}
 
-    it { is_expected.not_to have_selector("a", text: "New Volunteer") }
+    before do
+      enable_pundit(view, user)
+      allow(view).to receive(:current_user).and_return(user)
+      assign :volunteers, []
+      sign_in user
+    end
+    
+    it do 
+      is_expected.not_to have_selector("a", text: "New Volunteer")
+    end
   end
 end

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe "volunteers" do
+  subject { render template: "volunteers/index" }
+
+  context "while signed in as other user diferent to admin" do
+    before do
+      sign_in_as_volunteer
+    end
+
+    it { is_expected.not_to have_selector("a", text: "New Volunteer") }
+  end
+end


### PR DESCRIPTION
### What GitHub issue is this PR for if any?
Resolves #996 

### What changed, and why?

I moved all of the permission logic from UI/views into pundit policy files.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪

- Well, I added new tests in `spec/policies` for check permissions in actions.
- I needed to refactor and fixed some tests because some view does not have a pundit activate.
-  I think to improve organization in some tests using let and before.

### Screenshots, please :)

I'm not changed anything views, only move the logic into pundit policy files.

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![challenge accepted](https://media.giphy.com/media/LPrAK9rEedDwjtL1J0/giphy.gif)
