### PR TITLE
Set up Rack Attack to throttle abusive requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "paper_trail" # tracking changes
 gem "pg", ">= 0.18", "< 2.0" # Use postgresql as the database for Active Record
 gem "puma", "~> 5.0" # Use Puma as the app server
 gem "pundit" # for authorization management - based on user.role field
+gem "rack-attack" # for blocking & throttling abusive requests
 gem "skylight" # automated performance testing https://www.skylight.io/
 gem "webpacker", "~> 5.2" # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "image_processing", "~> 1.12" # Set of higher-level helper methods for image processing.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.2.3)
+    rack-attack (6.3.1)
+      rack (>= 1.0, < 3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -359,6 +361,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   pundit
+  rack-attack
   rails (~> 6.0.3)
   rake
   rspec-rails (~> 4.0.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,6 +45,15 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Rack Attack configuration
+  #
+  # The specs on Docker can be really slow to run, so increase the period of
+  # time that the limit is allowed
+  config.throttle_login_period = 2.minutes
+  # Set IP_BLOCKLIST for testing. Can't stub in spec since environment variable
+  # gets read during application initialization.
+  ENV["IP_BLOCKLIST"] = "4.5.6.7, 9.8.7.6,100.101.102.103"
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.after_initialize do

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,118 @@
+class Rack::Attack
+  # Docker specs are really slow, so use test configuration to modify throttle
+  # login period.
+  THROTTLE_LOGIN_PERIOD = Rails.configuration.respond_to?(:throttle_login_period) ? Rails.configuration.throttle_login_period : 20.seconds
+
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blocklisting and
+  # safelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  Rack::Attack.safelist("allow from localhost") do |req|
+    # Requests are allowed if the return value is truthy
+    req.ip == "127.0.0.1" || req.ip == "::1"
+  end
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  throttle("req/ip", limit: 300, period: 5.minutes) do |req|
+    req.ip unless req.path.start_with?("/packs")
+  end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /xxxx/sign_in by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle("logins/ip", limit: 5, period: THROTTLE_LOGIN_PERIOD) do |req|
+    if req.path =~ /sign_in/ && req.post?
+      req.ip
+    end
+  end
+
+  # Throttle POST requests to /xxxx/sign_in by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that's not very common and shouldn't happen to you. (Knock
+  # on wood!)
+  throttle("logins/email", limit: 5, period: THROTTLE_LOGIN_PERIOD) do |req|
+    if req.path =~ /sign_in/ && req.post?
+      # return the email if present, nil otherwise
+      req.params.dig("user", "email").presence ||
+        req.params.dig("all_casa_admin", "email").presence
+    end
+  end
+
+  Rack::Attack.blocklist("fail2ban pentesters") do |req|
+    # `filter` returns truthy value if request fails, or if it's from a
+    # previously banned IP so the request is blocked
+    Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 3, findtime: 10.minutes, bantime: 1.day) do
+      # The count for the IP is incremented if the return value is truthy
+      CGI.unescape(req.query_string) =~ %r{/etc/passwd} ||
+        req.path.match?(/etc\/passwd/) ||
+        req.path.match(/wp-admin/i) ||
+        req.path.match(/wp-login/i) ||
+        req.path.match(/php/i) ||
+        req.path.match(/sql/i) ||
+        req.path.match(/PMA\d+/i) ||
+        req.path.match(/serverstatus/i) ||
+        req.path.match(/config\/server/i) ||
+        req.path.match(/xmlrpc/i) ||
+        req.path.match(/a2billing/i) ||
+        req.path.match(/testproxy/i) ||
+        req.path.match(/shopdb/i) ||
+        req.path.match(/index.action/i) ||
+        req.path.match(/etc\/services/i)
+    end
+  end
+
+  bad_ips = ENV["IP_BLOCKLIST"]
+  if bad_ips.present?
+    spammers = bad_ips.split(/\s*,\s*/)
+    spammer_regexp = Regexp.union(spammers)
+    blocklist("block bad ips") do |request|
+      request.ip =~ spammer_regexp
+    end
+  end
+
+  ### Custom Throttle Response ###
+
+  # By default, Rack::Attack returns an HTTP 429 for throttled responses,
+  # which is just fine.
+  #
+  # If you want to return 503 so that the attacker might be fooled into
+  # believing that they've successfully broken your app (or you just want to
+  # customize the response), then uncomment these lines.
+  # self.throttled_response = lambda do |env|
+  #  [ 503,  # status
+  #    {},   # headers
+  #    ['']] # body
+  # end
+end

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -1,0 +1,213 @@
+require "rails_helper"
+
+RSpec.describe Rack::Attack do
+  include Rack::Test::Methods
+
+  # https://makandracards.com/makandra/46189-how-to-rails-cache-for-individual-rspec-tests
+  # memory store is per process and therefore no conflicts in parallel tests
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+  let(:cache) { Rails.cache }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(memory_store)
+    Rails.cache.clear
+  end
+
+  def app
+    Rails.application
+  end
+
+  let(:header) { {"REMOTE_ADDR" => remote_ip} }
+  let(:params) { {} }
+  let(:limit) { 5 }
+
+  describe "throttle excessive requests by single IP address" do
+    shared_examples "correctly throttles" do
+      it "changes the request status to 429 if greater than limit" do
+        (limit * 2).times do |i|
+          post path, params, header
+          expect(last_response.status).to_not eq 429 if i < limit
+          expect(last_response.status).to eq(429) if i >= limit
+        end
+      end
+    end
+
+    it_behaves_like "correctly throttles" do
+      let(:path) { "/users/sign_in" }
+      let(:remote_ip) { "111.200.300.123" }
+    end
+
+    it_behaves_like "correctly throttles" do
+      let(:path) { "/all_casa_admins/sign_in" }
+      let(:remote_ip) { "111.200.300.456" }
+    end
+  end
+
+  describe "localhost is not throttled" do
+    let(:remote_ip) { "127.0.0.1" }
+    let(:path) { "/users/sign_in" }
+
+    it "does not change the request status to 429" do
+      (limit * 2).times do |i|
+        post path, params, header
+        expect(last_response.status).to_not eq(429) if i > limit
+      end
+    end
+  end
+
+  describe "throttle excessive requests for email login by variety of IP addresses" do
+    shared_examples "correctly throttles" do
+      it "changes the request status to 429 when greater than limit" do
+        (limit * 2).times do |i|
+          header = {"REMOTE_ADDR" => "#{remote_ip}#{i}"}
+          post path, params, header
+          expect(last_response.status).to_not eq 429 if i < limit
+          expect(last_response.status).to eq(429) if i >= limit
+        end
+      end
+    end
+
+    it_behaves_like "correctly throttles" do
+      let(:user) { create(:user, email: "foo@example.com") }
+      let(:remote_ip) { "189.23.45.1" }
+      let(:path) { "/users/sign_in" }
+      let(:params) {
+        {
+          user: {
+            email: user.email,
+            password: "badpassword"
+          }
+        }
+      }
+    end
+
+    it_behaves_like "correctly throttles" do
+      let(:user) { create(:all_casa_admin, email: "bar@example.com") }
+      let(:remote_ip) { "199.23.45.1" }
+      let(:path) { "/all_casa_admins/sign_in" }
+      let(:first_block) { "223" }
+      let(:params) {
+        {
+          all_casa_admin: {
+            email: user.email,
+            password: "badpassword"
+          }
+        }
+      }
+    end
+  end
+
+  context "blocklist" do
+    let(:path) { "/users/sign_in" }
+
+    context "good ip" do
+      let(:remote_ip) { "101.202.103.104" }
+
+      it "is not blocked" do
+        post path, params, header
+        expect(last_response.status).to_not eq(403)
+      end
+    end
+
+    context "bad ips" do
+      # IP_BLOCKLIST environment variable set in config/environments/test.rb
+      shared_examples "blocks request" do
+        it "changes the request status to 403" do
+          post path, params, header
+          expect(last_response.status).to eq(403)
+        end
+      end
+
+      it_behaves_like "blocks request" do
+        let(:remote_ip) { "4.5.6.7" }
+      end
+
+      it_behaves_like "blocks request" do
+        let(:remote_ip) { "9.8.7.6" }
+      end
+
+      it_behaves_like "blocks request" do
+        let(:remote_ip) { "100.101.102.103" }
+      end
+    end
+  end
+
+  describe "fail2ban" do
+    shared_examples "bans successfully" do
+      it "changes the request status to 403" do
+        head path, params, header
+        expect(last_response.status).to eq(403)
+      end
+    end
+
+    context "phpmyadmin" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "1.2.33.4" }
+        let(:path) { "/phpMyAdmin/" }
+      end
+    end
+
+    context "phpmyadmin4" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "55.66.77.88" }
+        let(:path) { "/phpMyAdmin4/" }
+      end
+    end
+
+    context "sql/phpmy-admin" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.66.77.99" }
+        let(:path) { "/sql/phpmy-admin/" }
+      end
+    end
+
+    context "db/phpmyadmin-32" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.96.77.99" }
+        let(:path) { "/db/phpMyAdmin-3/" }
+      end
+    end
+
+    context "sqlmanager" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.95.77.99" }
+        let(:path) { "/mysql/mysqlmanager/" }
+      end
+    end
+
+    context "PMA year" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.94.77.99" }
+        let(:path) { "/PMA2014" }
+      end
+    end
+
+    context "mysql" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.93.77.99" }
+        let(:path) { "/mysql/dbadmin/" }
+      end
+    end
+
+    context "config/server" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.92.77.99" }
+        let(:path) { "/config/server" }
+      end
+    end
+
+    context "config/server" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.91.77.99" }
+        let(:path) { "/_ServerStatus" }
+      end
+    end
+
+    context "etc/services" do
+      it_behaves_like "bans successfully" do
+        let(:remote_ip) { "44.89.77.99" }
+        let(:path) { "/etc/services" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1358 

### What changed, and why?
Added Rack Attack gem. Basic functionality:
* Throttles all requests from a single IP to 60 requests per minute
* Allows 5 login attempts (for a variety of email/password combos) per 20 seconds from a single IP
* Allows 5 login attempts (for a single email address) per 20 seconds from a range of IPs
* Will block for 1 day any IPs attempting to hit a variety of admin-related endpoints (like for WordPress, MySQL, etc.)
* Completely blocks IP addresses set in our own IP_BLOCKLIST environment variable

### How is this tested? (please write tests!) 💖💪
Added specs

### TODO

- [x] Add IP address hitting production for the `remember_me` error to IP_BLOCKLIST on Heroku (see #1234).