### PR TITLE
#1112 - Add dependent/destroy relationships to models as appropriate so that seeding is idempotent

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,9 +1,9 @@
 class CasaCase < ApplicationRecord
   has_paper_trail
 
-  has_many :case_assignments
+  has_many :case_assignments, dependent: :destroy
   has_many(:volunteers, through: :case_assignments, source: :volunteer, class_name: "User")
-  has_many :case_contacts
+  has_many :case_contacts, dependent: :destroy
   validates :case_number, uniqueness: {case_sensitive: false}, presence: true
   belongs_to :casa_org
 

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -1,10 +1,11 @@
 class CasaOrg < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
-  has_many :users
-  has_many :casa_cases
-  has_many :contact_type_groups
+  has_many :users, dependent: :destroy
+  has_many :casa_cases, dependent: :destroy
+  has_many :contact_type_groups, dependent: :destroy
   has_one :casa_org_logo, dependent: :destroy
+  has_many :hearing_types, dependent: :destroy
 
   delegate :url, :alt_text, :size, to: :casa_org_logo, prefix: :logo, allow_nil: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
 
   has_many :case_assignments, foreign_key: "volunteer_id", dependent: :destroy
   has_many :casa_cases, through: :case_assignments
-  has_many :case_contacts, foreign_key: "creator_id", dependent: :destroy
+  has_many :case_contacts, foreign_key: "creator_id"
 
   has_many :supervisor_volunteers, foreign_key: "supervisor_id"
   has_many :volunteers, -> { includes(:supervisor_volunteer).order(:display_name) },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,9 @@ class User < ApplicationRecord
 
   belongs_to :casa_org
 
-  has_many :case_assignments, foreign_key: "volunteer_id"
+  has_many :case_assignments, foreign_key: "volunteer_id", dependent: :destroy
   has_many :casa_cases, through: :case_assignments
-  has_many :case_contacts, foreign_key: "creator_id"
+  has_many :case_contacts, foreign_key: "creator_id", dependent: :destroy
 
   has_many :supervisor_volunteers, foreign_key: "supervisor_id"
   has_many :volunteers, -> { includes(:supervisor_volunteer).order(:display_name) },
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   has_one :supervisor_volunteer, -> {
     where(is_active: true)
-  }, foreign_key: "volunteer_id"
+  }, foreign_key: "volunteer_id", dependent: :destroy
   has_one :supervisor, through: :supervisor_volunteer
 
   scope :volunteers_with_no_supervisor, lambda { |org|

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -204,7 +204,9 @@ ACTIVE_RECORD_CLASSES = [
 ]
 
 def destroy_all
-  [CasaOrg, AllCasaAdmin, ContactType].each { |klass| klass.destroy_all }
+  # Order is important here; CaseContact must be destroyed before the User that created it.
+  # The User is destroyed as a result of destroying the CasaOrg.
+  [CaseContact, CasaOrg, AllCasaAdmin, ContactType].each { |klass| klass.destroy_all }
 
   non_empty_classes = ACTIVE_RECORD_CLASSES.select { |klass| klass.count > 0 }
   unless non_empty_classes.empty?

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -204,7 +204,12 @@ ACTIVE_RECORD_CLASSES = [
 ]
 
 def destroy_all
-  ACTIVE_RECORD_CLASSES.each { |klass| klass.destroy_all }
+  [CasaOrg, AllCasaAdmin, ContactType].each { |klass| klass.destroy_all }
+
+  non_empty_classes = ACTIVE_RECORD_CLASSES.select { |klass| klass.count > 0 }
+  unless non_empty_classes.empty?
+    raise "destroy_all did not result in the following classes being empty: #{non_empty_classes.join(', ')}"
+  end
 end
 
 def after_party


### PR DESCRIPTION
...which will make the development seeding script idempotent.

### What github issue is this PR for, if any?
Resolves #1112

### What changed, and why?
Some `dependent: :destroy` relationships have been added. Currently, the only top level objects that need to be destroyed in order to empty the data base are `CasaOrg`, `AllCasaAdmin`, and `ContactType`.

### How is this tested? (please write tests!) 💖💪
A test has been added to the script to ensure that all the known tables have been emptied before records are added.