### PR TITLE
Test seeding for only development, no longer for qa and staging.

### DIFF
--- a/spec/seeds/seeds_spec.rb
+++ b/spec/seeds/seeds_spec.rb
@@ -3,18 +3,18 @@ require "rake"
 
 def empty_ar_classes
   ar_classes = [
-      AllCasaAdmin,
-      CasaAdmin,
-      CasaCase,
-      CasaOrg,
-      CaseAssignment,
-      CaseContact,
-      ContactType,
-      ContactTypeGroup,
-      Supervisor,
-      SupervisorVolunteer,
-      User,
-      Volunteer
+    AllCasaAdmin,
+    CasaAdmin,
+    CasaCase,
+    CasaOrg,
+    CaseAssignment,
+    CaseContact,
+    ContactType,
+    ContactTypeGroup,
+    Supervisor,
+    SupervisorVolunteer,
+    User,
+    Volunteer
   ]
   ar_classes.select { |klass| klass.count == 0 }.map(&:name)
 end
@@ -23,7 +23,7 @@ RSpec.describe "Seeds" do
   describe "test development DB" do
     before do
       Rails.application.load_tasks
-      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
     end
 
     it "successfully populates all necessary tables" do

--- a/spec/seeds/seeds_spec.rb
+++ b/spec/seeds/seeds_spec.rb
@@ -3,34 +3,32 @@ require "rake"
 
 def empty_ar_classes
   ar_classes = [
-    AllCasaAdmin,
-    CasaAdmin,
-    CasaCase,
-    CasaOrg,
-    CaseAssignment,
-    CaseContact,
-    ContactType,
-    ContactTypeGroup,
-    Supervisor,
-    SupervisorVolunteer,
-    User,
-    Volunteer
+      AllCasaAdmin,
+      CasaAdmin,
+      CasaCase,
+      CasaOrg,
+      CaseAssignment,
+      CaseContact,
+      ContactType,
+      ContactTypeGroup,
+      Supervisor,
+      SupervisorVolunteer,
+      User,
+      Volunteer
   ]
   ar_classes.select { |klass| klass.count == 0 }.map(&:name)
 end
 
 RSpec.describe "Seeds" do
-  ["development", "qa", "staging"].each do |environment|
-    describe "for environment: #{environment}" do
-      before do
-        Rails.application.load_tasks
-        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(environment))
-      end
+  describe "test development DB" do
+    before do
+      Rails.application.load_tasks
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+    end
 
-      it "successfully populates all necessary tables" do
-        ActiveRecord::Tasks::DatabaseTasks.load_seed
-        expect(empty_ar_classes).to eq([])
-      end
+    it "successfully populates all necessary tables" do
+      ActiveRecord::Tasks::DatabaseTasks.load_seed
+      expect(empty_ar_classes).to eq([])
     end
   end
 end


### PR DESCRIPTION
Now that the same seed code is used for all three environments, we can test that code once. This cuts the seed test time to a quarter of what it was before.