### PR TITLE
Refactor/Improve specs readability

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper, type: :helper do
   describe "#page_header" do
     it "links to the user dashboard if user logged in" do
       current_organization = build_stubbed(:casa_org)

--- a/spec/helpers/case_contacts_helper_spec.rb
+++ b/spec/helpers/case_contacts_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CaseContactsHelper do
+RSpec.describe CaseContactsHelper do
   describe "#render_back_link" do
     it "renders back link to home page when user is a volunteer" do
       current_user = create(:volunteer)

--- a/spec/helpers/sidebar_helper_spec.rb
+++ b/spec/helpers/sidebar_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe SidebarHelper do
+RSpec.describe SidebarHelper do
   describe "#menu_item" do
     it "does not render sidebar menu item when not visible" do
       menu_item = helper.menu_item(label: "Supervisors", path: supervisors_path, visible: false)

--- a/spec/lib/importers/case_importer_spec.rb
+++ b/spec/lib/importers/case_importer_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe CaseImporter do
-  let(:casa_org_id) { import_user.casa_org.id }
   subject(:case_importer) { CaseImporter.new(import_file_path, casa_org_id) }
+
+  let(:casa_org_id) { import_user.casa_org.id }
   let!(:import_user) { create(:casa_admin) }
   let(:import_file_path) { Rails.root.join("spec", "fixtures", "casa_cases.csv") }
 
-  before(:each) do
+  before do
     allow(case_importer).to receive(:email_addresses_to_users) do |_clazz, comma_separated_emails|
       create_list(:volunteer, comma_separated_emails.split(",").size)
     end
@@ -52,9 +53,11 @@ RSpec.describe CaseImporter do
 
     context "when the importer has already run once" do
       before { case_importer.import_cases }
+
       it "does not duplicate casa case files from csv files" do
         expect { case_importer.import_cases }.to change(CasaCase, :count).by(0)
       end
+
       it "returns an error message when there are cases not imported" do
         alert = case_importer.import_cases
         expect(alert[:type]).to eq(:error)

--- a/spec/lib/importers/file_importer_spec.rb
+++ b/spec/lib/importers/file_importer_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe FileImporter do
 
   describe "import" do
     it "assumes headers" do
-      file_importer.import { |f| true }
+      file_importer.import { |_f| true }
       expect(file_importer.number_imported).to eq(2)
     end
 
     it "resets the count of how many have been imported, each time" do
-      file_importer.import { |f| true }
-      file_importer.import { |f| true }
+      file_importer.import { |_f| true }
+      file_importer.import { |_f| true }
       expect(file_importer.number_imported).to eq(2)
     end
 
@@ -27,7 +27,7 @@ RSpec.describe FileImporter do
 
     it "captures errors" do
       expect {
-        file_importer.import do |row|
+        file_importer.import do |_row|
           raise "Something bad"
         end
       }.not_to raise_error
@@ -35,7 +35,7 @@ RSpec.describe FileImporter do
     end
 
     it "returns hash with expected attributes" do
-      result = file_importer.import { |f| true }
+      result = file_importer.import { |_f| true }
       expect(result.keys).to contain_exactly(:type, :message, :exported_rows)
     end
 

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SupervisorImporter do
 
   let(:supervisor_importer) do
     importer = SupervisorImporter.new(import_file_path, casa_org_id)
-    allow(importer).to receive(:email_addresses_to_users) do |clazz, supervisor_volunteers|
+    allow(importer).to receive(:email_addresses_to_users) do |_clazz, supervisor_volunteers|
       create_list(:volunteer, supervisor_volunteers.split(",").size)
     end
     importer

--- a/spec/models/all_casa_admin_spec.rb
+++ b/spec/models/all_casa_admin_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe AllCasaAdmin, type: :model do
   describe "#role" do
     subject(:all_casa_admin) { create :all_casa_admin }
+
     it { expect(all_casa_admin.role).to eq "All Casa Admin" }
   end
 end

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CasaAdmin, type: :model do
 
   describe "#role" do
     subject(:admin) { create :casa_admin }
+
     it { expect(admin.role).to eq "Casa Admin" }
   end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CasaCase do
     end
   end
 
-  context "#update_cleaning_contact_types" do
+  describe "#update_cleaning_contact_types" do
     it "cleans up contact types before saving" do
       group = create(:contact_type_group)
       type1 = create(:contact_type, contact_type_group: group)
@@ -100,12 +100,12 @@ RSpec.describe CasaCase do
 
       casa_case = create(:casa_case, contact_types: [type1])
 
-      expect(casa_case.casa_case_contact_types.count).to eql 1
+      expect(casa_case.casa_case_contact_types.count).to be 1
       expect(casa_case.contact_types).to match_array([type1])
 
       casa_case.update_cleaning_contact_types({casa_case_contact_types_attributes: [{contact_type_id: type2.id}]})
 
-      expect(casa_case.casa_case_contact_types.count).to eql 1
+      expect(casa_case.casa_case_contact_types.count).to be 1
       expect(casa_case.contact_types.reload).to match_array([type2])
     end
   end
@@ -116,21 +116,21 @@ RSpec.describe CasaCase do
         casa_case = create(:casa_case, court_date: "2020-09-13 02:11:58")
         casa_case.clear_court_dates
 
