### PR TITLE
court report email reminders no longer sent for inactive assignments

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -36,7 +36,7 @@ class Volunteer < User
 
   def self.email_court_report_reminder
     active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|
-      volunteer.case_assignments.each do |case_assignment|
+      volunteer.case_assignments.is_active.each do |case_assignment|
         current_case = case_assignment.casa_case
         report_due_date = current_case.court_report_due_date
         if (report_due_date == Date.current + COURT_REPORT_SUBMISSION_REMINDER) && current_case.court_report_not_submitted?

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -10,13 +10,16 @@ RSpec.describe Volunteer, type: :model do
     # Should NOT send emails for these two cases
     let!(:casa_case2) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 8.days) }
     let!(:casa_case3) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days, court_report_submitted_at: Time.current, court_report_status: :submitted) }
+    let!(:casa_case4) { create(:casa_case, casa_org: casa_org, court_report_due_date: Date.current + 7.days) }
 
     let(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
     let(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
     let(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
+    let(:case_assignment_unassigned) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case4, is_active: false) }
     let!(:v1) { create(:volunteer, casa_org: casa_org, case_assignments: [case_assignment1, case_assignment2, case_assignment3]) }
     let!(:v2) { create(:volunteer, casa_org: casa_org, active: false) }
     let!(:v3) { create(:volunteer, casa_org: casa_org) }
+    let!(:v4) { create(:volunteer, casa_org: casa_org, case_assignments: [case_assignment_unassigned]) }
 
     before { stub_const("Volunteer::COURT_REPORT_SUBMISSION_REMINDER", 7.days) }
 
@@ -24,6 +27,11 @@ RSpec.describe Volunteer, type: :model do
       expect(VolunteerMailer).to receive(:court_report_reminder).with(v1, Date.current + 7.days)
       expect(VolunteerMailer).to_not receive(:court_report_reminder).with(v2, anything)
       expect(VolunteerMailer).to_not receive(:court_report_reminder).with(v3, anything)
+      described_class.email_court_report_reminder
+    end
+
+    it "should not send reminders about unassigned cases" do
+      expect(VolunteerMailer).to_not receive(:court_report_reminder).with(v4, anything)
       described_class.email_court_report_reminder
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1437

### What changed, and why?
inactive case assignments are ignored when sending email reminders about court reports

### How is this tested? (please write tests!) 💖💪
One test to check that email reminders aren't sent for a user with an inactive case assignment