### PR TITLE
Set rack_test as default driver for system tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,19 +36,4 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = :random
-
-  config.before(:each, type: :system) do
-    if ENV["DOCKER"]
-      driven_by :selenium_chrome_headless_in_container
-      Capybara.server_host = "0.0.0.0"
-      Capybara.server_port = 4000
-      Capybara.app_host = "http://web:4000"
-    else
-      driven_by :selenium_chrome_headless
-    end
-  end
-
-  config.before(:each, type: :system, js: false) do
-    driven_by :rack_test
-  end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -26,3 +26,20 @@ Capybara.register_driver :selenium_chrome_headless do |app|
       args: %w[--headless --disable-gpu --disable-site-isolation-trials --window-size=1280,900]
     )
 end
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    if ENV["DOCKER"]
+      driven_by :selenium_chrome_headless_in_container
+      Capybara.server_host = "0.0.0.0"
+      Capybara.server_port = 4000
+      Capybara.app_host = "http://web:4000"
+    else
+      driven_by :selenium_chrome_headless
+    end
+  end
+end

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "casa_admins/edit", type: :system do
     end
   end
 
-  it "can successfully deactivate" do
+  it "can successfully deactivate", js: true do
     another = create(:casa_admin)
     visit edit_casa_admin_path(another)
 

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -36,11 +36,10 @@ RSpec.describe "casa_cases/edit", type: :system do
       expect(page).not_to have_text("Deactivate Case")
     end
 
-    it "deactivates a case" do
+    it "deactivates a case", js: true do
       visit edit_casa_case_path(casa_case)
 
       click_on "Deactivate CASA Case"
-      sleep 10
       click_on "Yes, deactivate"
       expect(page).to have_text("Case #{casa_case.case_number} has been deactivated")
       expect(page).to have_text("Case was deactivated on: #{casa_case.updated_at.strftime(DateFormat::MM_DD_YYYY)}")
@@ -52,10 +51,9 @@ RSpec.describe "casa_cases/edit", type: :system do
       expect(page).to_not have_text("Year")
     end
 
-    it "reactivates a case" do
+    it "reactivates a case", js: true do
       visit edit_casa_case_path(casa_case)
       click_on "Deactivate CASA Case"
-      sleep 10
       click_on "Yes, deactivate"
       click_on "Reactivate CASA Case"
 
@@ -202,7 +200,7 @@ RSpec.describe "casa_cases/edit", type: :system do
       after { travel_back }
 
       context "when a volunteer is assigned to a case" do
-        it "marks the volunteer as assigned and shows the start date of the assignment" do
+        it "marks the volunteer as assigned and shows the start date of the assignment", js: true do
           expect(casa_case.case_assignments.count).to eq 1
 
           unassign_button = page.find("input.btn-outline-danger")
@@ -222,7 +220,7 @@ RSpec.describe "casa_cases/edit", type: :system do
       end
 
       context "when a volunteer is unassigned from a case" do
-        it "marks the volunteer as unassigned and shows assignment start/end dates" do
+        it "marks the volunteer as unassigned and shows assignment start/end dates", js: true do
           unassign_button = page.find("input.btn-outline-danger")
           expect(unassign_button.value).to eq "Unassign Volunteer"
 
@@ -244,7 +242,7 @@ RSpec.describe "casa_cases/edit", type: :system do
       context "when supervisor other than volunteer's supervisor" do
         before { volunteer.update(supervisor: create(:supervisor)) }
 
-        it "unassigns volunteer" do
+        it "unassigns volunteer", js: true do
           unassign_button = page.find("input.btn-outline-danger")
           expect(unassign_button.value).to eq "Unassign Volunteer"
 

--- a/spec/system/casa_orgs/edit_spec.rb
+++ b/spec/system/casa_orgs/edit_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "casa_orgs/edit", type: :system do
     expect(page).to have_text(hearing_type.name)
   end
 
