### PR TITLE
Make "Manage Court Details" Active column match columns above it true vs Yes

### DIFF
--- a/app/views/casa_orgs/_hearing_types.html.erb
+++ b/app/views/casa_orgs/_hearing_types.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<table class="table table-striped table-bordered">
+<table class="table table-striped table-bordered" id="hearing-types">
   <thead>
     <tr>
       <th>Name</th>

--- a/app/views/casa_orgs/_hearing_types.html.erb
+++ b/app/views/casa_orgs/_hearing_types.html.erb
@@ -21,7 +21,7 @@
           <%= hearing_type.name %>
         </td>
         <td scope="row">
-          <%= hearing_type.active %>
+          <%= hearing_type.active ? "Yes" : "No" %>
         </td>
         <td>
           <%= link_to "Edit", edit_hearing_type_path(hearing_type) %>

--- a/spec/system/edit_casa_org_spec.rb
+++ b/spec/system/edit_casa_org_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "Edit Casa Org", type: :system do
 
   it "has hearing types table" do
     scroll_to(page.find("table#hearing-types", visible: false))
-    expect(page).to have_table(id: 'hearing-types')
+    expect(page).to have_table(
+      id: 'hearing-types',
+      with_rows:
+      [
+        ['Spec Test Hearing Type', 'Yes', 'Edit']
+      ]
+    )
   end
 end

--- a/spec/system/edit_casa_org_spec.rb
+++ b/spec/system/edit_casa_org_spec.rb
@@ -20,4 +20,9 @@ RSpec.describe "Edit Casa Org", type: :system do
     expect(page).to have_text("Spec Test Hearing Type")
     expect(page).to have_text(hearing_type.name)
   end
+
+  it "has hearing types table" do
+    scroll_to(page.find("table#hearing-types", visible: false))
+    expect(page).to have_table(id: 'hearing-types')
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/1073

### What changed, and why?
Changed the "Manage Court Details" table to display Yes/No instead of true/false for Active.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
I've added to the edit page system a test that checks there is a row with 'Spec Test Hearing Type', 'Yes', 'Edit' in the hearing types table.

I've have preferred to use the `:with_cols` option to only match on "Active: Yes" rather than coupling the test to the other values in the same row. However this matcher doesn't understand the layout of the table as is.

### Screenshots please :)
<img width="1322" alt="Screenshot 2020-10-18 at 00 43 02" src="https://user-images.githubusercontent.com/14929975/96355580-f1c3fb80-10da-11eb-88c7-2b99c818358e.png">


### Outstanding questions
Should I also change the column header from "Active" to "Active?" for consistency?
