### PR TITLE
Remove Devise remember_me attribute

### DIFF
--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -13,7 +13,6 @@ end
 #  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
-#  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  created_at             :datetime         not null

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -26,7 +26,6 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  type                   :string

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -17,7 +17,6 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  type                   :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,7 +152,6 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  type                   :string

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -88,7 +88,6 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
-#  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  type                   :string

--- a/db/migrate/20201120103041_remove_remember_created_at_from_users.rb
+++ b/db/migrate/20201120103041_remove_remember_created_at_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveRememberCreatedAtFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/migrate/20201120103146_remove_remember_created_at_from_all_casa_admins.rb
+++ b/db/migrate/20201120103146_remove_remember_created_at_from_all_casa_admins.rb
@@ -1,0 +1,5 @@
+class RemoveRememberCreatedAtFromAllCasaAdmins < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :all_casa_admins, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_08_142333) do
+ActiveRecord::Schema.define(version: 2020_11_20_103146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_11_08_142333) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_all_casa_admins_on_email", unique: true
@@ -194,7 +193,6 @@ ActiveRecord::Schema.define(version: 2020_11_08_142333) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "casa_org_id", null: false


### PR DESCRIPTION
 - the application only uses the Devise timeoutable module to
   time limit user access. It does not use Devise's Rememberable
   module. However, the remember_me attribute has been configured
   by accident.

 - this was noticed when script attacks in production caused
   exceptions on the app on the remember_created_at attribute.
   https://github.com/rubyforgood/casa/issues/1348

 - this PR removes the remember_me attribute from the application

---

### What github issue is this PR for, if any?
Resolves #1348

### What changed, and why?
Described in the git commit above.

### How will this affect user permissions?
It won't

### How is this tested? (please write tests!) 💖💪
The wasn't part of the application and wasn't tested. It's removed now. I've
checked that the timeout works as before (no reason to have broken!).
