### PR TITLE
Remove case_contact.contact_types

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -41,13 +41,13 @@ class CaseContactDecorator < Draper::Decorator
   end
 
   def contact_types
-    object.db_contact_types
+    object.contact_types
       &.map { |ct| ct.name }
       &.to_sentence(last_word_connector: ", and ") || ""
   end
 
   def report_contact_types
-    object.db_contact_types&.map { |ct| ct.name }&.join("|")
+    object.contact_types&.map { |ct| ct.name }&.join("|")
   end
 
   def medium_type

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -19,8 +19,7 @@ class CaseContact < ApplicationRecord
   belongs_to :casa_case
 
   has_many :case_contact_contact_type
-  # TODO: Rename this relation to `contact_types` when the column with the same name is droped
-  has_many :db_contact_types, through: :case_contact_contact_type, source: :contact_type
+  has_many :contact_types, through: :case_contact_contact_type, source: :contact_type
 
   accepts_nested_attributes_for :case_contact_contact_type
 
@@ -44,7 +43,7 @@ class CaseContact < ApplicationRecord
   }
   scope :contact_type, ->(contact_type = nil) {
     if contact_type.present?
-      joins(:db_contact_types)
+      joins(:contact_types)
         .where("contact_types.name in (?)", contact_type)
     end
   }

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -106,7 +106,6 @@ end
 #
 #  id                         :bigint           not null, primary key
 #  contact_made               :boolean          default(FALSE)
-#  contact_types              :string           is an Array
 #  duration_minutes           :integer          not null
 #  medium_type                :string
 #  miles_driven               :integer          default(0), not null
@@ -120,9 +119,8 @@ end
 #
 # Indexes
 #
-#  index_case_contacts_on_casa_case_id   (casa_case_id)
-#  index_case_contacts_on_contact_types  (contact_types) USING gin
-#  index_case_contacts_on_creator_id     (creator_id)
+#  index_case_contacts_on_casa_case_id  (casa_case_id)
+#  index_case_contacts_on_creator_id    (creator_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20201013171632_remove_contact_types_from_case_contacts.rb
+++ b/db/migrate/20201013171632_remove_contact_types_from_case_contacts.rb
@@ -1,6 +1,6 @@
 class RemoveContactTypesFromCaseContacts < ActiveRecord::Migration[6.0]
   def change
     # case_contacts.contact_types has been deprecated in favor of case_contact.case_contact_contact_type
-    remove_column :case_contacts, :contact_types, :string
+    remove_column :case_contacts, :contact_types, :string, array: true, default: []
   end
 end

