### PR TITLE
Fix time in rack attack specs to avoid flaky tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,10 +46,6 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Rack Attack configuration
-  #
-  # The specs on Docker can be really slow to run, so increase the period of
-  # time that the limit is allowed
-  config.throttle_login_period = 2.minutes
   # Set IP_BLOCKLIST for testing. Can't stub in spec since environment variable
   # gets read during application initialization.
   ENV["IP_BLOCKLIST"] = "4.5.6.7, 9.8.7.6,100.101.102.103"

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,4 @@
 class Rack::Attack
-  # Docker specs are really slow, so use test configuration to modify throttle
-  # login period.
-  THROTTLE_LOGIN_PERIOD = Rails.configuration.respond_to?(:throttle_login_period) ? Rails.configuration.throttle_login_period : 20.seconds
-
   ### Configure Cache ###
 
   # If you don't want to use Rails.cache (Rack::Attack's default), then
@@ -48,7 +44,7 @@ class Rack::Attack
   # Throttle POST requests to /xxxx/sign_in by IP address
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
-  throttle("logins/ip", limit: 5, period: THROTTLE_LOGIN_PERIOD) do |req|
+  throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
     if req.path =~ /sign_in/ && req.post?
       req.ip
     end
@@ -62,7 +58,7 @@ class Rack::Attack
   # throttle logins for another user and force their login requests to be
   # denied, but that's not very common and shouldn't happen to you. (Knock
   # on wood!)
-  throttle("logins/email", limit: 5, period: THROTTLE_LOGIN_PERIOD) do |req|
+  throttle("logins/email", limit: 5, period: 20.seconds) do |req|
     if req.path =~ /sign_in/ && req.post?
       # return the email if present, nil otherwise
       req.params.dig("user", "email").presence ||

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Rack::Attack do
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
+    travel_to Time.current
   end
+
+  after { travel_back }
 
   def app
     Rails.application


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1379 

### What changed, and why?
Rack Attack creates a bucket based on the timestamp and counts the number of hits in that bucket. Since the tests may cross into the next bucket as time passes, the test for blocking a request sometimes fails. So in the testing environment, use a fixed timestamp so only one bucket is used, and then check that too many hits in the bucket successfully throttles the request.
