### PR TITLE
[Issue#1067] change My Cases table text when empty

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -70,7 +70,15 @@ $('document').ready(() => {
     if (columnVisible) { $('#visibleColumns input[data-column="' + index + '"]').prop('checked', true) } else { $('#visibleColumns input[data-column="' + index + '"]').prop('checked', false) }
   })
 
-  $('table#casa_cases').DataTable({ searching: false })
+  $('table#casa_cases').DataTable(
+    {
+      language: {
+        emptyTable: "No active cases"
+      },
+      searching: false
+    }
+  )
+
   $('table#case_contacts').DataTable(
     {
       scrollX: true,

--- a/spec/system/volunteer_views_dashboard_spec.rb
+++ b/spec/system/volunteer_views_dashboard_spec.rb
@@ -1,19 +1,29 @@
 require "rails_helper"
 
 RSpec.describe "volunteer views dashboard", type: :system do
+  let(:volunteer) { create(:volunteer) }
+
+  before(:each) do
+    sign_in volunteer
+  end
+
   it "sees all their casa cases" do
-    volunteer = create(:volunteer)
     casa_case_1 = create(:casa_case, casa_org: volunteer.casa_org, case_number: "SLAVA-1")
     casa_case_2 = create(:casa_case, casa_org: volunteer.casa_org, case_number: "SLAVA-2")
     casa_case_3 = create(:casa_case, casa_org: volunteer.casa_org, case_number: "SLAVA-3")
     create(:case_assignment, volunteer: volunteer, casa_case: casa_case_1)
     create(:case_assignment, volunteer: volunteer, casa_case: casa_case_2)
 
-    sign_in volunteer
     visit root_path
     expect(page).to have_text("My Cases")
     expect(page).to have_text(casa_case_1.case_number)
     expect(page).to have_text(casa_case_2.case_number)
     expect(page).not_to have_text(casa_case_3.case_number)
+  end
+
+  it "displays 'No active cases' when they don't have any assignments" do
+    visit root_path
+    expect(page).to have_text("My Cases")
+    expect(page).to have_text("No active cases")
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1067

### What changed, and why?
This PR updates the "My Cases" table to display "No active cases" (instead of "No data available in table") to help users understand why the table is empty. 

resources:
- DataTables [language.emptyTable](https://datatables.net/reference/option/language.emptyTable) parameter 


### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
- added a test that searches for the `No active cases` text when the volunteer viewing the dashboard has no case assignments (spec/system/volunteer_views_dashboard_spec.rb)

### Screenshots please :)
<img width="1203" alt="Screen Shot 2020-10-14 at 3 23 08 PM" src="https://user-images.githubusercontent.com/18665669/96041299-32005100-0e31-11eb-95da-eba8827c5115.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
