### PR TITLE
remove link from My Cases if user is volunteer

### DIFF
--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -133,9 +133,14 @@
           <td><%= casa_case.decorate.transition_aged_youth_icon %></td>
           <td>
             <% if casa_case.active? %>
-            <%= safe_join(assigned_volunteers(casa_case).map { |vol|
-              link_to(vol.display_name, edit_volunteer_path(vol)) },
-              ", ") %>
+              <% if current_user.volunteer? %>
+                <%= safe_join(assigned_volunteers(casa_case).map { |vol| 
+                  vol.display_name }, ", ") %>
+              <% else %>
+                <%= safe_join(assigned_volunteers(casa_case).map { |vol| 
+                  link_to(vol.display_name, edit_volunteer_path(vol)) },
+                  ", ") %>
+              <% end %>
             <% else %>
               Case was deactivated on: <%= casa_case.updated_at.strftime("%m-%d-%Y") %>
             <% end %>

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :casa_case do
-    sequence(:case_number) { |n| n }
+    sequence(:case_number) { |n| "CINA-#{n}" }
     transition_aged_youth { false }
     birth_month_year_youth { 16.years.ago }
     casa_org

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require "simplecov"
 require "pry"
 SimpleCov.start do
-  add_filter '/spec/'
-  add_filter '/lib/tasks/auto_annotate_models.rake'
+  add_filter "/spec/"
+  add_filter "/lib/tasks/auto_annotate_models.rake"
   add_group "Models", "/app/models"
   add_group "Controllers", "/app/controllers"
   add_group "Channels", "/app/channels"

--- a/spec/system/admin_views_dashboard_spec.rb
+++ b/spec/system/admin_views_dashboard_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe "admin views dashboard", type: :system do
 
   after { travel_back }
 
+  it "sees volunteer names as links in Cases table" do
+    volunteer = create(:volunteer, display_name: "Bob Loblaw", casa_org: organization)
+    casa_case = create(:casa_case, active: true, casa_org: organization, case_number: "CINA-1")
+    create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
+
+    sign_in admin
+    visit casa_cases_path
+
+    expect(page).to have_text("Bob Loblaw")
+    expect(page).to have_link("Bob Loblaw", href: "/volunteers/#{volunteer.id}/edit")
+  end
+
   it "displays other admins within the same CASA organization" do
     admin2 = create(:casa_admin, email: "Jon@org.com", casa_org: organization)
     admin3 = create(:casa_admin, email: "Bon@org.com", casa_org: organization)

--- a/spec/system/volunteer_views_dashboard_spec.rb
+++ b/spec/system/volunteer_views_dashboard_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "volunteer views dashboard", type: :system do
-  let(:volunteer) { create(:volunteer) }
+  let(:volunteer) { create(:volunteer, display_name: "Bob Loblaw") }
 
   before do
     sign_in volunteer
@@ -19,6 +19,16 @@ RSpec.describe "volunteer views dashboard", type: :system do
     expect(page).to have_text(casa_case_1.case_number)
     expect(page).to have_text(casa_case_2.case_number)
     expect(page).not_to have_text(casa_case_3.case_number)
+  end
+
+  it "sees volunteer names in Cases table as plain text" do
+    casa_case = create(:casa_case, active: true, casa_org: volunteer.casa_org, case_number: "CINA-1")
+    create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
+
+    visit root_path
+
+    expect(page).to have_text("Bob Loblaw")
+    expect(page).to have_no_link("Bob Loblaw")
   end
 
   it "displays 'No active cases' when they don't have any assignments" do

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -43,16 +43,18 @@ RSpec.describe "casa_cases/index", type: :system do
 
   it "Filters active/inactive casa_cases" do
     active_case = create(:casa_case, active: true, casa_org: organization)
+    active_case1 = create(:casa_case, active: true, casa_org: organization)
     inactive_case = create(:casa_case, active: false, casa_org: organization)
 
     create(:case_assignment, volunteer: volunteer, casa_case: active_case)
+    create(:case_assignment, volunteer: volunteer, casa_case: active_case1)
     create(:case_assignment, volunteer: volunteer, casa_case: inactive_case)
 
     visit casa_cases_path
     expect(page).to have_selector(".casa-case-filters")
 
     # by default, only active casa cases are shown
-    expect(page.all("table#casa-cases tbody tr").count).to eq [active_case].size
+    expect(page.all("table#casa-cases tbody tr").count).to eq [active_case, active_case1].size
 
     click_on "Status"
     find(:css, 'input[data-value="Active"]').click


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1270 

### What changed, and why?
Volunteers can't click on names in 'Assigned to' column anymore, as they don't have permissions to view/edit them anyway.

### How will this affect user permissions?
- Volunteer permissions: Volunteers can't click on names in 'Assigned to' column anymore
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
added tests to `spec/system/admin_views_dashboard_spec.rb` and `spec/system/volunteer_views_dashboard_spec.rb`
updated test in `spec/views/casa_cases/index.html.erb_spec.rb` (this test was only passing because it was checking for the wrong thing; updated it with correct details)

### Screenshots please :)
<img width="1279" alt="Screenshot 2020-11-11 at 22 32 01" src="https://user-images.githubusercontent.com/22390758/98871991-badccd80-246d-11eb-8188-b04bbfef0194.png">