### PR TITLE
IGNORE: just interested in screen output in CI environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,8 @@ SimpleCov.start do
   add_group "Database", "/db"
 end
 
+system('cat /etc/os-release')
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
Ignore this pull request.  I'm just running the "cat /etc/os-release" command in the continuous integration environment.