### PR TITLE
Removes validate_inclusion_of test

### DIFF
--- a/spec/models/emancipation_category_spec.rb
+++ b/spec/models/emancipation_category_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe EmancipationCategory, type: :model do
   it { is_expected.to have_many(:emancipation_options) }
-  it { is_expected.to validate_inclusion_of(:mutually_exclusive).in_array([true, false]) }
   it { is_expected.to validate_presence_of(:name) }
 
   context "When creating a new category" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What changed, and why?
According to the
[shoulda_matchers](https://github.com/thoughtbot/shoulda-matchers/blob/master/lib/shoulda/matchers/active_model/validate_inclusion_of_matcher.rb#L56)
docs, they discourage using `validate_inclusion_of` with a boolean
column. This will also remove the warning when running the specs.

