### PR TITLE
WIP: Add specified_style_attributes method, use it in a test to restrict test to 1 attribute.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ RSpec.configure do |config|
   config.include SessionHelper, type: :view
   config.include SessionHelper, type: :request
   config.include Organizational, type: :view
+  config.include CssHelpers
   config.after do
     Warden.test_reset!
   end
@@ -47,17 +48,4 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "#{::Rails.root}/tmp/persistent_examples.txt"
 
   config.filter_rails_from_backtrace!
-end
-
-
-# Returns a hash of _specified_ (as opposed to runtime-adjusted/overridden) CSS attributes for an element
-def specified_style_attributes(capybara_element)
-  style_string = capybara_element['style']
-  attribute_strings = style_string.split(';')
-  attribute_strings.each_with_object({}) do |string, style_hash|
-    first_colon_position = string.index(':')
-    key = string[0...first_colon_position].strip
-    value = string[(first_colon_position+1)..-1].strip
-    style_hash[key] = value
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,3 +48,16 @@ RSpec.configure do |config|
 
   config.filter_rails_from_backtrace!
 end
+
+
+# Returns a hash of _specified_ (as opposed to runtime-adjusted/overridden) CSS attributes for an element
+def specified_style_attributes(capybara_element)
+  style_string = capybara_element['style']
+  attribute_strings = style_string.split(';')
+  attribute_strings.each_with_object({}) do |string, style_hash|
+    first_colon_position = string.index(':')
+    key = string[0...first_colon_position].strip
+    value = string[(first_colon_position+1)..-1].strip
+    style_hash[key] = value
+  end
+end

--- a/spec/support/css_helpers.rb
+++ b/spec/support/css_helpers.rb
@@ -1,0 +1,14 @@
+module CssHelpers
+
+  # Returns a hash of _specified_ (as opposed to runtime-adjusted/overridden) CSS attributes for an element
+  def specified_style_attributes(capybara_element)
+    style_string = capybara_element['style']
+    attribute_strings = style_string.split(';')
+    attribute_strings.each_with_object({}) do |string, style_hash|
+      first_colon_position = string.index(':')
+      key = string[0...first_colon_position].strip
+      value = string[(first_colon_position+1)..-1].strip
+      style_hash[key] = value
+    end
+  end
+end

--- a/spec/system/admin_views_case_contact_index_spec.rb
+++ b/spec/system/admin_views_case_contact_index_spec.rb
@@ -6,17 +6,21 @@ RSpec.describe "admin views case contacts index page", type: :system do
   let!(:case_contact) { create(:case_contact, duration_minutes: 105, casa_case: casa_case) }
 
   it "successfully renders the table header and table body as the same width" do
+
     admin = create(:casa_admin, casa_org: organization)
     sign_in admin
 
     visit case_contacts_path
 
     table_header = all('.case-contacts-table').first
-    table_body = all('.case-contacts-table').last
-    expect(table_header['style']).to have_text table_body['style']
+    table_body   = all('.case-contacts-table').last
+
+    width = ->(element) { specified_style_attributes(element)['width'] }
+
+    expect(width.(table_header)).to eq(width.(table_body))
 
     # Resize page and check again
     page.driver.browser.manage.window.resize_to(2000,2000)
-    expect(table_header['style']).to have_text table_body['style']
+    expect(width.(table_header)).to eq(width.(table_body))
   end
 end


### PR DESCRIPTION
The method added assists in testing CSS specified attribute values. I say _specified_ attributes because it tests the values _specified_ for the element, which may be modified at runtime. It parses the string returned by `capybara_element['style']` and returns a hash of attribute key/value pairs.

I don't know, is this functionality provided somewhere else? It is _not_ the same as interrogating the actual values at runtime.

In addition, I've modified a unit test to use this method so that it is more immune to future unrelated attribute changes.

I've put the method in `rails_helper.rb` but realize there is probably a better place for it. What would that place be?