### PR TITLE
Improve copy and error for past-quarter case contact editing

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -82,15 +82,15 @@ class CaseContact < ApplicationRecord
     !contact_made.nil?
   end
 
-  def allowed_edit?
+  def created_in_current_quarter?
     today = Time.zone.now
     occurred_at.end_of_quarter > today
   end
 
   def check_if_allow_edit
-    return if allowed_edit?
+    return if created_in_current_quarter?
 
-    errors[:base] << "cannot edit past case contacts outside of quarter"
+    errors[:base] << "cannot edit case contacts created before the current quarter"
   end
 
   def supervisor_id

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -44,10 +44,10 @@
   </td>
   <td>
     <% if Pundit.policy(current_user, contact).update? %>
-      <% if contact.allowed_edit? %>
+      <% if contact.created_in_current_quarter? %>
         <%= link_to 'Edit', edit_case_contact_path(contact) %>
       <% else %>
-        <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="Disallow edit contact after end of quarter"></i>
+        <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="This case contact was created in a previous quarter and is therefore no longer editable"></i>
       <% end %>
     <% end %>
   </td>

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe CaseContact, type: :model do
   it "can't be updated when occured_at is after the last day of the month in the quarter that the case contact was created" do
     case_contact = create(:case_contact, occurred_at: Time.zone.now - 1.year)
     expect(case_contact).to_not be_valid
-    expect(case_contact.errors[:base]).to eq(["cannot edit past case contacts outside of quarter"])
+    expect(case_contact.errors[:base]).to eq(["cannot edit case contacts created before the current quarter"])
   end
 
   context "#update_cleaning_contact_types" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
Change tooltip copy to make it more understandable based on user testing feedback
> I checked under cases and made sure - these are both cases assigned to this Supervisor.  I see that the ? says "disallow edit contact after quarter" -- not sure if that's a note to programmers or if that would be the note to me as a supervisor. But I'm not sure why some get it and others don't?

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
existing spec us updated

### Screenshots please :)

<img width="1289" alt="Screen Shot 2020-10-19 at 4 40 02 PM" src="https://user-images.githubusercontent.com/578159/96523133-ca2f7900-1229-11eb-8ed2-bc556fc4b800.png">
