### PR TITLE
1219 unassign volunteer button overflow

### DIFF
--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -5,41 +5,42 @@
     <% if @casa_case.volunteers.present? %>
       <br>
       <h3>Assigned Volunteers</h3>
-      <table class='table case-list'>
-        <thead>
-          <tr>
-            <th>Volunteer Name</th>
-            <th>Volunteer Email</th>
-            <th>Status</th>
-            <th>Start Date</th>
-            <th>End Date</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @casa_case.case_assignments.each do |assignment| %>
+      <div class="table-responsive">
+        <table class='table case-list'>
+          <thead>
             <tr>
-              <td data-test="volunteer-name">
-                <%= link_to assignment.volunteer.decorate.name, edit_volunteer_path(assignment.volunteer) %>
-              </td>
-              <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
-              <td data-test="assigned">
-                <% if assignment.is_active? %>
-                  <span class='badge badge-success text-uppercase'>Assigned</span>
-                <% else %>
-                  <span class="badge badge-danger text-uppercase">
-                    <%= assignment.volunteer.active? ? "Unassigned" : "Deactivated volunteer" %>
-                  </span>
-                <% end %>
-              </td>
-              <td data-test="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
-              <td data-test="assignment-end">
-                <% unless assignment.is_active? %>
-                  <%= assignment.updated_at.strftime("%B %e, %Y") %>
-                <% end %>
-              </td>
-              <td data-test="action">
-                <% if policy(assignment).unassign? %>
+              <th>Volunteer Name</th>
+              <th>Volunteer Email</th>
+              <th>Status</th>
+              <th>Start Date</th>
+              <th>End Date</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @casa_case.case_assignments.each do |assignment| %>
+              <tr>
+                <td data-test="volunteer-name">
+                  <%= link_to assignment.volunteer.decorate.name, edit_volunteer_path(assignment.volunteer) %>
+                </td>
+                <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
+                <td data-test="assigned">
+                  <% if assignment.is_active? %>
+                    <span class='badge badge-success text-uppercase'>Assigned</span>
+                  <% else %>
+                    <span class="badge badge-danger text-uppercase">
+                      <%= assignment.volunteer.active? ? "Unassigned" : "Deactivated volunteer" %>
+                    </span>
+                  <% end %>
+                </td>
+                <td data-test="assignment-start"><%= assignment.created_at.strftime("%B %e, %Y") %></td>
+                <td data-test="assignment-end">
+                  <% unless assignment.is_active? %>
+                    <%= assignment.updated_at.strftime("%B %e, %Y") %>
+                  <% end %>
+                </td>
+                <td data-test="action">
+                  <% if policy(assignment).unassign? %>
                     <%= button_to 'Unassign Volunteer',
                       unassign_case_assignment_path(assignment),
                       method: :patch,
@@ -47,19 +48,20 @@
                   <% elsif !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
                     <%= link_to "Activate Volunteer",
                       activate_volunteer_path(assignment.volunteer,
-                      redirect_to_path: 'casa_case',
-                      casa_case_id: @casa_case.id
-                    ),
-                    method: :patch,
-                    class: "btn btn-outline-success" %>
-                <% else %>
-                  None
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+                        redirect_to_path: 'casa_case',
+                        casa_case_id: @casa_case.id
+                      ),
+                      method: :patch,
+                      class: "btn btn-outline-success" %>
+                  <% else %>
+                    None
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     <% end %>
 
     <br>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -40,13 +40,13 @@
               </td>
               <td data-test="action">
                 <% if policy(assignment).unassign? %>
-                  <%= button_to 'Unassign Volunteer',
-                    unassign_case_assignment_path(assignment),
-                    method: :patch,
-                    class: "btn btn-outline-danger" %>
-                <% elsif !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
-                  <%= link_to "Activate Volunteer",
-                    activate_volunteer_path(assignment.volunteer,
+                    <%= button_to 'Unassign Volunteer',
+                      unassign_case_assignment_path(assignment),
+                      method: :patch,
+                      class: "btn btn-outline-danger text-wrap" %>
+                  <% elsif !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
+                    <%= link_to "Activate Volunteer",
+                      activate_volunteer_path(assignment.volunteer,
                       redirect_to_path: 'casa_case',
                       casa_case_id: @casa_case.id
                     ),


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1219 

### What changed, and why?
The table-responsive class has been added, it allows the contents of the table to be scrolled horizontally when  table items do not fit completely [Check table-responsive use on bootstrap docs](https://getbootstrap.com/docs/4.1/content/tables/#responsive-tables)
The text-wrap class has added to the button, that allows text to be wrapped. So the button takes up less space and its contents are displayed completely in a large part of the viewport [Check text-wrap use on bootstrap docs](https://getbootstrap.com/docs/4.4/utilities/text/#text-wrapping-and-overflow)

### How will this affect user permissions?
This not affect user permissions

### How is this tested? (please write tests!) 💖💪
This is a UI fix. Is automated testing necessary for this?

### Screenshots please :)
![Peek 2020-10-29 20-35](https://user-images.githubusercontent.com/6165892/97643463-75a8ac80-1a26-11eb-8cdf-b5da5e82ce3c.gif)

### Feelings gif
![Waiting for feedback](https://media.giphy.com/media/12bxfl9s6hkwGA/giphy.gif)
