### PR TITLE
Ensure that volunteers can't be assigned casa cases from a different organization

### DIFF
--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -18,7 +18,7 @@ class CaseAssignment < ApplicationRecord
   def casa_case_and_volunteer_must_belong_to_same_casa_org
     return if casa_case.casa_org_id == volunteer.casa_org_id
 
-    errors.add(:volunteer, "Volunteer and case must belong to the same organization")
+    errors.add(:volunteer, "and case must belong to the same organization")
   end
 end
 

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -7,9 +7,18 @@ class CaseAssignment < ApplicationRecord
   validates :casa_case_id, uniqueness: {scope: :volunteer_id} # only 1 row allowed per case-volunteer pair
   validates :volunteer, presence: true
   validate :assignee_must_be_volunteer
+  validate :casa_case_and_volunteer_must_belong_to_same_casa_org, if: -> { casa_case.present? && volunteer.present? }
+
+  private
 
   def assignee_must_be_volunteer
     errors.add(:volunteer, "Case assignee must be a volunteer") unless volunteer.is_a?(Volunteer) && volunteer.active?
+  end
+
+  def casa_case_and_volunteer_must_belong_to_same_casa_org
+    return if casa_case.casa_org_id == volunteer.casa_org_id
+
+    errors.add(:volunteer, "Volunteer and case must belong to the same organization")
   end
 end
 

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -130,7 +130,8 @@ class DbPopulator
         case_number: generate_case_number,
         transition_aged_youth: random_true_false
       )
-      CaseAssignment.create!(casa_case: new_casa_case, volunteer: volunteers.sample(random: rng))
+      casa_org_volunteers = volunteers.select { |volunteer| volunteer.casa_org_id = casa_org.id }
+      CaseAssignment.create!(casa_case: new_casa_case, volunteer: casa_org_volunteers.sample(random: rng))
 
       random_case_contact_count.times do
         create_case_contact(new_casa_case)

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -9,7 +9,13 @@ FactoryBot.define do
     court_report_status { :not_submitted }
 
     trait :with_case_assignments do
-      case_assignments { build_list(:case_assignment, 2) }
+      after(:create) do |casa_case, _|
+        casa_org = casa_case.casa_org
+        2.times.map do
+          volunteer = create(:volunteer, casa_org: casa_org)
+          create(:case_assignment, casa_case: casa_case, volunteer: volunteer)
+        end
+      end
     end
 
     trait :active do

--- a/spec/helpers/casa_case_helper_spec.rb
+++ b/spec/helpers/casa_case_helper_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe CasaCaseHelper do
-  let(:volunteer1) { create(:volunteer) }
-  let(:volunteer2) { create(:volunteer) }
-  let(:case_assignment1) { create(:case_assignment, is_active: false, volunteer: volunteer1) }
-  let(:case_assignment2) { create(:case_assignment, is_active: true, volunteer: volunteer2) }
-  let(:casa_case) { create(:casa_case, case_assignments: [case_assignment1, case_assignment2]) }
+  let(:casa_org) { create(:casa_org) }
+  let(:volunteer1) { create(:volunteer, casa_org: casa_org) }
+  let(:volunteer2) { create(:volunteer, casa_org: casa_org) }
+  let!(:case_assignment1) { create(:case_assignment, casa_case: casa_case, is_active: false, volunteer: volunteer1) }
+  let!(:case_assignment2) { create(:case_assignment, casa_case: casa_case, is_active: true, volunteer: volunteer2) }
+  let(:casa_case) { create(:casa_case, casa_org: casa_org) }
 
   describe "#assigned_volunteers" do
     it "returns an array of volunteers assigned to a case" do
@@ -13,7 +14,7 @@ RSpec.describe CasaCaseHelper do
     end
 
     context "when case assignment is not active" do
-      let(:casa_case1) { create(:casa_case, case_assignments: [case_assignment1]) }
+      let(:casa_case1) { create(:casa_case, casa_org: casa_org, case_assignments: [case_assignment1]) }
 
       it "returns an empty array" do
         expect(assigned_volunteers(casa_case1)).to eq([])
@@ -21,7 +22,7 @@ RSpec.describe CasaCaseHelper do
     end
 
     context "when case has no assignments" do
-      let(:casa_case2) { create(:casa_case) }
+      let(:casa_case2) { create(:casa_case, casa_org: casa_org) }
 
       it "returns an empty array" do
         expect(assigned_volunteers(casa_case2)).to eq([])

--- a/spec/lib/importers/case_importer_spec.rb
+++ b/spec/lib/importers/case_importer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CaseImporter do
 
   before do
     allow(case_importer).to receive(:email_addresses_to_users) do |_clazz, comma_separated_emails|
-      create_list(:volunteer, comma_separated_emails.split(",").size)
+      create_list(:volunteer, comma_separated_emails.split(",").size, casa_org_id: casa_org_id)
     end
   end
 

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -47,16 +47,16 @@ RSpec.describe CasaCase do
   describe ".actively_assigned_to" do
     it "only returns cases actively assigned to a volunteer" do
       current_user = create(:volunteer)
