### PR TITLE
Fix simplecov and Code Climate Test Reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 env:
-  global:
-    - CC_TEST_REPORTER_ID=31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
-
 language: ruby
 
 cache:

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :test do
   gem "capybara-screenshot"
   gem "rake"
   gem "selenium-webdriver"
-  gem "simplecov", "~> 0.19.0", require: false # pinned as a workaround for https://github.com/codeclimate/test-reporter/issues/418
+  gem "simplecov", "~> 0.17.1", require: false # 0.17.1 pinned as a workaround for https://github.com/codeclimate/test-reporter/issues/418
   gem "webdrivers", require: false # Easy installation and use of web drivers to run system tests with browsers; do not initially require as causes conflict with Docker setup
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    json (2.3.1)
     launchy (2.5.0)
       addressable (~> 2.7)
     letter_opener (1.7.0)
@@ -270,10 +271,11 @@ GEM
     semantic_range (2.3.0)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
-    simplecov (0.19.0)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.3)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     skylight (4.3.1)
       skylight-core (= 4.3.1)
     skylight-core (4.3.1)
@@ -357,7 +359,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   selenium-webdriver
   shoulda-matchers
-  simplecov (~> 0.19.0)
+  simplecov (~> 0.17.1)
   skylight
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1040 

### What changed, and why?
Simplecov version, after some time searching and looking at the errors and logs on Travis and checking the configuration for the test reporter I found a problem with simplecov 0.18+ and CodeClimate Test Reporter, some changes in simplecov 0.18 are not compatible with the actual CodeClimate Test Reporter, to make it work together I fixed the version of simplecov to 0.17.1, as stated on the issue https://github.com/codeclimate/test-reporter/issues/418 CodeClimate core team is trying to work with simplecov to make 0.18 compatible with test reporter.

### What is still needed?
I need someone with permission to edit the settings on this repo to add an env var called `CC_TEST_REPORTER_ID` with the CodeClimamte Test Reporter ID, that can be achieved similar to the example below:
![image](https://user-images.githubusercontent.com/9721558/96637814-991c7a80-12f5-11eb-925e-099f4730492e.png)

### Screenshots please :)
_**note that I tested the screenshots below with the current `CC_TEST_REPORTER_ID` on the travis.yml, we need to check if this ID is the correct one and add it to the repo env var on Repo Settings as stated above.**_

before:
![image](https://user-images.githubusercontent.com/9721558/96637689-683c4580-12f5-11eb-8051-32de80fe995b.png)

after:
![image](https://user-images.githubusercontent.com/9721558/96637602-4642c300-12f5-11eb-9c23-bb41377af7ea.png)

at the moment, waiting for the repo env var:
![image](https://user-images.githubusercontent.com/9721558/96638693-ef3ded80-12f6-11eb-8344-6ec3b5b77beb.png)

