### PR TITLE
Do not allow volunteers to set hearing type or judge on casa case form

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -42,6 +42,14 @@ class CasaCasePolicy
     user.casa_admin? || user.supervisor?
   end
 
+  def update_hearing_type?
+    user.casa_admin? || user.supervisor?
+  end
+
+  def update_judge?
+    user.casa_admin? || user.supervisor?
+  end
+
   def update_court_report_due_date?
     user.casa_admin? || user.supervisor?
   end
@@ -62,9 +70,9 @@ class CasaCasePolicy
 
     case @user
     when CasaAdmin
-      common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date])
+      common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
     when Supervisor
-      common_attrs.concat(%i[court_date court_report_due_date])
+      common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
     else
       common_attrs
     end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -4,7 +4,7 @@
       <%= render "/shared/error_messages", resource: casa_case %>
 
       <div class="field form-group">
-        <% if !casa_case.persisted? || Pundit.policy(current_user, casa_case).update_case_number? %>
+        <% if casa_case.new_record? || policy(casa_case).update_case_number? %>
           <%= form.label :case_number %>
           <%= form.text_field :case_number, class: "form-control" %>
         <% else %>
@@ -12,27 +12,31 @@
         <% end %>
       </div>
 
-      <div class="field form-group">
-        <%= form.label :hearing_type_id %>
-        <%= form.collection_select(
-          :hearing_type_id,
-          HearingType.active.for_organization(current_organization),
-          :id, :name,
-          { include_hidden: false, prompt: "-Select Hearing Type-" },
-          { class: "form-control" }
-        ) %>
-      </div>
+      <% if policy(casa_case).update_hearing_type? %>
+        <div class="field form-group">
+          <%= form.label :hearing_type_id %>
+          <%= form.collection_select(
+            :hearing_type_id,
+            HearingType.active.for_organization(current_organization),
+            :id, :name,
+            { include_hidden: false, prompt: "-Select Hearing Type-" },
+            { class: "form-control" }
+          ) %>
+        </div>
+      <% end %>
 
-      <div class="field form-group">
-        <%= form.label :judge_id %>
-        <%= form.collection_select(
-          :judge_id,
-          Judge.for_organization(current_organization),
-          :id, :name,
-          { include_hidden: false, prompt: "-Select Judge-" },
-          { class: "form-control" }
-        ) %>
-      </div>
+      <% if policy(casa_case).update_judge? %>
+        <div class="field form-group">
+          <%= form.label :judge_id %>
+          <%= form.collection_select(
+            :judge_id,
+            Judge.for_organization(current_organization),
+            :id, :name,
+            { include_hidden: false, prompt: "-Select Judge-" },
+            { class: "form-control" }
+          ) %>
+        </div>
+      <% end %>
 
       <div class="field form-group">
         <% if policy(casa_case).update_court_date? %>

--- a/spec/factories/hearing_type.rb
+++ b/spec/factories/hearing_type.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :hearing_type do
     casa_org { create(:casa_org) }
-    name { "Emergency Hearing" }
+    sequence(:name) { |n| "Emergency Hearing #{n}" }
     active { true }
   end
 end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "/casa_cases", type: :request do
   let(:organization) { create(:casa_org) }
-  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true, casa_org_id: organization.id} }
+  let(:hearing_type) { create(:hearing_type) }
+  let(:judge) { create(:judge) }
+  let(:valid_attributes) { {case_number: "1234", transition_aged_youth: true, casa_org_id: organization.id, hearing_type_id: hearing_type.id, judge_id: judge.id} }
   let(:invalid_attributes) { {case_number: nil} }
   let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "111") }
 
@@ -61,6 +63,15 @@ RSpec.describe "/casa_cases", type: :request do
           post casa_cases_url, params: {casa_case: valid_attributes}
           expect(response).to redirect_to(casa_case_url(CasaCase.last))
         end
+
+        it "sets fields correctly" do
+          post casa_cases_url, params: {casa_case: valid_attributes}
+          casa_case = CasaCase.last
+          expect(casa_case.casa_org).to eq organization
+          expect(casa_case.transition_aged_youth).to be true
+          expect(casa_case.hearing_type).to eq hearing_type
+          expect(casa_case.judge).to eq judge
+        end
       end
 
       context "with invalid parameters" do
@@ -80,12 +91,20 @@ RSpec.describe "/casa_cases", type: :request do
 
     describe "PATCH /update" do
       context "with valid parameters" do
-        let(:new_attributes) { {case_number: "12345"} }
+        let(:new_attributes) {
+          {
+            case_number: "12345",
+            hearing_type_id: hearing_type.id,
+            judge_id: judge.id
+          }
+        }
 
         it "updates the requested casa_case" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           casa_case.reload
           expect(casa_case.case_number).to eq "12345"
+          expect(casa_case.hearing_type).to eq hearing_type
+          expect(casa_case.judge).to eq judge
         end
 
         it "redirects to the casa_case" do
@@ -141,13 +160,24 @@ RSpec.describe "/casa_cases", type: :request do
 
     describe "PATCH /update" do
       context "with valid parameters" do
-        let(:new_attributes) { {case_number: "12345", court_report_submitted: true} }
+        let(:new_attributes) {
+          {
+            case_number: "12345",
+            court_report_submitted: true,
+            hearing_type_id: hearing_type.id,
+            judge_id: judge.id
+          }
+        }
 
-        it "updates fields (except case_number)" do
+        it "updates permitted fields" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           casa_case.reload
-          expect(casa_case.case_number).to eq "111"
           expect(casa_case.court_report_submitted).to be true
+
+          # Not permitted
+          expect(casa_case.case_number).to eq "111"
+          expect(casa_case.hearing_type).to_not eq hearing_type
+          expect(casa_case.judge).to_not eq judge
         end
 
         it "redirects to the casa_case" do

--- a/spec/system/admin_edits_a_case_spec.rb
+++ b/spec/system/admin_edits_a_case_spec.rb
@@ -25,11 +25,14 @@ RSpec.describe "admin edits case", type: :system do
   it "edits case" do
     visit casa_case_path(casa_case.id)
     click_on "Edit Case Details"
+    expect(page).to have_select("Hearing type")
+    expect(page).to have_select("Judge")
     has_no_checked_field? :court_report_submitted
     check "Court report submitted"
     click_on "Update CASA Case"
 
     has_checked_field? :court_report_submitted
+
     expect(page).to have_text("Court Date")
     expect(page).to have_text("Court Report Due Date")
     expect(page).to have_text("Day")

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "volunteer edits case", type: :system do
 
   it "clicks back button after editing case" do
     visit edit_casa_case_path(casa_case)
+
+    expect(page).to_not have_select("Hearing type")
+    expect(page).to_not have_select("Judge")
+
     check "Court report submitted"
     click_on "Update CASA Case"
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1268 

### What changed, and why?

*  Removed Hearing Types and Judges from Casa Case form for volunteers
* Added `hearing_type_id` and `judge_id` to strong parameters so supervisors and admins can actually update those fields

### How will this affect user permissions?
- Volunteer permissions: fixed so can't select hearing types or judges for casa cases
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
* Added admin/supervisor/volunteer specs
* Added request specs

### Screenshots please :)

<img width="1289" alt="Screen Shot 2020-11-05 at 9 55 01 PM" src="https://user-images.githubusercontent.com/1938665/98332045-c5e9b680-1fb2-11eb-8025-908f15be66c6.png">

<img width="681" alt="Screen Shot 2020-11-05 at 9 55 49 PM" src="https://user-images.githubusercontent.com/1938665/98332054-caae6a80-1fb2-11eb-8c97-69dbbfed81a1.png">