--- a/db/migrate/20201013171632_remove_contact_types_from_case_contacts.rb
+++ b/db/migrate/20201013171632_remove_contact_types_from_case_contacts.rb
@@ -1,0 +1,6 @@
+class RemoveContactTypesFromCaseContacts < ActiveRecord::Migration[6.0]
+  def change
+    # case_contacts.contact_types has been deprecated in favor of case_contact.case_contact_contact_type
+    remove_column :case_contacts, :contact_types, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_191326) do
+ActiveRecord::Schema.define(version: 2020_10_13_171632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,12 +98,10 @@ ActiveRecord::Schema.define(version: 2020_10_05_191326) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "contact_made", default: false
     t.string "medium_type"
-    t.string "contact_types", array: true
     t.integer "miles_driven", default: 0, null: false
     t.boolean "want_driving_reimbursement", default: false
     t.string "notes"
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
-    t.index ["contact_types"], name: "index_case_contacts_on_contact_types", using: :gin
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"
   end
 

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -102,7 +102,7 @@ CaseContact.first_or_create!(
   creator: volunteer,
   duration_minutes: 30,
   occurred_at: 2.months.ago,
-  db_contact_types: ContactType.take(2),
+  contact_types: ContactType.take(2),
   medium_type: CaseContact::CONTACT_MEDIUMS.sample,
   miles_driven: 5,
   want_driving_reimbursement: false,

--- a/db/seeds/qa.rb
+++ b/db/seeds/qa.rb
@@ -122,7 +122,7 @@ vols.map do |vol|
           duration_minutes:
               likely_durations.sample,
           occurred_at: occurred_at,
-          db_contact_types: ContactType.take(2),
+          contact_types: ContactType.take(2),
           medium_type: CaseContact::CONTACT_MEDIUMS.sample,
           miles_driven: miles_driven,
           want_driving_reimbursement: want_driving_reimbursement,

--- a/db/seeds/staging.rb
+++ b/db/seeds/staging.rb
@@ -122,7 +122,7 @@ vols.map do |vol|
           duration_minutes:
               likely_durations.sample,
           occurred_at: occurred_at,
-          db_contact_types: ContactType.take(2),
+          contact_types: ContactType.take(2),
           medium_type: CaseContact::CONTACT_MEDIUMS.sample,
           miles_driven: miles_driven,
           want_driving_reimbursement: want_driving_reimbursement,

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -40,19 +40,19 @@ RSpec.describe CaseContactDecorator do
   describe "#contact_types" do
     subject(:contact_types) { decorated_case_contact.contact_types }
 
-    let(:case_contact) { build(:case_contact, db_contact_types: db_contact_types) }
+    let(:case_contact) { build(:case_contact, contact_types: contact_types) }
     let(:decorated_case_contact) do
       described_class.new(case_contact)
     end
 
     context "when the contact_types is an empty array" do
-      let(:db_contact_types) { [] }
+      let(:contact_types) { [] }
 
       it { is_expected.to eql("") }
     end
 
     context "when the contact_types is an array with three or more values" do
-      let(:db_contact_types) do
+      let(:contact_types) do
         [
           build(:contact_type, name: "School"),
           build(:contact_type, name: "Therapist"),
@@ -64,7 +64,7 @@ RSpec.describe CaseContactDecorator do
     end
 
     context "when the contact types is an array with less than three values" do
-      let(:db_contact_types) do
+      let(:contact_types) do
         [
           build(:contact_type, name: "School"),
           build(:contact_type, name: "Therapist")

--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :creator, factory: :user
     association :casa_case
 
+    contact_types { [create(:contact_type)] }
     duration_minutes { 60 }
     occurred_at { Time.zone.now }
     contact_made { false }

--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     association :creator, factory: :user
     association :casa_case
 
-    contact_types { ["therapist"] }
     duration_minutes { 60 }
     occurred_at { Time.zone.now }
     contact_made { false }

--- a/spec/factories/case_contact_contact_type.rb
+++ b/spec/factories/case_contact_contact_type.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :case_contact_contact_type do
+        contact_type_id { create(:contact_type).id }
+        case_contact_id { create(:case_contact).id }
+    end
+  end

--- a/spec/factories/case_contact_contact_type.rb
+++ b/spec/factories/case_contact_contact_type.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
-    factory :case_contact_contact_type do
-        contact_type
-        case_contact
-    end
+  factory :case_contact_contact_type do
+    contact_type
+    case_contact
   end
+end

--- a/spec/factories/case_contact_contact_type.rb
+++ b/spec/factories/case_contact_contact_type.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
     factory :case_contact_contact_type do
-        contact_type_id { create(:contact_type).id }
-        case_contact_id { create(:case_contact).id }
+        contact_type
+        case_contact
     end
   end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -155,8 +155,8 @@ RSpec.describe CaseContactReport, type: :model do
           school = create(:contact_type, name: "School")
           create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
-          contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, db_contact_types: [court]})
-          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, db_contact_types: [school]})
+          contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
+          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
 
           create(:case_contact, {occurred_at: 100.days.ago})
           report = CaseContactReport.new({contact_type: "Court"})
@@ -173,12 +173,12 @@ RSpec.describe CaseContactReport, type: :model do
           therapist = create(:contact_type, name: "Therapist")
           untransitioned_casa_case = create(:casa_case, transition_aged_youth: false)
           transitioned_casa_case = create(:casa_case, transition_aged_youth: true)
-          contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, db_contact_types: [court])
-          create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, db_contact_types: [court])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, db_contact_types: [court])
-          contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, db_contact_types: [school])
-          contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, db_contact_types: [court, school])
-          contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, db_contact_types: [therapist])
+          contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
+          create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
+          create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: [court])
+          contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [school])
+          contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court, school])
+          contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [therapist])
 
           aggregate_failures do
             report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Court"})

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -88,15 +88,15 @@ RSpec.describe CaseContact, type: :model do
       type1 = create(:contact_type, contact_type_group: group)
       type2 = create(:contact_type, contact_type_group: group)
 
