### PR TITLE
Change the format invalid headers when imports

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -98,8 +98,8 @@ class ImportsController < ApplicationController
 
     unless header_valid?(file_header, import_type)
       message = "#{ERR_INVALID_HEADER}<p class='mt-4'>" \
-        "<b>Expected Header</b>: #{header[import_type]}.</p>" \
-        "<p><b>Received Header</b>: #{file_header}</p>"
+        "<b>Expected Header</b>: #{header[import_type].join(',')}.</p>" \
+        "<p><b>Received Header</b>: #{file_header.join(',')}</p>"
 
       {type: :error, message: message}
     end

--- a/spec/requests/imports_request_spec.rb
+++ b/spec/requests/imports_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "/imports", type: :request do
         file: fixture_file_upload(supervisor_file)
       }
 
-      expect(request.session[:import_error]).to include("Expected", VolunteerImporter::IMPORT_HEADER.to_s)
+      expect(request.session[:import_error]).to include("Expected", VolunteerImporter::IMPORT_HEADER.join(','))
       expect(response).to redirect_to(imports_url(import_type: "volunteer"))
     end
 
@@ -43,7 +43,7 @@ RSpec.describe "/imports", type: :request do
         file: fixture_file_upload(volunteer_file)
       }
 
-      expect(request.session[:import_error]).to include("Expected", SupervisorImporter::IMPORT_HEADER.to_s)
+      expect(request.session[:import_error]).to include("Expected", SupervisorImporter::IMPORT_HEADER.join(','))
       expect(response).to redirect_to(imports_url(import_type: "supervisor"))
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "/imports", type: :request do
         file: fixture_file_upload(supervisor_file)
       }
 
-      expect(request.session[:import_error]).to include("Expected", CaseImporter::IMPORT_HEADER.to_s)
+      expect(request.session[:import_error]).to include("Expected", CaseImporter::IMPORT_HEADER.join(','))
       expect(response).to redirect_to(imports_url(import_type: "casa_case"))
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1012

### What changed, and why?

- Changed the response format when an import fails because invalid headers.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
 

### Screenshots please :)

![Screen Shot 2020-10-08 at 00 03 15](https://user-images.githubusercontent.com/7256891/95417036-abf87d80-08f9-11eb-9770-1e9e46092c44.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
