### PR TITLE
quick fix for Case Contacts page, add a rule to hide mobile label on desktop

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -22,6 +22,12 @@ label {
   box-shadow: 0 4px 12px 5px rgba(0,0,0,0.08);
 }
 
+/* ASSUMPTION: default screen size is desktop view (> 1024px) */
+/* As 'mobile-label' class is mobile only, not display them on desktop view */
+table.table {
+  span.mobile-label { display: none; }
+}
+
 @media only screen and (max-width: 1024px) {
   .content {
     padding: 3rem 0;


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1020 

### What changed, and why?
quick fix for Case Contacts page
currently showing header names (`span.mobile-label`) in table cell
added a rule to hide `mobile-label` on desktop view

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Manual QA

### Screenshots please :)
![image](https://user-images.githubusercontent.com/44339322/95545595-0a347600-0a4a-11eb-801f-ebf3eb38b543.png)
