### PR TITLE
Use already created Org for factories

### DIFF
--- a/spec/factories/case_assignment.rb
+++ b/spec/factories/case_assignment.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :case_assignment do
     transient do
-      casa_org { create(:casa_org) }
+      casa_org { CasaOrg.first || create(:casa_org) }
     end
 
     is_active { true }

--- a/spec/factories/hearing_type.rb
+++ b/spec/factories/hearing_type.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :hearing_type do
-    casa_org { create(:casa_org) }
+    casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:name) { |n| "Emergency Hearing #{n}" }
     active { true }
   end

--- a/spec/factories/judges.rb
+++ b/spec/factories/judges.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :judge do
-    casa_org { create(:casa_org) }
+    casa_org { CasaOrg.first || create(:casa_org) }
     name { Faker::Name.name }
     active { true }
   end

--- a/spec/factories/supervisor_volunteer.rb
+++ b/spec/factories/supervisor_volunteer.rb
@@ -1,15 +1,10 @@
 FactoryBot.define do
   factory :supervisor_volunteer do
+    supervisor { create(:supervisor) }
+    volunteer { create(:volunteer) }
+
     transient do
-      casa_org { create(:casa_org) }
-    end
-
-    supervisor do
-      create(:supervisor, casa_org: @overrides[:volunteer].present? ? @overrides[:volunteer].casa_org : casa_org)
-    end
-
-    volunteer do
-      create(:volunteer, casa_org: @overrides[:supervisor].present? ? @overrides[:supervisor].casa_org : casa_org)
+      casa_org { CasaOrg.first || create(:casa_org) }
     end
 
     trait :inactive do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    casa_org { create(:casa_org) }
+    casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:email) { |n| "email#{n}@example.com" }
     sequence(:display_name) { |n| "User #{n}" }
     password { "123456" }

--- a/spec/factories/volunteer.rb
+++ b/spec/factories/volunteer.rb
@@ -1,9 +1,5 @@
 FactoryBot.define do
   factory :volunteer, class: "Volunteer", parent: :user do
-    casa_org do
-      @overrides[:casa_org] || @overrides[:supervisor].try(:casa_org) || create(:casa_org)
-    end
-
     trait :inactive do
       active { false }
     end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -201,7 +201,8 @@ RSpec.describe Volunteer, type: :model do
     context "volunteers" do
       let!(:unassigned1) { create(:volunteer, display_name: "aaa", casa_org: casa_org) }
       let!(:unassigned2) { create(:volunteer, display_name: "bbb", casa_org: casa_org) }
-      let!(:unassigned2_different_org) { create(:volunteer, display_name: "ccc") }
+      let!(:different_org) { create(:casa_org) }
+      let!(:unassigned2_different_org) { create(:volunteer, display_name: "ccc", casa_org: different_org) }
       let!(:assigned1) { create(:volunteer, display_name: "ddd", casa_org: casa_org) }
       let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1) }
       let!(:assigned2_different_org) { assignment1.volunteer }

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,1 +1,43 @@
-RSpec.configure { |config| config.include FactoryBot::Syntax::Methods }
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  # Any factory that takes more than .5 seconds to create will show in the
+  # console when running the tests.
+  config.before(:suite) do
+    ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |name, start, finish, id, payload|
+      execution_time_in_seconds = finish - start
+
+      if execution_time_in_seconds >= 0.5
+        warn "Slow factory: #{payload[:name]} using strategy #{payload[:strategy]}"
+      end
+    end
+  end
+
+  # This will output records as they are created. Handy for debugging but very
+  # noisy.
+  # config.before(:each) do
+  #   ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |name, start, finish, id, payload|
+  #     $stderr.puts "FactoryBot: #{payload[:strategy]}(:#{payload[:name]})"
+  #   end
+  # end
+
+  # This will output total database records being created. Commented out to
+  # keep the spec output clean.
+  #
+  # factory_bot_results = {}
+  # config.before(:suite) do
+  #   ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |name, start, finish, id, payload|
+  #     factory_name = payload[:name]
+  #     strategy_name = payload[:strategy]
+  #     factory_bot_results[factory_name] ||= {}
+  #     factory_bot_results[factory_name][:total] ||= 0
+  #     factory_bot_results[factory_name][:total] += 1
+  #     factory_bot_results[factory_name][strategy_name] ||= 0
+  #     factory_bot_results[factory_name][strategy_name] += 1
+  #   end
+  # end
+  #
+  # config.after(:suite) do
+  #   p factory_bot_results
+  # end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
#1449

### What changed, and why?
We were creating orgs in many of the factories and I think we can just
use the already created one. We were creating ~2600 orgs per test run
and with this change we are down to ~1300. Probably not a huge
difference in overall time but as things grow, small changes like this
will add up.

I also added some FactoryBot logging in `spec/support/factory_bot.rb`.
It's pretty noisy so it's commented out but will be useful when
debugging slow tests in the future.