### PR TITLE
resolves #1162 - added option to mark hearing type as inactive

### DIFF
--- a/app/models/hearing_type.rb
+++ b/app/models/hearing_type.rb
@@ -4,7 +4,6 @@ class HearingType < ApplicationRecord
   belongs_to :casa_org
 
   validates :name, presence: true, uniqueness: {scope: %i[casa_org]}
-  validates :active, presence: true
 
   scope :for_organization, ->(org) { where(casa_org: org) }
   scope :active, -> { where(active: true) }

--- a/spec/models/hearing_type_spec.rb
+++ b/spec/models/hearing_type_spec.rb
@@ -2,6 +2,5 @@ require "rails_helper"
 
 RSpec.describe HearingType, type: :model do
   it { is_expected.to belong_to(:casa_org) }
-  it { is_expected.to validate_presence_of(:active) }
   it { is_expected.to validate_presence_of(:name) }
 end

--- a/spec/requests/hearing_types_spec.rb
+++ b/spec/requests/hearing_types_spec.rb
@@ -1,0 +1,162 @@
+require "rails_helper"
+
+RSpec.describe "/hearing_types", type: :request do
+  describe "GET /hearing_types/new" do
+    context "when logged in as admin user" do
+      it "should allow access to hearing type create page" do
+        sign_in_as_admin
+
+        get new_hearing_type_path
+
+        expect(response).to be_successful
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      it "should not allow access to hearing type create page" do
+        sign_in_as_volunteer
+
+        get new_hearing_type_path
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+
+    context "when an unauthenticated request is made" do
+      it "should not allow access to hearing type create page" do
+        get new_hearing_type_path
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "POST /hearing_types" do
+    let(:params) { {hearing_type: {name: "New Hearing", active: true}} }
+    context "when logged in as admin user" do
+      it "should successfully create a hearing type" do
+        casa_org = create(:casa_org)
+        sign_in create(:casa_admin, casa_org: casa_org)
+
+        expect {
+          post hearing_types_path, params: params
+        }.to change(HearingType, :count).by(1)
+
+        hearing_type = HearingType.last
+
+        expect(hearing_type.name).to eql "New Hearing"
+        expect(hearing_type.active).to be_truthy
+        expect(response).to redirect_to edit_casa_org_path(casa_org)
+        expect(response.request.flash[:notice]).to eq "Hearing Type was successfully created."
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      it "should not create a hearing type" do
+        sign_in_as_volunteer
+
+        post hearing_types_path, params: params
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+
+    context "when an unauthenticated request is made" do
+      it "should not create a hearing type" do
+        post hearing_types_path, params: params
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "GET /hearing_types/:id/edit" do
+    context "when logged in as admin user" do
+      it "should allow access to hearing type edit page" do
+        sign_in_as_admin
+
+        get edit_hearing_type_path(create(:hearing_type))
+
+        expect(response).to be_successful
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      it "should not allow access to hearing type edit page" do
+        sign_in_as_volunteer
+
+        get edit_hearing_type_path(create(:hearing_type))
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+
+    context "when an unauthenticated request is made" do
+      it "should not allow access to hearing type edit page" do
+        get edit_hearing_type_path(create(:hearing_type))
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "PUT /hearing_types/:id" do
+    let(:casa_org) { create(:casa_org) }
+    let(:params) { {hearing_type: {name: "New Name", active: true}} }
+
+    context "when logged in as admin user" do
+      it "should successfully update hearing type with active status" do
+        sign_in create(:casa_admin, casa_org: casa_org)
+
+        hearing_type = create(:hearing_type)
+
+        put hearing_type_path(hearing_type), params: params
+
+        hearing_type.reload
+        expect(hearing_type.name).to eq "New Name"
+        expect(hearing_type.active).to be_truthy
+
+        expect(response).to redirect_to edit_casa_org_path(casa_org)
+        expect(response.request.flash[:notice]).to eq "Hearing Type was successfully updated."
+      end
+
+      it "should successfully update hearing type with inactive status" do
+        sign_in create(:casa_admin, casa_org: casa_org)
+
+        hearing_type = create(:hearing_type)
+
+        put hearing_type_path(hearing_type), params: params
+
+        hearing_type.update(active: false)
+        hearing_type.reload
+        expect(hearing_type.name).to eq "New Name"
+        expect(hearing_type.active).to be_falsey
+
+        expect(response).to redirect_to edit_casa_org_path(casa_org)
+        expect(response.request.flash[:notice]).to eq "Hearing Type was successfully updated."
+      end
+    end
+
+    context "when logged in as a non-admin user" do
+      it "should not update hearing type" do
+        sign_in_as_volunteer
+
+        put hearing_type_path(create(:hearing_type)), params: params
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+
+    context "when an unauthenticated request is made" do
+      it "should not update hearing type" do
+        put hearing_type_path(create(:hearing_type)), params: params
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1162 

### What changed, and why?
removed validation for hearing type to be active
when active checkbox unticked, saves status as inactive
allows for inactive status where it would previous throw error if empty

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
inactive status saving successfully via manual testing

### Screenshots please :)
![inactive_hearing](https://user-images.githubusercontent.com/67130477/97082903-aa98b600-1658-11eb-9d54-c0f95e01c552.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![happy](https://media.giphy.com/media/l3V0dy1zzyjbYTQQM/giphy.gif)