-  it "has hearing types table" do
+  it "has hearing types table", js: true do
     scroll_to(page.find("table#hearing-types", visible: false))
     expect(page).to have_table(
       id: "hearing-types",

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "case_contacts/edit", type: :system do
   let!(:case_contact) { create(:case_contact, duration_minutes: 105, casa_case: casa_case) }
 
   context "when admin" do
-    it "admin successfully edits case contact" do
+    it "admin successfully edits case contact", js: true do
       admin = create(:casa_admin, casa_org: organization)
       sign_in admin
 
@@ -29,7 +29,7 @@ RSpec.describe "case_contacts/edit", type: :system do
     let(:volunteer) { create(:volunteer, casa_org: organization) }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
-    it "is successful" do
+    it "is successful", js: true do
       case_contact = create(:case_contact, duration_minutes: 105, casa_case: casa_case, creator: volunteer)
       sign_in volunteer
       visit edit_case_contact_path(case_contact)

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "case_contacts/new", type: :system do
       fill_in "case_contact_occurred_at", with: "04/04/2020"
     end
 
-    it "is successful" do
+    it "is successful", js: true do
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -46,7 +46,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(page).to_not have_text("Hidden")
     end
 
-    it "should display full text in table if notes are less than 100 characters" do
+    it "should display full text in table if notes are less than 100 characters", js: true do
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -64,7 +64,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(page).not_to have_text("Read more")
     end
 
-    it "should allow expanding or hiding if notes are more than 100 characters" do
+    it "should allow expanding or hiding if notes are more than 100 characters", js: true do
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -111,7 +111,7 @@ RSpec.describe "case_contacts/new", type: :system do
     let!(:grp_with_hidden) { create(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization) }
     let!(:hidden_type) { create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden) }
 
-    it "is successful" do
+    it "is successful", js: true do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -148,7 +148,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(CaseContact.first.duration_minutes).to eq 105
     end
 
-    it "submits the form when no note was added" do
+    it "submits the form when no note was added", js: true do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -177,7 +177,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(CaseContact.first.notes).to eq ""
     end
 
-    it "submits the form when note is added and confirmed" do
+    it "submits the form when note is added and confirmed", js: true do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -238,7 +238,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     context "with invalid inputs" do
-      it "re-renders the form with errors, but preserving all previously entered selections" do
+      it "re-renders the form with errors, but preserving all previously entered selections", js: true do
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         future_date = 2.days.from_now
@@ -284,7 +284,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     context "with contact made not checked" do
-      it "does not re-render form, preserves all previously entered selections" do
+      it "does not re-render form, preserves all previously entered selections", js: true do
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         future_date = 2.days.from_now

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe "case_court_reports/index", type: :system do
       expect(page).to have_selector "#btnGenerateReport", **options
     end
 
-    it "does not see 'Download Court Report' button, which is hidden" do
+    it "does not see 'Download Court Report' button, which is hidden", js: true do
       options = {text: "Download Court Report", visible: :hidden}
 
       expect(page).to have_selector "#btnDownloadReport", **options
     end
 
-    it "shows a select element with default selection 'Select a case to generate report'" do
+    it "shows a select element with default selection 'Select a case to generate report'", js: true do
       expected_text = "Select a case to generate report"
 
       expect(page).to have_selector "#case-selection option[value]", text: expected_text
@@ -61,11 +61,11 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     context "'Generate Report' button" do
-      it "does not become disabled" do
+      it "does not become disabled", js: true do
         expect(page).not_to have_selector "#btnGenerateReport[disabled]"
       end
 
-      it "does not have label changed to 'Court report generating. Do not refresh or leave this page'" do
+      it "does not have label changed to 'Court report generating. Do not refresh or leave this page'", js: true do
         options = {text: "Court report generating. Do not refresh or leave this page"}
 
         expect(page).not_to have_selector "#btnGenerateReport[disabled]", **options
@@ -73,13 +73,13 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     context "'Download Court Report' button" do
-      it "does not become visible" do
+      it "does not become visible", js: true do
         options = {text: "Download Court Report", visible: :hidden}
 
         expect(page).to have_selector "#btnDownloadReport", **options
       end
 
