### PR TITLE
Turn off auto width for case contacts dataTable

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -73,6 +73,7 @@ $('document').ready(() => {
   $('table#casa_cases').DataTable({ searching: false })
   $('table#case_contacts').DataTable(
     {
+      autoWidth: false,
       scrollX: true,
       searching: false,
       order: [[0, 'desc']]

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -73,7 +73,6 @@ $('document').ready(() => {
   $('table#casa_cases').DataTable({ searching: false })
   $('table#case_contacts').DataTable(
     {
-      autoWidth: false,
       scrollX: true,
       searching: false,
       order: [[0, 'desc']]

--- a/app/javascript/src/stylesheets/pages/case_contacts.scss
+++ b/app/javascript/src/stylesheets/pages/case_contacts.scss
@@ -26,3 +26,8 @@ legend {
 .slider-row {
     margin: 0px;
 }
+
+.dataTables_scrollHeadInner,
+.case-contacts-table {
+  width: 100% !important;
+}

--- a/spec/system/admin_views_case_contact_index_spec.rb
+++ b/spec/system/admin_views_case_contact_index_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "admin views case contacts index page", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let!(:case_contact) { create(:case_contact, duration_minutes: 105, casa_case: casa_case) }
+
+  it "successfully renders the table header and table body as the same width" do
+    admin = create(:casa_admin, casa_org: organization)
+    sign_in admin
+
+    visit case_contacts_path
+
+    table_header = all('.case-contacts-table').first
+    table_body = all('.case-contacts-table').last
+    expect(table_header['style']).to have_text table_body['style']
+
+    # Resize page and check again
+    page.driver.browser.manage.window.resize_to(2000,2000)
+    expect(table_header['style']).to have_text table_body['style']
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #1038 

### What changed, and why?

Our data tables were calculating the wrong width. Overwriting those classes width's to be `100%` made them render as expected. 

-- Another way we could fix this is by turning the autoWidth function off, just like how we're doing in `dashboard.js` to the `volunteersTable`. However if we do this, the table doesn't scale when shrinking and expanding the window.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

Added a test to make sure both the `case-contact-table`'s have the same width. 

### Screenshots please :)

![image](https://user-images.githubusercontent.com/48076414/95890218-7c120580-0d51-11eb-8389-65881e29f649.png)
Scaled
![image](https://user-images.githubusercontent.com/48076414/95895318-7d92fc00-0d58-11eb-85dd-a4f0c7a066ca.png)

### Feelings gif (optional)
![alt text](https://media.giphy.com/media/3ov9jQoUOwwxaW9VYY/giphy.gif)
