### PR TITLE
Adds tests for remaining specs that were pending

### DIFF
--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -19,6 +19,29 @@ RSpec.describe "/casa_cases", type: :request do
         get casa_cases_url
         expect(response).to be_successful
       end
+
+      it "shows all my organization's cases" do
+        volunteer_1 = create(:volunteer, casa_org: user.casa_org)
+        volunteer_2 = create(:volunteer, casa_org: user.casa_org)
+        create(:case_assignment, volunteer: volunteer_1)
+        create(:case_assignment, volunteer: volunteer_2)
+
+        get casa_cases_url
+
+        expect(response.body).to include(volunteer_1.casa_cases.first.case_number)
+        expect(response.body).to include(volunteer_2.casa_cases.first.case_number)
+      end
+
+      it "doesn't show other organizations' cases" do
+        my_case_assignment = create(:case_assignment, casa_org: user.casa_org)
+        different_org = create(:casa_org)
+        not_my_case_assignment = create(:case_assignment, casa_org: different_org)
+
+        get casa_cases_url
+
+        expect(response.body).to include(my_case_assignment.casa_case.case_number)
+        expect(response.body).not_to include(not_my_case_assignment.casa_case.case_number)
+      end
     end
 
     describe "GET /show" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe "/dashboard", type: :request do
   let(:organization) { create(:casa_org) }
-  let(:volunteer) { create(:volunteer, casa_org: organization) }
-  let(:admin) { create(:casa_admin, casa_org: organization) }
 
   context "as a volunteer" do
+    let(:volunteer) { create(:volunteer, casa_org: organization) }
     before do
+      create(:case_assignment, volunteer: volunteer)
       sign_in volunteer
     end
 
@@ -17,13 +17,39 @@ RSpec.describe "/dashboard", type: :request do
         expect(response).to redirect_to(casa_cases_path)
       end
 
-      it "shows my cases"
-      it "doesn't show other volunteers' cases"
-      it "doesn't show other organizations' cases"
+      it "shows my cases" do
+        get root_url
+        follow_redirect!
+
+        expect(response.body).to include(volunteer.casa_cases.first.case_number)
+      end
+
+      it "doesn't show other volunteers' cases" do
+        not_logged_in_volunteer = create(:volunteer)
+        create(:case_assignment, volunteer: not_logged_in_volunteer)
+
+        get root_url
+        follow_redirect!
+
+        expect(response.body).to include(volunteer.casa_cases.first.case_number)
+        expect(response.body).not_to include(not_logged_in_volunteer.casa_cases.first.case_number)
+      end
+
+      it "doesn't show other organizations' cases" do
+        different_org = create(:casa_org)
+        not_my_case_assignment = create(:case_assignment, casa_org: different_org)
+
+        get root_url
+        follow_redirect!
+
+        expect(response.body).to include(volunteer.casa_cases.first.case_number)
+        expect(response.body).not_to include(not_my_case_assignment.casa_case.case_number)
+      end
     end
   end
 
   context "as an admin" do
+    let(:admin) { create(:casa_admin, casa_org: organization) }
     before do
       sign_in admin
     end
@@ -34,9 +60,6 @@ RSpec.describe "/dashboard", type: :request do
 
         expect(response).to redirect_to(supervisors_path)
       end
-
-      it "shows all my organization's cases"
-      it "doesn't show other organizations' cases"
     end
   end
 end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     context "with invalid inputs" do
-      xit "re-renders the form with errors, but preserving all previously entered selections" do
+      it "re-renders the form with errors, but preserving all previously entered selections" do
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         future_date = 2.days.from_now


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1310

### What changed, and why?
Adding tests for the rest of the pending ones. I moved two from the
`dashboard_spec.rb` to `casa_cases_spec.rb` as admin are redirected to the
`supervisors_path` and not cases like volunteers are.

The `case_contacts_spec` turned green once I quit skipping it. So maybe that one
is good to go?

### Screenshots please :)
Nothing but green!
![image](https://user-images.githubusercontent.com/113754/101993999-8df62300-3c84-11eb-9e6f-a73362e26551.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.tenor.com/images/73cca45a93f91944b2c9fdd4b05c3c53/tenor.gif)