### PR TITLE
Modify sign out for all_casa_admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,14 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
 
+  def after_sign_out_path_for(resource_or_scope)
+    if resource_or_scope == :all_casa_admin
+      new_all_casa_admin_session_path
+    else
+      root_path
+    end
+  end
+
   private
 
   def must_be_admin

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,6 +29,13 @@ describe ApplicationHelper, type: :helper do
       expect(helper.session_link).to match(destroy_user_session_path)
     end
 
+    it "links to the sign_out page when all_casa_admin is signed in" do
+      allow(helper).to receive(:user_signed_in?).and_return(false)
+      allow(helper).to receive(:all_casa_admin_signed_in?).and_return(true)
+
+      expect(helper.session_link).to match(destroy_all_casa_admin_session_path)
+    end
+
     it "links to the sign_in page when user is not signed in" do
       allow(helper).to receive(:user_signed_in?).and_return(false)
       allow(helper).to receive(:all_casa_admin_signed_in?).and_return(false)

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -17,6 +17,7 @@ describe "AllCasaAdmin auth", type: :system do
       click_link "Log out"
       expect(page).to_not have_text "sign in before continuing"
       expect(page).to have_text "Signed out successfully"
+      expect(page).to have_text "All CASA Log In"
     end
   end
 


### PR DESCRIPTION
Make the sign out path for all_casa_admmin lead to
the new session path for all_casa_admin

### What github issue is this PR for, if any?
Resolves #1187 

### What changed, and why?
Clicking log out now leads to the correct log-in page for all_casa_admins.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Check for "All CASA Log In" text after log out redirect.


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://gif-free.com/uploads/posts/2017-11/1509959847_snoopy-dancing.gif)
