### PR TITLE
Un/assign volunteer to a supervisor on Volunteer page

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -6,9 +6,8 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
     supervisor_volunteer.is_active = true unless supervisor_volunteer&.is_active?
     supervisor_volunteer.save
-    flash_message = "#{Volunteer.find(params[:volunteer_id]).display_name} was assigned to #{supervisor_volunteer_parent.display_name}"
 
-    redirect_to after_action_path(supervisor_volunteer_parent), notice: flash_message
+    redirect_to after_action_path(supervisor_volunteer_parent)
   end
 
   def unassign

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -3,18 +3,12 @@ class SupervisorVolunteersController < ApplicationController
   before_action :must_be_admin_or_supervisor, only: :unassign
 
   def create
-    puts '------------------------------------------------'
-    puts '------------------------------------------------'
-    puts supervisor_volunteer_parent.display_name
-    puts supervisor_volunteer_params
-    puts '------------------------------------------------'
-    puts '------------------------------------------------'
-
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
     supervisor_volunteer.is_active = true unless supervisor_volunteer&.is_active?
     supervisor_volunteer.save
+    flash_message = "#{Volunteer.find(params[:volunteer_id]).display_name} was assigned to #{supervisor_volunteer_parent.display_name}"
 
-    redirect_to after_action_path(supervisor_volunteer_parent)
+    redirect_to after_action_path(supervisor_volunteer_parent), notice: flash_message
   end
 
   def unassign
@@ -46,7 +40,7 @@ class SupervisorVolunteersController < ApplicationController
     if params[:supervisor_id]
       Supervisor.find(params[:supervisor_id])
     else
-      Volunteer.find(params[:volunteer_id])
+      Supervisor.find(supervisor_volunteer_params[:supervisor_id])
     end
   end
 end

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -3,6 +3,13 @@ class SupervisorVolunteersController < ApplicationController
   before_action :must_be_admin_or_supervisor, only: :unassign
 
   def create
+    puts '------------------------------------------------'
+    puts '------------------------------------------------'
+    puts supervisor_volunteer_parent.display_name
+    puts supervisor_volunteer_params
+    puts '------------------------------------------------'
+    puts '------------------------------------------------'
+
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
     supervisor_volunteer.is_active = true unless supervisor_volunteer&.is_active?
     supervisor_volunteer.save

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -31,6 +31,7 @@ class VolunteersController < ApplicationController
   end
 
   def edit
+    @supervisors = policy_scope current_organization.supervisors
   end
 
   def update

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -131,8 +131,32 @@
 
 <div class="card card-container">
   <div class="card-body">
+    <br>
     <% if @volunteer.has_supervisor? %>
-        <span class="font-weight-bold"> Current Supervisor: </span> <%= @volunteer.supervisor.display_name %>
+        <h5> <span class="font-weight-bold">Current Supervisor:</span> <%= @volunteer.supervisor.display_name %> <h5>
+
+        <br>
+        <%= button_to 'Unassign from Supervisor',
+                      unassign_supervisor_volunteer_path(@volunteer),
+                      method: :patch,
+                      class: "btn btn-danger" %>
+    <% else %>
+        <h5>Currently Unassigned to a Supervisor</h5> 
+        <br>
+        <h3>Assign a Supervisor</h3>
+        <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(volunteer_id: @volunteer.id) do |form| %>
+
+          <div class='form-group'>
+            <label for='supervisor_volunteer_supervisor_id'>Select a Supervisor</label>
+            <select name='supervisor_volunteer[supervisor_id]' class='form-control select2'>
+              <% @supervisors.each do |supervisor| %>
+                <option value="<%= supervisor.id %>"><%= supervisor.display_name %></option>
+              <% end %>
+            </select>
+          </div>
+          <%= form.hidden_field :volunteer_id, :value => @volunteer.id %>
+          <%= form.submit 'Assign Supervisor', class: 'btn btn-primary' %>
+        <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -141,8 +141,6 @@
                       method: :patch,
                       class: "btn btn-danger" %>
     <% else %>
