### PR TITLE
resolves #1180 - all casa admin can edit/activate/deactivate other admins

### DIFF
--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -18,6 +18,19 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
     end
   end
 
+  def edit
+    @casa_admin = CasaAdmin.find(params[:id])
+  end
+
+  def update
+    @casa_admin = CasaAdmin.find(params[:id])
+    if @casa_admin.update(all_casa_admin_params)
+      redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was successfully updated."
+    else
+      render :edit
+    end
+  end
+
   private
 
   def set_casa_org

--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -31,6 +31,28 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
     end
   end
 
+  def activate
+    @casa_admin = CasaAdmin.find(params[:id])
+    if @casa_admin.activate
+      CasaAdminMailer.account_setup(@casa_admin).deliver
+
+      redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was activated."
+    else
+      render :edit
+    end
+  end
+
+  def deactivate
+    @casa_admin = CasaAdmin.find(params[:id])
+    if @casa_admin.deactivate
+      CasaAdminMailer.deactivation(@casa_admin).deliver
+
+      redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was deactivated."
+    else
+      render :edit
+    end
+  end
+
   private
 
   def set_casa_org

--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -34,7 +34,7 @@
 
 
               <div class="actions">
-                <%= link_to "Activate Admin",
+                <%= link_to "Activate",
                           activate_all_casa_admins_casa_org_casa_admin_path,
                           method: :patch,
                           class: "btn btn-outline-success" %>

--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -1,0 +1,24 @@
+<%= link_to "Back", all_casa_admins_casa_org_path(@casa_org) %>
+
+<h1>Edit Admin</h1>
+
+<div class="card card-container">
+  <div class="card-body">
+    <%= form_for @casa_admin, as: :all_casa_admin, url: all_casa_admins_casa_org_casa_admin_path do |form| %>
+      <%= render "/shared/error_messages", resource: @casa_admin %>
+
+      <div class="field form-group">
+        <%= form.label :email %>
+        <%= form.email_field :email, class: "form-control" %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "Update Profile", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+    <br>
+  </div>
+</div>
+
+
+

--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -11,10 +11,39 @@
         <%= form.label :email %>
         <%= form.email_field :email, class: "form-control" %>
       </div>
+         <% if @casa_admin.persisted? %>
+        <div class="field form-group">
+          <% if @casa_admin.active? %>
+            Admin is <span class="badge badge-success text-uppercase display-1">Active</span>
+            <br>
+            <br>
 
-      <div class="actions">
-        <%= form.submit "Update Profile", class: "btn btn-primary" %>
-      </div>
+            <div class="actions">
+              <%= link_to "Deactivate",
+              deactivate_all_casa_admins_casa_org_casa_admin_path,
+              method: :patch,
+              class: "btn btn-outline-danger",
+              data: { confirm: t("forms.casa_admin.mark_inactive_warning") } %>
+              <%= form.submit "Update Profile", class: "btn btn-primary" %>
+            </div>
+          <% else %>
+            <div class="alert alert-danger">
+              Admin was deactivated on: <%= @casa_admin.updated_at.strftime("%m-%d-%Y") %>
+            </div>
+            <% if @casa_admin.active == false %>
+
+
+              <div class="actions">
+                <%= link_to "Activate Admin",
+                          activate_all_casa_admins_casa_org_casa_admin_path,
+                          method: :patch,
+                          class: "btn btn-outline-success" %>
+                  <%= form.submit "Update Profile", class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
     <br>
   </div>

--- a/app/views/all_casa_admins/casa_orgs/show.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/show.html.erb
@@ -14,6 +14,7 @@
         <th>Name</th>
         <th>Email</th>
         <th>Created At</th>
+        <th>Actions</th>
       </tr>
       </thead>
       <tbody>
@@ -22,6 +23,7 @@
           <td><%= admin.display_name %></td>
           <td><%= admin.email %></td>
           <td><%= admin.created_at.strftime('%B %e, %Y') %></td>
