### PR TITLE
Swap styles for Login and Forgot Password buttons

### DIFF
--- a/app/views/all_casa_admins/sessions/new.html.erb
+++ b/app/views/all_casa_admins/sessions/new.html.erb
@@ -18,10 +18,11 @@
             </div>
 
             <div class="actions">
-              <%= f.submit "Log in", class: "btn btn-outline-primary" %>
+              <%= f.submit "Log in", class: "btn btn-info" %>
             </div>
           <% end %>
 
+          <br>
           <%= render "all_casa_admins/shared/links" %>
 
           <br>

--- a/app/views/all_casa_admins/shared/_links.html.erb
+++ b/app/views/all_casa_admins/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br>
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn btn-outline-primary' %><br>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
             </div>
 
             <div class="actions">
-              <%= f.submit "Log in", class: "btn btn-outline-primary" %>
+              <%= f.submit "Log in", class: "btn btn-info" %>
             </div>
           <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn btn-info' %><br>
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'btn btn-outline-primary' %><br>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1223 

### What changed, and why?
In both Log In pages, the styles for the 'Log In' button and the 'Forgot Password' have been swapped. This way, the Log In button  is now filled and might be more eye-catching as a main action button.

### How will this affect user permissions?
No changes.

### How is this tested? (please write tests!) 💖💪
As this change does not impact system behavior in any way, no tests have been written.

### Screenshots please :)
#### Guest Log In page with button styles swapped
![image](https://user-images.githubusercontent.com/15658199/97717178-42f0c980-1aa3-11eb-8f73-4ecd72e01186.png)

#### AllCasaAdmin Log In page with button styles swapped
![image](https://user-images.githubusercontent.com/15658199/97717246-5734c680-1aa3-11eb-81e0-84a38e752efb.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![Every day is a good day when you paint.](https://media.giphy.com/media/AbPNdmgk6TJK/giphy.gif)