-        <h5>Currently Unassigned to a Supervisor</h5> 
-        <br>
         <h3>Assign a Supervisor</h3>
         <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(volunteer_id: @volunteer.id) do |form| %>
 

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -126,3 +126,13 @@
     <% end %>
   </div>
 </div>
+
+<h1 class="pt-5">Manage Supervisor</h1>
+
+<div class="card card-container">
+  <div class="card-body">
+    <% if @volunteer.has_supervisor? %>
+        <span class="font-weight-bold"> Current Supervisor: </span> <%= @volunteer.supervisor.display_name %>
+    <% end %>
+  </div>
+</div>

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
       end
     end
 
-    context "when passing the supervisor_id as the supervisor_volunteer_params" do 
+    context "when passing the supervisor_id as the supervisor_volunteer_params" do
       let!(:association) do
         create(
           :supervisor_volunteer,
@@ -87,9 +87,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         )
       end
 
-      it "will still set the association as active" do 
+      it "will still set the association as active" do
         valid_parameters = {
-          supervisor_volunteer: {supervisor_id: supervisor.id}, 
+          supervisor_volunteer: {supervisor_id: supervisor.id},
           volunteer_id: volunteer.id
         }
         sign_in(admin)

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -76,6 +76,33 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         expect(SupervisorVolunteer.where(supervisor: supervisor, volunteer: volunteer).exists?).to be(true)
       end
     end
+
+    context "when passing the supervisor_id as the supervisor_volunteer_params" do 
+      let!(:association) do
+        create(
+          :supervisor_volunteer,
+          supervisor: supervisor,
+          volunteer: volunteer,
+          is_active: false
+        )
+      end
+
+      it "will still set the association as active" do 
+        valid_parameters = {
+          supervisor_volunteer: {supervisor_id: supervisor.id}, 
+          volunteer_id: volunteer.id
+        }
+        sign_in(admin)
+
+        expect {
+          post supervisor_volunteers_url, params: valid_parameters
+        }.not_to change(SupervisorVolunteer, :count)
+        expect(response).to redirect_to edit_supervisor_path(supervisor)
+
+        association.reload
+        expect(association.is_active?).to be(true)
+      end
+    end
   end
 
   context "PATCH /unassign" do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe "/volunteers", type: :request do
       let!(:other_volunteer) { create(:volunteer) }
 
       it "does not update the volunteer" do
+        volunteer.supervisor = create(:supervisor)
+
         patch volunteer_path(volunteer), params: {
           volunteer: {email: other_volunteer.email, display_name: "New Name"}
         }

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -71,33 +71,33 @@ RSpec.describe "volunteers/edit", type: :system do
     expect(inactive_volunteer.reload).to be_active
   end
 
-  it "allows the admin to unassign a volunteer from a supervisor" do 
+  it "allows the admin to unassign a volunteer from a supervisor" do
     supervisor = create(:supervisor, display_name: "Haka Haka")
     volunteer = create(:volunteer, display_name: "Bolu Bolu", supervisor: supervisor)
 
     sign_in admin
-    
+
     visit edit_volunteer_path(volunteer)
 
-    expect(page).to have_content('Current Supervisor: Haka Haka')
-    
+    expect(page).to have_content("Current Supervisor: Haka Haka")
+
     click_on "Unassign from Supervisor"
 
     expect(page).to have_content("Bolu Bolu was unassigned from Haka Haka")
   end
 
-  it "shows the admin the option to assign an unassigned volunteer to a different supervisor" do 
+  it "shows the admin the option to assign an unassigned volunteer to a different supervisor" do
     supervisor = create(:supervisor, display_name: "Haka Haka")
     volunteer = create(:volunteer)
 
-    sign_in admin 
+    sign_in admin
 
     visit edit_volunteer_path(volunteer)
 
