### PR TITLE
Authorizes deactive and reactivate controller's method

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -59,26 +59,26 @@ class CasaCasesController < ApplicationController
   end
 
   def deactivate
-    casa_case = CasaCase.find(params[:id])
+    @casa_case = CasaCase.find(params[:id])
 
-    return render :edit unless Pundit.policy(current_user, casa_case).update_case_status?
+    authorize @casa_case, :update_case_status?
 
-    flash_message = "Case #{casa_case.case_number} has been deactivated."
-    if casa_case.deactivate
-      redirect_to edit_casa_case_path(casa_case), notice: flash_message
+    if @casa_case.deactivate
+      flash_message = "Case #{@casa_case.case_number} has been deactivated."
+      redirect_to edit_casa_case_path(@casa_case), notice: flash_message
     else
       render :edit
     end
   end
 
   def reactivate
-    casa_case = CasaCase.find(params[:id])
+    @casa_case = CasaCase.find(params[:id])
 
-    return render :edit unless Pundit.policy(current_user, casa_case).update_case_status?
+    authorize @casa_case, :update_case_status?
 
-    flash_message = "Case #{casa_case.case_number} has been reactivated."
-    if casa_case.reactivate
-      redirect_to edit_casa_case_path(casa_case), notice: flash_message
+    if @casa_case.reactivate
+      flash_message = "Case #{@casa_case.case_number} has been reactivated."
+      redirect_to edit_casa_case_path(@casa_case), notice: flash_message
     else
       render :edit
     end

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -60,7 +60,9 @@ class CasaCasesController < ApplicationController
 
   def deactivate
     casa_case = CasaCase.find(params[:id])
-    # TODO: authorize action with pundit
+
+    return render :edit unless Pundit.policy(current_user, casa_case).update_case_status?
+
     flash_message = "Case #{casa_case.case_number} has been deactivated."
     if casa_case.deactivate
       redirect_to edit_casa_case_path(casa_case), notice: flash_message
@@ -71,7 +73,9 @@ class CasaCasesController < ApplicationController
 
   def reactivate
     casa_case = CasaCase.find(params[:id])
-    # TODO: authorize action w/ Pundit
+
+    return render :edit unless Pundit.policy(current_user, casa_case).update_case_status?
+
     flash_message = "Case #{casa_case.case_number} has been reactivated."
     if casa_case.reactivate
       redirect_to edit_casa_case_path(casa_case), notice: flash_message

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -10,5 +10,13 @@ FactoryBot.define do
     trait :with_case_assignments do
       case_assignments { build_list(:case_assignment, 2) }
     end
+
+    trait :active do
+      active { true }
+    end
+
+    trait :inactive do
+      active { false }
+    end
   end
 end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -117,6 +117,74 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to redirect_to(casa_cases_url)
       end
     end
+
+    describe "PATCH /casa_cases/:id/deactivate" do
+      let(:casa_case) { create(:casa_case, :active, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "deactivates the requested casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq false
+      end
+
+      it "redirects to the casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(response).to redirect_to(edit_casa_case_path)
+      end
+
+      it "flashes success message" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        expect(flash[:notice]).to include("Case #{casa_case.case_number} has been deactivated.")
+      end
+
+      context 'when deactivation fails' do
+        before do
+          allow_any_instance_of(CasaCase).to receive(:deactivate).and_return(false)
+        end
+
+        it "does not deactivate the requested casa_case" do
+          patch deactivate_casa_case_path(casa_case), params: params
+          casa_case.reload
+          expect(casa_case.active).to eq true
+        end
+      end
+    end
+
+    describe "PATCH /casa_cases/:id/reactivate" do
+      let(:casa_case) { create(:casa_case, :inactive, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "reactivates the requested casa_case" do
+        patch reactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq true
+      end
+
+      it "redirects to the casa_case" do
+        patch reactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(response).to redirect_to(edit_casa_case_path)
+      end
+
+      it "flashes success message" do
+        patch reactivate_casa_case_path(casa_case), params: params
+        expect(flash[:notice]).to include("Case #{casa_case.case_number} has been reactivated.")
+      end
+
+      context 'when reactivation fails' do
+        before do
+          allow_any_instance_of(CasaCase).to receive(:reactivate).and_return(false)
+        end
+
+        it "does not reactivate the requested casa_case" do
+          patch deactivate_casa_case_path(casa_case), params: params
+          casa_case.reload
+          expect(casa_case.active).to eq false
+        end
+      end
+    end
   end
 
   describe "as a volunteer" do
@@ -169,6 +237,28 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_successful
         expect(response.body).to include(mine.case_number)
         expect(response.body).not_to include(other.case_number)
+      end
+    end
+
+    describe "PATCH /casa_cases/:id/deactivate" do
+      let(:casa_case) { create(:casa_case, :active, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "does not deactivate the requested casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq true
+      end
+    end
+
+    describe "PATCH /casa_cases/:id/reactivate" do
+      let(:casa_case) { create(:casa_case, :inactive, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "does not deactivate the requested casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq false
       end
     end
   end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -305,5 +305,27 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_successful
       end
     end
+
+    describe "PATCH /casa_cases/:id/deactivate" do
+      let(:casa_case) { create(:casa_case, :active, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "does not deactivate the requested casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq true
+      end
+    end
+
+    describe "PATCH /casa_cases/:id/reactivate" do
+      let(:casa_case) { create(:casa_case, :inactive, casa_org: organization, case_number: "111") }
+      let(:params) { { id: casa_case.id } }
+
+      it "does not deactivate the requested casa_case" do
+        patch deactivate_casa_case_path(casa_case), params: params
+        casa_case.reload
+        expect(casa_case.active).to eq false
+      end
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1193

### What changed, and why?

The following actions are guarded by Pundit in the views, but there is nothing checking in the controllers for permissions.

- This PR is authorizing `deactivate` and `reactivate` methods with `Pundit` as well.
- Adds specs to methods in controller.

### How will this affect user permissions?
Permissions are already set.

- Volunteer permissions: -
- Supervisor permissions: - 
- Admin permissions: - 

### How is this tested? (please write tests!) 💖💪
New and old code paths got specs  👍 

### Screenshots please :)
It does not introduces any new UI it just relies on default authorization and existing forms.

### Feelings gif (optional)