### PR TITLE
Fix court_report_submitted error in rake task

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -23,6 +23,7 @@ class Volunteer < User
     ACTIONS_COLUMN
   ].freeze
   CONTACT_MADE_IN_DAYS_NUM = 14
+  COURT_REPORT_SUBMISSION_REMINDER = 7.days
 
   scope :with_no_supervisor, lambda { |org|
     joins("left join supervisor_volunteers "\
@@ -37,7 +38,7 @@ class Volunteer < User
     includes(:case_assignments).where(active: true).where.not(case_assignments: nil).find_each do |volunteer|
       volunteer.case_assignments.each do |case_assignment|
         current_case = case_assignment.casa_case
-        if (current_case.court_report_due_date == Date.today + 7.days) && !current_case.court_report_submitted_at
+        if (current_case.court_report_due_date == Date.current + COURT_REPORT_SUBMISSION_REMINDER) && !current_case.court_report_submitted_at
           report_due_date = current_case.court_report_due_date
           VolunteerMailer.court_report_reminder(volunteer, report_due_date)
         end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -33,6 +33,18 @@ class Volunteer < User
       .where(supervisor_volunteers: {id: nil})
   }
 
+  def self.email_court_report_reminder
+    includes(:case_assignments).where(active: true).where.not(case_assignments: nil).find_each do |volunteer|
+      volunteer.case_assignments.each do |case_assignment|
+        current_case = case_assignment.casa_case
+        if (current_case.court_report_due_date == Date.today + 7.days) && !current_case.court_report_submitted_at
+          report_due_date = current_case.court_report_due_date
+          VolunteerMailer.court_report_reminder(volunteer, report_due_date)
+        end
+      end
+    end
+  end
+
   # Activates this volunteer.
   def activate
     update(active: true)

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -35,11 +35,11 @@ class Volunteer < User
   }
 
   def self.email_court_report_reminder
-    includes(:case_assignments).where(active: true).where.not(case_assignments: nil).find_each do |volunteer|
+    active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|
       volunteer.case_assignments.each do |case_assignment|
         current_case = case_assignment.casa_case
-        if (current_case.court_report_due_date == Date.current + COURT_REPORT_SUBMISSION_REMINDER) && !current_case.court_report_submitted_at
-          report_due_date = current_case.court_report_due_date
+        report_due_date = current_case.court_report_due_date
+        if (report_due_date == Date.current + COURT_REPORT_SUBMISSION_REMINDER) && current_case.court_report_not_submitted?
           VolunteerMailer.court_report_reminder(volunteer, report_due_date)
         end
       end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -48,7 +48,7 @@
     <h6><strong>Court Report Status:</strong> <%= @casa_case.decorate.court_report_submission %></h6>
     </p>
 
-    <% if @casa_case.court_report_submitted_at %>
+    <% unless @casa_case.court_report_not_submitted? %>
       <p>
       <h6><strong>Court Report Submitted Date:</strong> <%= @casa_case.decorate.court_report_submitted_date %></h6></p>
     <% end %>

--- a/lib/tasks/court_report_due_reminder.rake
+++ b/lib/tasks/court_report_due_reminder.rake
@@ -1,12 +1,4 @@
 desc "Send an email to volunteers when their court report is due in 1 week, run by heroku scheduler."
 task court_report_due_reminder: :environment do
-  Volunteer.includes(:case_assignments).where(active: true).where.not(case_assignments: nil).find_each do |volunteer|
-    volunteer.case_assignments.each do |case_assignment|
-      current_case = case_assignment.casa_case
-      if (current_case.court_report_due_date == Date.today + 7.days) && !current_case.court_report_submitted
-        report_due_date = current_case.court_report_due_date
-        VolunteerMailer.court_report_reminder(volunteer, report_due_date)
-      end
-    end
-  end
+  Volunteer.email_court_report_reminder
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Volunteer, type: :model do
+  describe ".email_court_report_reminder" do
+    let!(:casa_org) { create(:casa_org) }
+    let!(:casa_case1) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 7.days) }
+    let!(:casa_case2) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 8.days) }
+    let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 7.days, court_report_submitted_at: Time.current) }
+    let!(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
+    let!(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
+    let!(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
+    let!(:v1) { create(:volunteer, casa_org: casa_org, case_assignments: [case_assignment1, case_assignment2, case_assignment3]) }
+    let!(:v2) { create(:volunteer, casa_org: casa_org, active: false) }
+    let!(:v3) { create(:volunteer, casa_org: casa_org) }
+
+    it "sends one mailer" do
+      expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.today+7.days)
+      described_class.email_court_report_reminder
+    end
+  end
+
   describe "#activate" do
     let(:volunteer) { create(:volunteer, :inactive) }
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -3,20 +3,27 @@ require "rails_helper"
 RSpec.describe Volunteer, type: :model do
   describe ".email_court_report_reminder" do
     let!(:casa_org) { create(:casa_org) }
+
+    # Should send email for this case
     let!(:casa_case1) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days) }
+
+    # Should NOT send emails for these two cases
     let!(:casa_case2) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 8.days) }
-    let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days, court_report_submitted_at: Time.current) }
-    let!(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
-    let!(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
-    let!(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
+    let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days, court_report_submitted_at: Time.current, court_report_status: :submitted) }
+
+    let(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
+    let(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
+    let(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
     let!(:v1) { create(:volunteer, casa_org: casa_org, case_assignments: [case_assignment1, case_assignment2, case_assignment3]) }
     let!(:v2) { create(:volunteer, casa_org: casa_org, active: false) }
     let!(:v3) { create(:volunteer, casa_org: casa_org) }
 
-    before { stub_const("COURT_REPORT_SUBMISSION_REMINDER", 7.days) }
+    before { stub_const("Volunteer::COURT_REPORT_SUBMISSION_REMINDER", 7.days) }
 
     it "sends one mailer" do
-      expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.current+7.days)
+      expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.current + 7.days)
+      expect(VolunteerMailer).to_not receive(:court_report_reminder).with(v2, anything)
+      expect(VolunteerMailer).to_not receive(:court_report_reminder).with(v3, anything)
       described_class.email_court_report_reminder
     end
   end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe Volunteer, type: :model do
   describe ".email_court_report_reminder" do
     let!(:casa_org) { create(:casa_org) }
-    let!(:casa_case1) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 7.days) }
-    let!(:casa_case2) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 8.days) }
-    let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.today + 7.days, court_report_submitted_at: Time.current) }
+    let!(:casa_case1) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days) }
+    let!(:casa_case2) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 8.days) }
+    let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days, court_report_submitted_at: Time.current) }
     let!(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
     let!(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
     let!(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
@@ -13,8 +13,10 @@ RSpec.describe Volunteer, type: :model do
     let!(:v2) { create(:volunteer, casa_org: casa_org, active: false) }
     let!(:v3) { create(:volunteer, casa_org: casa_org) }
 
+    before { stub_const("COURT_REPORT_SUBMISSION_REMINDER", 7.days) }
+
     it "sends one mailer" do
-      expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.today+7.days)
+      expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.current+7.days)
       described_class.email_court_report_reminder
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1386

### What changed, and why?
* Moved the bulk of the court report not-submitted email rake task to a class method so it could more easily be tested
* Fixed bug with old `court_report_submitted` field

### How is this tested? (please write tests!) 💖💪
* Wrote unit test for new class method that sends court report reminder emails
