### PR TITLE
Only display judge names if Casa org has judges

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -25,17 +25,19 @@
         </div>
       <% end %>
 
-      <% if policy(casa_case).update_judge? %>
-        <div class="field form-group">
-          <%= form.label :judge_id %>
-          <%= form.collection_select(
-            :judge_id,
-            Judge.for_organization(current_organization),
-            :id, :name,
-            { include_hidden: false, prompt: "-Select Judge-" },
-            { class: "form-control" }
-          ) %>
-        </div>
+      <% if Judge.for_organization(current_organization).any? %>
+        <% if policy(casa_case).update_judge? %>
+          <div class="field form-group">
+            <%= form.label :judge_id %>
+            <%= form.collection_select(
+              :judge_id,
+              Judge.for_organization(current_organization),
+              :id, :name,
+              { include_hidden: false, prompt: "-Select Judge-" },
+              { class: "form-control" }
+            ) %>
+          </div>
+        <% end %>
       <% end %>
 
       <div class="field form-group">

--- a/spec/system/supervisor_edits_case_spec.rb
+++ b/spec/system/supervisor_edits_case_spec.rb
@@ -96,4 +96,24 @@ RSpec.describe "supervisor edits case", type: :system do
     expect(page).not_to have_text("Reactivate Case")
     expect(page).not_to have_text("Update Casa Case")
   end
+
+  context "When a Casa instance has no judge names added" do
+    it "does not display judge names details" do
+      casa_case = create(:casa_case, casa_org: casa_org, judge: nil)
+
+      visit edit_casa_case_path(casa_case)
+
+      expect(page).not_to have_select("Judge")
+    end
+  end
+
+  context "When an admin has added judge names to a Casa instance" do
+    it "displays judge details as select option" do
+      judge = create :judge, casa_org: casa_org
+
+      visit edit_casa_case_path(casa_case)
+
+      expect(page).to have_select("Judge")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1153

### What changed, and why?
This ensures the "Select Judge" dropdown is not displayed when
editing/creating cases belonging to a Casa org that has no Judges
assigned. This is done by wrapping the select with a conditional that checks if there are any judges for the current organisation.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
The PR adds two tests in the `spec/system/supervisor_edits_case_spec.rb´,  ensuring the Judge select menu is available when there are judges assigned and checking the menu is not available when there are none.

### Screenshots please :)

Select menu unavailable:
![Screenshot 2020-11-07 at 16 37 32](https://user-images.githubusercontent.com/658761/98446754-a029f200-2117-11eb-9287-c73fe2461e79.png)

Select menu available:
![Screenshot 2020-11-07 at 16 38 39](https://user-images.githubusercontent.com/658761/98446771-c0f24780-2117-11eb-9d5b-3b061e96500d.png)
