### PR TITLE
Don't revert logo if non logo details are updated

### DIFF
--- a/app/controllers/casa_orgs_controller.rb
+++ b/app/controllers/casa_orgs_controller.rb
@@ -13,7 +13,6 @@ class CasaOrgsController < ApplicationController
   def update
     respond_to do |format|
       if @casa_org.update(casa_org_update_params)
-        @casa_org.logo.attach(casa_org_update_params[:logo])
         format.html { redirect_to edit_casa_org_path, notice: "CASA organization was successfully updated." }
         format.json { render :show, status: :ok, location: @casa_org }
       else

--- a/spec/requests/casa_orgs_spec.rb
+++ b/spec/requests/casa_orgs_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe "CasaOrgs", type: :request do
           }.to change(ActiveStorage::Attachment, :count).by(1)
         end
 
+        it "doesn't revert logo to default if non logo details are updated" do
+          casa_org.update(logo: logo)
+
+          expect {
+            patch casa_org_url(casa_org), params: {casa_org: valid_attributes}
+          }.not_to change(ActiveStorage::Attachment, :count)
+        end
+
         it "redirects to the casa_org" do
           patch casa_org_url(casa_org), params: {casa_org: valid_attributes}
           casa_org.reload


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1434

### What changed, and why?
Fixes bug where if you upload a logo for an org and then later
update the org but don't include a logo, it will delete the previously
uploaded logo.

### How is this tested? (please write tests!) 💖💪
Added regression test to verify the logo is not deleted when the user submits
the org form with no logo.