-        expect(casa_case.court_date).to eql nil
+        expect(casa_case.court_date).to be nil
       end
 
       it "clears report due date" do
         casa_case = create(:casa_case, court_date: "2020-09-13 02:11:58", court_report_due_date: "2020-09-13 02:11:58")
         casa_case.clear_court_dates
 
-        expect(casa_case.court_report_due_date).to eql nil
+        expect(casa_case.court_report_due_date).to be nil
       end
 
       it "sets court report as unsubmitted" do
         casa_case = create(:casa_case, court_date: "2020-09-13 02:11:58", court_report_submitted: true)
         casa_case.clear_court_dates
 
-        expect(casa_case.court_report_submitted).to eql false
+        expect(casa_case.court_report_submitted).to be false
       end
     end
   end

--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CaseAssignment do
   let(:casa_case_2) { create(:casa_case) }
   let(:volunteer_2) { create(:volunteer) }
 
-  it "should only allow active volunteers to be assigned" do
+  it "only allow active volunteers to be assigned" do
     expect(casa_case_1.case_assignments.new(volunteer: volunteer_1)).to be_valid
     casa_case_1.reload
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CaseContactReport, type: :model do
       expect(case_contact_data[1]).to eq("60")
     end
   end
+
   describe "filter behavior" do
     describe "occured at range filter" do
       it "uses date range if provided" do
@@ -38,6 +39,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+
       it "returns all date ranges if not provided" do
         create(:case_contact, {occurred_at: 20.days.ago})
         create(:case_contact, {occurred_at: 100.days.ago})
@@ -45,6 +47,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(2)
       end
+
       it "returns only the volunteer" do
         volunteer = create(:volunteer)
         create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
@@ -53,6 +56,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+
       it "returns only the volunteer with date range" do
         volunteer = create(:volunteer)
         create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
@@ -63,6 +67,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+
       it "returns only the volunteer with the specified supervisors" do
         supervisor = create(:supervisor)
         volunteer = create(:volunteer)
@@ -79,6 +84,7 @@ RSpec.describe CaseContactReport, type: :model do
         expect(contacts).to eq([contact])
       end
     end
+
     describe "case contact behavior" do
       it "returns only the case contacts with where contact was made" do
         create(:case_contact, {contact_made: true})
@@ -88,6 +94,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+
       it "returns only the case contacts with where contact was NOT made" do
         create(:case_contact, {contact_made: true})
         create(:case_contact, {contact_made: false})
@@ -96,6 +103,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
+
       it "returns only the case contacts with where contact was made or NOT made" do
         create(:case_contact, {contact_made: true})
         create(:case_contact, {contact_made: false})
@@ -236,6 +244,7 @@ RSpec.describe CaseContactReport, type: :model do
             expect(report.case_contacts).to eq(CaseContact.all)
           end
         end
+
         context "when select nothing on Case Type Group" do
           it "does no filtering & returns 3 case contacts" do
             report = CaseContactReport.new(

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe CaseContact, type: :model do
   context "validations" do
-    it { should validate_numericality_of(:miles_driven).is_less_than 10000 }
-    it { should validate_numericality_of(:miles_driven).is_greater_than_or_equal_to 0 }
+    it { is_expected.to validate_numericality_of(:miles_driven).is_less_than 10_000 }
+    it { is_expected.to validate_numericality_of(:miles_driven).is_greater_than_or_equal_to 0 }
   end
 
   it "belongs to a creator" do
@@ -82,7 +82,7 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact.errors[:base]).to eq(["cannot edit case contacts created before the current quarter"])
   end
 
-  context "#update_cleaning_contact_types" do
+  describe "#update_cleaning_contact_types" do
     it "cleans up contact types before saving" do
       group = create(:contact_type_group)
       type1 = create(:contact_type, contact_type_group: group)
@@ -90,12 +90,12 @@ RSpec.describe CaseContact, type: :model do
 
       case_contact = create(:case_contact, contact_types: [type1])
 
-      expect(case_contact.case_contact_contact_type.count).to eql 1
+      expect(case_contact.case_contact_contact_type.count).to be 1
       expect(case_contact.contact_types).to match_array([type1])
 
       case_contact.update_cleaning_contact_types({case_contact_contact_type_attributes: [{contact_type_id: type2.id}]})
 
-      expect(case_contact.case_contact_contact_type.count).to eql 1
+      expect(case_contact.case_contact_contact_type.count).to be 1
       expect(case_contact.contact_types.reload).to match_array([type2])
     end
   end

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe CaseCourtReport, type: :model do
     describe "has valid @context" do
       subject { report.context }
 
-      it { should_not be_empty }
-      it { should be_instance_of Hash }
+      it { is_expected.not_to be_empty }
+      it { is_expected.to be_instance_of Hash }
 
       it "has the following keys [:created_date, :casa_case, :case_contacts, :volunteer]" do
         expected = %i[created_date casa_case case_contacts volunteer]
@@ -62,6 +62,7 @@ RSpec.describe CaseCourtReport, type: :model do
   describe "when receiving INVALID path_to_template" do
     let(:casa_case_with_contacts) { volunteer.casa_cases.first }
     let(:nonexistent_path) { "app/documents/templates/nonexisitent_report_template.docx" }
