### PR TITLE
Add notes to casa_contact show table

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -5,6 +5,9 @@ class CaseContactDecorator < Draper::Decorator
   # - `N` minutes
   # - `N` hours `M` minutes
   # - `N` hours
+
+  NOTES_WORD_LIMIT = 100
+
   def duration_minutes
     minutes = object.duration_minutes
 
@@ -69,5 +72,9 @@ class CaseContactDecorator < Draper::Decorator
     else
       object.medium_type
     end
+  end
+
+  def notes
+    object.notes.to_s.truncate(NOTES_WORD_LIMIT)
   end
 end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -66,6 +66,7 @@
           <th>Miles Driven</th>
           <th>Want reimbursement?</th>
           <th>Created by</th>
+          <th>Notes</th>
           <th>Actions</th>
         </tr>
         </thead>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -42,6 +42,21 @@
       <%= contact.creator&.display_name %>
     <% end %>
   </td>
+  <td class="read-more">
+    <span class="mobile-label">Notes</span>
+    <%- if contact.notes && contact.notes.length > CaseContactDecorator::NOTES_WORD_LIMIT %>
+      <div class="limited-notes" style="display: block;">
+        <%= contact.decorate.notes %>
+        <span><a role="button" href="#" onClick="moreText(event)">Read more</a></span>
+      </div>
+      <div class="full-notes" style="display: none;">
+        <%= contact.notes %>
+        <span><a role="button" href="#" onClick="lessText(event)">Hide</a></span>
+      </div>
+    <%- else %>
+      <%= contact.notes %>
+    <%- end %>
+  </td>
   <td>
     <% if Pundit.policy(current_user, contact).update? %>
       <% if contact.created_in_current_quarter? %>
@@ -52,3 +67,22 @@
     <% end %>
   </td>
 </tr>
+
+<script type="text/javascript">
+
+  function moreText(event) {
+    event.preventDefault();
+    const table_cell = event.target.closest('td');
+
+    table_cell.querySelectorAll('.full-notes')[0].style.display = 'block';
+    table_cell.querySelectorAll('.limited-notes')[0].style.display = 'none';
+  }
+
+  function lessText(event) {
+    event.preventDefault();
+    const table_cell = event.target.closest('td');
+
+    table_cell.querySelectorAll('.full-notes')[0].style.display = 'none';
+    table_cell.querySelectorAll('.limited-notes')[0].style.display = 'block';
+  }
+</script>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -20,6 +20,7 @@
           <th>Miles Driven</th>
           <th>Want reimbursement?</th>
           <th>Created by</th>
+          <th>Notes</th>
           <th>Actions</th>
         </tr>
         </thead>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1133

### What changed, and why?

* This adds a `Notes` column to the case contact table.
* If notes are greater than 100 characters it gets truncated with a `Read more` toggle. Clicking `Read more` shows the full text, and a `Hide` toggle will appear in place. 
* If notes are less than 100 characters it gets shown in full without any toggles.

### How is this tested? (please write tests!) 💖💪
* Tested adding a short note and a long note in a system spec. The short note will get shown in the table in full, while the long note will get shown truncated but with a `Read more` toggle option. Tested that showing and hiding text works. 

### Screenshots please :)
![2020-10-26 20 41 08](https://user-images.githubusercontent.com/16447748/97255209-611da780-17cd-11eb-87df-1f4f9d812295.gif)
