### PR TITLE
(WIP) [1079] CaseContacts Table: Align row columns with header

### DIFF
--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+'use strict'
+
+require('jest')
+var $ = require('jquery')
+var _ = require('lodash')
+global.$ = $
+global.jQuery = $
+
+describe('dashboard.js', () => {
+  describe('DataTable tests', () => {
+    function initializeDocumentWithTable (id, numberOfRows = 1) {
+      var mockTable = `<table id=${id}>` +
+                      '<tr> <th>Column1</th> <th>Column2</th> <th>Column3</th> </tr>'
+      _.range(numberOfRows).forEach((rowNum) => (
+        mockTable += '<tr> ' +
+                      `  <td>some data#${rowNum}</td>` +
+                      `  <td>other data#${rowNum}</td>` +
+                      `  <td>more data#${rowNum}</td> ` +
+                      '</tr>'
+      ))
+      mockTable += '</table>'
+      document.body.innerHTML = mockTable
+      // trying to get the sideffects to trigger
+      require('../src/dashboard')
+    }
+
+    describe('casa_cases table', () => {
+      test("displays 'No active cases' if the table is empty", () => {
+        window.onload = (event) => {
+        }
+        initializeDocumentWithTable('casa_cases', 0)
+
+        expect($.contains($('table'), 'No active cases')).toBe(true)
+      })
+    })
+
+    describe('tables with scroll enabled', () => {
+      beforeEach(() => {
+        initializeDocumentWithTable('case_contacts')
+      })
+
+      test("case contacts table renders with 'width=100%'", () => {
+        /* This test ensures we retain the css workaround
+        *  to the "DataTables with scroll enabled result in
+        *  column/header misalignment" bug
+        *  (see https://datatables.net/manual/tech-notes/6)
+        */
+        $('table').each(function () {
+          expect($(this).css('width')).toEqual('100%')
+        })
+        expect($('.dataTables_scrollHeadInner').css('width')).toEqual('100%')
+      })
+    })
+  })
+})

--- a/app/javascript/src/stylesheets/pages/case_contacts.scss
+++ b/app/javascript/src/stylesheets/pages/case_contacts.scss
@@ -28,6 +28,6 @@ legend {
 }
 
 .dataTables_scrollHeadInner,
-.case-contacts-table {
+.dataTables_scroll table {
   width: 100% !important;
 }


### PR DESCRIPTION
# What github issue is this PR for, if any? 
Resolves #1079

### What changed, and why?
- add styling to address scrollable tables header/column
  misalignment (see https://datatables.net/manual/tech-notes/6 and
  https://datatables.net/forums/discussion/42659/table-header-width-not-aligned-with-body-width)
- started adding tests for the jQuery functionality in app/javascript/src/dashboard.js

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
WIP! trying to add jest tests

### Screenshots please :)

![stretchColHeaderAlignment](https://user-images.githubusercontent.com/18665669/96192335-6ea07b00-0f0b-11eb-835c-3f357fe9e24a.gif)
*Note: When the window gets smaller (shortly before switching to what looks like the mobile layout), the header/columns are slightly off... :/ I thought removing the `scrollX: true` from the DataTable definition would resolve this, but that didn't seem to help

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![rabbit hole](https://media.giphy.com/media/swtiK9jRfE0zS/giphy.gif)

