### PR TITLE
Added validations for court report submission date and status

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,5 +1,3 @@
-require_relative "../validators/court_report_validator"
-
 class CasaCase < ApplicationRecord
   TABLE_COLUMNS = %w[
     case_number

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,4 +1,4 @@
-require_relative '../validators/court_report_validator'
+require_relative "../validators/court_report_validator"
 
 class CasaCase < ApplicationRecord
   TABLE_COLUMNS = %w[

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -66,6 +66,22 @@ class CasaCase < ApplicationRecord
   delegate :name, to: :hearing_type, prefix: true, allow_nil: true
   delegate :name, to: :judge, prefix: true, allow_nil: true
 
+  # Validation class for :court_report_status & :court_report_submitted_at. Adds specific errors based on record data.
+  class CourtReportValidator < ActiveModel::Validator
+    def validate(record)
+      # Check for no timestamp and a submission value other than 'not_submitted'.
+      if record.court_report_submitted_at.nil? && record.court_report_status != "not_submitted"
+        record.errors[:court_report_status] << "Court report submission date can't be nil if status is anything but not_submitted."
+      # Check for timestamp with a 'not_submitted' status.
+      elsif !record.court_report_submitted_at.nil? && record.court_report_status == "not_submitted"
+        record.errors[:court_report_submitted_at] << "Submission date must be nil if court report status is not submitted."
+      end
+    end
+  end
+
+  # Validation to check timestamp and submission status of a case
+  validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
+
   def court_report_status=(value)
     super
     if court_report_not_submitted?

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,3 +1,5 @@
+require_relative '../validators/court_report_validator'
+
 class CasaCase < ApplicationRecord
   TABLE_COLUMNS = %w[
     case_number
@@ -65,19 +67,6 @@ class CasaCase < ApplicationRecord
 
   delegate :name, to: :hearing_type, prefix: true, allow_nil: true
   delegate :name, to: :judge, prefix: true, allow_nil: true
-
-  # Validation class for :court_report_status & :court_report_submitted_at. Adds specific errors based on record data.
-  class CourtReportValidator < ActiveModel::Validator
-    def validate(record)
-      # Check for no timestamp and a submission value other than 'not_submitted'.
-      if record.court_report_submitted_at.nil? && record.court_report_status != "not_submitted"
-        record.errors[:court_report_status] << "Court report submission date can't be nil if status is anything but not_submitted."
-      # Check for timestamp with a 'not_submitted' status.
-      elsif !record.court_report_submitted_at.nil? && record.court_report_status == "not_submitted"
-        record.errors[:court_report_submitted_at] << "Submission date must be nil if court report status is not submitted."
-      end
-    end
-  end
 
   # Validation to check timestamp and submission status of a case
   validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]

--- a/app/validators/court_report_validator.rb
+++ b/app/validators/court_report_validator.rb
@@ -1,12 +1,12 @@
 # Validation class for :court_report_status & :court_report_submitted_at. Adds specific errors based on record data.
 class CourtReportValidator < ActiveModel::Validator
-    def validate(record)
-      # Check for no timestamp and a submission value other than 'not_submitted'.
-      if record.court_report_submitted_at.nil? && !record.court_report_not_submitted?
-        record.errors[:court_report_status] << "Court report submission date can't be nil if status is anything but not_submitted."
-      # Check for timestamp with a 'not_submitted' status.
-      elsif record.court_report_submitted_at && record.court_report_not_submitted?
-        record.errors[:court_report_submitted_at] << "Submission date must be nil if court report status is not submitted."
-      end
+  def validate(record)
+    # Check for no timestamp and a submission value other than 'not_submitted'.
+    if record.court_report_submitted_at.nil? && !record.court_report_not_submitted?
+      record.errors[:court_report_status] << "Court report submission date can't be nil if status is anything but not_submitted."
+    # Check for timestamp with a 'not_submitted' status.
+    elsif record.court_report_submitted_at && record.court_report_not_submitted?
+      record.errors[:court_report_submitted_at] << "Submission date must be nil if court report status is not submitted."
     end
   end
+end

--- a/app/validators/court_report_validator.rb
+++ b/app/validators/court_report_validator.rb
@@ -1,0 +1,12 @@
+# Validation class for :court_report_status & :court_report_submitted_at. Adds specific errors based on record data.
+class CourtReportValidator < ActiveModel::Validator
+    def validate(record)
+      # Check for no timestamp and a submission value other than 'not_submitted'.
+      if record.court_report_submitted_at.nil? && !record.court_report_not_submitted?
+        record.errors[:court_report_status] << "Court report submission date can't be nil if status is anything but not_submitted."
+      # Check for timestamp with a 'not_submitted' status.
+      elsif record.court_report_submitted_at && record.court_report_not_submitted?
+        record.errors[:court_report_submitted_at] << "Submission date must be nil if court report status is not submitted."
+      end
+    end
+  end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -229,4 +229,27 @@ RSpec.describe CasaCase do
       expect(casa_case.reload.assigned_volunteers).to eq [volunteer2]
     end
   end
+
+  describe "report submission" do
+    # Creating a case whith a status other than not_submitted and a nil submission date
+    it "rejects cases with a court report status, but no submission date" do
+      casa_org = create(:casa_org)
+      bad_case = create(:casa_case, casa_org: casa_org)
+      bad_case.court_report_status = 2
+      bad_case.court_report_submitted_at = nil
+      bad_case.valid?
+
+      expect(bad_case.errors[:court_report_status]).to include("Court report submission date can't be nil if status is anything but not_submitted.")
+    end
+
+    it "rejects cases with a submission date, but no status" do
+      casa_org = create(:casa_org)
+      bad_case = create(:casa_case, casa_org: casa_org)
+      bad_case.court_report_status = 0
+      bad_case.court_report_submitted_at = DateTime.now
+      bad_case.valid?
+
+      expect(bad_case.errors[:court_report_submitted_at]).to include("Submission date must be nil if court report status is not submitted.")
+    end
+  end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -240,7 +240,8 @@ RSpec.describe CasaCase do
       bad_case.valid?
 
       expect(bad_case.errors[:court_report_status]).to include(
-        "Court report submission date can't be nil if status is anything but not_submitted.")
+        "Court report submission date can't be nil if status is anything but not_submitted."
+      )
     end
 
     it "rejects cases with a submission date, but no status" do
@@ -251,7 +252,8 @@ RSpec.describe CasaCase do
       bad_case.valid?
 
       expect(bad_case.errors[:court_report_submitted_at]).to include(
-        "Submission date must be nil if court report status is not submitted.")
+        "Submission date must be nil if court report status is not submitted."
+      )
     end
   end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -235,21 +235,23 @@ RSpec.describe CasaCase do
     it "rejects cases with a court report status, but no submission date" do
       casa_org = create(:casa_org)
       bad_case = create(:casa_case, casa_org: casa_org)
