### PR TITLE
Fixes contacts made in past 60 days sort

### DIFF
--- a/app/datatables/application_datatable.rb
+++ b/app/datatables/application_datatable.rb
@@ -48,7 +48,7 @@ class ApplicationDatatable
   end
 
   def build_order_clause
-    Arel.sql "#{order_by} #{order_direction}" if order_by.present?
+    Arel.sql "#{order_by} #{order_direction} NULLS LAST" if order_by.present?
   end
 
   def order_by

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -242,11 +242,14 @@ RSpec.describe "VolunteerDatatable" do
           assigned_volunteers
             .order(id: :desc)
             .sort_by { |v| v.case_contacts.where(occurred_at: 60.days.ago.to_date..).count }
-            .sort_by { |v| v.case_contacts.exists?(occurred_at: 60.days.ago.to_date..) ? 0 : 1 }
         end
 
         it "is successful" do
           check_desc_order.call
+        end
+
+        it "should move blanks to the end" do
+          expect(values[0][:contacts_made_in_past_days]).not_to be_blank
         end
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1452

### What changed, and why?
When on the list of volunteers, if you sorted by
`contacts_made_in_past_days` descending, it would put blanks first. This change
will now move the blanks to end.

### How is this tested? (please write tests!) 💖💪
Added regression test to verify sorting now puts actual values before blanks.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/113754/102018600-d7517b80-3d33-11eb-9490-6ef1a0692c0e.png)
