### PR TITLE
Fix Docker specs

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,6 +2,7 @@
   <div class="sidebar-heading text-center">
     <% if all_casa_admin_signed_in? || !current_organization.logo.attached? %>
       <%= image_pack_tag("media/src/images/default-logo.png",
+                         id: "casa-logo",
                          alt: "CASA Logo",
                          class: "d-inline-block align-text-bottom") %>
     <% else %>

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Rack::Attack do
   before do
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear
-    travel_to Time.current
   end
 
-  after { travel_back }
+  around do
+    freeze_time
+  end
 
   def app
     Rails.application

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "VolunteerDatatable" do
         end
 
         it "is successful" do
-          expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["", "", "", "", "3", "2"]
+          expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["3", "2", "", "", "", ""]
         end
 
         it "should move blanks to the end" do

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -115,20 +115,24 @@ RSpec.describe "VolunteerDatatable" do
 
     describe "supervisor_name" do
       let(:order_by) { "supervisor_name" }
-      let(:sorted_models) { assigned_volunteers.order(:id).sort_by { |v| v.supervisor.display_name } }
+      let(:sorted_models) { assigned_volunteers.sort_by { |v| v.supervisor.display_name } }
 
       context "when ascending" do
         it "is successful" do
-          check_asc_order.call
+          sorted_models.each_with_index do |model, idx|
+            expect(values[idx][:supervisor][:name]).to eq model.supervisor.display_name
+          end
         end
       end
 
       context "when descending" do
         let(:order_direction) { "desc" }
-        let(:sorted_models) { assigned_volunteers.order(id: :desc).sort_by { |v| v.supervisor.display_name } }
+        let(:sorted_models) { assigned_volunteers.sort_by { |v| v.supervisor.display_name } }
 
         it "is successful" do
-          check_desc_order.call
+          sorted_models.reverse.each_with_index do |model, idx|
+            expect(values[idx][:supervisor][:name]).to eq model.supervisor.display_name
+          end
         end
       end
     end
@@ -164,20 +168,24 @@ RSpec.describe "VolunteerDatatable" do
           volunteer.casa_cases.exists?(transition_aged_youth: true) ? 1 : 0
         }
       end
-      let(:sorted_models) { assigned_volunteers.order(:id).sort_by(&transition_aged_youth_bool_to_int) }
+      let(:sorted_models) { assigned_volunteers.sort_by(&transition_aged_youth_bool_to_int) }
 
       context "when ascending" do
         it "is successful" do
-          check_asc_order.call
+          sorted_models.each_with_index do |model, idx|
+            expect(values[idx][:has_transition_aged_youth_cases]).to eq model.casa_cases.exists?(transition_aged_youth: true).to_s
+          end
         end
       end
 
       context "when descending" do
         let(:order_direction) { "desc" }
-        let(:sorted_models) { assigned_volunteers.order(id: :desc).sort_by(&transition_aged_youth_bool_to_int) }
+        let(:sorted_models) { assigned_volunteers.sort_by(&transition_aged_youth_bool_to_int) }
 
         it "is successful" do
-          check_desc_order.call
+          sorted_models.reverse.each_with_index do |model, idx|
+            expect(values[idx][:has_transition_aged_youth_cases]).to eq model.casa_cases.exists?(transition_aged_youth: true).to_s
+          end
         end
       end
     end
@@ -232,7 +240,7 @@ RSpec.describe "VolunteerDatatable" do
 
       context "when ascending" do
         it "is successful" do
-          check_asc_order.call
+          expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["2", "3", "", "", "", ""]
         end
       end
 
@@ -245,7 +253,7 @@ RSpec.describe "VolunteerDatatable" do
         end
 
         it "is successful" do
-          check_desc_order.call
+          expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["", "", "", "", "3", "2"]
         end
 
         it "should move blanks to the end" do

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "VolunteerDatatable" do
       context "when ascending" do
         it "is successful" do
           sorted_models.each_with_index do |model, idx|
-            expect(values[idx][:supervisor][:name]).to eq model.supervisor.display_name
+            expect(CGI.unescapeHTML(values[idx][:supervisor][:name])).to eq model.supervisor.display_name
           end
         end
       end
@@ -131,7 +131,7 @@ RSpec.describe "VolunteerDatatable" do
 
         it "is successful" do
           sorted_models.reverse.each_with_index do |model, idx|
-            expect(values[idx][:supervisor][:name]).to eq model.supervisor.display_name
+            expect(CGI.unescapeHTML(values[idx][:supervisor][:name])).to eq model.supervisor.display_name
           end
         end
       end

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe "volunteers/index", type: :system do
 
         visit volunteers_path
 
-        expect(page).to have_xpath("//img[@src = '/packs-test/media/src/images/default-logo-c9048fc43854499e952e4b62a505bf35.png' and @alt='CASA Logo']")
+        expect(page.find("#casa-logo")["src"]).to match "default-logo"
+        expect(page.find("#casa-logo")["alt"]).to have_content "CASA Logo"
       end
     end
 
@@ -164,8 +165,8 @@ RSpec.describe "volunteers/index", type: :system do
         visit volunteers_path
         click_on "Supervisor"
         allow_any_instance_of(User).to receive(:timedout?).and_return true
-        find(:css, "#unassigned-vol-filter").set(true)
-        expect(page).to have_text "You need to sign in before continuing."
+        visit volunteers_path
+        expect(page).to have_text "sign in again to continue"
         expect(current_path).to eq new_user_session_path
       end
     end
@@ -248,8 +249,8 @@ RSpec.describe "volunteers/index", type: :system do
         visit volunteers_path
         click_on "Supervisor"
         allow_any_instance_of(User).to receive(:timedout?).and_return true
-        find(:css, "#unassigned-vol-filter").set(true)
-        expect(page).to have_text "You need to sign in before continuing."
+        visit volunteers_path
+        expect(page).to have_text "sign in again to continue"
         expect(current_path).to eq new_user_session_path
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1461 

### What changed, and why?
* For reals fixed Rack Attack specs: `travel_to` does not freeze the time, but `freeze_time` does!
* Added more reliable check for `src` and `alt` attributes on logo spec
* The datatable specs were not reliably returning the values in a consistent order, since it was sorting on values that had duplicates. For example, if sorting on supervisor names, the results were getting returned with the supervisors ordered as:

```
["Ciara Fahey", "Ciara Fahey", "Ms. Roselee Cormier", "Ms. Roselee Cormier", "Travis Braun", "Travis Braun"]
```

However, since there was no secondary ordering, the comparisons of the volunteer ids were sometimes failing.

