### PR TITLE
#1104 added bug report formlink in sidebar and footer

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -48,6 +48,7 @@
           <% if policy(:application).modify_organization? %>
             <%= link_to "Edit Organization", edit_casa_org_path(current_organization), class: "list-group-item" %>
           <% end %>
+          <%= link_to "Report a site issue", "https://rubyforgood.typeform.com/to/iXY4BubB", class: "list-group-item", target:"_blank" %>
           <li class="list-group-item">
             <%= current_user.email %>
           </li>

--- a/app/views/layouts/footers/_not_logged_in.html.erb
+++ b/app/views/layouts/footers/_not_logged_in.html.erb
@@ -5,6 +5,7 @@
     <a href="https://rubyforgood.org/" class="rfglink" target="_blank">
       <%= image_pack_tag("media/src/images/rfglogo.png", class: "rfglogo") %>
     </a>
+    <%= link_to "Report a site issue", "https://rubyforgood.typeform.com/to/iXY4BubB", class: "rfglink" %>
   </span>
 
   <div class="footer-logos">

--- a/spec/views/layouts/footer.html.erb_spec.rb
+++ b/spec/views/layouts/footer.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "layout/footer", type: :view do
+
+  context "when not logged in" do
+
+    it "renders report issue link on the footer" do
+      render partial: "layouts/footers/not_logged_in"
+      expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
+    end
+  end
+end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -31,6 +31,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Volunteers", href: "/volunteers")
       expect(rendered).to have_link("Cases", href: "/casa_cases")
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
     end
@@ -55,6 +56,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("My Cases", href: "/casa_cases")
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Generate Court Report", href: "/case_court_reports")
+      expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
@@ -82,6 +84,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
       expect(rendered).to have_link("Admins", href: "/casa_admins")
+      expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
     end
   end


### PR DESCRIPTION
Resolves #1104 

**Changes**
Have added link to report issues on the sidebar for logged in users & in footer for users not logged in.
Opening the form link in new tab as it is a different domain. Please confirm if this behaviour is okay.

**Tests:**
Have added tests in sidebar.html.erb_spec & created footer.html.erb_spec

**Screenshots:**
For logged in user, the link appears on the sidebar

![image](https://user-images.githubusercontent.com/5791109/96332640-e6dd7c80-1082-11eb-855d-45e86343f145.png)

For users not logged in yet, it appears on the footer

![image](https://user-images.githubusercontent.com/5791109/96332691-12f8fd80-1083-11eb-933a-85548ecd69b9.png)




