### PR TITLE
Admin login message fix when logging back in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,12 +121,23 @@ class User < ApplicationRecord
   end
 
   # Called by Devise to generate an error message when a user is not active.
-  def inactive_message
-    !active ? :inactive : super
+  def inactive_message 
+    !active ? ( admin_self_deactivated? ? :admin_self_deactivated : :inactive ) : super
   end
 
   def serving_transition_aged_youth?
     casa_cases.where(transition_aged_youth: true).any?
+  end
+
+  def admin_self_deactivated?
+    return false if (!casa_admin? || active)
+    return id.to_s == last_deactivated_by
+  end
+
+  def last_deactivated_by
+    versions.where(event: "update").reverse.each do |version|
+      return version.whodunnit if version.reify.active
+    end
   end
 end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,6 +8,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
+      admin_self_deactivated: "Your account is currently inactive. Please contact your CASA administrator for more details."
       inactive: "Your account is currently inactive. Please contact your supervisor for more details."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1043
https://github.com/rubyforgood/casa/issues/1043

### What changed, and why?
Error message changed.
When admin deactivates himself/herself, On his/her login, the error message was to be changed.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Manually:
 - deactivating the admin user on it's own.. and then logging in. Works as expected.
 - when the admin is deactivated by someone else. Works as expected.
 - when admin deactivates other user, Works as expected. 
 

### Screenshots please :)
1.
<img width="981" alt="Screenshot 2020-10-14 at 3 45 09 AM" src="https://user-images.githubusercontent.com/40358683/95921857-b3bf9280-0dcf-11eb-9974-a5ad67b7b8cc.png">
2.
<img width="1199" alt="Screenshot 2020-10-14 at 3 46 37 AM" src="https://user-images.githubusercontent.com/40358683/95922011-faad8800-0dcf-11eb-87dd-a17d710e7ebf.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
