### PR TITLE
Ensure users can only view, modify, and assign cases within their organization

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -1,6 +1,6 @@
 class CasaCasesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_casa_case, only: %i[show edit update destroy]
+  before_action :set_casa_case, only: %i[show edit update destroy deactivate reactivate]
   before_action :set_contact_types, only: %i[new edit update create]
   before_action :require_organization!
 
@@ -59,8 +59,6 @@ class CasaCasesController < ApplicationController
   end
 
   def deactivate
-    @casa_case = CasaCase.find(params[:id])
-
     authorize @casa_case, :update_case_status?
 
     if @casa_case.deactivate
@@ -72,8 +70,6 @@ class CasaCasesController < ApplicationController
   end
 
   def reactivate
-    @casa_case = CasaCase.find(params[:id])
-
     authorize @casa_case, :update_case_status?
 
     if @casa_case.reactivate

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -51,7 +51,7 @@ class SupervisorsController < ApplicationController
   end
 
   def available_volunteers
-    @available_volunteers = Volunteer.volunteers_with_no_supervisor(current_user.casa_org)
+    @available_volunteers = Volunteer.with_no_supervisor(current_user.casa_org)
   end
 
   def supervisor_values

--- a/app/models/supervisor_volunteer.rb
+++ b/app/models/supervisor_volunteer.rb
@@ -5,9 +5,18 @@ class SupervisorVolunteer < ApplicationRecord
   belongs_to :supervisor, class_name: "User"
   validates :supervisor_id, uniqueness: {scope: :volunteer_id} # only 1 row allowed per supervisor-volunteer pair
   validates :volunteer_id, uniqueness: {scope: :is_active}, if: :is_active?
+  validate :ensure_supervisor_and_volunteer_belong_to_same_casa_org, if: -> { supervisor.present? && volunteer.present? }
 
   def is_active?
     is_active == true
+  end
+
+  private
+
+  def ensure_supervisor_and_volunteer_belong_to_same_casa_org
+    return if supervisor.casa_org_id == volunteer.casa_org_id
+
+    errors.add(:volunteer, "and supervisor must belong to the same organization")
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,15 +25,6 @@ class User < ApplicationRecord
   }, foreign_key: "volunteer_id", dependent: :destroy
   has_one :supervisor, through: :supervisor_volunteer
 
-  scope :volunteers_with_no_supervisor, lambda { |org|
-    joins("left join supervisor_volunteers "\
-          "on supervisor_volunteers.volunteer_id = users.id "\
-          "and supervisor_volunteers.is_active")
-      .active
-      .in_organization(org)
-      .where(supervisor_volunteers: {id: nil})
-  }
-
   scope :active, -> { where(active: true) }
 
   scope :in_organization, lambda { |org|

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -13,6 +13,15 @@ class Volunteer < User
     actions
   ].freeze
 
+  scope :with_no_supervisor, lambda { |org|
+    joins("left join supervisor_volunteers "\
+          "on supervisor_volunteers.volunteer_id = users.id "\
+          "and supervisor_volunteers.is_active")
+      .active
+      .in_organization(org)
+      .where(supervisor_volunteers: { id: nil })
+  }
+
   # Activates this volunteer.
   def activate
     update(active: true)

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -19,7 +19,7 @@ class Volunteer < User
           "and supervisor_volunteers.is_active")
       .active
       .in_organization(org)
-      .where(supervisor_volunteers: { id: nil })
+      .where(supervisor_volunteers: {id: nil})
   }
 
   # Activates this volunteer.

--- a/spec/factories/case_assignment.rb
+++ b/spec/factories/case_assignment.rb
@@ -1,8 +1,17 @@
 FactoryBot.define do
   factory :case_assignment do
+    transient do
+      casa_org { create(:casa_org) }
+    end
+
     is_active { true }
 
-    association :casa_case
-    association :volunteer, factory: :volunteer
+    casa_case do
+      create(:casa_case, casa_org: @overrides[:volunteer].try(:casa_org) || casa_org)
+    end
+
+    volunteer do
+      create(:volunteer, casa_org: @overrides[:casa_case].try(:casa_org) || casa_org)
+    end
   end
 end

--- a/spec/factories/supervisor_volunteer.rb
+++ b/spec/factories/supervisor_volunteer.rb
@@ -1,7 +1,16 @@
 FactoryBot.define do
   factory :supervisor_volunteer do
-    association :supervisor, factory: :supervisor
-    association :volunteer, factory: :volunteer
+    transient do
+      casa_org { create(:casa_org) }
+    end
+
+    supervisor do
+      create(:supervisor, casa_org: @overrides[:volunteer].present? ? @overrides[:volunteer].casa_org : casa_org)
+    end
+
+    volunteer do
+      create(:volunteer, casa_org: @overrides[:supervisor].present? ? @overrides[:supervisor].casa_org : casa_org)
+    end
 
     trait :inactive do
       is_active { false }

