### PR TITLE
remove Case Contacts from admin/supervisor sidebar

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -16,7 +16,9 @@
           <%= menu_item(label: "Supervisors", path: supervisors_path, visible: policy(Supervisor).index?) %>
           <%= menu_item(label: "Volunteers", path: volunteers_path, visible: policy(Volunteer).index?) %>
           <%= menu_item(label: cases_index_title, path: casa_cases_path) %>
-          <%= menu_item(label: "Case Contacts", path: case_contacts_path) %>
+          <% if current_user.volunteer? %>
+            <%= menu_item(label: "Case Contacts", path: case_contacts_path) %>
+          <% end %>
           <%= menu_item(label: "Admins", path: casa_admins_path, visible: policy(CasaAdmin).index?) %>
         <% end %>
       </div>

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -42,7 +42,7 @@ describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
       expect(rendered).to have_link("Volunteers", href: "/volunteers")
       expect(rendered).to have_link("Cases", href: "/casa_cases")
-      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to_not have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
@@ -93,7 +93,7 @@ describe "layout/sidebar", type: :view do
 
       expect(rendered).to have_link("Volunteers", href: "/volunteers")
       expect(rendered).to have_link("Cases", href: "/casa_cases")
-      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to_not have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
       expect(rendered).to have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")


### PR DESCRIPTION
Per issue #1181, remove the route to the case contacts in the
sidebar for admin and supervisor users.

### What github issue is this PR for, if any?
Resolves #1181 

### What changed, and why?
The Case Contacts item was removed from the sidebar for admin and supervisor users.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
The sidebar test were modified to expect there not to be a link for the supervisor and admin users.

### Screenshots please :)
<img width="280" alt="Screen Shot 2020-10-24 at 9 44 28 PM" src="https://user-images.githubusercontent.com/22206525/97097724-1de2fd80-1642-11eb-95b6-a5ed4020e10b.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media4.giphy.com/media/ui1hpJSyBDWlG/giphy.gif)
