### PR TITLE
Added eager loading to VolunteersController#index action

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -7,7 +7,7 @@ class VolunteersController < ApplicationController
   def index
     # Return all active/inactive volunteers, inactive will be filtered by default
     @volunteers = policy_scope(
-      current_organization.volunteers.includes(:versions, :supervisor, :casa_cases, case_assignments: [:casa_case]).references(:supervisor, :casa_cases)
+      current_organization.volunteers.includes(:versions, :supervisor, :supervisor_volunteer, :casa_cases, case_assignments: [:casa_case]).references(:supervisor, :casa_cases)
     ).decorate
   end
 


### PR DESCRIPTION
 - Adds supervisor_volunteer to eager loading
 - from Bullet log message

---

### What github issue is this PR for, if any?
Applied against #1234 - this fixes an N+1 in `/volunteers` I do not know if it changes the loading time in QA.

### What changed, and why?
/volunteers is slow loading in QA. This fixes an N+1 bug which may or may not help.  

### How will this affect user permissions?
It won't

### How is this tested? (please write tests!) 💖💪

When you load` /volunteers` you get the following suggestion from Bullet: 

```
user: [censored]
GET /volunteers
USE eager loading detected
  Volunteer => [:supervisor_volunteer]
  Add to your query: .includes([:supervisor_volunteer])
Call stack
  /Users/[censored]/Documents/code/projects/casa/app/models/volunteer.rb:47:in `has_supervisor?'
  /Users/[censored]/Documents/code/projects/casa/app/views/volunteers/index.html.erb:143:in `block in _app_views_volunteers_index_html_erb___3469684865829442258_43140'
  /Users/[censored]/Documents/code/projects/casa/app/views/volunteers/index.html.erb:133:in `_app_views_volunteers_index_html_erb___3469684865829442258_43140'

```
After completing the suggestion the log message disappears.