+
     it "will raise Zip::Error when generating report" do
       bad_report = CaseCourtReport.new(
         case_id: casa_case_with_contacts.id,

--- a/spec/models/contact_type_group_spec.rb
+++ b/spec/models/contact_type_group_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "contact_type_group"
 
 RSpec.describe ContactTypeGroup, type: :model do
-  it "should not have duplicate names" do
+  it "does not have duplicate names" do
     org_id = create(:casa_org).id
     create_contact_type_group = -> { create(:contact_type_group, {name: "Test1", casa_org_id: org_id}) }
     create_contact_type_group.call

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Supervisor, type: :model do
   describe "#role" do
     subject(:supervisor) { create :supervisor }
+
     it { expect(supervisor.role).to eq "Supervisor" }
   end
 end

--- a/spec/models/supervisor_volunteer_spec.rb
+++ b/spec/models/supervisor_volunteer_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe SupervisorVolunteer do
   let(:supervisor_1) { create(:supervisor) }
   let(:supervisor_2) { create(:supervisor) }
 
-  it "should assign a volunteer to a supervisor" do
+  it "assigns a volunteer to a supervisor" do
     supervisor_1.volunteers << volunteer_1
     expect(volunteer_1.supervisor).to eq(supervisor_1)
   end
 
-  it "should only allow 1 supervisor per volunteer" do
+  it "only allow 1 supervisor per volunteer" do
     supervisor_1.volunteers << volunteer_1
     supervisor_1.save
     expect { supervisor_2.volunteers << volunteer_1 }.to raise_error(StandardError)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe User, type: :model do
     user = build(:user, display_name: "")
     expect(user.valid?).to be false
   end
+
   it "returns all case_contacts associated with this user and the casa case id supplied" do
     volunteer = create(:volunteer, :with_casa_cases)
 
@@ -51,7 +52,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "supervisors" do
-    context "#volunteers_serving_transistion_aged_youth" do
+    describe "#volunteers_serving_transistion_aged_youth" do
       it "returns the number of transition aged youth on a supervisor" do
         assignment1 = create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: true))
         assignment2 = create(:case_assignment, casa_case: create(:casa_case, transition_aged_youth: true))
@@ -64,16 +65,16 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "#no_contact_for_two_weeks" do
+    describe "#no_contact_for_two_weeks" do
       let(:supervisor) { create(:supervisor) }
 
       it "returns zero for a volunteer that has successfully made contact in at least one contact_case within the last 2 weeks" do
         volunteer_1 = create(:volunteer, :with_casa_cases, supervisor: supervisor)
 
         case_of_interest_1 = volunteer_1.casa_cases.first
-        create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: false, occurred_at: 1.weeks.ago)
+        create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: false, occurred_at: 1.week.ago)
         expect(supervisor.no_contact_for_two_weeks).to eq(1)
-        create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: true, occurred_at: 1.weeks.ago)
+        create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: true, occurred_at: 1.week.ago)
         expect(supervisor.no_contact_for_two_weeks).to eq(0)
       end
 
@@ -159,12 +160,15 @@ RSpec.describe User, type: :model do
 
   describe "#volunteers_with_no_supervisor?" do
     subject { User.volunteers_with_no_supervisor(casa_org) }
+
     let(:casa_org) { create(:casa_org) }
+
     context "no volunteers" do
       it "returns none" do
         expect(subject).to eq([])
       end
     end
+
     context "volunteers" do
       let!(:unassigned1) { create(:volunteer, display_name: "aaa", casa_org: casa_org) }
       let!(:unassigned2) { create(:volunteer, display_name: "bbb", casa_org: casa_org) }

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -75,11 +75,12 @@ RSpec.describe Volunteer, type: :model do
   describe "#made_contact_with_all_cases_in_days?" do
     let(:volunteer) { create(:volunteer) }
     let(:casa_case) { create(:casa_case) }
-    let(:create_case_contact) {
-      ->(occurred_at, contact_made) {
+    let(:create_case_contact) do
+      lambda { |occurred_at, contact_made|
         create(:case_contact, casa_case: casa_case, creator: volunteer, occurred_at: occurred_at, contact_made: contact_made)
       }
-    }
+    end
+
     before do
       create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: true)
     end
@@ -152,6 +153,7 @@ RSpec.describe Volunteer, type: :model do
 
   describe "#role" do
     subject(:volunteer) { create :volunteer }
