### PR TITLE
issue 1265: add vertical spacing "Filter By" buttons

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -28,6 +28,10 @@ table.table {
   span.mobile-label { display: none; }
 }
 
+#dropdownMenuButton {
+  margin: 6px 0;
+}
+
 @media only screen and (max-width: 1024px) {
 
   .login-header {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1265 

### What changed, and why?
Added a `margin` rule to add 6px of vertical spacing to the top and bottom of each "Filter By" button. This means that there will be effectively 12px of vertical space between buttons when screen size forces these buttons to go above/below each other. This creates a more discernible separation between the buttons, making them easier to interact with.


### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
## Before 
![casa_before](https://user-images.githubusercontent.com/38586565/102242293-82427080-3ebf-11eb-810a-c85409ff6e5d.png)

## After
<img width="479" alt="Screen Shot 2020-12-15 at 10 08 28 AM" src="https://user-images.githubusercontent.com/38586565/102242317-8a9aab80-3ebf-11eb-83e5-1475d6960703.png">