### PR TITLE
Hide sidebar scroll when theres no overflow

### DIFF
--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -45,7 +45,7 @@
   flex-direction: column;
   justify-content: space-between;
   height: calc(100vh - 144px);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .sidebar-wrapper .sidebar-menu {


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
![Screen Shot 2020-12-09 at 8 03 41 PM](https://user-images.githubusercontent.com/578159/101720152-b3ebaf80-3a59-11eb-9d92-0b210e9bbf36.png)
![Screen Shot 2020-12-09 at 8 03 34 PM](https://user-images.githubusercontent.com/578159/101720156-b5b57300-3a59-11eb-875c-71ee9c263d27.png)