+          <td><%= link_to "Edit", edit_all_casa_admins_casa_org_casa_admin_path(selected_organization, admin) %></td>
         </tr>
       <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,12 @@ Rails.application.routes.draw do
 
   namespace :all_casa_admins do
     resources :casa_orgs, only: [:new, :create, :show] do
-      resources :casa_admins, only: [:new, :create]
+      resources :casa_admins, only: [:new, :create, :edit, :update] do
+        member do
+          patch :deactivate
+          patch :activate
+        end
+      end
     end
   end
 

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -23,23 +23,23 @@ RSpec.describe "/all_casa_admins/casa_orgs/:casa_org_id/casa_admins" do
 
   describe "PATCH /update" do
     let(:email) { "casa_admin@example.com" }
-    let(:casa_admin) { CasaAdmin.new}
+    let(:casa_admin) { CasaAdmin.new }
 
     context "when current casa admin is editing another casa admin's profile" do
       it "should successfully update another casa admin's email" do
-        casa_admin.update(:email => "new_email@example.com")
+        casa_admin.update(email: "new_email@example.com")
 
         expect(casa_admin.email).to eq("new_email@example.com")
       end
       it "should successfully deactivate another casa admin's profile" do
-        casa_admin.active == true
+        casa_admin.active = true
         casa_admin.deactivate
 
         expect(casa_admin.active).to eq(false)
       end
 
       it "should successfully activate another casa admin's profile" do
-        casa_admin.active == false
+        casa_admin.active = false
         casa_admin.activate
 
         expect(casa_admin.active).to eq(true)

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe "/all_casa_admins/casa_orgs/:casa_org_id/casa_admins" do
 
         expect(casa_admin.email).to eq("new_email@example.com")
       end
+      it "should successfully deactivate another casa admin's profile" do
+        casa_admin.active == true
+        casa_admin.deactivate
+
+        expect(casa_admin.active).to eq(false)
+      end
+
+      it "should successfully activate another casa admin's profile" do
+        casa_admin.active == false
+        casa_admin.activate
+
+        expect(casa_admin.active).to eq(true)
+      end
     end
   end
 end

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -20,5 +20,18 @@ RSpec.describe "/all_casa_admins/casa_orgs/:casa_org_id/casa_admins" do
       end
     end
   end
+
+  describe "PATCH /update" do
+    let(:email) { "casa_admin@example.com" }
+    let(:casa_admin) { CasaAdmin.new}
+
+    context "when current casa admin is editing another casa admin's profile" do
+      it "should successfully update another casa admin's email" do
+        casa_admin.update(:email => "new_email@example.com")
+
+        expect(casa_admin.email).to eq("new_email@example.com")
+      end
+    end
+  end
 end
 # TODO: test admin creation as an all_casa_admin


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1180 

### What changed, and why?
- added edit link to casa org admins table & added edit page to allow all casa admins to edit other admins details
- updated controller with update, activate & deactivate
- added new routes to include activate & deactivate
- all casa admin can now update email, activate & deactivate other admin
 
### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
manual testing & rspec tests to check that updates to email & active status are successfully saved

### Screenshots please :)

![casa_org_admins](https://user-images.githubusercontent.com/67130477/97173145-312dce80-17e4-11eb-9e77-2c0522cd7e8e.png)
![edit_admin](https://user-images.githubusercontent.com/67130477/97174683-87037600-17e6-11eb-8974-bbf4d44a3fd1.png)
![email_updated](https://user-images.githubusercontent.com/67130477/97174472-4277da80-17e6-11eb-9d39-3f6e3adf604b.png)
![admin_deactivated](https://user-images.githubusercontent.com/67130477/97174451-3b50cc80-17e6-11eb-8951-947d8a0ab161.png)
![updated_casa_org_admins](https://user-images.githubusercontent.com/67130477/97173265-61756d00-17e4-11eb-9a67-9a1e9866078c.png)

