### PR TITLE
Change redirect after create or edit

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -12,7 +12,7 @@ class CasaAdminsController < ApplicationController
 
   def update
     if @casa_admin.update(update_casa_admin_params)
-      redirect_to root_path, notice: "Admin was successfully updated."
+      redirect_to casa_admins_path, notice: "Admin was successfully updated."
     else
       render :edit
     end
@@ -27,7 +27,7 @@ class CasaAdminsController < ApplicationController
 
     if @casa_admin.save
       @casa_admin.invite!
-      redirect_to root_path, notice: "New Admin created."
+      redirect_to casa_admins_path, notice: "New Admin created."
     else
       render new_casa_admin_path
     end

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "/casa_admins", type: :request do
         expect(casa_admin.email).to eq expected_email
         expect(casa_admin.display_name).to eq expected_display_name
 
-        expect(response).to redirect_to root_path
+        expect(response).to redirect_to casa_admins_path
         expect(response.request.flash[:notice]).to eq "Admin was successfully updated."
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1015 

### What changed, and why?

Change redirect after create or edit casa admins to admins page
### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

fixed old spec
### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