-      case_contact = create(:case_contact, db_contact_types: [type1])
+      case_contact = create(:case_contact, contact_types: [type1])
 
       expect(case_contact.case_contact_contact_type.count).to eql 1
-      expect(case_contact.db_contact_types).to match_array([type1])
+      expect(case_contact.contact_types).to match_array([type1])
 
       case_contact.update_cleaning_contact_types({case_contact_contact_type_attributes: [{contact_type_id: type2.id}]})
 
       expect(case_contact.case_contact_contact_type.count).to eql 1
-      expect(case_contact.db_contact_types.reload).to match_array([type2])
+      expect(case_contact.contact_types.reload).to match_array([type2])
     end
   end
 end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe "/case_contacts", type: :request do
         contact_type = create(:contact_type, name: "Attorney")
         contact_type2 = create(:contact_type, name: "Therapist")
         case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case, contact_types: [contact_type])
-        #case_contact = create(:case_contact, creator: volunteer, case_contact_contact_type: [case_contact_contact_type], casa_case: casa_case)
 
         patch case_contact_url(case_contact), params: {
           case_contact: {

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "/case_contacts", type: :request do
         }
         expect(response).to redirect_to(casa_case_path(case_contact.casa_case_id))
 
-        expect(case_contact.reload.db_contact_types.first.name).to eq "Attorney"
+        expect(case_contact.reload.contact_types.first.name).to eq "Attorney"
       end
     end
 
@@ -85,17 +85,20 @@ RSpec.describe "/case_contacts", type: :request do
       before { sign_in other_volunteer }
 
       it "does not allow update of case contacts created by other volunteers" do
-        case_contact = create(:case_contact, creator: volunteer, contact_types: ["therapist"], casa_case: casa_case)
+        contact_type = create(:contact_type, name: "Attorney")
+        contact_type2 = create(:contact_type, name: "Therapist")
+        case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case, contact_types: [contact_type])
+        #case_contact = create(:case_contact, creator: volunteer, case_contact_contact_type: [case_contact_contact_type], casa_case: casa_case)
 
         patch case_contact_url(case_contact), params: {
           case_contact: {
-            contact_types: ["attorney"]
+            contact_types: [contact_type2]
           }
         }
         expect(response).to redirect_to(root_path)
 
         case_contact.reload
-        expect(case_contact.contact_types).to eq(["therapist"])
+        expect(case_contact.contact_types.first.name).to eq("Attorney")
       end
     end
 

--- a/spec/system/admin_adds_a_case_contact_spec.rb
+++ b/spec/system/admin_adds_a_case_contact_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
     }.to change(CaseContact, :count).by(1)
 
     expect(CaseContact.first.casa_case_id).to eq casa_case.id
-    expect(CaseContact.first.db_contact_types).to match_array([school, therapist])
+    expect(CaseContact.first.contact_types).to match_array([school, therapist])
     expect(CaseContact.first.duration_minutes).to eq 105
   end
 

--- a/spec/system/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/system/volunteer_adds_a_case_contact_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe "volunteer adds a case contact", type: :system do
     }.to change(CaseContact, :count).by(1)
 
     expect(CaseContact.first.casa_case_id).to eq volunteer_casa_case_one.id
-    expect(CaseContact.first.db_contact_types.map(&:name)).to include "School"
-    expect(CaseContact.first.db_contact_types.map(&:name)).to include "Therapist"
+    expect(CaseContact.first.contact_types.map(&:name)).to include "School"
+    expect(CaseContact.first.contact_types.map(&:name)).to include "Therapist"
     expect(CaseContact.first.duration_minutes).to eq 105
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1050 

### What changed, and why?
- Removes Contact Types column from Case Contact Table (code uses ```case_contact.case_contact_types``` instead of```case_contact.contact_types```)
- Case Contact now ```has_many contact_types``` (previously ```db_contact_types```)
   - This has been updated in seeding files, tests, and models

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
- Current tests have all been updated to reflect changes
- Not sure if any other tests are wanted/required for this since this is cleaning up, not changing functinality

### Screenshots please :)


### Feelings gif (optional)
![alt text](https://media.giphy.com/media/LmNwrBhejkK9EFP504/giphy.gif)
