### PR TITLE
Removes puts in view spec

### DIFF
--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe "casa_cases/index", type: :system do
       sign_in admin
     end
 
-    after(:each) do
-      # customize based on which type of logs you want displayed
-      log_types = page.driver.browser.manage.logs.available_types
-      log_types.each do |t|
-        puts t.to_s + ": " + page.driver.browser.manage.logs.get(t).join("\n")
-      end
-    end
-
     it "Displays the Cases title" do
       visit casa_cases_path
       expect(page).to have_text("Cases")


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
Not sure if anyone is using this but was maybe added for debugging
purposes. It logs either `browser:` or `driver:`. I think we can remove
for now to continue cleaning up the test out.
