### PR TITLE
Fix spelling mistake of transition

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
     case_contacts.where(contact_made: true).order(:occurred_at).last
   end
 
-  def volunteers_serving_transistion_aged_youth
+  def volunteers_serving_transition_aged_youth
     volunteers.includes(:casa_cases)
       .where(casa_cases: {transition_aged_youth: true}).size
   end

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -28,7 +28,7 @@
           </td>
           <td id="volunteer-assignments-<%= supervisor.id %>"> <%= supervisor.volunteers.size %></td>
           <td id="serving-transition-aged-youth-<%= supervisor.id %>">
-            <%= supervisor.volunteers_serving_transistion_aged_youth %>
+            <%= supervisor.volunteers_serving_transition_aged_youth %>
           </td>
           <td id="no-contact-<%= supervisor.id %>">
             <%= supervisor.no_contact_for_two_weeks %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "supervisors" do
-    describe "#volunteers_serving_transistion_aged_youth" do
+    describe "#volunteers_serving_transition_aged_youth" do
       it "returns the number of transition aged youth on a supervisor" do
         casa_org = create(:casa_org)
         casa_cases = [
@@ -65,7 +65,7 @@ RSpec.describe User, type: :model do
           volunteer = create(:volunteer, supervisor: supervisor, casa_org: casa_org)
           volunteer.casa_cases << casa_case
         end
-        expect(supervisor.volunteers_serving_transistion_aged_youth).to eq(2)
+        expect(supervisor.volunteers_serving_transition_aged_youth).to eq(2)
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
No

### What changed, and why?
Spelling of method: `volunteers_serving_transistion_aged_youth` to `volunteers_serving_transition_aged_youth`
(an extra s in transition)

That's it ...