### PR TITLE
1258 - Hide casa case prefix filter to volunteer user

### DIFF
--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -60,13 +60,15 @@
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
-      <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Casa Case Prefix
-      </button>
-      <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="CINA" checked>CINA</a></li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="TPR" checked>TPR</a></li>
-      </div>
+      <% unless current_user.volunteer? %>
+        <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Casa Case Prefix
+        </button>
+      <% end %>
+        <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
+          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="CINA" checked>CINA</a></li>
+          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="TPR" checked>TPR</a></li>
+        </div>
     </div>
   </div>
 </div>

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -8,69 +8,87 @@ RSpec.describe "casa_cases/index", type: :system do
   let(:volunteer) { create :volunteer, casa_org: organization }
   let(:admin) { create(:casa_admin, casa_org: organization) }
 
-  before do
-    sign_in admin
-  end
+  context "when signed in as an admin" do
+    before do
+      sign_in admin
+    end
 
-  after(:each) do
-    # customize based on which type of logs you want displayed
-    log_types = page.driver.browser.manage.logs.available_types
-    log_types.each do |t|
-      puts t.to_s + ": " + page.driver.browser.manage.logs.get(t).join("\n")
+    after(:each) do
+      # customize based on which type of logs you want displayed
+      log_types = page.driver.browser.manage.logs.available_types
+      log_types.each do |t|
+        puts t.to_s + ": " + page.driver.browser.manage.logs.get(t).join("\n")
+      end
+    end
+
+    it "Displays the Cases title" do
+      visit casa_cases_path
+      expect(page).to have_text("Cases")
+    end
+
+    it "Has a New Case Contact button" do
+      visit casa_cases_path
+      expect(page).to have_link("New Case", href: new_casa_case_path)
+    end
+
+    it "Displays casa case prefix filter" do
+      visit casa_cases_path
+      expect(page).to have_selector("button", text: "Casa Case Prefix")
+    end
+
+    it "Displays Casa Cases table titles" do
+      visit casa_cases_path
+      expect(page).to have_selector("th", text: "Case Number")
+      expect(page).to have_selector("th", text: "Hearing Type")
+      expect(page).to have_selector("th", text: "Judge")
+      expect(page).to have_selector("th", text: "Status")
+      expect(page).to have_selector("th", text: "Transition Aged Youth")
+      expect(page).to have_selector("th", text: "Assigned To")
+      expect(page).to have_selector("th", text: "Actions")
+    end
+
+    it "Filters active/inactive casa_cases" do
+      active_case = create(:casa_case, active: true, casa_org: organization)
+      active_case1 = create(:casa_case, active: true, casa_org: organization)
+      inactive_case = create(:casa_case, active: false, casa_org: organization)
+
+      create(:case_assignment, volunteer: volunteer, casa_case: active_case)
+      create(:case_assignment, volunteer: volunteer, casa_case: active_case1)
+      create(:case_assignment, volunteer: volunteer, casa_case: inactive_case)
+
+      visit casa_cases_path
+      expect(page).to have_selector(".casa-case-filters")
+
+      # by default, only active casa cases are shown
+      expect(page.all("table#casa-cases tbody tr").count).to eq [active_case, active_case1].size
+
+      click_on "Status"
+      find(:css, 'input[data-value="Active"]').click
+      expect(page).to have_text("No matching records found")
+
+      find(:css, 'input[data-value="Inactive"]').click
+      expect(page.all("table#casa-cases tbody tr").count).to eq [inactive_case].size
+    end
+
+    it "Only displays cases belonging to user's org" do
+      org_cases = create_list :casa_case, 3, active: true, casa_org: organization
+      other_org_cases = create_list :casa_case, 3, active: true
+
+      visit casa_cases_path
+
+      org_cases.each { |casa_case| expect(page).to have_content casa_case.case_number }
+      other_org_cases.each { |casa_case| expect(page).not_to have_content casa_case.case_number }
     end
   end
 
-  it "Displays the Cases title" do
-    visit casa_cases_path
-    expect(page).to have_text("Cases")
-  end
+  context "when signed in as a volunteer" do
+    before do
+      sign_in volunteer
+    end
 
-  it "Has a New Case Contact button" do
-    visit casa_cases_path
-    expect(page).to have_link("New Case", href: new_casa_case_path)
-  end
-
-  it "Displays Casa Cases table titles" do
-    visit casa_cases_path
-    expect(page).to have_selector("th", text: "Case Number")
-    expect(page).to have_selector("th", text: "Hearing Type")
-    expect(page).to have_selector("th", text: "Judge")
-    expect(page).to have_selector("th", text: "Status")
-    expect(page).to have_selector("th", text: "Transition Aged Youth")
-    expect(page).to have_selector("th", text: "Assigned To")
-    expect(page).to have_selector("th", text: "Actions")
-  end
-
-  it "Filters active/inactive casa_cases" do
-    active_case = create(:casa_case, active: true, casa_org: organization)
-    active_case1 = create(:casa_case, active: true, casa_org: organization)
-    inactive_case = create(:casa_case, active: false, casa_org: organization)
-
-    create(:case_assignment, volunteer: volunteer, casa_case: active_case)
-    create(:case_assignment, volunteer: volunteer, casa_case: active_case1)
-    create(:case_assignment, volunteer: volunteer, casa_case: inactive_case)
-
-    visit casa_cases_path
-    expect(page).to have_selector(".casa-case-filters")
-
-    # by default, only active casa cases are shown
-    expect(page.all("table#casa-cases tbody tr").count).to eq [active_case, active_case1].size
-
-    click_on "Status"
-    find(:css, 'input[data-value="Active"]').click
-    expect(page).to have_text("No matching records found")
-
-    find(:css, 'input[data-value="Inactive"]').click
-    expect(page.all("table#casa-cases tbody tr").count).to eq [inactive_case].size
-  end
-
-  it "Only displays cases belonging to user's org" do
-    org_cases = create_list :casa_case, 3, active: true, casa_org: organization
-    other_org_cases = create_list :casa_case, 3, active: true
-
-    visit casa_cases_path
-
-    org_cases.each { |casa_case| expect(page).to have_content casa_case.case_number }
-    other_org_cases.each { |casa_case| expect(page).not_to have_content casa_case.case_number }
+    it "Hides casa case prefix filter" do
+      visit casa_cases_path
+      expect(page).to_not have_selector("button", text: "Casa Case Prefix")
+    end
   end
 end


### PR DESCRIPTION
 - do not show casa case prefix filter to volunteer, because
   they will only ever have 1 or 2 cases

---

### What github issue is this PR for, if any?
Resolves #1258

### What changed, and why?
Added a conditional around "Casa case prefix filter". Originally I had the conditional around the dropdown but if the dropdown is missing the case rows are filtered out.

### How will this affect user permissions?
It won't

### How is this tested? (please write tests!) 💖💪
So testing for the absence of something, in this case a button, is tricky. Instead I tested for the presence of the button in the administration mode. I could add a test for volunteer user that was that it didn't find the button?


### Screenshots please :)
# Volunteer screen
![1258-volunteer](https://user-images.githubusercontent.com/1710795/100127689-45aec680-2e77-11eb-859e-199693fc646c.png)

# Admin screen
![1258-admin](https://user-images.githubusercontent.com/1710795/100127886-7abb1900-2e77-11eb-92e3-447e87e2d032.png)


