### PR TITLE
Don't show Emancipation Checklist to non-volunteers

### DIFF
--- a/app/controllers/emancipation_checklists_controller.rb
+++ b/app/controllers/emancipation_checklists_controller.rb
@@ -1,4 +1,5 @@
 class EmancipationChecklistsController < ApplicationController
   def show
+    authorize :application, :see_emancipation_checklist?
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,6 +9,10 @@ class ApplicationPolicy
     user.supervisor? || user.casa_admin?
   end
 
+  def see_emancipation_checklist?
+    user.volunteer?
+  end
+
   def see_import_page?
     user.casa_admin?
   end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -23,8 +23,9 @@
           <%#<% if current_user.casa_case&.emancipation_checklist  %>
           <%#<%= menu_item(label: "Emancipation Checklist", path: emancipation_checklist_path) %>
           <%# <% end %>
-
-          <%= menu_item(label: "Emancipation Checklist", path: emancipation_checklist_path(0)) %>
+          <% if policy(:application).see_emancipation_checklist? %>
+            <%= menu_item(label: "Emancipation Checklist", path: emancipation_checklist_path(0)) %>
+          <% end %>
           <%= menu_item(label: "Admins", path: casa_admins_path, visible: policy(CasaAdmin).index?) %>
         <% end %>
       </div>

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe ApplicationPolicy do
       expect(subject).not_to permit(create(:supervisor))
     end
   end
+
+  permissions :see_emancipation_checklist? do
+    it "allows volunteers" do
+      expect(subject).to permit(create(:volunteer))
+    end
+
+    it "does not allow casa_admins" do
+      expect(subject).not_to permit(create(:casa_admin))
+    end
+
+    it "does not allow supervisors" do
+      expect(subject).not_to permit(create(:supervisor))
+    end
+  end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
   end
 
@@ -99,6 +100,7 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for if any?
Resolves #1267

### What changed, and why?
Remove Emancipation Checklist from the sidebar for supervisors and admins

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added specs

