### PR TITLE
Fix bugs in mobile view

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -29,6 +29,11 @@ table.table {
 }
 
 @media only screen and (max-width: 1024px) {
+
+  .login-header {
+    font-size: 0.75em !important;
+  }
+
   .content {
     padding: 3rem 0;
     margin-left: 0;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,6 +3,7 @@
     <div class="container">
       <div class="row">
         <div class="offset-xl-2 col-xl-8 col-lg-12 col-sm-8 col-md-8">
+          <br>
           <h2>Log in</h2>
           <br>
 
@@ -24,6 +25,7 @@
 
           <br>
           <%= render "devise/shared/links" %>
+          <br>
         </div>
       </div>
     </div>

--- a/app/views/layouts/_login_header.html.erb
+++ b/app/views/layouts/_login_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="navbar navbar-expand-lg bg-primary justify-content-between">
     <div class="navbar-brand py-0">
       <%= image_pack_tag("media/src/images/default-logo.png", alt: "CASA Logo", size: "70x38") %>
-      <strong><%= page_header %></strong>
+      <strong class="login-header"><%= page_header %></strong>
     </div>
   </nav>
 </header>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -52,7 +52,6 @@
             <%= current_user.email %>
           </li>
         <% end %>
-
         <% if all_casa_admin_signed_in? %>
           <div class="list-group-item">
             <%= current_all_casa_admin.email %>
@@ -60,6 +59,7 @@
           <%= link_to "Edit Profile", edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
         <%= session_link %>
+        <li></li>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit make the size of the page header dynamic so that in
mobile it is completely legible. Spaces are added to the top and
bottom of the login page to create spacing in mobile. Additionally,
an empty list element was added to combat a known bug in bootstrap
list-groups with height calculation on small screens.

### What github issue is this PR for, if any?
Resolves #1151

### What changed, and why?
The following view bugs have been fixed:
<img width="373" alt="Screen Shot 2020-10-21 at 1 36 46 PM" src="https://user-images.githubusercontent.com/22206525/96775283-ef98c000-13ac-11eb-96f6-904e22acbdfb.png">
 now looks like:
<img width="404" alt="Screen Shot 2020-10-21 at 2 51 53 PM" src="https://user-images.githubusercontent.com/22206525/96775315-ff180900-13ac-11eb-8675-718034ab410e.png">

and the collapsible menu that looked like this
<img width="402" alt="Screen Shot 2020-10-21 at 1 42 27 PM" src="https://user-images.githubusercontent.com/22206525/96775370-10f9ac00-13ad-11eb-8f9a-6d2be2722909.png">
now looks like:
<img width="402" alt="Screen Shot 2020-10-21 at 2 52 54 PM" src="https://user-images.githubusercontent.com/22206525/96775420-253da900-13ad-11eb-8bb6-b21111e897a8.png">


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Visual testing

### Screenshots please :)
See above

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media0.giphy.com/media/KBfKueAjIJV8Q/giphy.gif)`
