### PR TITLE
WIP: render volunteer names in plain text if current user is volunteer

### DIFF
--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -55,7 +55,11 @@
     <div>
       <h6><strong>Assigned Volunteers:</strong></h6>
       <% policy_scope(assigned_volunteers(@casa_case)).each_with_index do |volunteer, index| %>
-        <p><%= link_to "#{volunteer.decorate.name} ", edit_volunteer_path(volunteer) %></p>
+        <% if current_user.volunteer? %>
+          <p><%= volunteer.decorate.name %></p>
+        <% else %>
+          <p><%= link_to "#{volunteer.decorate.name} ", edit_volunteer_path(volunteer) %></p>
+        <% end %>
       <% end %>
       <br>
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1269 

### What changed, and why?
In Casa Case Detail View, volunteer names appeared as a link to all users. Now it appears as plain text if the current user is a volunteer.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

<img width="791" alt="Screenshot 2020-11-10 at 20 52 35" src="https://user-images.githubusercontent.com/22390758/98732177-b5608400-2396-11eb-9e28-6b326a464736.png">
