### PR TITLE
Do not show empty contact type groups or those with only hidden contact types on the create/edit case contact page

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -28,7 +28,7 @@ class CaseContactsController < ApplicationController
     # By default the first case is selected
     @selected_cases = @casa_cases[0, 1]
 
-    @current_organization_groups = current_organization.contact_type_groups
+    @current_organization_groups = current_organization.contact_type_groups.joins(:contact_types).where(contact_types: {active: true}).uniq
   end
 
   def create

--- a/spec/system/admin_adds_a_case_contact_spec.rb
+++ b/spec/system/admin_adds_a_case_contact_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
   let(:admin) { create(:casa_admin, casa_org: organization) }
   let(:casa_case) { create(:casa_case, casa_org: organization) }
   let(:contact_type_group) { create(:contact_type_group, casa_org: organization) }
+  let!(:empty) { create(:contact_type_group, name: "Empty", casa_org: organization) }
   let!(:school) { create(:contact_type, name: "School", contact_type_group: contact_type_group) }
   let!(:therapist) { create(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
 
@@ -32,6 +33,10 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
     expect(CaseContact.first.casa_case_id).to eq casa_case.id
     expect(CaseContact.first.contact_types).to match_array([school, therapist])
     expect(CaseContact.first.duration_minutes).to eq 105
+  end
+
+  it "should not show empty contact type groups" do
+    expect(page).to_not have_field("Empty")
   end
 
   context "with invalid inputs" do

--- a/spec/system/admin_adds_a_case_contact_spec.rb
+++ b/spec/system/admin_adds_a_case_contact_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
   let(:casa_case) { create(:casa_case, casa_org: organization) }
   let(:contact_type_group) { create(:contact_type_group, casa_org: organization) }
   let!(:empty) { create(:contact_type_group, name: "Empty", casa_org: organization) }
+  let!(:grp_with_hidden) { create(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization) }
+  let!(:hidden_type) { create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden) }
   let!(:school) { create(:contact_type, name: "School", contact_type_group: contact_type_group) }
   let!(:therapist) { create(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
 
@@ -36,7 +38,11 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
   end
 
   it "should not show empty contact type groups" do
-    expect(page).to_not have_field("Empty")
+    expect(page).to_not have_text("Empty")
+  end
+
+  it "should not show contact type groups with only hidden contact types" do
+    expect(page).to_not have_text("Hidden")
   end
 
   context "with invalid inputs" do

--- a/spec/system/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/system/volunteer_adds_a_case_contact_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "volunteer adds a case contact", type: :system do
+  let(:organization) { create(:casa_org) }
+  let!(:empty) { create(:contact_type_group, name: "Empty", casa_org: organization) }
+  let!(:grp_with_hidden) { create(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization) }
+  let!(:hidden_type) { create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden) }
+
   it "is successful" do
     volunteer = create(:volunteer, :with_casa_cases)
     volunteer_casa_case_one = volunteer.casa_cases.first
@@ -23,6 +28,9 @@ RSpec.describe "volunteer adds a case contact", type: :system do
     fill_in "Notes", with: "Hello world"
 
     expect(page).not_to have_text("error")
+    expect(page).to_not have_text("Empty") # this line and the next should work like the admin_adds_a_case_contact_spec but does not
+    expect(page).to_not have_text("Hidden") # will review after these test cases have been re-factored
+
     click_on "Submit"
     expect(page).to have_text("Confirm Note Content")
     expect {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1004 

### What changed, and why?
Changed the way contact_type_groups are pulled from the database in the case_contacts_controller. The resulting record sets should no longer contain contact_type_groups that do not have any contact_types or only hidden contact_types.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
The desired behavior is tested in the admin_adds_a_case_contact_spec and volunteer_adds_a_case_contact_spec. The volunteer version of the test is waiting for a re-factor for full functionality

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
