### PR TITLE
Bugfix/change select value to match contact type scope

### DIFF
--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -18,12 +18,11 @@ class CaseContactReportsController < ApplicationController
   private
 
   def report_params
-    params.permit(
-      :start_date, :end_date, :contact_made, :has_transitioned, :want_driving_reimbursement,
+    params.require(:report).permit(:start_date, :end_date,
+      :contact_made, :has_transitioned, :want_driving_reimbursement,
       {contact_type_ids: []},
       {contact_type_group_ids: []},
       {creator_ids: []},
-      {supervisor_ids: []}
-    )
+      {supervisor_ids: []})
   end
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -41,11 +41,8 @@ class CaseContact < ApplicationRecord
   scope :want_driving_reimbursement, ->(want_driving_reimbursement = nil) {
     where(want_driving_reimbursement: want_driving_reimbursement) if want_driving_reimbursement == true || want_driving_reimbursement == false
   }
-  scope :contact_type, ->(contact_type = nil) {
-    if contact_type.present?
-      joins(:contact_types)
-        .where("contact_types.name in (?)", contact_type)
-    end
+  scope :contact_type, ->(contact_type_ids = nil) {
+    includes(:contact_types).where("contact_types.id": [contact_type_ids]) if contact_type_ids.present?
   }
   scope :contact_type_groups, ->(contact_type_group_ids = nil) {
     # to handle case when passing ids == [''] && ids == nil

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -10,7 +10,7 @@
 
     <hr>
 
-    <%= form_with url: case_contact_reports_path(format: :csv), method: :get, local: true do |f| %>
+    <%= form_with url: case_contact_reports_path(format: :csv), scope: 'report', method: :get, local: true do |f| %>
       <div class="field form-group">
         <label><strong>Starting From:</strong></label>
         <%= f.date_field :start_date, class: "form-control", value: 6.months.ago.to_date %>

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -181,9 +181,8 @@ RSpec.describe CaseContactReport, type: :model do
 
         contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
-
         create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({contact_type: "Court"})
+        report = CaseContactReport.new({contact_type: [court.id]})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
         expect(contacts).to eq([contact])
@@ -264,15 +263,15 @@ RSpec.describe CaseContactReport, type: :model do
         contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [therapist])
 
         aggregate_failures do
-          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Court"})
+          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [court.id]})
           expect(report_1.case_contacts.length).to eq(2)
           expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
 
-          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "School"})
+          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [school.id]})
           expect(report_2.case_contacts.length).to eq(2)
           expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
 
-          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: "Therapist"})
+          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [therapist.id]})
           expect(report_3.case_contacts.length).to eq(1)
           expect(report_3.case_contacts.include?(contact6)).to eq(true)
         end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -99,4 +99,24 @@ RSpec.describe CaseContact, type: :model do
       expect(case_contact.contact_types.reload).to match_array([type2])
     end
   end
+
+  describe 'scopes' do
+    describe '.contact_type' do
+      it 'returns case contacts filtered by contact type id' do
+        group           = create(:contact_type_group)
+        youth_type      = create(:contact_type, name: 'Youth', contact_type_group: group)
+        supervisor_type = create(:contact_type, name: 'Supervisor', contact_type_group: group)
+        parent_type     = create(:contact_type, name: 'Parent', contact_type_group: group)
+
+        case_contacts_to_match = [
+          create(:case_contact, contact_types: [youth_type, supervisor_type]),
+          create(:case_contact, contact_types: [supervisor_type]),
+          create(:case_contact, contact_types: [youth_type, parent_type])
+        ]
+        create(:case_contact, contact_types: [parent_type])
+
+        expect(CaseContact.contact_type([youth_type.id, supervisor_type.id])).to match_array(case_contacts_to_match)
+      end
+    end
+  end
 end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -100,13 +100,13 @@ RSpec.describe CaseContact, type: :model do
     end
   end
 
-  describe 'scopes' do
-    describe '.contact_type' do
-      it 'returns case contacts filtered by contact type id' do
-        group           = create(:contact_type_group)
-        youth_type      = create(:contact_type, name: 'Youth', contact_type_group: group)
-        supervisor_type = create(:contact_type, name: 'Supervisor', contact_type_group: group)
-        parent_type     = create(:contact_type, name: 'Parent', contact_type_group: group)
+  describe "scopes" do
+    describe ".contact_type" do
+      it "returns case contacts filtered by contact type id" do
+        group = create(:contact_type_group)
+        youth_type = create(:contact_type, name: "Youth", contact_type_group: group)
+        supervisor_type = create(:contact_type, name: "Supervisor", contact_type_group: group)
+        parent_type = create(:contact_type, name: "Parent", contact_type_group: group)
 
         case_contacts_to_match = [
           create(:case_contact, contact_types: [youth_type, supervisor_type]),

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "/case_contact_reports", type: :request do
       let(:user) { create(:volunteer) }
 
       it "cannot view reports" do
-        get case_contact_reports_url(format: :csv)
+        get case_contact_reports_url(format: :csv), params: {report: {}}
         expect(response).to redirect_to root_path
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe "/case_contact_reports", type: :request do
         }
 
         it "renders a csv file to download" do
-          get case_contact_reports_url(format: :csv), params: case_contact_report_params
+          get case_contact_reports_url(format: :csv), params: {report: {start_date: 1.month.ago, end_date: Date.today}}
 
           expect(response).to be_successful
           expect(
@@ -40,7 +40,7 @@ RSpec.describe "/case_contact_reports", type: :request do
 
       context "without start_date and end_date" do
         it "renders a csv file to download" do
-          get case_contact_reports_url(format: :csv)
+          get case_contact_reports_url(format: :csv), params: {report: {start_date: "", end_date: ""}}
 
           expect(response).to be_successful
           expect(
@@ -55,7 +55,7 @@ RSpec.describe "/case_contact_reports", type: :request do
           contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
           create(:case_contact, {occurred_at: 100.days.ago})
 
-          get case_contact_reports_url(format: :csv), params: {creator_ids: [volunteer.id]}
+          get case_contact_reports_url(format: :csv), params: {report: {creator_ids: [volunteer.id]}}
 
           expect(response).to be_successful
           expect(

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "reports/index", type: :system do
 
   shared_examples "can view page" do
     it "downloads report" do
-      expect(page).to have_text "Case Contacts Report"
-      expect(page).to have_field("start_date", with: 6.months.ago.to_date)
-      expect(page).to have_field("end_date", with: Date.today.to_date)
+      expect(page).to have_text("Case Contacts Report") &
+        have_field("report_start_date", with: 6.months.ago.to_date) &
+        have_field("report_end_date", with: Date.today.to_date)
       click_on "Download Report"
       expect(page).to have_button "Download Report"
     end

--- a/spec/system/volunteer_adds_a_case_contact_spec.rb
+++ b/spec/system/volunteer_adds_a_case_contact_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "volunteer adds a case contact", type: :system do
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
       # Future date: invalid
-      fill_in "Occurred at", with: future_date.strftime("%Y/%m/%d")
+      fill_in "Occurred at", with: future_date.strftime("%Y-%m-%d")
       fill_in "Miles driven", with: "30"
       select "Yes", from: "Want driving reimbursement"
       fill_in "Notes", with: "Hello world"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1138 

### What changed, and why?
The scope on `models/case_contact.rb` to match the design on the Select, which is using ids in the value field, previously the scope was expecting the name of ContactType, not the ID.


### How is this tested? (please write tests!) 💖💪
Run the entire Rspec Test Suite and I made a spec to cover this scope.