### PR TITLE
Fix hidden logout button on mobile view

### DIFF
--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -45,6 +45,7 @@
   flex-direction: column;
   justify-content: space-between;
   height: calc(100vh - 144px);
+  overflow-y: scroll;
 }
 
 .sidebar-wrapper .sidebar-menu {

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -65,13 +65,12 @@
           </li>
         <% end %>
         <% if all_casa_admin_signed_in? %>
-          <div class="list-group-item">
+          <li class="list-group-item">
             <%= current_all_casa_admin.email %>
-          </div>
+          </li>
           <%= link_to "Edit Profile", edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
         <%= session_link %>
-        <li></li>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1275

### What changed, and why?

Currently in the mobile view, the side bar nav is not scrollable, making
the log out button inaccessible. This PR adds an `overflow-y: scroll` property to 
the sidebar container.

This PR also updates `list-group-item` from `div` to `li` for greater
consistency with the rest of the file, and for correct semantics.

### Screenshots please :)
Sorry these screenshots aren't great 😅. Let me know if I should retake. 

Before: Can't access log out button

![2020-11-14 11 57 17](https://user-images.githubusercontent.com/16447748/99155851-943ab480-2670-11eb-8edd-2ef57cd5e59f.gif)


After:  Can access logout button

![2020-11-14 11 48 54](https://user-images.githubusercontent.com/16447748/99155826-65244300-2670-11eb-84bd-e466c05240f7.gif)

