### PR TITLE
Cache deps when building CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,6 +57,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
+          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
+          bundler-cache: true
 
       - name: Install PostgreSQL client
         run: |
@@ -56,7 +57,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -28,6 +28,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
+        bundler-cache: true
 
     - name: install gem erb_lint
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -57,6 +57,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
+          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
+          bundler-cache: true
 
       - name: Install PostgreSQL client
         run: |
@@ -56,7 +57,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -28,10 +28,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
-
-    - name: install dependencies
-      run: |
-        bundle install
+        bundler-cache: true
 
     - name: lint
       run: bundle exec standardrb

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,10 +28,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
-
-      - name: install dependencies
-        run: |
-          bundle install
+          bundler-cache: true
 
       - name: brakeman
         run: bundle exec brakeman


### PR DESCRIPTION
This can speed up build times when deps are not altered.

### What github issue is this PR for, if any?
I don't believe there is an issue for this. Is it preferable to have one?

### What changed, and why?
Cache dependencies when building on the CI server

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
hmmm. There are no tests. If it runs it runs.

### Screenshots please :)
How about a gif?

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/3o7ZetIsjtbkgNE1I4/giphy.gif)