-      it "does not change href value from '#'" do
+      it "does not change href value from '#'", js: true do
         options = {id: "btnDownloadReport", visible: :hidden, href: "#"}
 
         expect(page).to have_link "Download Court Report", **options
@@ -98,16 +98,16 @@ RSpec.describe "case_court_reports/index", type: :system do
       click_button "Generate Report"
     end
 
-    it "has transition case option selected" do
+    it "has transition case option selected", js: true do
       expect(page).to have_select "case-selection", selected: transition_option_text
     end
 
     context "'Generate Report' button" do
-      it "becomes disabled" do
+      it "becomes disabled", js: true do
         expect(page).to have_selector "#btnGenerateReport[disabled]"
       end
 
-      it "has label changed to 'Court report generating. Do not refresh or leave this page'" do
+      it "has label changed to 'Court report generating. Do not refresh or leave this page'", js: true do
         options = {text: "Court report generating. Do not refresh or leave this page"}
 
         expect(page).to have_selector "#btnGenerateReport[disabled]", **options
@@ -115,13 +115,13 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     context "'Download Court Report' button" do
-      it "becomes visible" do
+      it "becomes visible", js: true do
         options = {text: "Download Court Report", visible: :visible}
 
         expect(page).to have_selector "#btnDownloadReport", **options
       end
 
-      it "changes href value from '#' to a link with .docx format" do
+      it "changes href value from '#' to a link with .docx format", js: true do
         download_link = "/case_court_reports/#{case_number}.docx"
 
         options = {id: "btnDownloadReport", visible: :visible, href: download_link}

--- a/spec/system/dashboard/show_spec.rb
+++ b/spec/system/dashboard/show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "dashboard/show", type: :system do
     expect(page).to have_no_link("Bob Loblaw")
   end
 
-  it "displays 'No active cases' when they don't have any assignments" do
+  it "displays 'No active cases' when they don't have any assignments", js: true do
     visit root_path
     expect(page).to have_text("My Cases")
     expect(page).to have_text("No active cases")

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "reports/index", type: :system do
   end
 
   shared_examples "can view page" do
-    it "downloads report" do
+    it "downloads report", js: true do
       expect(page).to have_text("Case Contacts Report") &
         have_field("report_start_date", with: 6.months.ago.to_date) &
         have_field("report_end_date", with: Date.today.to_date)

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "volunteers/edit", type: :system do
     end
   end
 
-  it "saves the user as inactive, but only if the admin confirms" do
+  it "saves the user as inactive, but only if the admin confirms", js: true do
     sign_in admin
     visit edit_volunteer_path(volunteer)
 

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "volunteers/index", type: :system do
 
   context "when admin" do
     context "when no logo_url" do
-      it "can see volunteers and navigate to their cases" do
+      it "can see volunteers and navigate to their cases", js: true do
         volunteer = create(:volunteer, :with_assigned_supervisor, display_name: "User 1", email: "casa@example.com", casa_org: organization)
         volunteer.casa_cases << create(:casa_case, casa_org: organization)
         volunteer.casa_cases << create(:casa_case, casa_org: organization)
@@ -37,7 +37,7 @@ RSpec.describe "volunteers/index", type: :system do
       end
     end
 
-    it "can show/hide columns on volunteers table" do
+    it "can show/hide columns on volunteers table", js: true do
       sign_in admin
 
       visit volunteers_path
@@ -62,7 +62,7 @@ RSpec.describe "volunteers/index", type: :system do
       expect(page).not_to have_text("Last Contact Made")
     end
 
-    it "can filter volunteers" do
+    it "can filter volunteers", js: true do
       assigned_volunteers = create_list(:volunteer, 3, :with_assigned_supervisor, casa_org: organization)
       inactive_volunteers = create_list(:volunteer, 2, :inactive, casa_org: organization)
       unassigned_volunteers = create_list(:volunteer, 1, casa_org: organization)
