### PR TITLE
Removed the -fd flag to clean up the screen output

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -114,7 +114,7 @@ $ docker-compose exec web rails c
 Run the testing suite from within the container:
 
 ```
-$ docker-compose exec web rspec spec -fd
+$ docker-compose exec web rspec spec
 ```
 
 System tests will generate a screenshot upon failure. The screenshots can be

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -114,6 +114,12 @@ $ docker-compose exec web rails c
 Run the testing suite from within the container:
 
 ```
+$ docker-compose exec web rspec spec -fd
+```
+
+For a shorter screen output from running the testing suite from within the container:
+
+```
 $ docker-compose exec web rspec spec
 ```
 

--- a/docker/test-log
+++ b/docker/test-log
@@ -12,10 +12,10 @@ echo '--------------------------------------------'
 echo 'END: docker-compose run web rails db:migrate'
 echo '--------------------------------------------'
 
-echo '---------------------------------------------'
-echo 'BEGIN: docker-compose exec web rspec spec -fd'
-echo '---------------------------------------------'
-docker-compose exec web rspec spec -fd
-echo '-------------------------------------------'
-echo 'END: docker-compose exec web rspec spec -fd'
-echo '-------------------------------------------'
+echo '-----------------------------------------'
+echo 'BEGIN: docker-compose exec web rspec spec'
+echo '-----------------------------------------'
+docker-compose exec web rspec spec
+echo '---------------------------------------'
+echo 'END: docker-compose exec web rspec spec'
+echo '---------------------------------------'


### PR DESCRIPTION
#1229 # What github issue is this PR for, if any?
Resolves #1206 .

### What changed, and why?
The "-fd" flag is removed from the RSpec command in the docker/test-log script and the instructions in the doc/DOCKER.md file.    Omitting the "-fd" flag means omitting the printing of every test.  The resulting cleaner output makes it easier to see warning and error messages.  This makes debugging the troubleshooting much easier.