### PR TITLE
Fix bug where volunteer link was not displaying

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -132,7 +132,7 @@
       <tbody>
       <% @volunteers.each do |volunteer| %>
         <tr>
-          <td data-search="<%= volunteer.past_names %>|<%= volunteer.display_name %>>
+          <td data-search="<%= volunteer.past_names %>|<%= volunteer.display_name %>">
               <%= link_to(volunteer.decorate.name, edit_volunteer_path(volunteer)) %>
               <% if !volunteer.made_contact_with_all_cases_in_days? %>
                 🕐

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -144,12 +144,12 @@
               <%= link_to(volunteer.supervisor.decorate.name, edit_supervisor_path(volunteer.supervisor)) %>
             <%- end %>
           </td>
-          <td class=" status-column "><%= volunteer.status %></td>
-          <td><%= volunteer&.assigned_to_transition_aged_youth? %></td>
+          <td class=" status-column "><%= volunteer.decorate.status %></td>
+          <td><%= volunteer.decorate&.assigned_to_transition_aged_youth? %></td>
           <td><%= safe_join(volunteer&.casa_cases&.map { |c| link_to(c.case_number, c) }, ", ") %></td>
           <td>
             <%= link_to_if volunteer&.most_recent_contact.present?,
-              volunteer.last_contact_made,
+              volunteer.decorate.last_contact_made,
               volunteer&.most_recent_contact&.casa_case %>
           </td>
           <td><%= volunteer&.recent_contacts_made %></td>

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -2,19 +2,27 @@ require "rails_helper"
 
 describe "volunteers" do
   subject { render template: "volunteers/index" }
+  let(:user) { build_stubbed :volunteer }
+  let(:volunteer) { create :volunteer }
 
-  context "while signed in as other user diferent to admin" do
-    let(:user) { build_stubbed :volunteer }
+  before do
+    enable_pundit(view, user)
+    allow(view).to receive(:current_user).and_return(user)
+    assign :volunteers, [volunteer]
+    sign_in user
+  end
 
-    before do
-      enable_pundit(view, user)
-      allow(view).to receive(:current_user).and_return(user)
-      assign :volunteers, []
-      sign_in user
-    end
+  context "when NOT signed in as an admin" do
+    it { is_expected.not_to have_selector("a", text: "New Volunteer") }
+  end
 
-    it do
-      is_expected.not_to have_selector("a", text: "New Volunteer")
-    end
+  context "when signed in as an admin" do
+    let(:user) { build_stubbed :casa_admin }
+
+    it { is_expected.to have_selector("a", text: "New Volunteer") }
+  end
+
+  context "links" do
+    it { is_expected.to have_link(volunteer.decorate.name) }
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1154 

### What changed, and why?

cdbb83f Create test for volunteer links
 - Created a test to check if the volunteer name is a link. Moved the test
  setup code to the top level scope. Also added an addtional test to check the happy path of an existing test.

 - In the index file I prepended some messages with the decorate message.
  For some reason in the view test it would error with message not found.
  I'm not sure what the architecture of the decorator is; however it seems
  strange that when live testing it is not needed. Does anybody have any
  insight on this?

fcd042c Add closing quotes
 - There was an ending quote missing causing the links to not display.
 - It seems this bug was introduced in PR #973

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

Unit test created.

### Screenshots please :)

<img width="750" alt="Screen Shot 2020-10-24 at 11 26 40 AM" src="https://user-images.githubusercontent.com/19519317/97065911-d467c380-15eb-11eb-87ea-f6ae551d00ec.png">


### Feelings gif (optional)

![alt text](https://media.giphy.com/media/xULW8N9O5WD32L5052/giphy.gif)
