### PR TITLE
#1014 - Arrange datepickers to block incompatible dates

### DIFF
--- a/app/javascript/src/index_reports.js
+++ b/app/javascript/src/index_reports.js
@@ -9,11 +9,19 @@ $('document').ready(() => {
   $('input[data-input-type="datepicker"]').on('changeDate', function () {
     const $form = $(this).parents('form')
 
-    const startDate = $form.find('input[name="startDate"]').val()
-    const endDate = $form.find('input[name="endDate"]').val()
+    const startDate = $form.find('input[name="start_date"]').val()
+    const endDate = $form.find('input[name="end_date"]').val()
 
     const downloadButton = $form.find('a[data-link-type="download-report"]')
-    const downloadUrl = '/case_contact_reports.csv?' + 'startDate=' + startDate + '&endDate=' + endDate
+
+    if (startDate > endDate) {
+      downloadButton.attr('hidden', true);
+      alert("Starting from date should be earlier than ending at date!!");
+    } else {
+      downloadButton.attr('hidden', false);
+    }
+
+    const downloadUrl = '/case_contact_reports.csv?' + 'start_date=' + startDate + '&end_date=' + endDate
 
     downloadButton.attr('href', downloadUrl)
   })

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -27,7 +27,7 @@
         constructing the URL using the inputs above with javascript.
       -->
       <%= link_to "Download Report",
-          case_contact_reports_path(start_date: 1.month.ago.to_date, end_date: Date.today.to_date, format: :csv),
+          case_contact_reports_path(start_date: 1.month.ago.to_date, end_date: Date.today.to_date),
           class: "btn btn-primary",
           data: { link_type: "download-report" } %>
     </form>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1014 

### What changed, and why?
Currently when user entering start_date and end_date there was no check if start date is bigger than end date. With this PR we aim to block this. If user enters bigger starting date then end date this error will be show. (Screenshot 1)

After invalid dates entered I made download button hidden, because of wrong url creation on datepicker.js (SS 2)

After user changes dates and correct the mistake download button will appear again. (SS 3)

I also notice small typos on index_reports.js and fixed them.

### How will this affect user permissions?
- Volunteer permissions: No change
- Supervisor permissions: No change
- Admin permissions: No change

### How is this tested? (please write tests!) 💖💪
I didn't see any form view testing. I tested manually

### Screenshots please :)
**Screenshot 1**
<img width="995" alt="Screen Shot 2020-10-10 at 17 10 04" src="https://user-images.githubusercontent.com/10260283/95657548-b4c99900-0b1d-11eb-879d-a58523d8e2ff.png">

**Screenshot 2**
<img width="975" alt="Screen Shot 2020-10-10 at 17 10 16" src="https://user-images.githubusercontent.com/10260283/95657553-b6935c80-0b1d-11eb-8955-5423e9e6325c.png">

**Screenshot 3**
<img width="898" alt="Screen Shot 2020-10-10 at 17 10 36" src="https://user-images.githubusercontent.com/10260283/95657554-b72bf300-0b1d-11eb-8759-66a97482d3f4.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/uUIFcDYRbvJTtxaFNa/giphy.gif)`
