### PR TITLE
case_contact.notes viewing and seeding tuning

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -74,7 +74,11 @@ class CaseContactDecorator < Draper::Decorator
     end
   end
 
-  def notes
-    object.notes.to_s.truncate(NOTES_WORD_LIMIT)
+  def limited_notes
+    object.notes.truncate(NOTES_WORD_LIMIT)
+  end
+
+  def full_notes
+    object.notes
   end
 end

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -46,15 +46,15 @@
     <span class="mobile-label">Notes</span>
     <%- if contact.notes && contact.notes.length > CaseContactDecorator::NOTES_WORD_LIMIT %>
       <div class="limited-notes" style="display: block;">
-        <%= contact.decorate.notes %>
+        <%= simple_format(contact.decorate.limited_notes) %>
         <span><a role="button" href="#" onClick="moreText(event)">Read more</a></span>
       </div>
       <div class="full-notes" style="display: none;">
-        <%= contact.notes %>
+        <%= simple_format(contact.decorate.full_notes) %>
         <span><a role="button" href="#" onClick="lessText(event)">Hide</a></span>
       </div>
     <%- else %>
-      <%= contact.notes %>
+      <%= simple_format(contact.decorate.full_notes) %>
     <%- end %>
   </td>
   <td>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,10 +23,10 @@ class SeederMain
   end
 
   def seed
-    puts "Erasing all objects from the data base..."
+    puts "Erasing all objects from the database..."
     destroy_all
 
-    puts "Creating the objects in the data base..."
+    puts "Creating the objects in the database..."
     db_populator.create_all_casa_admin("allcasaadmin@example.com")
     db_populator.create_all_casa_admin("all_casa_admin1@example.com")
     # TODO - always create at least 2 CASAs with different-looking data so we can find cross-CASA bugs

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -6,6 +6,8 @@
 class DbPopulator
   SEED_PASSWORD = "123456"
   WORD_LENGTH_TUNING = 10
+  LINE_BREAK_TUNING = 5
+  PREFIX_OPTIONS = ('A'.ord..'Z'.ord).to_a.map(&:chr)
 
   attr_reader :rng
 
@@ -26,6 +28,7 @@ class DbPopulator
   def create_org(options_hash)
     options = OpenStruct.new(options_hash)
     @casa_org_counter += 1
+    prefix = "org#{@casa_org_counter}#{PREFIX_OPTIONS[rng.rand(0..PREFIX_OPTIONS.length)] * 2}"
 
     options.org_name ||= "CASA Organization ##{@casa_org_counter}"
     casa_org = CasaOrg.find_or_create_by!(name: options.org_name) { |org|
@@ -40,8 +43,8 @@ class DbPopulator
       ]
     }
 
-    create_users(casa_org, options)
-    create_cases(casa_org, options)
+    create_users(casa_org, options, prefix)
+    create_cases(casa_org, options, prefix)
     casa_org
   end
 
@@ -49,7 +52,7 @@ class DbPopulator
 
   # Creates 3 users, 1 each for [Volunteer, Supervisor, CasaAdmin].
   # For org's after the first one created, adds an org number to the email address so that they will be globally unique
-  def create_users(casa_org, options)
+  def create_users(casa_org, options, prefix)
     # Generate email address; for orgs only after first org, and org number would be added, e.g.:
     # Org #1: volunteer1@example.com
     # Org #2: volunteer2-1@example.com
@@ -63,7 +66,7 @@ class DbPopulator
         attributes = {
           casa_org: casa_org,
           email: email.call(klass, n),
-          display_name: Faker::Name.name,
+          display_name: "#{prefix} #{Faker::Name.name}",
           password: SEED_PASSWORD,
           password_confirmation: SEED_PASSWORD,
           active: true
@@ -110,11 +113,11 @@ class DbPopulator
   end
 
   def note_generator(note_length)
-    available_chars = [("a".."z"), ("A".."Z"), (1..9), [" "] * WORD_LENGTH_TUNING].map(&:to_a).flatten.map(&:to_s)
+    available_chars = [("a".."z"), ("A".."Z"), (1..9), [" "] * WORD_LENGTH_TUNING, ["\n" * LINE_BREAK_TUNING]].map(&:to_a).flatten.map(&:to_s)
     (0...note_length).map { available_chars[rng.rand(available_chars.length)] }.join
   end
 
-  def create_case_contact(casa_case)
+  def create_case_contact(casa_case, prefix)
     CaseContact.create!(
       casa_case: casa_case,
       creator: casa_case.volunteers.sample(random: rng),
@@ -125,23 +128,23 @@ class DbPopulator
       miles_driven: rng.rand(5..40),
       want_driving_reimbursement: random_true_false,
       contact_made: random_true_false,
-      notes: note_generator(rng.rand(0..4000))
+      notes: "#{prefix} #{note_generator(rng.rand(0..4000))}"
     )
   end
 
-  def create_cases(casa_org, options)
+  def create_cases(casa_org, options, prefix)
     volunteers = Volunteer.where(active: true).to_a
     options.case_count.times do
       new_casa_case = CasaCase.create!(
         casa_org_id: casa_org.id,
-        case_number: generate_case_number,
+        case_number: "#{generate_case_number} #{prefix}",
         transition_aged_youth: random_true_false
       )
       casa_org_volunteers = volunteers.select { |volunteer| volunteer.casa_org_id == casa_org.id }
       CaseAssignment.create!(casa_case: new_casa_case, volunteer: casa_org_volunteers.sample(random: rng))
 
       random_case_contact_count.times do
-        create_case_contact(new_casa_case)
+        create_case_contact(new_casa_case, prefix)
       end
     end
   end

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -7,7 +7,7 @@ class DbPopulator
   SEED_PASSWORD = "123456"
   WORD_LENGTH_TUNING = 10
   LINE_BREAK_TUNING = 5
-  PREFIX_OPTIONS = ('A'.ord..'Z'.ord).to_a.map(&:chr)
+  PREFIX_OPTIONS = ("A".ord.."Z".ord).to_a.map(&:chr)
 
   attr_reader :rng
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1334

### What changed, and why?
Show linebreaks in notes in case contact view with simple_format. 
Add linebreaks to notes seed. 
Add casa org prefix to volunteer names and as postfix to casa case numbers (prefix breaks filter search)

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
existing spec + run seed and server locally

### Screenshots please :)
![Screen Shot 2020-11-13 at 10 15 20 PM](https://user-images.githubusercontent.com/578159/99141299-efcc5a00-25fe-11eb-902a-17d293b2650a.png)
![Screen Shot 2020-11-13 at 10 11 59 PM](https://user-images.githubusercontent.com/578159/99141300-f1961d80-25fe-11eb-8968-b09956e28e55.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
