### PR TITLE
Update specs to reflect new court report status select

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -18,7 +18,7 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def court_report_submitted_date
-    object.court_report_submitted_at&.strftime('%B%e, %Y')
+    object.court_report_submitted_at&.strftime("%B%e, %Y")
   end
 
   def case_contacts_ordered_by_occurred_at

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -23,7 +23,7 @@ class CasaCase < ApplicationRecord
   has_many :contact_types, through: :casa_case_contact_types, source: :contact_type
   accepts_nested_attributes_for :casa_case_contact_types
 
-  enum court_report_status: { not_submitted: 0, submitted: 1, in_review: 2, completed: 3 }, _prefix: :court_report
+  enum court_report_status: {not_submitted: 0, submitted: 1, in_review: 2, completed: 3}, _prefix: :court_report
 
   scope :ordered, -> { order(updated_at: :desc) }
   scope :actively_assigned_to, ->(volunteer) {
@@ -66,7 +66,7 @@ class CasaCase < ApplicationRecord
 
   def court_report_status=(value)
     super
-    if (court_report_not_submitted?)
+    if court_report_not_submitted?
       self.court_report_submitted_at = nil
     else
       self.court_report_submitted_at ||= Time.current

--- a/lib/tasks/deployment/20201108181154_backfill_court_report_submitted_at.rake
+++ b/lib/tasks/deployment/20201108181154_backfill_court_report_submitted_at.rake
@@ -1,9 +1,9 @@
 namespace :after_party do
-  desc 'Deployment task: Backfill court_report_submitted_at and court_report_status'
+  desc "Deployment task: Backfill court_report_submitted_at and court_report_status"
   task backfill_court_report_submitted_at: :environment do
     puts "Running deploy task 'backfill_court_report_submitted_at'"
 
-    CasaCase.where(court_report_submitted: true).in_batches.update_all(court_report_status: :submitted, 
+    CasaCase.where(court_report_submitted: true).in_batches.update_all(court_report_status: :submitted,
                                                                        court_report_submitted_at: Time.current)
 
     # Update task as completed.  If you remove the line below, the task will

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -8,25 +8,25 @@ RSpec.describe CasaCaseDecorator do
     context "when case_report_status is not_submitted" do
       let(:court_report_status) { :not_submitted }
 
-      it { is_expected.to eq('Not submitted') }
+      it { is_expected.to eq("Not submitted") }
     end
 
     context "when case_report_status is submitted" do
       let(:court_report_status) { :submitted }
 
-      it { is_expected.to eq('Submitted') }
+      it { is_expected.to eq("Submitted") }
     end
 
     context "when case_report_status is in_review" do
       let(:court_report_status) { :in_review }
 
-      it { is_expected.to eq('In review') }
+      it { is_expected.to eq("In review") }
     end
 
     context "when case_report_status is completed" do
       let(:court_report_status) { :completed }
 
-      it { is_expected.to eq('Completed') }
+      it { is_expected.to eq("Completed") }
     end
   end
 
@@ -34,10 +34,10 @@ RSpec.describe CasaCaseDecorator do
     subject { casa_case.decorate.court_report_submitted_date }
     let(:submitted_time) { Time.parse("Sun Nov 08 11:06:20 2020") }
     let(:casa_case) { build(:casa_case, court_report_submitted_at: submitted_time) }
-    
-    it { is_expected.to eq 'November 8, 2020' }
 
-    context 'when report is not submitted' do
+    it { is_expected.to eq "November 8, 2020" }
+
+    context "when report is not submitted" do
       let(:submitted_time) { nil }
 
       it { is_expected.to be_nil }

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CasaCase do
     end
   end
 
-  describe '#court_report_status=' do
+  describe "#court_report_status=" do
     let(:casa_case) { build(:casa_case) }
     subject { casa_case.court_report_status = court_report_status }
 
@@ -76,49 +76,49 @@ RSpec.describe CasaCase do
     before do
       travel_to submitted_time
     end
-  
+
     after do
       travel_back
     end
 
-    context 'when the case is already submitted' do
+    context "when the case is already submitted" do
       let(:casa_case) { build(:casa_case, court_report_status: :submitted, court_report_submitted_at: submitted_time) }
       before do
         travel_to the_future
       end
 
-      context 'when the status is completed' do
+      context "when the status is completed" do
         let(:court_report_status) { :completed }
 
-        it 'completes the court report and does not update time' do
+        it "completes the court report and does not update time" do
           is_expected.to eq :completed
           expect(casa_case.court_report_submitted_at).to eq(submitted_time)
         end
       end
 
-      context 'when the status is not_submitted' do
+      context "when the status is not_submitted" do
         let(:court_report_status) { :not_submitted }
 
-        it 'clears submission date and value' do
+        it "clears submission date and value" do
           is_expected.to eq :not_submitted
           expect(casa_case.court_report_submitted_at).to be_nil
         end
       end
     end
 
-    context 'when status is submitted' do
+    context "when status is submitted" do
       let(:court_report_status) { :submitted }
 
-      it 'tracks the court report submission' do
+      it "tracks the court report submission" do
         is_expected.to eq :submitted
         expect(casa_case.court_report_submitted_at).to eq(submitted_time)
       end
     end
 
-    context 'when the status is in review' do
+    context "when the status is in review" do
       let(:court_report_status) { :in_review }
 
-      it 'tracks the court report submission' do
+      it "tracks the court report submission" do
         is_expected.to eq :in_review
         expect(casa_case.court_report_submitted_at).to eq(submitted_time)
       end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "/casa_cases", type: :request do
         it "updates permitted fields" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           casa_case.reload
-          expect(casa_case.submitted?).to be_truthy
+          expect(casa_case.court_report_submitted?).to be_truthy
 
           # Not permitted
           expect(casa_case.case_number).to eq "111"
@@ -228,7 +228,7 @@ RSpec.describe "/casa_cases", type: :request do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           casa_case.reload
           expect(casa_case.case_number).to eq "111"
-          expect(casa_case.completed?).to be true
+          expect(casa_case.court_report_completed?).to be true
         end
 
         it "redirects to the casa_case" do

--- a/spec/system/admin_adds_new_case_spec.rb
+++ b/spec/system/admin_adds_new_case_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe "admin adds a new case", type: :system do
 
       select "1", from: "casa_case_court_report_due_date_3i"
       select "April", from: "casa_case_court_report_due_date_2i"
-      select next_year, from: "casa_case_court_report_due_date_1i" 
+      select next_year, from: "casa_case_court_report_due_date_1i"
 
       check "Transition aged youth"
       has_checked_field? "Transition aged youth"
 
-      select 'Submitted', from: "casa_case_court_report_status"
+      select "Submitted", from: "casa_case_court_report_status"
 
       click_on "Create CASA Case"
 

--- a/spec/system/admin_adds_new_case_spec.rb
+++ b/spec/system/admin_adds_new_case_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe "admin adds a new case", type: :system do
 
       select "1", from: "casa_case_court_report_due_date_3i"
       select "April", from: "casa_case_court_report_due_date_2i"
-      select next_year, from: "casa_case_court_report_due_date_1i"
+      select next_year, from: "casa_case_court_report_due_date_1i" 
 
       check "Transition aged youth"
       has_checked_field? "Transition aged youth"
+
+      select 'Submitted', from: "casa_case_court_report_status"
 
       click_on "Create CASA Case"
 

--- a/spec/system/admin_edits_a_case_spec.rb
+++ b/spec/system/admin_edits_a_case_spec.rb
@@ -14,12 +14,10 @@ RSpec.describe "admin edits case", type: :system do
 
   it "clicks back button after editing case" do
     visit edit_casa_case_path(casa_case)
-    check "Court report submitted"
-    has_checked_field? :court_report_submitted
+    select "Submitted", from: "casa_case_court_report_status"
     click_on "Back"
     visit edit_casa_case_path(casa_case)
-
-    has_no_checked_field? :court_report_submitted
+    expect(casa_case).not_to be_court_report_submitted
   end
 
   it "edits case" do
@@ -27,12 +25,9 @@ RSpec.describe "admin edits case", type: :system do
     click_on "Edit Case Details"
     expect(page).to have_select("Hearing type")
     expect(page).to have_select("Judge")
-    has_no_checked_field? :court_report_submitted
-    check "Court report submitted"
+    select "Submitted", from: "casa_case_court_report_status"
     click_on "Update CASA Case"
-
-    has_checked_field? :court_report_submitted
-
+    expect(page).to have_text("Submitted")
     expect(page).to have_text("Court Date")
     expect(page).to have_text("Court Report Due Date")
     expect(page).to have_text("Day")

--- a/spec/system/supervisor_edits_case_spec.rb
+++ b/spec/system/supervisor_edits_case_spec.rb
@@ -15,10 +15,9 @@ RSpec.describe "supervisor edits case", type: :system do
 
   it "edits case" do
     visit casa_case_path(casa_case)
-    expect(page).to have_text("Court Report Submission: Not Submitted")
+    expect(page).to have_text("Court Report Status: Not submitted")
     visit edit_casa_case_path(casa_case)
-    has_no_checked_field? :court_report_submitted
-    check "Court report submitted"
+    select "Submitted", from: "casa_case_court_report_status"
     check "Youth"
     select "4", from: "casa_case_court_date_3i"
     select "November", from: "casa_case_court_date_2i"
@@ -29,7 +28,6 @@ RSpec.describe "supervisor edits case", type: :system do
     select next_year, from: "casa_case_court_report_due_date_1i"
 
     click_on "Update CASA Case"
-    has_checked_field? :court_report_submitted
     has_checked_field? "Youth"
     has_no_checked_field? "Supervisor"
 
@@ -43,16 +41,15 @@ RSpec.describe "supervisor edits case", type: :system do
 
     visit casa_case_path(casa_case)
 
-    expect(page).to have_text("Court Report Submission: Submitted")
+    expect(page).to have_text("Court Report Status: Submitted")
     expect(page).to have_text("4-NOV-#{next_year}")
     expect(page).to have_text("8-SEP-#{next_year}")
   end
 
   it "will return error message if date fields are not fully selected" do
     visit casa_case_path(casa_case)
-    expect(page).to have_text("Court Report Submission: Not Submitted")
+    expect(page).to have_text("Court Report Status: Not submitted")
     visit edit_casa_case_path(casa_case)
-    has_no_checked_field? :court_report_submitted
 
     select "November", from: "casa_case_court_date_2i"
     select "April", from: "casa_case_court_report_due_date_2i"
@@ -65,9 +62,8 @@ RSpec.describe "supervisor edits case", type: :system do
 
   it "will return error message if date fields are not valid" do
     visit casa_case_path(casa_case)
-    expect(page).to have_text("Court Report Submission: Not Submitted")
+    expect(page).to have_text("Court Report Status: Not submitted")
     visit edit_casa_case_path(casa_case)
-    has_no_checked_field? :court_report_submitted
 
     select "31", from: "casa_case_court_date_3i"
     select "April", from: "casa_case_court_date_2i"

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe "volunteer edits case", type: :system do
     expect(page).to_not have_select("Hearing type")
     expect(page).to_not have_select("Judge")
 
-    check "Court report submitted"
+    select 'Submitted', from: "casa_case_court_report_status"
     click_on "Update CASA Case"
-
-    has_no_checked_field? :court_report_submitted
 
     click_on "Back"
 
@@ -27,12 +25,10 @@ RSpec.describe "volunteer edits case", type: :system do
 
   it "edits case" do
     visit casa_case_path(casa_case)
-    expect(page).to have_text("Court Report Submission: Not Submitted")
+    expect(page).to have_text("Court Report Status: Not submitted")
     visit edit_casa_case_path(casa_case)
-    has_no_checked_field? :court_report_submitted
-    check "Court report submitted"
+    select 'Submitted', from: "casa_case_court_report_status"
     click_on "Update CASA Case"
-    has_checked_field? :court_report_submitted
 
     expect(page).to have_text("Court Date")
     expect(page).to have_text("Court Report Due Date")
@@ -42,6 +38,6 @@ RSpec.describe "volunteer edits case", type: :system do
     expect(page).not_to have_text("Deactivate Case")
 
     visit casa_case_path(casa_case)
-    expect(page).to have_text("Court Report Submission: Submitted")
+    expect(page).to have_text("Court Report Status: Submitted")
   end
 end

--- a/spec/system/volunteer_edits_case_spec.rb
+++ b/spec/system/volunteer_edits_case_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "volunteer edits case", type: :system do
     expect(page).to_not have_select("Hearing type")
     expect(page).to_not have_select("Judge")
 
-    select 'Submitted', from: "casa_case_court_report_status"
+    select "Submitted", from: "casa_case_court_report_status"
     click_on "Update CASA Case"
 
     click_on "Back"
@@ -27,7 +27,7 @@ RSpec.describe "volunteer edits case", type: :system do
     visit casa_case_path(casa_case)
     expect(page).to have_text("Court Report Status: Not submitted")
     visit edit_casa_case_path(casa_case)
-    select 'Submitted', from: "casa_case_court_report_status"
+    select "Submitted", from: "casa_case_court_report_status"
     click_on "Update CASA Case"
 
     expect(page).to have_text("Court Date")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #806 

### What changed, and why?
`court_report_submitted` as a boolean only tracked whether or not the report had been submitted. It did not track when it was submitted nor if it was completed. This PR adds `court_report_status` which tracks the current status of the court report, and `court_report_submitted_at` which tracks when it was submitted.

Cases will now have a court report status of 'Not submitted' by default. All users can update `court_report_status`. When the `court_report_status` is set to 'Submitted', 'In review', or 'Completed' for the first time, the `court_report_submitted_at` field is immediately set. If the `court_report_status` is ever set to 'Not submitted', the `court_report_submitted_at` date field will be cleared.

This PR also adds an after_party backfill that modifies all cases that were previously marked as `court_report_submitted`. All cases will be updated to have a `court_report_submitted_at` of the current date and `court_report_status` of submitted.

### How will this affect user permissions?
- Volunteer permissions: No Change
- Supervisor permissions: No Change
- Admin permissions: No Change

### How is this tested? (please write tests!) 💖💪
- Using Unit tests, and updating the request specs for casa cases

### Screenshots
Details Page - Not Submitted (`court_report_status: :not_submitted, court_report_submitted_at: nil`)
<img src="https://user-images.githubusercontent.com/8124558/98481786-cb214e00-21ca-11eb-901e-6022edfed88d.png" width="250px" />
Details Page - Submitted (`court_report_status: :submitted, court_report_submitted_at: '2020-11-08 18:29:16'`)
<img src="https://user-images.githubusercontent.com/8124558/98481876-7f22d900-21cb-11eb-90d0-b2cf8cbed137.png" width="250px" />
Details Page - Completed (`court_report_status: :completed, court_report_submitted_at: '2020-11-08 18:29:16'`)
<img src="https://user-images.githubusercontent.com/8124558/98481941-fbb5b780-21cb-11eb-81d6-67c0f15acb39.png" width="250px" />
Edit Page
![image](https://user-images.githubusercontent.com/8124558/98481926-dc1e8f00-21cb-11eb-9f67-a6d7a3fb7a07.png)