--- a/spec/factories/volunteer.rb
+++ b/spec/factories/volunteer.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :volunteer, class: "Volunteer", parent: :user do
+    casa_org do
+      @overrides[:casa_org] || @overrides[:supervisor].try(:casa_org) || create(:casa_org)
+    end
+
     trait :inactive do
       active { false }
     end

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SupervisorImporter do
   let(:supervisor_importer) do
     importer = SupervisorImporter.new(import_file_path, casa_org_id)
     allow(importer).to receive(:email_addresses_to_users) do |_clazz, supervisor_volunteers|
-      create_list(:volunteer, supervisor_volunteers.split(",").size)
+      create_list(:volunteer, supervisor_volunteers.split(",").size, casa_org: import_user.casa_org)
     end
     importer
   end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -141,11 +141,11 @@ RSpec.describe CasaCase do
 
     context "when volunteer has case assignments" do
       let(:volunteer2) { create(:volunteer, casa_org: casa_org) }
-      let(:case_assignment1) { build(:case_assignment, volunteer: volunteer) }
-      let(:case_assignment2) { build(:case_assignment, volunteer: volunteer2) }
-      let!(:casa_case) { create(:casa_case, case_assignments: [case_assignment1, case_assignment2], casa_org: casa_org) }
+      let(:casa_case) { create(:casa_case, casa_org: casa_org) }
 
       it "returns cases to which volunteer is not assigned in same org" do
+        casa_case.volunteers << volunteer
+        casa_case.volunteers << volunteer2
         expect(described_class.available_for_volunteer(volunteer)).to eq [casa_case2, casa_case3, casa_case1]
       end
     end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -69,9 +69,10 @@ RSpec.describe CaseContactReport, type: :model do
       end
 
       it "returns only the volunteer with the specified supervisors" do
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        volunteer2 = create(:volunteer)
+        casa_org = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: casa_org)
+        volunteer = create(:volunteer, casa_org: casa_org)
+        volunteer2 = create(:volunteer, casa_org: casa_org)
         create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
         contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
@@ -180,9 +181,10 @@ RSpec.describe CaseContactReport, type: :model do
 
     describe "contact type filter functionality" do
       it "returns only the case contacts that include the case contact" do
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        volunteer2 = create(:volunteer)
+        casa_org = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: casa_org)
+        volunteer = create(:volunteer, casa_org: casa_org)
+        volunteer2 = create(:volunteer, casa_org: casa_org)
         court = create(:contact_type, name: "Court")
         school = create(:contact_type, name: "School")
         create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
@@ -199,9 +201,10 @@ RSpec.describe CaseContactReport, type: :model do
 
     describe "contact type group filter functionality" do
       before do
-        supervisor = create(:supervisor)
-        volunteer = create(:volunteer)
-        volunteer2 = create(:volunteer)
+        casa_org = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: casa_org)
+        volunteer = create(:volunteer, casa_org: casa_org)
+        volunteer2 = create(:volunteer, casa_org: casa_org)
         create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
         @contact_type_group = create(:contact_type_group, name: "Legal")

--- a/spec/models/supervisor_volunteer_spec.rb
+++ b/spec/models/supervisor_volunteer_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
 RSpec.describe SupervisorVolunteer do
-  let(:volunteer_1) { create(:volunteer) }
-  let(:supervisor_1) { create(:supervisor) }
-  let(:supervisor_2) { create(:supervisor) }
+  let(:casa_org_1) { create(:casa_org) }
+  let(:casa_org_2) { create(:casa_org) }
+  let(:volunteer_1) { create(:volunteer, casa_org: casa_org_1) }
+  let(:supervisor_1) { create(:supervisor, casa_org: casa_org_1) }
+  let(:supervisor_2) { create(:supervisor, casa_org: casa_org_1) }
 
   it "assigns a volunteer to a supervisor" do
     supervisor_1.volunteers << volunteer_1
@@ -14,5 +16,10 @@ RSpec.describe SupervisorVolunteer do
     supervisor_1.volunteers << volunteer_1
     supervisor_1.save
     expect { supervisor_2.volunteers << volunteer_1 }.to raise_error(StandardError)
+  end
+
+  it "requires supervisor and volunteer belong to same casa_org" do
+    supervisor_volunteer = supervisor_1.supervisor_volunteers.new(volunteer: volunteer_1)
+    expect { volunteer_1.update(casa_org: casa_org_2) }.to change(supervisor_volunteer, :valid?).to(false)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe User, type: :model do
           create(:casa_case, casa_org: casa_org, transition_aged_youth: true),
           create(:casa_case, casa_org: casa_org, transition_aged_youth: false)
         ]
-        supervisor = create(:supervisor)
+        supervisor = create(:supervisor, casa_org: casa_org)
         casa_cases.each do |casa_case|
           volunteer = create(:volunteer, supervisor: supervisor, casa_org: casa_org)
           volunteer.casa_cases << casa_case
@@ -152,34 +152,6 @@ RSpec.describe User, type: :model do
     context "when the user does not have a transition-aged-youth case" do
       it "is false" do
         expect(user).not_to be_serving_transition_aged_youth
