### PR TITLE
1117 bugfix casa admin download csv report

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -48,9 +48,11 @@ class CaseContact < ApplicationRecord
     end
   }
   scope :contact_type_groups, ->(contact_type_group_ids = nil) {
-    if contact_type_group_ids.present?
+    # to handle case when passing ids == [''] && ids == nil
+    if contact_type_group_ids&.join&.length&.positive?
       joins(contact_types: :contact_type_group)
         .where(contact_type_groups: { id: contact_type_group_ids })
+        .group(:id)
     end
   }
 

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -48,7 +48,10 @@ class CaseContact < ApplicationRecord
     end
   }
   scope :contact_type_groups, ->(contact_type_group_ids = nil) {
-    joins(:contact_types).where("contact_types.contact_type_group_id in (?)", contact_type_group_ids) if contact_type_group_ids.present?
+    if contact_type_group_ids.present?
+      joins(contact_types: :contact_type_group)
+        .where(contact_type_groups: { id: contact_type_group_ids })
+    end
   }
 
   IN_PERSON = "in-person".freeze

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -78,177 +78,203 @@ RSpec.describe CaseContactReport, type: :model do
         expect(contacts.length).to eq(1)
         expect(contacts).to eq([contact])
       end
-      describe "case contact behavior" do
-        it "returns only the case contacts with where contact was made" do
-          create(:case_contact, {contact_made: true})
-          create(:case_contact, {contact_made: false})
+    end
+    describe "case contact behavior" do
+      it "returns only the case contacts with where contact was made" do
+        create(:case_contact, {contact_made: true})
+        create(:case_contact, {contact_made: false})
 
-          report = CaseContactReport.new({contact_made: true})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
-        it "returns only the case contacts with where contact was NOT made" do
-          create(:case_contact, {contact_made: true})
-          create(:case_contact, {contact_made: false})
+        report = CaseContactReport.new({contact_made: true})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+      it "returns only the case contacts with where contact was NOT made" do
+        create(:case_contact, {contact_made: true})
+        create(:case_contact, {contact_made: false})
 
-          report = CaseContactReport.new({contact_made: false})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
-        it "returns only the case contacts with where contact was made or NOT made" do
-          create(:case_contact, {contact_made: true})
-          create(:case_contact, {contact_made: false})
+        report = CaseContactReport.new({contact_made: false})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+      end
+      it "returns only the case contacts with where contact was made or NOT made" do
+        create(:case_contact, {contact_made: true})
+        create(:case_contact, {contact_made: false})
 
-          report = CaseContactReport.new({contact_made: [true, false]})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(2)
-        end
+        report = CaseContactReport.new({contact_made: [true, false]})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(2)
+      end
+    end
+
+    describe "has transitioned behavior" do
+      it "returns only case contacts the youth has transitioned" do
+        case_case_1 = create(:casa_case, transition_aged_youth: false)
+        case_case_2 = create(:casa_case, transition_aged_youth: true)
+        create(:case_contact, {casa_case: case_case_1})
+        create(:case_contact, {casa_case: case_case_2})
+        report = CaseContactReport.new({has_transitioned: false})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
       end
 
