### PR TITLE
Remove route to "Generate Court Report" from sidebar for admins and supervisors

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -13,6 +13,10 @@ class ApplicationPolicy
     user.casa_admin?
   end
 
+  def see_court_reports_page?
+    user.volunteer?
+  end
+
   def modify_organization?
     user.casa_admin?
   end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -36,7 +36,9 @@
       <div class="list-group list-group-flush footer-nav">
         <% if user_signed_in? %>
           <%= link_to "Edit Profile", edit_users_path, class: "list-group-item" %>
-          <%= link_to  "Generate Court Reports", case_court_reports_path, class: "list-group-item" %>
+          <% if policy(:application).see_court_reports_page? %>
+            <%= link_to  "Generate Court Reports", case_court_reports_path, class: "list-group-item" %>
+          <% end %>
           <% if policy(:application).see_reports_page? %>
             <%= link_to "Generate Reports", reports_path, class: "list-group-item" %>
           <% end %>

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe ApplicationPolicy do
       expect(subject).not_to permit(create(:volunteer))
     end
   end
+
+  permissions :see_court_reports_page? do
+    it "allows volunteers" do
+      expect(subject).to permit(create(:volunteer))
+    end
+
+    it "does not allow casa_admins" do
+      expect(subject).not_to permit(create(:casa_admin))
+    end
+
+    it "does not allow supervisors" do
+      expect(subject).not_to permit(create(:supervisor))
+    end
+  end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -32,6 +32,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Cases", href: "/casa_cases")
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
+      expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
     end
   end
 
@@ -81,6 +82,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
       expect(rendered).to have_link("Admins", href: "/casa_admins")
+      expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves  #1103

### What changed, and why?
I created a new policy to manage who can see the "Generate Court Report" link in navbar

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: will not see the link in navbar for "Generate Court Report"
- Admin permissions: will not see the link in navbar for "Generate Court Report"

### How is this tested? (please write tests!) 💖💪
- Added a new policy spec
- Added new expectations to sidebar spec

### Screenshots please :)
**Volunteer view:**
![Captura de tela de 2020-10-15 17-57-12](https://user-images.githubusercontent.com/42655535/96252768-e06ada00-0f88-11eb-82fd-bfd8ccb2d8fc.png)

 **Admin view:**
![Captura de tela de 2020-10-15 17-56-40](https://user-images.githubusercontent.com/42655535/96252881-0b552e00-0f89-11eb-8fd6-2d9fbda7d3e6.png)

**Supervisor view:**
![Captura de tela de 2020-10-15 17-55-58](https://user-images.githubusercontent.com/42655535/96252935-1e67fe00-0f89-11eb-941a-f71acab1801a.png)


