### PR TITLE
Only send email if day is Monday

### DIFF
--- a/lib/tasks/send_supervisor_digest.rake
+++ b/lib/tasks/send_supervisor_digest.rake
@@ -1,6 +1,8 @@
 desc "Send an email to supervisors each week to share an overview of their volunteers' activities"
 task send_supervisor_digest: :environment do
-  Supervisor.find_each do |supervisor|
-    SupervisorMailer.weekly_digest(supervisor)
+  if Time.now.monday?
+    Supervisor.find_each do |supervisor|
+      SupervisorMailer.weekly_digest(supervisor)
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
More follow up on  #1346 

### What changed, and why?
Sorry, one more small change for the weekly supervisor summary email.

I went to schedule this on Heroku Scheduler and we can only schedule daily, hourly, or every 10 minutes.  So I'll have to run this every day and check if it's Monday before executing the code.

This isn't exactly ideal.  Maybe if someday we have lots of tasks we'll want to find another solution?  This seems like a fine solution for now, and it's free.  But let me know if you want me to do something else, otherwise if you merge this code I'll schedule heroku to run daily.

![casa-production_·_Scheduler___Heroku](https://user-images.githubusercontent.com/10904005/100103402-d911d880-2e32-11eb-944e-4cdac52fe799.jpg)
