### PR TITLE
Fix time zone error (#1065).

### DIFF
--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "/case_contact_reports", type: :request do
   let!(:case_contact) { create(:case_contact) }
 
   before do
-    travel_to Time.local(2020,1,1)
+    travel_to Time.zone.local(2020,1,1)
     sign_in user
   end
   after { travel_back }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1065

### What changed, and why?
A call to `Time.local` was changed to `Time.zone.local` to ensure that the time zone being used in the tests was the time zone for which the Rails server was configured (and not necessarily the server host's native time zone).