### PR TITLE
Fixes Case Contact Report including wrong Org data

### DIFF
--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -26,10 +26,9 @@ class CaseContactReportsController < ApplicationController
       :want_driving_reimbursement,
       contact_type_ids: [],
       contact_type_group_ids: [],
-      casa_org_id: current_organization.id,
       creator_ids: [],
       supervisor_ids: []
-    )
+    ).merge(casa_org_id: current_organization.id)
     convert_radio_options_to_boolean(parameters)
     parameters
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1340

### What changed, and why?
Because `casa_org_id` isn't included in the form params from the view,
it wasn't being permitted in `report_params`. I moved it to be merged
in after we permit the params from the form.

### How is this tested? (please write tests!) 💖💪
Regression test added to verify `casa_org_id` is actually passed in to
`CaseContactReport`.
I also had to modify another test as it was passing due to the same bug.