### PR TITLE
Remove court report submitted

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -157,7 +157,6 @@ end
 #  court_date                :datetime
 #  court_report_due_date     :datetime
 #  court_report_status       :integer          default("not_submitted")
-#  court_report_submitted    :boolean          default(FALSE), not null
 #  court_report_submitted_at :datetime
 #  transition_aged_youth     :boolean          default(FALSE), not null
 #  created_at                :datetime         not null

--- a/db/migrate/20201120215756_remove_court_report_submitted_from_casa_cases.rb
+++ b/db/migrate/20201120215756_remove_court_report_submitted_from_casa_cases.rb
@@ -1,0 +1,5 @@
+class RemoveCourtReportSubmittedFromCasaCases < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :casa_cases, :court_report_submitted, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_103146) do
+ActiveRecord::Schema.define(version: 2020_11_20_215756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,7 +63,6 @@ ActiveRecord::Schema.define(version: 2020_11_20_103146) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "casa_org_id", null: false
     t.datetime "birth_month_year_youth"
-    t.boolean "court_report_submitted", default: false, null: false
     t.datetime "court_date"
     t.datetime "court_report_due_date"
     t.bigint "hearing_type_id"

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe CasaCase do
         casa_case = create(:casa_case, court_date: "2020-09-13 02:11:58", court_report_status: :submitted)
         casa_case.clear_court_dates
 
-        expect(casa_case.court_report_submitted).to be false
+        expect(casa_case.court_report_status).to eq "not_submitted"
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1359

### What changed, and why?
Removed redundant field court_report_submitted from casa_cases table and fixed a spec that failed after the field was removed.