-      end
-    end
-  end
-
-  describe "#volunteers_with_no_supervisor?" do
-    subject { User.volunteers_with_no_supervisor(casa_org) }
-
-    let(:casa_org) { create(:casa_org) }
-
-    context "no volunteers" do
-      it "returns none" do
-        expect(subject).to eq([])
-      end
-    end
-
-    context "volunteers" do
-      let!(:unassigned1) { create(:volunteer, display_name: "aaa", casa_org: casa_org) }
-      let!(:unassigned2) { create(:volunteer, display_name: "bbb", casa_org: casa_org) }
-      let!(:unassigned2_different_org) { create(:volunteer, display_name: "ccc") }
-      let!(:assigned1) { create(:volunteer, display_name: "ddd", casa_org: casa_org) }
-      let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1) }
-      let!(:assigned2_different_org) { assignment1.volunteer }
-      let!(:unassigned_inactive_volunteer) { create(:volunteer, display_name: "eee", casa_org: casa_org, active: false) }
-      let!(:previously_assigned) { create(:volunteer, display_name: "fff", casa_org: casa_org) }
-      let!(:inactive_assignment) { create(:supervisor_volunteer, volunteer: previously_assigned, is_active: false) }
-
-      it "returns unassigned volunteers" do
-        expect(subject.map(&:display_name).sort).to eq(["aaa", "bbb", "fff"])
       end
     end
   end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -159,4 +159,32 @@ RSpec.describe Volunteer, type: :model do
 
     it { expect(volunteer.role).to eq "Volunteer" }
   end
+
+  describe "#with_no_supervisor" do
+    subject { Volunteer.with_no_supervisor(casa_org) }
+
+    let(:casa_org) { create(:casa_org) }
+
+    context "no volunteers" do
+      it "returns none" do
+        expect(subject).to eq []
+      end
+    end
+
+    context "volunteers" do
+      let!(:unassigned1) { create(:volunteer, display_name: "aaa", casa_org: casa_org) }
+      let!(:unassigned2) { create(:volunteer, display_name: "bbb", casa_org: casa_org) }
+      let!(:unassigned2_different_org) { create(:volunteer, display_name: "ccc") }
+      let!(:assigned1) { create(:volunteer, display_name: "ddd", casa_org: casa_org) }
+      let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1) }
+      let!(:assigned2_different_org) { assignment1.volunteer }
+      let!(:unassigned_inactive_volunteer) { create(:volunteer, display_name: "eee", casa_org: casa_org, active: false) }
+      let!(:previously_assigned) { create(:volunteer, display_name: "fff", casa_org: casa_org) }
+      let!(:inactive_assignment) { create(:supervisor_volunteer, volunteer: previously_assigned, is_active: false) }
+
+      it "returns unassigned volunteers" do
+        expect(subject.map(&:display_name).sort).to eq ["aaa", "bbb", "fff"]
+      end
+    end
+  end
 end

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 RSpec.describe "/supervisor_volunteers", type: :request do
   let!(:admin) { create(:casa_admin) }
-  let!(:supervisor) { create(:supervisor) }
-  let!(:volunteer) { create(:volunteer) }
+  let!(:casa_org) { create(:casa_org) }
+  let!(:supervisor) { create(:supervisor, casa_org: casa_org) }
+  let!(:volunteer) { create(:volunteer, casa_org: casa_org) }
 
   context "POST /create" do
     context "when no pre-existing association between supervisr and volunteer exists" do
@@ -49,7 +50,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
     end
 
     context "when an inactive association between the volunteer and a different supervisor exists" do
-      let!(:other_supervisor) { create(:supervisor) }
+      let!(:other_supervisor) { create(:supervisor, casa_org: casa_org) }
       let!(:previous_association) do
         create(
           :supervisor_volunteer,

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -63,4 +63,14 @@ RSpec.describe "casa_cases/index", type: :system do
     find(:css, 'input[data-value="Inactive"]').click
     expect(page.all("table#casa-cases tbody tr").count).to eq [inactive_case].size
   end
+
+  it "Only displays cases belonging to user's org" do
+    org_cases = create_list :casa_case, 3, active: true, casa_org: organization
+    other_org_cases = create_list :casa_case, 3, active: true
+
+    visit casa_cases_path
+
+    org_cases.each { |casa_case| expect(page).to have_content casa_case.case_number }
+    other_org_cases.each { |casa_case| expect(page).not_to have_content casa_case.case_number }
+  end
 end

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe "supervisors/edit", type: :view do
   end
 
   it "does not display the 'Unassign' button next to volunteer no longer supervised by the supervisor" do
-    supervisor = create :supervisor
-    volunteer = create :volunteer
+    casa_org = create :casa_org
+    supervisor = create :supervisor, casa_org: casa_org
+    volunteer = create :volunteer, casa_org: casa_org
     create :supervisor_volunteer, :inactive, supervisor: supervisor, volunteer: volunteer
 
     assign :supervisor, supervisor


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1322 

### What changed, and why?
Adds validation to require that volunteers are only assigned to supervisors within their organization. Adjusts controllers to ensure users can only view and modify cases and assignments within their organization.

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Specs were added and updated to reflect all changes.