### PR TITLE
Fix "contact_type_group" duplication of names 

### DIFF
--- a/app/models/contact_type_group.rb
+++ b/app/models/contact_type_group.rb
@@ -2,7 +2,7 @@ class ContactTypeGroup < ApplicationRecord
   belongs_to :casa_org
   has_many :contact_types
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   scope :for_organization, ->(org) { where(casa_org: org) }
 end

--- a/case-contacts-report-1602730057.csv
+++ b/case-contacts-report-1602730057.csv
@@ -1,0 +1,1 @@
+Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes

--- a/case-contacts-report-1602730059.csv
+++ b/case-contacts-report-1602730059.csv
@@ -1,0 +1,1 @@
+Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes

--- a/spec/models/contact_type_group_spec.rb
+++ b/spec/models/contact_type_group_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+require "contact_type_group"
+
+RSpec.describe ContactTypeGroup, type: :model do
+  it "should not have duplicate names" do
+    name = create(:contact_type_group, {name: "Test1"})
+
+    expect{create(:contact_type_group, {name: "Test1"})}.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken')
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves  #883

### What changed, and why?
I added validation to the contact_type_group model to fix the duplication of the group names, so there isn't a confusion when creating groups. 

### How will this affect user permissions?
- Volunteer permissions: Makes it easier to create group forms.
- Supervisor permissions: 
- Admin permissions: 

### How is this tested? (please write tests!) 💖💪
It's tests are in the ./spec/models/contact_type_group_spec.rb to test the error we get back "ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken'"

### Screenshots please :)
![image](https://user-images.githubusercontent.com/59214236/96386009-ab67ae80-1165-11eb-8bbb-1887266a86a3.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