-    expect(page).to have_content('Select a Supervisor')
-    expect(page).to have_content('Assign a Supervisor')
-  end 
-  
+    expect(page).to have_content("Select a Supervisor")
+    expect(page).to have_content("Assign a Supervisor")
+  end
+
   context "with a deactivated case" do
     it "displays inactive message" do
       deactivated_casa_case = create(:casa_case, active: false, casa_org: volunteer.casa_org, volunteers: [volunteer])

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
     context "with invalid data" do
       it "shows error message for duplicate email" do
+        volunteer.supervisor = create(:supervisor)
         fill_in "volunteer_email", with: admin.email
         fill_in "volunteer_display_name", with: "Mickey Mouse"
         click_on "Submit"
@@ -29,6 +30,7 @@ RSpec.describe "volunteers/edit", type: :system do
       end
 
       it "shows error message for empty fields" do
+        volunteer.supervisor = create(:supervisor)
         fill_in "volunteer_email", with: ""
         fill_in "volunteer_display_name", with: ""
         click_on "Submit"
@@ -69,6 +71,33 @@ RSpec.describe "volunteers/edit", type: :system do
     expect(inactive_volunteer.reload).to be_active
   end
 
+  it "allows the admin to unassign a volunteer from a supervisor" do 
+    supervisor = create(:supervisor, display_name: "Haka Haka")
+    volunteer = create(:volunteer, display_name: "Bolu Bolu", supervisor: supervisor)
+
+    sign_in admin
+    
+    visit edit_volunteer_path(volunteer)
+
+    expect(page).to have_content('Current Supervisor: Haka Haka')
+    
+    click_on "Unassign from Supervisor"
+
+    expect(page).to have_content("Bolu Bolu was unassigned from Haka Haka")
+  end
+
+  it "shows the admin the option to assign an unassigned volunteer to a different supervisor" do 
+    supervisor = create(:supervisor, display_name: "Haka Haka")
+    volunteer = create(:volunteer)
+
+    sign_in admin 
+
+    visit edit_volunteer_path(volunteer)
+
+    expect(page).to have_content('Select a Supervisor')
+    expect(page).to have_content('Assign a Supervisor')
+  end 
+  
   context "with a deactivated case" do
     it "displays inactive message" do
       deactivated_casa_case = create(:casa_case, active: false, casa_org: volunteer.casa_org, volunteers: [volunteer])

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe "volunteers/edit", type: :system do
   end
 
   it "shows the admin the option to assign an unassigned volunteer to a different supervisor" do
-    supervisor = create(:supervisor, display_name: "Haka Haka")
     volunteer = create(:volunteer)
 
     sign_in admin


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1399

### What changed, and why?
This PR will add the capability for supervisors and admin users to un/assign a volunteer from and to a supervisor on the 'Editing Volunteer' page.  

### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor & Admin permissions: Un/assign a volunteer from and to a supervisor

### How is this tested? (please write tests!) 💖💪
- For users that are admin and supervisors, I tested the availability and function of the 'Unassign from Supervisor' button on the 'Editing Volunteer' page for a volunteer who's currently under a supervisor.
- Assigning an unassigned volunteer to a supervisor from the 'Editing Volunteer' page will pass the `supervisor_id` as the `supervisor_volunteer_params`. I tested that the association between the volunteer and supervisor is valid and will still be set as active. 

### Screenshots please :)
- 'Editing Volunteer' page for an unassigned volunteer
<img width="1440" alt="Screen Shot 2020-12-15 at 4 55 54 PM" src="https://user-images.githubusercontent.com/67928223/102282794-c43ad900-3ef6-11eb-9d23-b1528032a474.png">

- 'Editing Volunteer' page for an assigned volunteer
<img width="1440" alt="Screen Shot 2020-12-15 at 4 56 30 PM" src="https://user-images.githubusercontent.com/67928223/102282840-de74b700-3ef6-11eb-89ae-ec1c9adb42aa.png">
