### PR TITLE
error when admin imports inactive casa_case

### DIFF
--- a/app/lib/importers/case_importer.rb
+++ b/app/lib/importers/case_importer.rb
@@ -16,7 +16,13 @@ class CaseImporter < FileImporter
       if casa_case
         case_number = casa_case.case_number
         failures = []
-        failures << "Case #{case_number} already exists" if result[:existing]
+        if result[:existing]
+          if result[:deactivated]
+            failures << "Case #{case_number} already exists, but is inactive. Reactivate the CASA case instead."
+          else
+            failures << "Case #{case_number} already exists"
+          end
+        end
         volunteers = email_addresses_to_users(Volunteer, String(row[:case_assignment]))
         volunteers.each do |volunteer|
           if volunteer.casa_cases.exists?(casa_case.id)
@@ -38,7 +44,10 @@ class CaseImporter < FileImporter
   def create_casa_case(row_data)
     casa_case_params = row_data.to_hash.slice(:case_number, :transition_aged_youth, :birth_month_year_youth)
     casa_case = CasaCase.find_by(casa_case_params)
-    return {casa_case: casa_case, existing: true} if casa_case.present?
+
+    return {casa_case: casa_case, existing: true, deactivated: true} if casa_case.present? && !casa_case.active
+
+    return {casa_case: casa_case, existing: true, deactivated: false} if casa_case.present?
 
     casa_case = CasaCase.new(casa_case_params)
     casa_case.casa_org_id = org_id

--- a/spec/fixtures/existing_casa_case.csv
+++ b/spec/fixtures/existing_casa_case.csv
@@ -1,0 +1,2 @@
+case_number,transition_aged_youth,case_assignment,birth_month_year_youth
+CINA-00-0000,TRUE,volunteer1@example.net,

--- a/spec/requests/imports_request_spec.rb
+++ b/spec/requests/imports_request_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "/imports", type: :request do
   let(:volunteer_file) { Rails.root.join("spec", "fixtures", "volunteers.csv") }
   let(:supervisor_file) { Rails.root.join("spec", "fixtures", "supervisors.csv") }
+  let(:case_file) { Rails.root.join("spec", "fixtures", "casa_cases.csv") }
+  let(:existing_case_file) { Rails.root.join("spec", "fixtures", "existing_casa_case.csv") }
   let(:supervisor_volunteers_file) { Rails.root.join("spec", "fixtures", "supervisor_volunteers.csv") }
   let(:casa_admin) { create(:casa_admin) }
 
@@ -119,6 +121,59 @@ RSpec.describe "/imports", type: :request do
       expect(Supervisor.find_by(email: "s6@example.com").volunteers.size).to eq(0)
 
       expect(response).to redirect_to(imports_url(import_type: "supervisor"))
+    end
+
+    it "creates case in cases CSV imports" do
+      sign_in casa_admin
+
+      expect(CasaCase.count).to eq(0)
+
+      expect {
+        post imports_url,
+          params: {
+            import_type: "casa_case",
+            file: fixture_file_upload(case_file)
+          }
+      }.to change(CasaCase, :count).by(3)
+
+      expect(response).to redirect_to(imports_url(import_type: "casa_case"))
+    end
+    it "produces an error when a case already exists in cases CSV imports" do
+      sign_in casa_admin
+      create(:casa_case, case_number: "CINA-00-0000", transition_aged_youth: "true", birth_month_year_youth: nil)
+
+      expect(CasaCase.count).to eq(1)
+
+      expect {
+        post imports_url,
+          params: {
+            import_type: "casa_case",
+            file: fixture_file_upload(existing_case_file)
+          }
+      }.to change(CasaCase, :count).by(0)
+
+      expect(request.session[:import_error]).to include("Not all rows were imported.")
+      expect(request.session[:exported_rows]).to include("Case CINA-00-0000 already exists")
+      expect(response).to redirect_to(imports_url(import_type: "casa_case"))
+    end
+    it "produces an error when a deactivated case already exists in cases CSV imports" do
+      sign_in casa_admin
+
+      create(:casa_case, case_number: "CINA-00-0000", transition_aged_youth: "true", birth_month_year_youth: nil, active: "false")
+
+      expect(CasaCase.count).to eq(1)
+
+      expect {
+        post imports_url,
+          params: {
+            import_type: "casa_case",
+            file: fixture_file_upload(existing_case_file)
+          }
+      }.to change(CasaCase, :count).by(0)
+
+      expect(request.session[:import_error]).to include("Not all rows were imported.")
+      expect(request.session[:exported_rows]).to include("Case CINA-00-0000 already exists, but is inactive. Reactivate the CASA case instead.")
+      expect(response).to redirect_to(imports_url(import_type: "casa_case"))
     end
   end
 end


### PR DESCRIPTION
An additional check was made to provide a different error
message to an admin importing an existing case that is
inactive. This Provides more useful information than just telling
them that the case already exists.

Tests were added to ensure that the error message renders correctly.

### What github issue is this PR for, if any?
Resolves #1190 

### What changed, and why?
An additional check was made to provide a different error
message to an admin importing an existing case that is
inactive. This provides more useful information than just telling
them that the case already exists.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Tests were added to ensure that the error message renders correctly.

### Screenshots please :)
<img width="1051" alt="Screen Shot 2020-10-28 at 12 43 16 PM" src="https://user-images.githubusercontent.com/22206525/97475375-2c1f6b00-191b-11eb-9fd5-79d765c82df3.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![gif](https://www.google.com/url?sa=i&url=https%3A%2F%2Fgiphy.com%2Fgifs%2Fschittscreek-JotCDL833qFLmOgpnC&psig=AOvVaw33w05HNWUT4Wgmq-MZnKww&ust=1603993442988000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCIirjrHr1-wCFQAAAAAdAAAAABAJ)