-      inactive_case = create(:casa_case)
+      inactive_case = create(:casa_case, casa_org: current_user.casa_org)
       create(:case_assignment, casa_case: inactive_case, volunteer: current_user, is_active: false)
-      active_cases = create_list(:casa_case, 2)
+      active_cases = create_list(:casa_case, 2, casa_org: current_user.casa_org)
       active_cases.each do |casa_case|
         create(:case_assignment, casa_case: casa_case, volunteer: current_user, is_active: true)
       end
 
       other_user = create(:volunteer)
-      other_active_case = create(:casa_case)
-      other_inactive_case = create(:casa_case)
+      other_active_case = create(:casa_case, casa_org: other_user.casa_org)
+      other_inactive_case = create(:casa_case, casa_org: other_user.casa_org)
       create(:case_assignment, casa_case: other_active_case, volunteer: other_user, is_active: true)
       create(
         :case_assignment,
@@ -140,8 +140,9 @@ RSpec.describe CasaCase do
     end
 
     context "when volunteer has case assignments" do
-      let(:case_assignment1) { create(:case_assignment, volunteer: volunteer) }
-      let(:case_assignment2) { create(:case_assignment) }
+      let(:volunteer2) { create(:volunteer, casa_org: casa_org) }
+      let(:case_assignment1) { build(:case_assignment, volunteer: volunteer) }
+      let(:case_assignment2) { build(:case_assignment, volunteer: volunteer2) }
       let!(:casa_case) { create(:casa_case, case_assignments: [case_assignment1, case_assignment2], casa_org: casa_org) }
 
       it "returns cases to which volunteer is not assigned in same org" do

--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe CaseAssignment do
-  let(:casa_case_1) { create(:casa_case) }
-  let(:volunteer_1) { create(:volunteer) }
-  let(:inactive) { create(:volunteer, :inactive) }
-  let(:supervisor) { create(:supervisor) }
-  let(:casa_case_2) { create(:casa_case) }
-  let(:volunteer_2) { create(:volunteer) }
+  let(:casa_org_1) { create(:casa_org) }
+  let(:casa_case_1) { create(:casa_case, casa_org: casa_org_1) }
+  let(:volunteer_1) { create(:volunteer, casa_org: casa_org_1) }
+  let(:inactive) { create(:volunteer, :inactive, casa_org: casa_org_1) }
+  let(:supervisor) { create(:supervisor, casa_org: casa_org_1) }
+  let(:casa_case_2) { create(:casa_case, casa_org: casa_org_1) }
+  let(:volunteer_2) { create(:volunteer, casa_org: casa_org_1) }
+  let(:casa_org_2) { create(:casa_org) }
 
   it "only allow active volunteers to be assigned" do
     expect(casa_case_1.case_assignments.new(volunteer: volunteer_1)).to be_valid
@@ -34,5 +36,10 @@ RSpec.describe CaseAssignment do
 
     expect(casa_case_1.reload.volunteers).to eq([volunteer_1])
     expect(casa_case_2.reload.volunteers).to eq([volunteer_1])
+  end
+
+  it "requires case and volunteer belong to the same organization" do
+    case_assignment = casa_case_1.case_assignments.new(volunteer: volunteer_1)
+    expect { volunteer_1.update(casa_org: casa_org_2) }.to change(case_assignment, :valid?).to false
   end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Volunteer, type: :model do
 
     it "sets all of a volunteer's case assignments to inactive" do
       case_contacts =
-        3.times.map do
+        3.times.map {
           create(:case_assignment, casa_case: create(:casa_case, casa_org: volunteer.casa_org), volunteer: volunteer)
-        end
+        }
 
       volunteer.deactivate
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe Volunteer, type: :model do
     end
 
     it "sets all of a volunteer's case assignments to inactive" do
-      case_contacts = create_list(:case_assignment, 3, volunteer: volunteer)
+      case_contacts =
+        3.times.map do
+          create(:case_assignment, casa_case: create(:casa_case, casa_org: volunteer.casa_org), volunteer: volunteer)
+        end
 
       volunteer.deactivate
 
@@ -74,7 +77,7 @@ RSpec.describe Volunteer, type: :model do
 
   describe "#made_contact_with_all_cases_in_days?" do
     let(:volunteer) { create(:volunteer) }
-    let(:casa_case) { create(:casa_case) }
+    let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
     let(:create_case_contact) do
       lambda { |occurred_at, contact_made|
         create(:case_contact, casa_case: casa_case, creator: volunteer, occurred_at: occurred_at, contact_made: contact_made)
@@ -108,7 +111,7 @@ RSpec.describe Volunteer, type: :model do
 
     context "when volunteer has not made recent contact in just one case" do
       it "returns false" do
-        casa_case2 = create(:casa_case)
+        casa_case2 = create(:casa_case, casa_org: volunteer.casa_org)
         create(:case_assignment, casa_case: casa_case2, volunteer: volunteer, is_active: true)
         create(:case_contact, casa_case: casa_case2, creator: volunteer, occurred_at: Date.current - 60.days, contact_made: true)
         create_case_contact.call(Date.current, true)

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DashboardPolicy do
   permissions :create_cases_section? do
     context "when user is a volunteer with casa_cases" do
       it "permits user to see cases section" do
-        volunteer.casa_cases << create(:casa_case)
+        volunteer.casa_cases << create(:casa_case, casa_org: volunteer.casa_org)
         expect(Pundit.policy(volunteer, :dashboard).create_case_contacts?).to eq true
       end
     end

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "/case_assignments", type: :request do
+  let(:admin) { create(:casa_admin) }
+  let(:volunteer) { create(:volunteer) }
+  let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
+
   describe "POST /create" do
     context "when the volunteer has been previously assigned to the casa_case" do
       it "reassigns the volunteer to the casa_case" do
-        admin = create(:casa_admin)
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
         create(:case_assignment, is_active: false, volunteer: volunteer, casa_case: casa_case)
 
         sign_in admin
@@ -22,10 +23,6 @@ RSpec.describe "/case_assignments", type: :request do
 
     context "when the case assignment parent is a volunteer" do
       it "creates a new case assignment for the volunteer" do
-        admin = create(:casa_admin)
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
-
         sign_in admin
 
         expect {
@@ -39,10 +36,6 @@ RSpec.describe "/case_assignments", type: :request do
 
     context "when the case assignment parent is a casa_case" do
       it "creates a new case assignment for the casa_case" do
-        admin = create(:casa_admin)
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
-
         sign_in admin
 
         expect {
@@ -58,9 +51,6 @@ RSpec.describe "/case_assignments", type: :request do
   describe "DELETE /destroy" do
     context "when the case assignment parent is a volunteer" do
       it "destroys the case assignment from the volunteer" do
-        admin = create(:casa_admin)
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
         assignment = create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
 
         sign_in admin
@@ -75,9 +65,6 @@ RSpec.describe "/case_assignments", type: :request do
 
     context "when the case assignment parent is a casa_case" do
       it "destroys the case assignment from the casa_case" do
-        admin = create(:casa_admin)
-        volunteer = create(:volunteer)
-        casa_case = create(:casa_case)
         assignment = create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
 
         sign_in admin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 require "simplecov"
 require "pry"
 SimpleCov.start do
-  add_filter '/spec/'
-  add_filter '/lib/tasks/auto_annotate_models.rake'
+  add_filter "/spec/"
+  add_filter "/lib/tasks/auto_annotate_models.rake"
   add_group "Models", "/app/models"
   add_group "Controllers", "/app/controllers"
   add_group "Channels", "/app/channels"

--- a/spec/system/admin_edit_volunteer_spec.rb
+++ b/spec/system/admin_edit_volunteer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Admin: Editing Volunteers", type: :system do
 
   context "with a deactivated case" do
     it "displays inactive message" do
-      deactivated_casa_case = create(:casa_case, active: false, volunteers: [volunteer])
+      deactivated_casa_case = create(:casa_case, active: false, casa_org: volunteer.casa_org, volunteers: [volunteer])
       sign_in admin
 
       visit edit_volunteer_path(volunteer)

--- a/spec/views/casa_cases/show.html.erb_spec.rb
+++ b/spec/views/casa_cases/show.html.erb_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "casa_cases/show", type: :system do
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
   let(:volunteer) { create :volunteer, display_name: "Andy Dwyer", casa_org: organization }
-  let(:case_assignment) { create(:case_assignment, volunteer: volunteer) }
-  let(:casa_case) { create(:casa_case, casa_org: organization, case_assignments: [case_assignment]) }
+  let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
 
   context "user is an admin" do
     it "redirects to edit volunteer page when volunteer name clicked" do


### PR DESCRIPTION
### What github issue is this PR for
Resolves #1323 

### What changed
Validation was added to `case_assignments` to check that the associated `casa_case` and `volunteer` both have the same `casa_org`.

### How will this affect user permissions?
It shouldn't.

### How is this tested?
Testing was added to `spec/models/case_assignment_spec.rb`, and multiple specs and factories were updated to account for the new requirement.

### Screenshots
<img width="944" alt="Screen Shot 2020-11-12 at 2 47 46 AM" src="https://user-images.githubusercontent.com/29066220/98910670-7b27dd00-2491-11eb-8c41-402857f55c52.png">
If someone somehow selects an invalid volunteer...
<img width="1477" alt="Screen Shot 2020-11-12 at 2 38 21 AM" src="https://user-images.githubusercontent.com/29066220/98910734-8ed34380-2491-11eb-8c5f-e4acdf00e593.png">