+
     it { expect(volunteer.role).to eq "Volunteer" }
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ApplicationPolicy do
+  subject { described_class }
+
   let(:casa_admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
   let(:volunteer) { create(:volunteer) }
-  subject { described_class }
 
   permissions :see_reports_page? do
     it "allows casa_admins" do

--- a/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
+++ b/spec/policies/case_assigment_policy/case_assigment_policy_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CaseAssignmentPolicy do
     it "does not allow unassign if case_assignment is inactive" do
       is_expected.not_to permit(casa_admin, case_assignment_inactive)
     end
+
     context "when user is an admin" do
       it "allow update when case_assignment is active" do
         is_expected.to permit(casa_admin, case_assignment)

--- a/spec/policies/case_contact_policy/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy/case_contact_policy_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe CaseContactPolicy do
+  subject { described_class }
+
   let(:casa_admin) { create(:casa_admin) }
   let(:case_contact) { create(:case_contact) }
   let(:volunteer) { create(:volunteer) }
   let(:supervisor) { create(:supervisor) }
-  subject { described_class }
 
   permissions :show? do
     it "allows casa_admins" do

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe DashboardPolicy do
+  subject { described_class }
+
   let(:user) { create(:user) }
   let(:casa_admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
   let(:volunteer) { create(:volunteer) }
-  subject { described_class }
 
   permissions :show? do
     it "permits user to show" do

--- a/spec/policies/supervisor_policy_spec.rb
+++ b/spec/policies/supervisor_policy_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe SupervisorPolicy do
+  subject { described_class }
+
   let(:casa_admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
   let(:volunteer) { create(:volunteer) }
-  subject { described_class }
 
   permissions :update_supervisor_email? do
     context "when user is an admin or is the record" do

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe VolunteerPolicy do
+  subject { described_class }
+
   let(:admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
   let(:volunteer) { create(:volunteer) }
-  subject { described_class }
 
   permissions :create?, :new?, :update_volunteer_email? do
     context "when user is a casa admin" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,4 +48,6 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "#{::Rails.root}/tmp/persistent_examples.txt"
 
   config.filter_rails_from_backtrace!
+
+  config.disable_monkey_patching!
 end

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -26,19 +26,20 @@ RSpec.describe "/all_casa_admins/casa_orgs/:casa_org_id/casa_admins" do
     let(:casa_admin) { CasaAdmin.new }
 
     context "when current casa admin is editing another casa admin's profile" do
-      it "should successfully update another casa admin's email" do
+      it "successfully update another casa admin's email" do
         casa_admin.update(email: "new_email@example.com")
 
         expect(casa_admin.email).to eq("new_email@example.com")
       end
-      it "should successfully deactivate another casa admin's profile" do
+
+      it "successfully deactivate another casa admin's profile" do
         casa_admin.active = true
         casa_admin.deactivate
 
         expect(casa_admin.active).to eq(false)
       end
 
-      it "should successfully activate another casa admin's profile" do
+      it "successfully activate another casa admin's profile" do
         casa_admin.active = false
         casa_admin.activate
 

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe "/all_casa_admins", type: :request do
     before { sign_in admin }
 
     context "with valid parameters" do
-      let(:params) {
+      let(:params) do
         {
           all_casa_admin: {
             password: "newpassword",
             password_confirmation: "newpassword"
           }
         }
-      }
+      end
 
       it "updates the all_casa_admin password" do
         patch update_password_all_casa_admins_path, params: params
@@ -62,14 +62,14 @@ RSpec.describe "/all_casa_admins", type: :request do
     end
 
     context "with invalid parameters" do
-      let(:params) {
+      let(:params) do
         {
           all_casa_admin: {
             password: "newpassword",
             password_confirmation: "badmatch"
           }
         }
-      }
+      end
 
       it "does not update the all_casa_admin password" do
         patch update_password_all_casa_admins_path, params: params

--- a/spec/requests/casa_orgs_request_spec.rb
+++ b/spec/requests/casa_orgs_request_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "CasaOrgs", type: :request do
 
   describe "as a volunteer" do
     before { sign_in create(:volunteer, casa_org: casa_org) }
+
     describe "GET /edit" do
       it "render a failed response" do
         get edit_casa_org_url(casa_org)

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "/case_contact_reports", type: :request do
     travel_to Time.zone.local(2020, 1, 1)
     sign_in user
   end
+
   after { travel_back }
 
   describe "GET /case_contact_reports" do
@@ -21,12 +22,12 @@ RSpec.describe "/case_contact_reports", type: :request do
 
     shared_examples "can view reports" do
       context "with start_date and end_date" do
-        let(:case_contact_report_params) {
+        let(:case_contact_report_params) do
           {
             start_date: 1.month.ago,
             end_date: Date.today
           }
-        }
+        end
 
         it "renders a csv file to download" do
           get case_contact_reports_url(format: :csv), params: {report: {start_date: 1.month.ago, end_date: Date.today}}

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "/case_court_reports", type: :request do
   describe "GET /case_court_reports/:id" do
     context "when a valid / existing case is sent" do
       let(:casa_case) { volunteer.casa_cases.first }
+
       before do
         get case_court_report_path(casa_case.case_number, format: "docx")
       end
@@ -36,6 +37,7 @@ RSpec.describe "/case_court_reports", type: :request do
 
     context "when an INVALID / non-existing case is sent" do
       let(:invalid_casa_case) { build_stubbed(:casa_case) }
+
       before do
         get case_court_report_path(invalid_casa_case.case_number, format: "docx")
       end

--- a/spec/requests/contact_type_groups_spec.rb
+++ b/spec/requests/contact_type_groups_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "/contact_type_groups", type: :request do
 
   describe "PUT /contact_type_groups/:id" do
     let(:params) { {contact_type_group: {name: "New Group Name", active: false}} }
+
     context "logged in as admin user" do
       it "can successfully update a contact type group" do
         casa_org = create(:casa_org)

--- a/spec/requests/contact_type_spec.rb
+++ b/spec/requests/contact_type_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/contact_types", type: :request do
   let(:group) { create(:contact_type_group) }
+
   describe "GET /contact_types/new" do
     context "logged in as admin user" do
       it "can successfully access a contact type create page" do
@@ -35,6 +36,7 @@ RSpec.describe "/contact_types", type: :request do
 
   describe "POST /contact_types" do
     let(:params) { {contact_type: {name: "New Contact", contact_type_group_id: group.id, active: true}} }
+
     context "logged in as admin user" do
       it "can successfully create a contact type" do
         casa_org = create(:casa_org)
@@ -109,6 +111,7 @@ RSpec.describe "/contact_types", type: :request do
     let(:casa_org) { create(:casa_org) }
     let(:new_group) { create(:contact_type_group, casa_org: casa_org) }
     let(:params) { {contact_type: {name: "New Name", contact_type_group_id: new_group.id, active: false}} }
+
     context "logged in as admin user" do
       it "can successfully update a contact type" do
         sign_in create(:casa_admin, casa_org: casa_org)

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "/dashboard", type: :request do
+RSpec.describe "/dashboard", type: :request do
   let(:organization) { create(:casa_org) }
   let(:volunteer) { create(:volunteer, casa_org: organization) }
   let(:admin) { create(:casa_admin, casa_org: organization) }

--- a/spec/requests/hearing_types_spec.rb
+++ b/spec/requests/hearing_types_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "/hearing_types", type: :request do
   describe "GET /hearing_types/new" do
     context "when logged in as admin user" do
-      it "should allow access to hearing type create page" do
+      it "allows access to hearing type create page" do
         sign_in_as_admin
 
         get new_hearing_type_path
@@ -13,7 +13,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when logged in as a non-admin user" do
-      it "should not allow access to hearing type create page" do
+      it "does not allow access to hearing type create page" do
         sign_in_as_volunteer
 
         get new_hearing_type_path
@@ -24,7 +24,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when an unauthenticated request is made" do
-      it "should not allow access to hearing type create page" do
+      it "does not allow access to hearing type create page" do
         get new_hearing_type_path
 
         expect(response).to redirect_to new_user_session_path
@@ -34,8 +34,9 @@ RSpec.describe "/hearing_types", type: :request do
 
   describe "POST /hearing_types" do
     let(:params) { {hearing_type: {name: "New Hearing", active: true}} }
+
     context "when logged in as admin user" do
-      it "should successfully create a hearing type" do
+      it "successfully create a hearing type" do
         casa_org = create(:casa_org)
         sign_in create(:casa_admin, casa_org: casa_org)
 
@@ -53,7 +54,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when logged in as a non-admin user" do
-      it "should not create a hearing type" do
+      it "does not create a hearing type" do
         sign_in_as_volunteer
 
         post hearing_types_path, params: params
@@ -64,7 +65,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when an unauthenticated request is made" do
-      it "should not create a hearing type" do
+      it "does not create a hearing type" do
         post hearing_types_path, params: params
 
         expect(response).to redirect_to new_user_session_path
@@ -74,7 +75,7 @@ RSpec.describe "/hearing_types", type: :request do
 
   describe "GET /hearing_types/:id/edit" do
     context "when logged in as admin user" do
-      it "should allow access to hearing type edit page" do
+      it "allows access to hearing type edit page" do
         sign_in_as_admin
 
         get edit_hearing_type_path(create(:hearing_type))
@@ -84,7 +85,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when logged in as a non-admin user" do
-      it "should not allow access to hearing type edit page" do
+      it "does not allow access to hearing type edit page" do
         sign_in_as_volunteer
 
         get edit_hearing_type_path(create(:hearing_type))
@@ -95,7 +96,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when an unauthenticated request is made" do
-      it "should not allow access to hearing type edit page" do
+      it "does not allow access to hearing type edit page" do
         get edit_hearing_type_path(create(:hearing_type))
 
         expect(response).to redirect_to new_user_session_path
@@ -108,7 +109,7 @@ RSpec.describe "/hearing_types", type: :request do
     let(:params) { {hearing_type: {name: "New Name", active: true}} }
 
     context "when logged in as admin user" do
-      it "should successfully update hearing type with active status" do
+      it "successfully update hearing type with active status" do
         sign_in create(:casa_admin, casa_org: casa_org)
 
         hearing_type = create(:hearing_type)
@@ -123,7 +124,7 @@ RSpec.describe "/hearing_types", type: :request do
         expect(response.request.flash[:notice]).to eq "Hearing Type was successfully updated."
       end
 
-      it "should successfully update hearing type with inactive status" do
+      it "successfully update hearing type with inactive status" do
         sign_in create(:casa_admin, casa_org: casa_org)
 
         hearing_type = create(:hearing_type)
@@ -141,7 +142,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when logged in as a non-admin user" do
-      it "should not update hearing type" do
+      it "does not update hearing type" do
         sign_in_as_volunteer
 
         put hearing_type_path(create(:hearing_type)), params: params
@@ -152,7 +153,7 @@ RSpec.describe "/hearing_types", type: :request do
     end
 
     context "when an unauthenticated request is made" do
-      it "should not update hearing type" do
+      it "does not update hearing type" do
         put hearing_type_path(create(:hearing_type)), params: params
 
         expect(response).to redirect_to new_user_session_path

--- a/spec/requests/imports_request_spec.rb
+++ b/spec/requests/imports_request_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe "/imports", type: :request do
       expect(response).to redirect_to(imports_url(import_type: "supervisor"))
     end
     # TODO: Dominique to make test for importing csv for multiple supervisors for 1 volunteer
+
     it "creates supervisors and assigns the volunteer if not already assigned" do
       sign_in casa_admin
 

--- a/spec/requests/judges_spec.rb
+++ b/spec/requests/judges_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "/judges", type: :request do
 
   describe "POST /judges" do
     let(:params) { {judge: {name: "Joe Judge", active: true}} }
+
     context "logged in as admin user" do
       it "can successfully create a judge" do
         casa_org = create(:casa_org)
@@ -109,6 +110,7 @@ RSpec.describe "/judges", type: :request do
   describe "PUT /judges/:id" do
     let(:judge) { create(:judge) }
     let(:params) { {judge: {name: "New Name", judge_id: judge.id, active: false}} }
+
     context "logged in as admin user" do
       it "can successfully update a judge" do
         casa_org = create(:casa_org)

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
           is_active: false
         )
       end
+
       it "sets that association to active" do
         valid_parameters = {
           supervisor_volunteer: {volunteer_id: volunteer.id},
@@ -114,6 +115,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
       let!(:association) do
         create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
       end
+
       it "does not set the is_active flag on the association to false" do
         sign_in volunteer
 

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "/supervisors", type: :request do
   let(:admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
 
-  let(:update_supervisor_params) {
+  let(:update_supervisor_params) do
     {supervisor: {email: "newemail@gmail.com", display_name: "New Name"}}
-  }
+  end
 
   describe "GET /new" do
     it "admin can view the new supervisor page" do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe "/volunteers", type: :request do
     before do
       sign_in admin
     end
+
     context "with valid params" do
-      let(:params) {
+      let(:params) do
         {
           volunteer: {
             display_name: "Example",
@@ -45,7 +46,8 @@ RSpec.describe "/volunteers", type: :request do
             casa_org_id: admin.casa_org_id
           }
         }
-      }
+      end
+
       it "creates a new volunteer" do
         post volunteers_url, params: params
         expect(response).to have_http_status(:redirect)
@@ -61,8 +63,9 @@ RSpec.describe "/volunteers", type: :request do
         }.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
+
     context "with invalid parameters" do
-      let(:params) {
+      let(:params) do
         {
           volunteer: {
             display_name: "",
@@ -70,7 +73,8 @@ RSpec.describe "/volunteers", type: :request do
             casa_org_id: admin.casa_org_id
           }
         }
-      }
+      end
+
       it "does not create a new volunteer" do
         expect {
           post volunteers_url, params: params

--- a/spec/system/admin_adds_a_case_contact_spec.rb
+++ b/spec/system/admin_adds_a_case_contact_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe "admin or supervisor adds a case contact", type: :system do
     expect(CaseContact.first.duration_minutes).to eq 105
   end
 
-  it "should not show empty contact type groups" do
+  it "does not show empty contact type groups" do
     expect(page).to_not have_text("Empty")
   end
 
-  it "should not show contact type groups with only hidden contact types" do
+  it "does not show contact type groups with only hidden contact types" do
     expect(page).to_not have_text("Hidden")
   end
 

--- a/spec/system/admin_adds_new_case_spec.rb
+++ b/spec/system/admin_adds_new_case_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "admin adds a new case", type: :system do
     it "does not create a new case" do
       click_on "Create CASA Case"
 
-      expect(current_path).to eq(casa_cases_path)
+      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
       expect(page).to have_content("Case number can't be blank")
     end
   end
@@ -66,7 +66,7 @@ RSpec.describe "admin adds a new case", type: :system do
       fill_in "Case number", with: case_number
       click_on "Create CASA Case"
 
-      expect(current_path).to eq(casa_cases_path)
+      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
       expect(page).to have_content("Case number has already been taken")
     end
   end

--- a/spec/system/admin_assign_a_volunteer_to_case_spec.rb
+++ b/spec/system/admin_assign_a_volunteer_to_case_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "admin or supervisor assign and unassign a volunteer to case", ty
 
     click_on "Assign Volunteer"
   end
+
   after { travel_back }
 
   context "when a volunteer is assigned to a case" do

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Admin: Editing Volunteers", type: :system do
         click_on "Submit"
         expect(page).to have_text "already been taken"
       end
+
       it "shows error message for empty fields" do
         fill_in "volunteer_email", with: ""
         fill_in "volunteer_display_name", with: ""

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "admin views dashboard", type: :system do
   let(:admin) { create(:casa_admin, casa_org: organization) }
 
   before { travel_to Time.zone.local(2020, 8, 29, 4, 5, 6) }
+
   after { travel_back }
 
   it "displays other admins within the same CASA organization" do

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "all casa admins with casa orgs", type: :system do
+RSpec.describe "all casa admins with casa orgs", type: :system do
   context "as an all casa admin" do
     let(:all_casa_admin) { create(:all_casa_admin, email: "theexample@example.com") }
     let(:current_organization) { create(:casa_org) }

--- a/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admins_casa_orgs_spec.rb
@@ -4,6 +4,7 @@ describe "all casa admins with casa orgs", type: :system do
   context "as an all casa admin" do
     let(:all_casa_admin) { create(:all_casa_admin, email: "theexample@example.com") }
     let(:current_organization) { create(:casa_org) }
+
     before { sign_in all_casa_admin }
 
     it "lets admin navigate to an organization and see casa_admins" do

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Authentication", type: :system do
 
   context "when authenticated user" do
     let(:user) { create(:casa_admin) }
+
     before { sign_in user }
 
     it "renders dashboard page and shows correct flash message upon sign out" do

--- a/spec/system/can_sign_in_as_all_casa_admin_spec.rb
+++ b/spec/system/can_sign_in_as_all_casa_admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "AllCasaAdmin auth", type: :system do
+RSpec.describe "AllCasaAdmin auth", type: :system do
   let(:all_casa_admin) { create(:all_casa_admin) }
   let(:volunteer) { create(:volunteer) }
 

--- a/spec/system/creating_casa_admins_spec.rb
+++ b/spec/system/creating_casa_admins_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "When an admin creates a new admin", type: :system do
+RSpec.describe "When an admin creates a new admin", type: :system do
   before do
     admin = create(:casa_admin)
     sign_in admin
@@ -8,11 +8,11 @@ RSpec.feature "When an admin creates a new admin", type: :system do
     click_on("New Admin")
   end
 
-  scenario "they navigate to the new admin page" do
+  it "they navigate to the new admin page" do
     expect(page).to have_content("Create New Casa Admin")
   end
 
-  scenario "it creates when providing a valid email" do
+  it "creates when providing a valid email" do
     fill_in "Email", with: "casa_admin1@example.com"
     fill_in "Display Name", with: "Derrick Dev"
     click_button("Submit")
@@ -20,7 +20,7 @@ RSpec.feature "When an admin creates a new admin", type: :system do
     expect(page).to have_content "New Admin created."
   end
 
-  scenario "it fails when providing an invalid email" do
+  it "fails when providing an invalid email" do
     fill_in "Email", with: "casa_admin1@"
     fill_in "Display Name", with: "Derrick Dev"
     click_button("Submit")

--- a/spec/system/edit_user_system_spec.rb
+++ b/spec/system/edit_user_system_spec.rb
@@ -35,19 +35,19 @@ RSpec.describe "Editing Profile", type: :system do
     expect(page).to have_text("Password was successfully updated.")
   end
 
-  it "should not be able to update the email if user is a volunteer" do
+  it "is not able to update the email if user is a volunteer" do
     sign_in volunteer
     visit edit_users_path
     expect(page).to have_field("Email", disabled: true)
   end
 
-  it "should not be able to update the email if user is a supervisor" do
+  it "is not able to update the email if user is a supervisor" do
     sign_in supervisor
     visit edit_users_path
     expect(page).to have_field("Email", disabled: true)
   end
 
-  it "should not be able to update the profile without display name as an admin" do
+  it "is not able to update the profile without display name as an admin" do
     sign_in admin
     visit edit_users_path
 
@@ -57,7 +57,7 @@ RSpec.describe "Editing Profile", type: :system do
     expect(page).to have_text("Display name can't be blank")
   end
 
-  it "should be able to update the email if user is a admin" do
+  it "is able to update the email if user is a admin" do
     sign_in admin
     visit edit_users_path
     expect(page).to have_field("Email", disabled: false)

--- a/spec/system/session_spec.rb
+++ b/spec/system/session_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Session", type: :system do
   context "when a user is timed out" do
     let(:user) { create(:casa_admin) }
+
     before { sign_in user }
 
     it "ends the current session and redirects to sign in page after timeout" do

--- a/spec/system/supervisor_assigns_volunteers.rb
+++ b/spec/system/supervisor_assigns_volunteers.rb
@@ -29,6 +29,7 @@ RSpec.describe "supervisor volunteer assignment", type: :system do
     let(:organization) { create(:casa_org) }
     let!(:supervisor) { create(:supervisor, casa_org: organization) }
     let!(:volunteer_1) { create(:volunteer, display_name: "AAA", casa_org: organization) }
+
     it "does not error out when adding non existent volunteer" do
       sign_in supervisor
       visit edit_supervisor_path(supervisor)

--- a/spec/system/volunteer_edits_a_case_contact_spec.rb
+++ b/spec/system/volunteer_edits_a_case_contact_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "volunteer edits a case contact", type: :system do
     expect(case_contact.medium_type).to eq "letter"
     expect(case_contact.contact_made).to eq true
   end
+
   context "when the case contact occurred last quarter" do
     let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 94.days.ago) }
 

--- a/spec/system/volunteer_views_dashboard_spec.rb
+++ b/spec/system/volunteer_views_dashboard_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "volunteer views dashboard", type: :system do
   let(:volunteer) { create(:volunteer) }
 
-  before(:each) do
+  before do
     sign_in volunteer
   end
 

--- a/spec/views/casa_admins/admins_table.html.erb_spec.rb
+++ b/spec/views/casa_admins/admins_table.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "admins_table", type: :view do
+RSpec.describe "admins_table", type: :view do
   it "allows editing admin users" do
     admin = build_stubbed :casa_admin
     enable_pundit(view, admin)

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -11,6 +11,7 @@ describe "casa_cases/edit" do
 
   context "when accessed by a volunteer" do
     let(:user) { build_stubbed(:volunteer, casa_org: organization) }
+
     it "does not include volunteer assignment" do
       assign :casa_case, create(:casa_case, casa_org: organization)
 

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "casa_cases/edit" do
+RSpec.describe "casa_cases/edit" do
   let(:organization) { create(:casa_org) }
 
   before do

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -14,6 +14,7 @@ describe "casa_cases/new" do
 
   context "while signed in as admin" do
     let(:user) { build_stubbed(:casa_admin) }
+
     before do
       sign_in user
     end
@@ -24,6 +25,7 @@ describe "casa_cases/new" do
 
   context "while signed in as supervisor" do
     let(:user) { build_stubbed(:supervisor) }
+
     before do
       sign_in user
     end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "casa_cases/new" do
+RSpec.describe "casa_cases/new" do
   subject { render template: "casa_cases/new" }
 
   before do

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "case_contacts/case_contact" do
   let(:user) { build_stubbed(:casa_admin) }
+
   before do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "case_contacts/case_contact" do
+RSpec.describe "case_contacts/case_contact" do
   let(:user) { build_stubbed(:casa_admin) }
 
   before do

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "case_contacts/edit" do
+RSpec.describe "case_contacts/edit" do
   before do
     user = build_stubbed(:volunteer)
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/case_contacts/index.html.erb_spec.rb
+++ b/spec/views/case_contacts/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "case_contacts/index" do
+RSpec.describe "case_contacts/index" do
   let(:user) { build_stubbed(:volunteer) }
 
   before do

--- a/spec/views/case_contacts/index.html.erb_spec.rb
+++ b/spec/views/case_contacts/index.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "case_contacts/index" do
   let(:user) { build_stubbed(:volunteer) }
+
   before do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "case_contacts/new" do
+RSpec.describe "case_contacts/new" do
   subject { render template: "case_contacts/new" }
 
   before do

--- a/spec/views/case_court_reports/index.html.erb_spec.rb
+++ b/spec/views/case_court_reports/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "case_court_reports/index", type: :view do
+RSpec.describe "case_court_reports/index", type: :view do
   context "Volunteer views 'Generate Court Report' form" do
     let(:user) { create(:volunteer, :with_casa_cases) }
     let(:active_assigned_cases) { CasaCase.actively_assigned_to(user) }

--- a/spec/views/dashboard/show.html.erb_spec.rb
+++ b/spec/views/dashboard/show.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "dashboard/show", type: :view do
+RSpec.describe "dashboard/show", type: :view do
   context "logged in as an admin" do
   end
 end

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "layouts/application", type: :view do
+RSpec.describe "layouts/application", type: :view do
   subject { rendered }
 
   let(:title) { "CASA Volunteer Tracking" }

--- a/spec/views/layouts/footer.html.erb_spec.rb
+++ b/spec/views/layouts/footer.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "layout/footer", type: :view do
+RSpec.describe "layout/footer", type: :view do
   context "when not logged in" do
     it "renders report issue link on the footer" do
       render partial: "layouts/footers/not_logged_in"

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "layout/sidebar", type: :view do
+RSpec.describe "layout/sidebar", type: :view do
   before do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "supervisors/edit", type: :view do
+RSpec.describe "supervisors/edit", type: :view do
   before do
     admin = build_stubbed :casa_admin
     enable_pundit(view, admin)

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "supervisors/index" do
+RSpec.describe "supervisors/index" do
   let(:user) {}
 
   before do

--- a/spec/views/supervisors/new.html.erb_spec.rb
+++ b/spec/views/supervisors/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "supervisors/new" do
+RSpec.describe "supervisors/new" do
   subject { render template: "supervisors/new" }
 
   before do

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "volunteers" do
   subject { render template: "volunteers/index" }
+
   let(:user) { build_stubbed :volunteer }
   let(:volunteer) { create :volunteer }
 

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "volunteers" do
+RSpec.describe "volunteers" do
   subject { render template: "volunteers/index" }
 
   let(:user) { build_stubbed :volunteer }

--- a/spec/views/volunteers/new.html.erb_spec.rb
+++ b/spec/views/volunteers/new.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "volunteers/new" do
+RSpec.describe "volunteers/new" do
   subject { render template: "volunteers/new" }
 
   before do

--- a/spec/views/volunteers/new.html.erb_spec.rb
+++ b/spec/views/volunteers/new.html.erb_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 describe "volunteers/new" do
   subject { render template: "volunteers/new" }
+
   before do
     assign :volunteer, Volunteer.new
   end


### PR DESCRIPTION
### What changed, and why?
* Enforce that subject is the first definition in the test.
* Fix incorrect uses of context to specify methods.
* Change some descriptions
* Remove should syntax in favor of expect
* Use do end for multiline blocks `(example: let(:params) {... multilines ...} to  let(:params) do ... multilines ... end)`

#### Use the `disable_monkey_patching!` configuration option to disable all monkey patching done by RSpec:
* stops exposing DSL globally
* disables should and should_not syntax for rspec-expectations
* disables stub, should_receive, and should_not_receive syntax for rspec-mocks

### How is this tested? 💖💪
Running the full test suite.