### PR TITLE
Change case_numbers to only be unique within a CASA org

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -16,7 +16,7 @@ class CasaCase < ApplicationRecord
   has_many :assigned_volunteers, -> { active }, through: :active_case_assignments, source: :volunteer, class_name: "Volunteer"
   has_many :case_contacts, dependent: :destroy
   has_many :past_court_dates, dependent: :destroy
-  validates :case_number, uniqueness: {case_sensitive: false}, presence: true
+  validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true
   belongs_to :hearing_type, optional: true
   belongs_to :judge, optional: true
   belongs_to :casa_org
@@ -167,10 +167,10 @@ end
 #
 # Indexes
 #
-#  index_casa_cases_on_casa_org_id      (casa_org_id)
-#  index_casa_cases_on_case_number      (case_number) UNIQUE
-#  index_casa_cases_on_hearing_type_id  (hearing_type_id)
-#  index_casa_cases_on_judge_id         (judge_id)
+#  index_casa_cases_on_casa_org_id                  (casa_org_id)
+#  index_casa_cases_on_case_number_and_casa_org_id  (case_number,casa_org_id) UNIQUE
+#  index_casa_cases_on_hearing_type_id              (hearing_type_id)
+#  index_casa_cases_on_judge_id                     (judge_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20201123100716_remove_case_number_index_from_casa_cases.rb
+++ b/db/migrate/20201123100716_remove_case_number_index_from_casa_cases.rb
@@ -1,0 +1,5 @@
+class RemoveCaseNumberIndexFromCasaCases < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :casa_cases, column: :case_number, unique: true
+  end
+end

--- a/db/migrate/20201123112651_add_case_number_index_scoped_by_casa_org_to_casa_cases.rb
+++ b/db/migrate/20201123112651_add_case_number_index_scoped_by_casa_org_to_casa_cases.rb
@@ -1,0 +1,5 @@
+class AddCaseNumberIndexScopedByCasaOrgToCasaCases < ActiveRecord::Migration[6.0]
+  def change
+    add_index :casa_cases, [:case_number, :casa_org_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_215756) do
+ActiveRecord::Schema.define(version: 2020_11_23_112651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_215756) do
     t.datetime "court_report_submitted_at"
     t.integer "court_report_status", default: 0
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
-    t.index ["case_number"], name: "index_casa_cases_on_case_number", unique: true
+    t.index ["case_number", "casa_org_id"], name: "index_casa_cases_on_case_number_and_casa_org_id", unique: true
     t.index ["hearing_type_id"], name: "index_casa_cases_on_hearing_type_id"
     t.index ["judge_id"], name: "index_casa_cases_on_judge_id"
   end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CasaCase do
   it { is_expected.to belong_to(:hearing_type).optional }
   it { is_expected.to belong_to(:judge).optional }
   it { is_expected.to validate_presence_of(:case_number) }
-  it { is_expected.to validate_uniqueness_of(:case_number).case_insensitive }
+  it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id).case_insensitive }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }
 
   describe ".ordered" do

--- a/spec/system/admin_adds_new_case_spec.rb
+++ b/spec/system/admin_adds_new_case_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "admin adds a new case", type: :system do
-  let(:admin) { create(:casa_admin) }
+  let(:casa_org) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: casa_org) }
   let(:case_number) { "12345" }
   let!(:next_year) { (Date.today.year + 1).to_s }
 
@@ -61,8 +62,8 @@ RSpec.describe "admin adds a new case", type: :system do
     end
   end
 
-  context "when the case number already exists" do
-    let!(:casa_case) { create(:casa_case, case_number: case_number) }
+  context "when the case number already exists in the organization" do
+    let!(:casa_case) { create(:casa_case, case_number: case_number, casa_org: casa_org) }
 
     it "does not create a new case" do
       fill_in "Case number", with: case_number


### PR DESCRIPTION
 - Issue: https://github.com/rubyforgood/casa/issues/1355
 - Currently all case_numbers are unique within the application.
   We want to change it so that case_numbers are unique only
   within a CASA org. To following changes are required:
     - The `casa_cases` table needs to:
       - remove the more restrictive `case_number` index which
         requires all case_numbers to be unique
       - add new `case_number` index which is unique by
         `case_number` and `casa_org_id`
     - `CasaCase` model changes validation
     - Associated tests

---

### What github issue is this PR for, if any?
Resolves #1355 

### What changed, and why?
Removed the index that restricted case_numbers to be unique within the application.
Added an index that restricted case_number to be unique within a CASA org.

### How will this affect user permissions?
It does not

### How is this tested? (please write tests!) 💖💪
The changes broke tests at the model and system level which I have now fixed.

I then hand tested the behavior of the index before and after the change and made
sure you can rollback without error.