### PR TITLE
hide volunteer link in case contacts when current user is volunteer

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -31,15 +31,19 @@
   <td>
     <span class="mobile-label">Creator</span>
     <% if policy(contact).edit? %>
-      <% if contact.creator&.supervisor? %>
-        <%= link_to "#{contact.creator&.display_name} ", edit_supervisor_path(current_user) %>
-      <% elsif contact.creator&.casa_admin? %>
-        <%= link_to "#{contact.creator&.display_name} ", edit_users_path %>
+      <% if current_user.volunteer? %>
+        <%= contact.creator&.decorate.name %>
       <% else %>
-        <%= link_to "#{contact.creator&.display_name} ", edit_volunteer_path(contact.creator) %>
+        <% if contact.creator&.supervisor? %>
+          <%= link_to contact.creator&.decorate.name, edit_supervisor_path(current_user) %>
+        <% elsif contact.creator&.casa_admin? %>
+          <%= link_to contact.creator&.decorate.name, edit_users_path %>
+        <% else %>
+          <%= link_to contact.creator&.decorate.name, edit_volunteer_path(contact.creator) %>
+        <% end %>
       <% end %>
     <% else %>
-      <%= contact.creator&.display_name %>
+      <%= contact.creator&.decorate.name %>
     <% end %>
   </td>
   <td class="read-more">

--- a/spec/system/admin_views_a_case_spec.rb
+++ b/spec/system/admin_views_a_case_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "admin views case details", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "CINA-1") }
+  let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
+  let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+
+  before(:each) do
+    sign_in admin
+    visit casa_case_path(casa_case.id)
+  end
+
+  it "can see case creator in table" do
+    expect(page).to have_text("Bob Loblaw")
+  end
+
+  it "can navigate to edit volunteer page" do
+    expect(page).to have_link("Bob Loblaw", href: "/volunteers/#{volunteer.id}/edit")
+  end
+end

--- a/spec/system/volunteer_views_case_contacts_spec.rb
+++ b/spec/system/volunteer_views_case_contacts_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "volunteer views case contacts", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "CINA-1") }
+  let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
+  let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+
+  before(:each) do
+    sign_in volunteer
+    visit case_contacts_path
+  end
+
+  it "can see case creator in table" do
+    expect(page).to have_text("Bob Loblaw")
+  end
+
+  it "can navigate to edit volunteer page" do
+    expect(page).to have_no_link("Bob Loblaw")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1271 

### What changed, and why?
All users could click volunteer names in the 'Created by' column, in the Case Contacts table. But volunteers did not have permission to view these pages, so the link has been removed and names now appear as plain text.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Tests added in `spec/system/volunteer_views_case_contacts_spec.rb` and `/spec/system/admin_views_a_case_spec.rb`

### Screenshots please :)
<img width="1647" alt="Screenshot 2020-11-14 at 20 11 54" src="https://user-images.githubusercontent.com/22390758/99156046-b276d380-26b5-11eb-8579-3d938678dfcd.png">