### PR TITLE
Add helper method to show only volunteers not already assigned to the…

### DIFF
--- a/app/helpers/casa_cases_helper.rb
+++ b/app/helpers/casa_cases_helper.rb
@@ -1,7 +1,0 @@
-module CasaCasesHelper
-  def render_eligible_volunteers(volunteer)
-    if @casa_case.volunteers.exclude?(volunteer)
-      content_tag(:option, volunteer.display_name.to_s, {value: volunteer.id.to_s})
-    end
-  end
-end

--- a/app/helpers/casa_cases_helper.rb
+++ b/app/helpers/casa_cases_helper.rb
@@ -1,0 +1,7 @@
+module CasaCasesHelper
+	def render_eligible_volunteers(volunteer)
+		if @casa_case.volunteers.exclude?(volunteer)
+			content_tag(:option, "#{volunteer.display_name}", {value: "#{volunteer.id}"})
+		end
+	end
+end

--- a/app/helpers/casa_cases_helper.rb
+++ b/app/helpers/casa_cases_helper.rb
@@ -1,7 +1,7 @@
 module CasaCasesHelper
-	def render_eligible_volunteers(volunteer)
-		if @casa_case.volunteers.exclude?(volunteer)
-			content_tag(:option, "#{volunteer.display_name}", {value: "#{volunteer.id}"})
-		end
-	end
+  def render_eligible_volunteers(volunteer)
+    if @casa_case.volunteers.exclude?(volunteer)
+      content_tag(:option, volunteer.display_name.to_s, {value: volunteer.id.to_s})
+    end
+  end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -148,6 +148,10 @@ class CasaCase < ApplicationRecord
     update(active: true)
   end
 
+  def unassigned_volunteers
+    Volunteer.active.where.not(id: assigned_volunteers).order(:display_name)
+  end
+
   private
 
   def validate_date(day, month, year)

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -73,8 +73,8 @@
       <div class='form-group'>
         <label for='case_assignment_casa_case_id'>Select a Volunteer</label>
         <select id='case_assignment_casa_case_id' name='case_assignment[volunteer_id]' class='form-control select2'>
-          <% Volunteer.active.order(:display_name).each do |volunteer| %>
-            <%= render_eligible_volunteers(volunteer) %>
+          <% @casa_case.unassigned_volunteers.each do |volunteer| %>
+            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
           <% end %>
         </select>
       </div>

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -74,7 +74,7 @@
         <label for='case_assignment_casa_case_id'>Select a Volunteer</label>
         <select id='case_assignment_casa_case_id' name='case_assignment[volunteer_id]' class='form-control select2'>
           <% Volunteer.active.order(:display_name).each do |volunteer| %>
-            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+            <%= render_eligible_volunteers(volunteer) %>
           <% end %>
         </select>
       </div>

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -186,8 +186,7 @@ RSpec.describe "casa_cases/edit", type: :system do
       let(:supervisor1) { create(:supervisor, casa_org: organization) }
       let!(:volunteer) { create(:volunteer, supervisor: supervisor1, casa_org: organization) }
 
-      before do
-        travel_to Time.zone.local(2020, 8, 29, 4, 5, 6)
+      def sign_in_and_assign_volunteer
         sign_in supervisor1
         visit casa_case_path(casa_case.id)
         click_on "Edit Case Details"
@@ -197,10 +196,15 @@ RSpec.describe "casa_cases/edit", type: :system do
         click_on "Assign Volunteer"
       end
 
+      before do
+        travel_to Time.zone.local(2020, 8, 29, 4, 5, 6)
+      end
+
       after { travel_back }
 
       context "when a volunteer is assigned to a case" do
         it "marks the volunteer as assigned and shows the start date of the assignment", js: true do
+          sign_in_and_assign_volunteer
           expect(casa_case.case_assignments.count).to eq 1
 
           unassign_button = page.find("input.btn-outline-danger")
@@ -211,6 +215,7 @@ RSpec.describe "casa_cases/edit", type: :system do
         end
 
         it "shows an assignment start date and no assignment end date" do
+          sign_in_and_assign_volunteer
           assignment_start = page.find("td[data-test=assignment-start]").text
           assignment_end = page.find("td[data-test=assignment-end]").text
 
@@ -221,6 +226,7 @@ RSpec.describe "casa_cases/edit", type: :system do
 
       context "when a volunteer is unassigned from a case" do
         it "marks the volunteer as unassigned and shows assignment start/end dates", js: true do
+          sign_in_and_assign_volunteer
           unassign_button = page.find("input.btn-outline-danger")
           expect(unassign_button.value).to eq "Unassign Volunteer"
 
@@ -243,6 +249,7 @@ RSpec.describe "casa_cases/edit", type: :system do
         before { volunteer.update(supervisor: create(:supervisor)) }
 
         it "unassigns volunteer", js: true do
+          sign_in_and_assign_volunteer
           unassign_button = page.find("input.btn-outline-danger")
           expect(unassign_button.value).to eq "Unassign Volunteer"
 
@@ -256,6 +263,8 @@ RSpec.describe "casa_cases/edit", type: :system do
       it "when can assign only active volunteer to a case" do
         create(:volunteer, casa_org: organization)
         create(:volunteer, :inactive, casa_org: organization)
+
+        sign_in_and_assign_volunteer
 
         expect(find("select[name='case_assignment[volunteer_id]']").all("option").count).to eq 1
       end

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe "casa_cases/edit" do
   context "when assigning a new volunteer" do
     let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
 
-    it "does not have an option to select a volunteer that is already assigned to the casa case"
+    it "does not have an option to select a volunteer that is already assigned to the casa case" do
+      casa_case = create(:casa_case, casa_org: organization)
+      assign :casa_case, casa_case
+      assigned_volunteer = create(:volunteer)
+      create(:case_assignment, volunteer: assigned_volunteer, casa_case: casa_case)
+      unassigned_volunteer = create(:volunteer)
+
+      render template: "casa_cases/edit"
+
+      expect(rendered).to have_select("case_assignment_casa_case_id",
+        options: [unassigned_volunteer.display_name])
+    end
   end
 end

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe "casa_cases/edit" do
       expect(rendered).to include(CGI.escapeHTML("Youth's Birth Month & Year"))
     end
   end
+
+  context "when assigning a new volunteer" do
+    let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+
+    it "does not have an option to select a volunteer that is already assigned to the casa case"
+  end
 end


### PR DESCRIPTION
… current casa case being edited as able to be assigned to the case

### What github issue is this PR for, if any?
Resolves #1242 

### What changed, and why?
Added a helper method to only show volunteers who are not already assigned to the current casa case in the dropdown for assigning a new volunteer.

### How will this affect user permissions?
- Volunteer permissions: none
- Supervisor permissions: none
- Admin permissions: none

### How is this tested? (please write tests!) 💖💪
There is a pending spec but I'm not sure how to implement the test and would love help with figuring it out. I tried a bunch of things and searched around on the web for solutions but came up with nothing.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/54157657/102045596-15d05000-3d9f-11eb-8d06-a33c4da6a5e8.png)
![image](https://user-images.githubusercontent.com/54157657/102045633-254f9900-3d9f-11eb-8d11-c0f2db28e2dc.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
