### PR TITLE
Stub current_organization in view spec

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -16,7 +16,7 @@
         <%= form.label :hearing_type_id %>
         <%= form.collection_select(
           :hearing_type_id,
-          HearingType.active.for_organization(current_user.casa_org),
+          HearingType.active.for_organization(current_organization),
           :id, :name,
           { include_hidden: false, prompt: "-Select Hearing Type-" },
           { class: "form-control" }

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe "casa_cases/edit" do
   before do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_organization).and_return(user.casa_org)
   end
 
   context "when accessed by a volunteer" do

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -9,6 +9,7 @@ describe "casa_cases/new" do
 
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_organization).and_return(user.casa_org)
   end
 
   context "while signed in as admin" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1166 

### What changed, and why?
* Reverted to `current_organization` in casa case form.

* Stubbed `current_organization` in view spec. Did not figure out why the stack level too deep error was occurring, but since view spec doesn't actually hit the controller, okay to stub. There are existing request specs that work that test the controller and form view work just fine.
