### PR TITLE
fix empty report error

### DIFF
--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -20,9 +20,10 @@ class CaseContactReport
   def to_csv
     CSV.generate(headers: true) do |csv|
       csv << full_data(nil).keys.map(&:to_s).map(&:titleize)
-
-      @case_contacts.includes(:casa_case, :creator).decorate.each do |case_contact|
-        csv << full_data(case_contact).values
+      if @case_contacts.present?
+        @case_contacts.includes(:casa_case, :creator).decorate.each do |case_contact|
+          csv << full_data(case_contact).values
+        end
       end
     end
   end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -31,58 +31,83 @@ RSpec.describe CaseContactReport, type: :model do
   end
 
   describe "filter behavior" do
-    describe "occured at range filter" do
-      it "uses date range if provided" do
-        create(:case_contact, {occurred_at: 20.days.ago})
-        create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago})
+    context 'when result is empty' do
+      it 'returns only headers if result is empty' do
+        report = CaseContactReport.new(
+          {
+            "start_date"=> 1.days.ago,
+            "end_date"=> 1.days.ago,
+            "contact_made"=>true,
+            "has_transitioned"=>true,
+            "want_driving_reimbursement"=>true,
+            "contact_type_ids"=>["4"],
+            "contact_type_group_ids"=>["2", "3"],
+            "supervisor_ids"=>["2"]
+          }
+        )
         contacts = report.case_contacts
-        expect(contacts.length).to eq(1)
+
+        expect(report.to_csv).to eq(
+          "Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes\n"
+        )
+        expect(contacts.length).to eq(0)
       end
+    end
 
-      it "returns all date ranges if not provided" do
-        create(:case_contact, {occurred_at: 20.days.ago})
-        create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({})
-        contacts = report.case_contacts
-        expect(contacts.length).to eq(2)
-      end
+    context 'when result is not empty' do
+      describe "occured at range filter" do
+        it "uses date range if provided" do
+          create(:case_contact, {occurred_at: 20.days.ago})
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
 
-      it "returns only the volunteer" do
-        volunteer = create(:volunteer)
-        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
-        create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({creator_ids: [volunteer.id]})
-        contacts = report.case_contacts
-        expect(contacts.length).to eq(1)
-      end
+        it "returns all date ranges if not provided" do
+          create(:case_contact, {occurred_at: 20.days.ago})
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(2)
+        end
 
-      it "returns only the volunteer with date range" do
-        volunteer = create(:volunteer)
-        create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
-        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer.id})
+        it "returns only the volunteer" do
+          volunteer = create(:volunteer)
+          create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({creator_ids: [volunteer.id]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
 
-        create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_ids: [volunteer.id]})
-        contacts = report.case_contacts
-        expect(contacts.length).to eq(1)
-      end
+        it "returns only the volunteer with date range" do
+          volunteer = create(:volunteer)
+          create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer.id})
 
-      it "returns only the volunteer with the specified supervisors" do
-        casa_org = create(:casa_org)
-        supervisor = create(:supervisor, casa_org: casa_org)
-        volunteer = create(:volunteer, casa_org: casa_org)
-        volunteer2 = create(:volunteer, casa_org: casa_org)
-        create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, creator_ids: [volunteer.id]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+        end
 
-        contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
-        create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id})
+        it "returns only the volunteer with the specified supervisors" do
+          casa_org = create(:casa_org)
+          supervisor = create(:supervisor, casa_org: casa_org)
+          volunteer = create(:volunteer, casa_org: casa_org)
+          volunteer2 = create(:volunteer, casa_org: casa_org)
+          create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor)
 
-        create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
-        contacts = report.case_contacts
-        expect(contacts.length).to eq(1)
-        expect(contacts).to eq([contact])
+          contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id})
+          create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id})
+
+          create(:case_contact, {occurred_at: 100.days.ago})
+          report = CaseContactReport.new({supervisor_ids: [supervisor.id]})
+          contacts = report.case_contacts
+          expect(contacts.length).to eq(1)
+          expect(contacts).to eq([contact])
+        end
       end
     end
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe CaseContactReport, type: :model do
   end
 
   describe "filter behavior" do
-    context 'when result is empty' do
-      it 'returns only headers if result is empty' do
+    context "when result is empty" do
+      it "returns only headers if result is empty" do
         report = CaseContactReport.new(
           {
-            "start_date"=> 1.days.ago,
-            "end_date"=> 1.days.ago,
-            "contact_made"=>true,
-            "has_transitioned"=>true,
-            "want_driving_reimbursement"=>true,
-            "contact_type_ids"=>["4"],
-            "contact_type_group_ids"=>["2", "3"],
-            "supervisor_ids"=>["2"]
+            "start_date" => 1.days.ago,
+            "end_date" => 1.days.ago,
+            "contact_made" => true,
+            "has_transitioned" => true,
+            "want_driving_reimbursement" => true,
+            "contact_type_ids" => ["4"],
+            "contact_type_group_ids" => ["2", "3"],
+            "supervisor_ids" => ["2"]
           }
         )
         contacts = report.case_contacts
@@ -54,7 +54,7 @@ RSpec.describe CaseContactReport, type: :model do
       end
     end
 
-    context 'when result is not empty' do
+    context "when result is not empty" do
       describe "occured at range filter" do
         it "uses date range if provided" do
           create(:case_contact, {occurred_at: 20.days.ago})


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1333

### What changed, and why?

An `if` has been added to prevent `#includes` from being done when `@case_contacts` is empty.

### How will this affect user permissions?
None

### How is this tested? (please write tests!) 💖💪

**Rspec:** A new context was created to validate that the report will have no errors when empty.
**Web Interface (manual):** 
Fill in the report data with the same ones used in the image below where it was used to open the issue.
![Issue Image](https://user-images.githubusercontent.com/578159/99137311-d1eefd00-25de-11eb-8e0f-d9db882fa123.png)

### Screenshots please :)
![Report Success](https://i.imgur.com/yq7f2wF.png)

### Feelings gif (optional)

![Report](https://media.giphy.com/media/l2SpR6Fp2XfxNnkWI/giphy.gif)
