### PR TITLE
and return not && return

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -14,7 +14,7 @@ class CaseCourtReportsController < ApplicationController
   def show
     unless @casa_case
       flash[:alert] = "Report #{params[:id]} is not found."
-      redirect_to(case_court_reports_path) && return
+      redirect_to(case_court_reports_path) and return # rubocop:disable Style/AndOr
     end
 
     respond_to do |format|

--- a/app/controllers/concerns/accessible.rb
+++ b/app/controllers/concerns/accessible.rb
@@ -11,11 +11,11 @@ module Accessible
     if current_all_casa_admin
       flash.clear
       # if you have rails_admin. You can redirect anywhere really
-      redirect_to(authenticated_all_casa_admin_root_path) && return
+      redirect_to(authenticated_all_casa_admin_root_path) and return # rubocop:disable Style/AndOr
     elsif current_user
       flash.clear
       # The authenticated root path can be defined in your routes.rb in: devise_scope :user do...
-      redirect_to(authenticated_user_root_path) && return
+      redirect_to(authenticated_user_root_path) and return # rubocop:disable Style/AndOr
     end
   end
 end


### PR DESCRIPTION
As part of the conversation in #1164, we noticed that it was autocorrecting `and return` to `&& return` which isn't the same. Added a comment to disable the rule for those three lines.