-      describe "has transitioned behavior" do
-        it "returns only case contacts the youth has transitioned" do
-          case_case_1 = create(:casa_case, transition_aged_youth: false)
-          case_case_2 = create(:casa_case, transition_aged_youth: true)
-          create(:case_contact, {casa_case: case_case_1})
-          create(:case_contact, {casa_case: case_case_2})
-          report = CaseContactReport.new({has_transitioned: false})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
-
-        it "returns only case contacts the youth has transitioned" do
-          case_case_1 = create(:casa_case, transition_aged_youth: false)
-          case_case_2 = create(:casa_case, transition_aged_youth: true)
-          create(:case_contact, {casa_case: case_case_1})
-          create(:case_contact, {casa_case: case_case_2})
-          report = CaseContactReport.new({has_transitioned: true})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
-
-        it "returns case contacts with both youth has transitioned and youth has not transitioned" do
-          case_case_1 = create(:casa_case, transition_aged_youth: false)
-          case_case_2 = create(:casa_case, transition_aged_youth: true)
-          create(:case_contact, {casa_case: case_case_1})
-          create(:case_contact, {casa_case: case_case_2})
-          report = CaseContactReport.new({has_transitioned: ""})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(2)
-        end
+      it "returns only case contacts the youth has transitioned" do
+        case_case_1 = create(:casa_case, transition_aged_youth: false)
+        case_case_2 = create(:casa_case, transition_aged_youth: true)
+        create(:case_contact, {casa_case: case_case_1})
+        create(:case_contact, {casa_case: case_case_2})
+        report = CaseContactReport.new({has_transitioned: true})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
       end
 
-      describe "wanting driving reimbursement functionality" do
-        it "returns only contacts that want reimbursement" do
-          # want_driving_reimbursement
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+      it "returns case contacts with both youth has transitioned and youth has not transitioned" do
+        case_case_1 = create(:casa_case, transition_aged_youth: false)
+        case_case_2 = create(:casa_case, transition_aged_youth: true)
+        create(:case_contact, {casa_case: case_case_1})
+        create(:case_contact, {casa_case: case_case_2})
+        report = CaseContactReport.new({has_transitioned: ""})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(2)
+      end
+    end
 
-          report = CaseContactReport.new({want_driving_reimbursement: true})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
+    describe "wanting driving reimbursement functionality" do
+      it "returns only contacts that want reimbursement" do
+        # want_driving_reimbursement
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
 
-        it "returns only contacts that DO NOT want reimbursement" do
-          # want_driving_reimbursement
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
-
-          report = CaseContactReport.new({want_driving_reimbursement: false})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-        end
-
-        it "returns contacts that both want reimbursement and do not want reimbursement" do
-          # want_driving_reimbursement
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-          create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
-
-          report = CaseContactReport.new({want_driving_reimbursement: ""})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(2)
-        end
+        report = CaseContactReport.new({want_driving_reimbursement: true})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
       end
 
-      describe "contact type filter functionality" do
-        it "returns only the case contacts that include the case contact" do
-          supervisor = create(:supervisor)
-          volunteer = create(:volunteer)
-          volunteer2 = create(:volunteer)
-          court = create(:contact_type, name: "Court")
-          school = create(:contact_type, name: "School")
-          create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+      it "returns only contacts that DO NOT want reimbursement" do
+        # want_driving_reimbursement
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
 
-          contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
-          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
-
-          create(:case_contact, {occurred_at: 100.days.ago})
-          report = CaseContactReport.new({contact_type: "Court"})
-          contacts = report.case_contacts
-          expect(contacts.length).to eq(1)
-          expect(contacts).to eq([contact])
-        end
+        report = CaseContactReport.new({want_driving_reimbursement: false})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
       end
 
-      describe "contact type group filter functionality" do
-        before do
-          supervisor = create(:supervisor)
-          volunteer = create(:volunteer)
-          volunteer2 = create(:volunteer)
-          @contact_type_group = create(:contact_type_group, name: "Placement")
-          court = create(:contact_type, name: "Court", contact_type_group: @contact_type_group)
-          school = create(:contact_type, name: "School")
-          create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+      it "returns contacts that both want reimbursement and do not want reimbursement" do
+        # want_driving_reimbursement
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
+        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
 
-          @expected_contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
-          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
+        report = CaseContactReport.new({want_driving_reimbursement: ""})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(2)
+      end
+    end
 
