### PR TITLE
default date range for reports 6 months

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -13,7 +13,7 @@
     <%= form_with url: case_contact_reports_path(format: :csv), method: :get, local: true do |f| %>
       <div class="field form-group">
         <label><strong>Starting From:</strong></label>
-        <%= f.date_field :start_date, class: "form-control", value: 1.month.ago.to_date %>
+        <%= f.date_field :start_date, class: "form-control", value: 6.months.ago.to_date %>
       </div>
 
       <div class="field form-group">

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe "reports/index", type: :system do
   shared_examples "can view page" do
     it "downloads report" do
       expect(page).to have_text "Case Contacts Report"
+      expect(page).to have_field("start_date", with: 6.months.ago.to_date)
+      expect(page).to have_field("end_date", with: Date.today.to_date)
       click_on "Download Report"
       expect(page).to have_button "Download Report"
     end


### PR DESCRIPTION
This commit ensures that the default date range set for
the case generation page is 6 months as opposed to the
previous 30 days.

### What github issue is this PR for, if any?
Resolves #1148 

### What changed, and why?
The default date range for generate case reports was set to 6 months because it was requested.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
There were two lines added into the test that ensures that if the page can be viewed, the date fields are set properly.

### Screenshots please :)
<img width="882" alt="Screen Shot 2020-10-21 at 11 55 26 AM" src="https://user-images.githubusercontent.com/22206525/96752634-5958a000-1394-11eb-88c4-b7c3478a2957.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media2.giphy.com/media/1ykCCe2A2pHsCIR1QX/giphy.gif)`
