### PR TITLE
Added eager loading to CasaCasesController#index action

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -8,7 +8,7 @@ class CasaCasesController < ApplicationController
   # GET /casa_cases.json
   def index
     org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers)
-    @casa_cases = policy_scope(org_cases)
+    @casa_cases = policy_scope(org_cases).includes([:hearing_type, :judge])
   end
 
   # GET /casa_cases/1


### PR DESCRIPTION
### What github issue is this PR for, if any?
 None

### What changed, and why?
  Added eager loading to CasaCasesController#index action. Why? If optimization isn't compelling enough, then I'd say that removing N+1 means there will be fewer warnings in the log file allowing you to concentrate on what's left.

Every time you loaded in the CasaCasesContrller#index action you get the following in the log:

```
# log/development.log

user: [censored]
GET /casa_cases
USE eager loading detected
  CasaCase => [:hearing_type]
  Add to your query: .includes([:hearing_type])
Call stack
  /Users/[censored]/Documents/code/projects/casa/app/models/casa_case.rb:66:in `hearing_type_name'
  /Users/[censored]/Documents/code/projects/casa/app/views/casa_cases/index.html.erb:130:in `block in _app_views_casa_cases_index_html_erb___1018416056451763536_64540'
  /Users/[censored]/Documents/code/projects/casa/app/views/casa_cases/index.html.erb:127:in `_app_views_casa_cases_index_html_erb___1018416056451763536_64540'


user: [censored]
GET /casa_cases
USE eager loading detected
  CasaCase => [:judge]
  Add to your query: .includes([:judge])
Call stack
Call stack
  /Users/[censored]/Documents/code/projects/casa/app/models/casa_case.rb:67:in `judge_name'
  /Users/[censored]/Documents/code/projects/casa/app/views/casa_cases/index.html.erb:131:in `block in _app_views_casa_cases_index_html_erb___1018416056451763536_64540'
  /Users/[censored]/Documents/code/projects/casa/app/views/casa_cases/index.html.erb:127:in `_app_views_casa_cases_index_html_erb___1018416056451763536_64540'
```

### How will this affect user permissions?
  It won't.

### How is this tested? (please write tests!) 💖💪
After the change the eager loading message disappears from the log file. I looked to see if it actually loaded significantly faster but there are only two rows in the test data so nothing obvious. 

