### PR TITLE
remove empty list item

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -71,7 +71,6 @@
           <%= link_to "Edit Profile", edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
         <%= session_link %>
-        <li></li>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1299 

### What changed, and why?
There was an empty list item at the bottom of the sidebar menu, leaving a black dot at the bottom. Removed it.

### How is this tested? (please write tests!) 💖💪
haven't added tests for this

### Screenshots please :)
<img width="321" alt="Screenshot 2020-11-14 at 21 13 07" src="https://user-images.githubusercontent.com/22390758/99157125-55cbe680-26be-11eb-95d5-2be7ad2ede0c.png">
