### PR TITLE
uncomment tests in volunteer_adds_a_case_contact_spec.rb

### DIFF
--- a/spec/system/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/system/volunteer_adds_a_case_contact_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "volunteer adds a case contact", type: :system do
-  xit "is successful" do
+  it "is successful" do
     volunteer = create(:volunteer, :with_casa_cases)
     volunteer_casa_case_one = volunteer.casa_cases.first
     create_contact_types(volunteer_casa_case_one.casa_org)
@@ -35,7 +35,7 @@ RSpec.describe "volunteer adds a case contact", type: :system do
     expect(CaseContact.first.duration_minutes).to eq 105
   end
 
-  xit "submits the form when no note was added" do
+  it "submits the form when no note was added" do
     volunteer = create(:volunteer, :with_casa_cases)
     volunteer_casa_case_one = volunteer.casa_cases.first
     create_contact_types(volunteer_casa_case_one.casa_org)
@@ -64,7 +64,7 @@ RSpec.describe "volunteer adds a case contact", type: :system do
     expect(CaseContact.first.notes).to eq ""
   end
 
-  xit "submits the form when note is added and confirmed" do
+  it "submits the form when note is added and confirmed" do
     volunteer = create(:volunteer, :with_casa_cases)
     volunteer_casa_case_one = volunteer.casa_cases.first
     create_contact_types(volunteer_casa_case_one.casa_org)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1059 

### What changed, and why?
Re-enabled tests in ```volunteer_adds_a_case_contact_spec.rb``` that were previously x'ed for a deployment [here](https://github.com/rubyforgood/casa/commit/e70258b69e9420fd91921aeaede916b364c26501)

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
The tests pass!

That said, if there are any screenshots from what errors happened in deployment I'm happy to take a look at those. 

### Screenshots please :)


### Feelings gif (optional)
*waits suspiciously for CI tests to fail, because that seemed too easy*
![waiting suspiciously](https://media.giphy.com/media/QGNc7mqxzdmHm/giphy.gif)
