### PR TITLE
#1123 modified seeds to create3 AllCasaAdmins

### DIFF
--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -60,11 +60,16 @@ class PgCasaSeeder
   end
 
   def create_users
-    AllCasaAdmin.first_or_create!(
-        email: "allcasaadmin@example.com",
-        password: SEED_PASSWORD,
-        password_confirmation: SEED_PASSWORD
-    )
+
+    all_casa_admins = ["allcasaadmin@example.com", "all_casa_admin2@example.com", "all_casa_admin3@example.com"]
+
+    all_casa_admins.each do |admin_email|
+      AllCasaAdmin.create!(
+          email: admin_email,
+          password: SEED_PASSWORD,
+          password_confirmation: SEED_PASSWORD
+      )
+    end
 
     # seed users for all types [volunteer supervisor casa_admin]
     # volunteer users

--- a/db/seeds/qa.rb
+++ b/db/seeds/qa.rb
@@ -24,12 +24,15 @@ casa_case_count = 150
 supervisor_count = 5
 seed_password = "123456"
 casa_admin_count = 3
+all_casa_admins = ["allcasaadmin@example.com", "all_casa_admin2@example.com", "all_casa_admin3@example.com"]
 
-AllCasaAdmin.first_or_create(
-  email: "allcasaadmin@example.com",
-  password: seed_password,
-  password_confirmation: seed_password
-)
+all_casa_admins.each do |admin_email|
+  AllCasaAdmin.create!(
+      email: admin_email,
+      password: seed_password,
+      password_confirmation: seed_password
+  )
+end
 
 volunteer_users = []
 

--- a/db/seeds/staging.rb
+++ b/db/seeds/staging.rb
@@ -24,12 +24,15 @@ casa_case_count = 150
 supervisor_count = 5
 seed_password = "123456"
 casa_admin_count = 3
+all_casa_admins = ["allcasaadmin@example.com", "all_casa_admin2@example.com", "all_casa_admin3@example.com"]
 
-AllCasaAdmin.first_or_create(
-  email: "allcasaadmin@example.com",
-  password: seed_password,
-  password_confirmation: seed_password
-)
+all_casa_admins.each do |admin_email|
+  AllCasaAdmin.create!(
+    email: admin_email,
+    password: seed_password,
+    password_confirmation: seed_password
+  )
+end
 
 volunteer_users = []
 


### PR DESCRIPTION
Resolves #1123

**Changes**
development, qa and staging seeds to create multiple AllCasaAdmins

Following admin users will work now

1. allcasaadmin@example.com
2. all_casa_admin2@example.com
3. all_casa_admin3@example.com

**Screenshots**

Able to login with ``all_casa_admin2@example.com`` in development environment

![image](https://user-images.githubusercontent.com/5791109/96402382-5a9e9700-11f3-11eb-95e3-d8183d613a51.png)
