### PR TITLE
inactive cases are hidden in assignment selector

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,9 +299,6 @@ GEM
     standard (0.8.1)
       rubocop (= 1.0.0)
       rubocop-performance (= 1.8.1)
-    sweetalert2-rails (0.1.1)
-    sweetify (2.0.0)
-      actionpack
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -8,7 +8,7 @@ module UiHelper
       [
         "Not Assigned",
         CasaCase
-          .not_assigned(@volunteer.casa_org)
+          .not_assigned(@volunteer.casa_org).active
           .map { |casa_case| [casa_case.case_number, casa_case.id] }
       ],
       [

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -27,7 +27,7 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   }
   scope :not_assigned, ->(casa_org) {
-    where(casa_org_id: casa_org.id)
+    where(casa_org_id: casa_org.id, active: true)
       .left_outer_joins(:case_assignments)
       .where(case_assignments: {id: nil})
       .order(:case_number)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -27,7 +27,7 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   }
   scope :not_assigned, ->(casa_org) {
-    where(casa_org_id: casa_org.id, active: true)
+    where(casa_org_id: casa_org.id)
       .left_outer_joins(:case_assignments)
       .where(case_assignments: {id: nil})
       .order(:case_number)
@@ -40,6 +40,14 @@ class CasaCase < ApplicationRecord
 
   scope :due_date_passed, -> {
     where("court_date < ?", Time.now)
+  }
+
+  scope :active, -> {
+    where(active: true)
+  }
+
+  scope :inactive, -> {
+    where(active: false)
   }
 
   delegate :name, to: :hearing_type, prefix: true, allow_nil: true

--- a/spec/system/volunteer_inactive_case_assignment.rb
+++ b/spec/system/volunteer_inactive_case_assignment.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "volunteer assigned to multiple cases", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:supervisor) { create(:casa_admin, casa_org: organization) }
+
+  describe 'innactive case visibility' do
+    let!(:active_casa_case) { create(:casa_case, casa_org: organization, case_number: "ACTIVE") }
+    let!(:inactive_casa_case) { create(:casa_case, casa_org: organization, active: false, case_number: "INACTIVE") }
+    let!(:volunteer) { create(:volunteer, display_name: "Awesome Volunteer", casa_org: organization) }
+
+    it 'supervisor does not have inactive cases as an option to assign to a volunteer' do
+      sign_in supervisor
+      visit edit_volunteer_path(volunteer)
+
+      expect(page).to have_content(active_casa_case.case_number)
+      expect(page).not_to have_content(inactive_casa_case.case_number)
+    end
+  end
+end

--- a/spec/system/volunteer_inactive_case_assignment.rb
+++ b/spec/system/volunteer_inactive_case_assignment.rb
@@ -4,12 +4,12 @@ RSpec.describe "volunteer assigned to multiple cases", type: :system do
   let(:organization) { create(:casa_org) }
   let(:supervisor) { create(:casa_admin, casa_org: organization) }
 
-  describe 'innactive case visibility' do
+  describe "innactive case visibility" do
     let!(:active_casa_case) { create(:casa_case, casa_org: organization, case_number: "ACTIVE") }
     let!(:inactive_casa_case) { create(:casa_case, casa_org: organization, active: false, case_number: "INACTIVE") }
     let!(:volunteer) { create(:volunteer, display_name: "Awesome Volunteer", casa_org: organization) }
 
-    it 'supervisor does not have inactive cases as an option to assign to a volunteer' do
+    it "supervisor does not have inactive cases as an option to assign to a volunteer" do
       sign_in supervisor
       visit edit_volunteer_path(volunteer)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1184 

### What changed, and why?

Added a `active` scope on `CasaCase` and chained that scope onto the `not_assigned` scope used in `ui_helper` to display available cases for assignment. 

This is important to prevent the accidental assignment of an inactive case to a volunteer. 

### How will this affect user permissions?
- Volunteer permissions: no affect
- Supervisor permissions: no affect
- Admin permissions: no affect

### How is this tested? (please write tests!) 💖💪

Added a system test and tested manually

### Screenshots please :)

<img width="1002" alt="Screen Shot 2020-10-30 at 8 58 52 PM" src="https://user-images.githubusercontent.com/7292/97767498-c8e83100-1af2-11eb-8160-8eb28090262d.png">

<img width="205" alt="Screen Shot 2020-10-30 at 9 01 21 PM" src="https://user-images.githubusercontent.com/7292/97767549-1cf31580-1af3-11eb-9f13-f097ec1efdde.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

![awesome](https://media.giphy.com/media/3ohzdIuqJoo8QdKlnW/giphy.gif)