-      bad_case.court_report_status = 2
+      bad_case.court_report_status = :in_review
       bad_case.court_report_submitted_at = nil
       bad_case.valid?
 
-      expect(bad_case.errors[:court_report_status]).to include("Court report submission date can't be nil if status is anything but not_submitted.")
+      expect(bad_case.errors[:court_report_status]).to include(
+        "Court report submission date can't be nil if status is anything but not_submitted.")
     end
 
     it "rejects cases with a submission date, but no status" do
       casa_org = create(:casa_org)
       bad_case = create(:casa_case, casa_org: casa_org)
-      bad_case.court_report_status = 0
+      bad_case.court_report_status = :not_submitted
       bad_case.court_report_submitted_at = DateTime.now
       bad_case.valid?
 
-      expect(bad_case.errors[:court_report_submitted_at]).to include("Submission date must be nil if court report status is not submitted.")
+      expect(bad_case.errors[:court_report_submitted_at]).to include(
+        "Submission date must be nil if court report status is not submitted.")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1389 

### What changed, and why?
I added a custom validation class that extends `ActiveModel::Validator` and uses conditional logic to verify that `court_report_status` is appropriately set relative to the value of `court_report_submitted_at`. Now `court_report_status` must be undefined unless a time value is assigned to `court_report_submitted_at`.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Tests have been added to the `casa_case_spec.rb` file (lines 233-254) that verify the functionality of the changes addd.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/52436369/100828961-8da48f00-341d-11eb-8779-78b7e4633f1d.png)

![image](https://user-images.githubusercontent.com/52436369/100828933-82516380-341d-11eb-8012-460bf3ce204c.png)

![image](https://user-images.githubusercontent.com/52436369/100828992-97c68d80-341d-11eb-9a1d-806d10ae071b.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

`![alt text](https://media.giphy.com/media/doPrWYzSG1Vao/giphy.gif)`