-          create(:case_contact, {occurred_at: 100.days.ago})
-        end
+    describe "contact type filter functionality" do
+      it "returns only the case contacts that include the case contact" do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        volunteer2 = create(:volunteer)
+        court = create(:contact_type, name: "Court")
+        school = create(:contact_type, name: "School")
+        create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
-        it "returns only the case contacts whose contact_type includes the case contact type group ids" do
-          report = CaseContactReport.new(
-            { contact_type_group_ids: [@contact_type_group.id] }
-          )
-          expect(report.case_contacts.length).to eq(1)
-          expect(report.case_contacts).to eq([@expected_contact])
-        end
+        contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
+        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
 
-        it "behaves the same when contact_type_group_ids have empty values" do
-          report = CaseContactReport.new(
-            { contact_type_group_ids: ['', @contact_type_group.id, ''] }
-          )
-          expect(report.case_contacts.length).to eq(1)
-          expect(report.case_contacts).to eq([@expected_contact])
-        end
+        create(:case_contact, {occurred_at: 100.days.ago})
+        report = CaseContactReport.new({contact_type: "Court"})
+        contacts = report.case_contacts
+        expect(contacts.length).to eq(1)
+        expect(contacts).to eq([contact])
+      end
+    end
+
+    describe "contact type group filter functionality" do
+      before do
+        supervisor = create(:supervisor)
+        volunteer = create(:volunteer)
+        volunteer2 = create(:volunteer)
+        create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+
+        @contact_type_group = create(:contact_type_group, name: "Legal")
+        legal_court = create(:contact_type, name: "Court", contact_type_group: @contact_type_group)
+        legal_attorney = create(:contact_type, name: "Attorney", contact_type_group: @contact_type_group)
+        placement_school = create(:contact_type, name: "School", contact_type_group: create(:contact_type_group, name: "Placement"))
+
+        @expected_contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [legal_court, legal_attorney]})
+        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [placement_school]})
+        create(:case_contact, {occurred_at: 100.days.ago})
       end
 
-      describe "multiple filter behavior" do
-        it "only returns records that occured less than 30 days ago, the youth has transitioned, and the contact type was either court or therapist" do
-          court = create(:contact_type, name: "Court")
-          school = create(:contact_type, name: "School")
-          therapist = create(:contact_type, name: "Therapist")
-          untransitioned_casa_case = create(:casa_case, transition_aged_youth: false)
-          transitioned_casa_case = create(:casa_case, transition_aged_youth: true)
-          contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
-          create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
-          create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: [court])
-          contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [school])
-          contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court, school])
-          contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [therapist])
-
-          aggregate_failures do
-            report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Court"})
-            expect(report_1.case_contacts.length).to eq(2)
-            expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
-
-            report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "School"})
-            expect(report_2.case_contacts.length).to eq(2)
-            expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
-
-            report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Therapist"})
-            expect(report_3.case_contacts.length).to eq(1)
-            expect(report_3.case_contacts.include?(contact6)).to eq(true)
+      context "3 contacts each with 1 contact type groups: Legal, Placement and 1 random" do
+        context "when select 1 contact type group" do
+          it "returns 1 case contact whose contact_types belong to that group" do
+            report = CaseContactReport.new(
+              { contact_type_group_ids: [@contact_type_group.id] }
+            )
+            expect(report.case_contacts.length).to eq(1)
+            expect(report.case_contacts).to eq([@expected_contact])
           end