@@ -96,7 +96,7 @@ RSpec.describe "volunteers/index", type: :system do
       expect(page.all("table#volunteers tbody tr").count).to eq inactive_volunteers.count
     end
 
-    it "can go to the volunteer edit page from the volunteer list" do
+    it "can go to the volunteer edit page from the volunteer list", js: true do
       create(:volunteer, :with_assigned_supervisor, casa_org: organization)
       sign_in admin
 
@@ -121,7 +121,7 @@ RSpec.describe "volunteers/index", type: :system do
     end
 
     describe "supervisor column of volunteers table" do
-      it "is blank when volunteer has no supervisor" do
+      it "is blank when volunteer has no supervisor", js: true do
         create(:volunteer, casa_org: organization)
         sign_in admin
 
@@ -133,7 +133,7 @@ RSpec.describe "volunteers/index", type: :system do
         expect(supervisor_cell.text).to eq ""
       end
 
-      it "displays supervisor's name when volunteer has supervisor" do
+      it "displays supervisor's name when volunteer has supervisor", js: true do
         name = "Superduper Visor"
         supervisor = create(:supervisor, display_name: name, casa_org: organization)
         create(:volunteer, supervisor: supervisor, casa_org: organization)
@@ -145,7 +145,7 @@ RSpec.describe "volunteers/index", type: :system do
         expect(supervisor_cell.text).to eq name
       end
 
-      it "is blank when volunteer's supervisor is inactive" do
+      it "is blank when volunteer's supervisor is inactive", js: true do
         create(:volunteer, :with_inactive_supervisor, casa_org: organization)
         sign_in admin
 
@@ -159,7 +159,7 @@ RSpec.describe "volunteers/index", type: :system do
     end
 
     context "when timed out" do
-      it "prompts login" do
+      it "prompts login", js: true do
         sign_in admin
         visit volunteers_path
         click_on "Supervisor"
@@ -175,7 +175,7 @@ RSpec.describe "volunteers/index", type: :system do
     let(:supervisor) { create(:supervisor, casa_org: organization) }
     let(:input_field) { "div#volunteers_filter input" }
 
-    it "can filter volunteers" do
+    it "can filter volunteers", js: true do
       active_volunteers = create_list(:volunteer, 3, :with_assigned_supervisor, casa_org: organization)
       active_volunteers[2].supervisor = supervisor
 
@@ -201,7 +201,7 @@ RSpec.describe "volunteers/index", type: :system do
       expect(page.all("table#volunteers tbody tr").count).to eq inactive_volunteers.count
     end
 
-    it "can show/hide columns on volunteers table" do
+    it "can show/hide columns on volunteers table", js: true do
       sign_in supervisor
 
       visit volunteers_path
@@ -229,7 +229,7 @@ RSpec.describe "volunteers/index", type: :system do
     context "with volunteers" do
       let(:supervisor) { create(:supervisor, :with_volunteers) }
 
-      it "Search history is clean after navigating away from volunteers view" do
+      it "Search history is clean after navigating away from volunteers view", js: true do
         sign_in supervisor
         visit volunteers_path
 
@@ -243,7 +243,7 @@ RSpec.describe "volunteers/index", type: :system do
     end
 
     context "when timed out" do
-      it "prompts login" do
+      it "prompts login", js: true do
         sign_in supervisor
         visit volunteers_path
         click_on "Supervisor"

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "casa_cases/index", type: :system do
       expect(page).to have_selector("th", text: "Actions")
     end
 
-    it "Filters active/inactive casa_cases" do
+    it "Filters active/inactive casa_cases", js: true do
       active_case = create(:casa_case, active: true, casa_org: organization)
       active_case1 = create(:casa_case, active: true, casa_org: organization)
       inactive_case = create(:casa_case, active: false, casa_org: organization)


### PR DESCRIPTION
### What github issue is this PR for, if any?
#1449

### What changed, and why?
All the system tests were using the `selenium_chrome_headless` driver.
Now the default is the `rack_test` driver and to use the selenium driver
you just have to tag the test with `js: true`.