### PR TITLE
Fix case contact reports downloading

### DIFF
--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -4,6 +4,7 @@ class CaseContactReportsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    authorize :application, :see_reports_page?
     case_contact_report = CaseContactReport.new(report_params)
 
     respond_to do |format|

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,7 +1,7 @@
 class ReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :must_be_admin_or_supervisor
 
   def index
+    authorize :application, :see_reports_page?
   end
 end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -22,12 +22,12 @@
       </div>
 
       <!--
-        It seems like the send_data method used to download the CSV here does not work
-        with form submission whether the action is POST or GET, so for now we are
-        constructing the URL using the inputs above with javascript.
+        It seems like the send_data method used to download the CSV here does
+        not work with form submission whether the action is POST or GET, so for
+        now we are constructing the URL using the inputs above with javascript.
       -->
       <%= link_to "Download Report",
-          case_contact_reports_path(start_date: 1.month.ago.to_date, end_date: Date.today.to_date),
+          case_contact_reports_path(start_date: 1.month.ago.to_date, end_date: Date.today.to_date, format: :csv),
           class: "btn btn-primary",
           data: { link_type: "download-report" } %>
     </form>

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -1,41 +1,65 @@
 require "rails_helper"
 
 RSpec.describe "/case_contact_reports", type: :request do
-  let(:volunteer) { create(:volunteer) }
   let!(:case_contact) { create(:case_contact) }
 
   before do
     travel_to Time.local(2020,1,1)
-    sign_in volunteer
+    sign_in user
   end
   after { travel_back }
 
-  describe "GET /case_contact_reports with start_date and end_date" do
-    let(:case_contact_report_params) {
-      {
-        start_date: 1.month.ago,
-        end_date: Date.today
-      }
-    }
+  describe "GET /case_contact_reports" do
+    context "as volunteer" do
+      let(:user) { create(:volunteer) }
 
-    it "renders a csv file to download" do
-      get case_contact_reports_url(format: :csv), params: case_contact_report_params
-
-      expect(response).to be_successful
-      expect(
-        response.headers["Content-Disposition"]
-      ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
+      it "cannot view reports" do
+        get case_contact_reports_url(format: :csv)
+        expect(response).to redirect_to root_path
+      end
     end
-  end
 
-  describe "GET /case_contact_reports without start_date and end_date" do
-    it "renders a csv file to download" do
-      get case_contact_reports_url(format: :csv)
+    shared_examples "can view reports" do
+      context "with start_date and end_date" do
+        let(:case_contact_report_params) {
+          {
+            start_date: 1.month.ago,
+            end_date: Date.today
+          }
+        }
 
-      expect(response).to be_successful
-      expect(
-        response.headers["Content-Disposition"]
-      ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
+        it "renders a csv file to download" do
+          get case_contact_reports_url(format: :csv), params: case_contact_report_params
+
+          expect(response).to be_successful
+          expect(
+            response.headers["Content-Disposition"]
+          ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
+        end
+      end
+
+      context "without start_date and end_date" do
+        it "renders a csv file to download" do
+          get case_contact_reports_url(format: :csv)
+
+          expect(response).to be_successful
+          expect(
+            response.headers["Content-Disposition"]
+          ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
+        end
+      end
+    end
+
+    context "as supervisor" do
+      it_behaves_like "can view reports" do
+        let(:user) { create(:supervisor) }
+      end
+    end
+
+    context "as casa_admin" do
+      it_behaves_like "can view reports" do
+        let(:user) { create(:casa_admin) }
+      end
     end
   end
 end

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -1,38 +1,41 @@
 require "rails_helper"
 
 RSpec.describe "/case_contact_reports", type: :request do
-  describe "GET /case_contact_reports with start_date and end_date" do
-    it "renders a csv file to download" do
-      sign_in create(:volunteer)
-      create(:case_contact)
+  let(:volunteer) { create(:volunteer) }
+  let!(:case_contact) { create(:case_contact) }
 
+  before do
+    travel_to Time.local(2020,1,1)
+    sign_in volunteer
+  end
+  after { travel_back }
+
+  describe "GET /case_contact_reports with start_date and end_date" do
+    let(:case_contact_report_params) {
+      {
+        start_date: 1.month.ago,
+        end_date: Date.today
+      }
+    }
+
+    it "renders a csv file to download" do
       get case_contact_reports_url(format: :csv), params: case_contact_report_params
 
       expect(response).to be_successful
       expect(
         response.headers["Content-Disposition"]
-      ).to include 'attachment; filename="case-contacts-report-'
+      ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
     end
   end
 
   describe "GET /case_contact_reports without start_date and end_date" do
     it "renders a csv file to download" do
-      sign_in create(:volunteer)
-      create(:case_contact)
-
       get case_contact_reports_url(format: :csv)
 
       expect(response).to be_successful
       expect(
         response.headers["Content-Disposition"]
-      ).to include 'attachment; filename="case-contacts-report-'
+      ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
     end
-  end
-
-  def case_contact_report_params
-    {
-      start_date: 1.month.ago,
-      end_date: Date.today
-    }
   end
 end

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "reports/index", type: :system do
+  let!(:admin) { create(:casa_admin) }
+  let!(:case_contact) { create(:case_contact) }
+
+  before do
+    sign_in user
+    visit reports_path
+  end
+
+  context "when volunteer" do
+    let(:user) { create(:volunteer) }
+
+    it "redirects to root" do
+      expect(page).to_not have_text "Case Contacts Report"
+      expect(page).to have_text "not authorized"
+    end
+  end
+
+  shared_examples "can view page" do
+    it "downloads report" do
+      expect(page).to have_text "Case Contacts Report"
+      click_on "Download Report"
+      expect(page).to have_text "Download Report"
+    end
+  end
+
+  context "when supervisor" do
+    it_behaves_like "can view page" do
+      let(:user) { create(:supervisor) }
+    end
+  end
+
+  context "when casa_admin" do
+    it_behaves_like "can view page" do
+      let(:user) { create(:casa_admin) }
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1039 

### What changed, and why?
* Added csv format to case contacts report url
* Added restrictions in case_contact_reports controller to not allow volunteers
* Fixed case contact report request spec to test that volunteers cannot access route but supervisors and admins are allowed
* Modified Report controller to use Pundit authorization to be consistent with view

### How will this affect user permissions?
- Volunteer permissions: volunteers no longer allowed to access the /case_contacts_report url
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
* Fixed up request specs, added system test

### Screenshots please :)

<img width="1254" alt="Screen Shot 2020-10-11 at 8 23 30 PM" src="https://user-images.githubusercontent.com/1938665/95702021-05192780-0c00-11eb-98a8-12249844820c.png">