+        end
+
+        context "when select prompt option (value is empty) and 1 contact type group" do
+          it "returns 1 case contact whose contact_types belong to that group" do
+            report = CaseContactReport.new(
+              { contact_type_group_ids: ['', @contact_type_group.id, ''] }
+            )
+            expect(report.case_contacts.length).to eq(1)
+            expect(report.case_contacts).to eq([@expected_contact])
+          end
+        end
+
+        context "when select ONLY prompt option (value is empty) and NO contact type group" do
+          it "does no filtering & returns 3 case contacts" do
+            report = CaseContactReport.new(
+              { contact_type_group_ids: [''] }
+            )
+            expect(report.case_contacts.length).to eq(3)
+            expect(report.case_contacts).to eq(CaseContact.all)
+          end
+        end
+        context "when select nothing on Case Type Group" do
+          it "does no filtering & returns 3 case contacts" do
+            report = CaseContactReport.new(
+              { contact_type_group_ids: nil }
+            )
+            expect(report.case_contacts.length).to eq(3)
+            expect(report.case_contacts).to eq(CaseContact.all)
+          end
+        end
+      end
+    end
+
+    describe "multiple filter behavior" do
+      it "only returns records that occured less than 30 days ago, the youth has transitioned, and the contact type was either court or therapist" do
+        court = create(:contact_type, name: "Court")
+        school = create(:contact_type, name: "School")
+        therapist = create(:contact_type, name: "Therapist")
+        untransitioned_casa_case = create(:casa_case, transition_aged_youth: false)
+        transitioned_casa_case = create(:casa_case, transition_aged_youth: true)
+        contact1 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
+        create(:case_contact, occurred_at: 40.days.ago, casa_case: transitioned_casa_case, contact_types: [court])
+        create(:case_contact, occurred_at: 20.days.ago, casa_case: untransitioned_casa_case, contact_types: [court])
+        contact4 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [school])
+        contact5 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [court, school])
+        contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [therapist])
+
+        aggregate_failures do
+          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Court"})
+          expect(report_1.case_contacts.length).to eq(2)
+          expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
+
+          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "School"})
+          expect(report_2.case_contacts.length).to eq(2)
+          expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
+
+          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Therapist"})
+          expect(report_3.case_contacts.length).to eq(1)
+          expect(report_3.case_contacts.include?(contact6)).to eq(true)
         end
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves the first 2 bugs mentioned in #1117 

### What changed, and why?
Refactored scope `contact_type_groups` to fix unhandled bug for 
- unhandled situation when user selects the prompt option (with value as am empty string) in Contact Type Group filter
  - `where("contact_types.contact_type_group_id in (?)", contact_type_group_ids)`: `contact_type_group_id` is expecting a `bigint` type, but is given empty string `""`
- duplicate records when `case_contact` involves many `contact_types` of the same `contact_type_group`

```rb
# app/models/case_contact.rb  

  scope :contact_type_groups, ->(contact_type_group_ids = nil) {
    # to handle case when passing ids == [''] && ids == nil
    if contact_type_group_ids&.join&.length&.positive?
      joins(contact_types: :contact_type_group)
        .where(contact_type_groups: { id: contact_type_group_ids })
        .group(:id)
    end
  }
```

In test file `app/models/case_contact.rb`, move other test examples out of "occured at range filter" text example. So that, it makes more sense when looking from high level view. See screenshot:

![image](https://user-images.githubusercontent.com/44339322/96552874-1e0c9180-1300-11eb-823d-4479ba03fbf9.png)


### How will this affect user permissions?
N/A


### How is this tested? (please write tests!) 💖💪
Refactored and added tests for Contact Type Group filter to cover for edge cases when 
- user selects prompt option => contact_type_group_ids = [""] 
- user selects prompt option and other group types => contact_type_group_ids = ["", "1", "2"] 
- user selects nothing in the Contact Type Group filter => contact_type_group_ids = nil

Test cases locates at
  - `app/models/case_contact.rb`


### Screenshots please :)
![image](https://user-images.githubusercontent.com/44339322/96552347-5a8bbd80-12ff-11eb-89d1-0a94bb20da43.png)

**Report outcome when select 1 group type: CASA & with / without prompt option**
![image](https://user-images.githubusercontent.com/44339322/96551936-cae60f00-12fe-11eb-8b82-3db235ea158e.png)

**Report outcome when select prompt option / select nothing**
![image](https://user-images.githubusercontent.com/44339322/96552216-2e703c80-12ff-11eb-81c7-64a38da05899.png)
