### PR TITLE
[fix] supervisor unable to re-assign case to volunteer

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -5,7 +5,7 @@ class CaseAssignmentsController < ApplicationController
 
   def create
     case_assignments = case_assignment_parent.case_assignments
-    existing_case_assignment = case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], is_active: false).first
+    existing_case_assignment = case_assignments.where(volunteer_id: params[:volunteer_id], is_active: false).first
 
     if existing_case_assignment.present?
       if existing_case_assignment.update(is_active: true)

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -5,7 +5,11 @@ class CaseAssignmentsController < ApplicationController
 
   def create
     case_assignments = case_assignment_parent.case_assignments
-    existing_case_assignment = case_assignments.where(volunteer_id: params[:volunteer_id], is_active: false).first
+    existing_case_assignment = if params[:volunteer_id]
+      case_assignments.where(casa_case_id: case_assignment_params[:casa_case_id], is_active: false).first
+    else
+      case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], is_active: false).first
+    end
 
     if existing_case_assignment.present?
       if existing_case_assignment.update(is_active: true)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -47,7 +47,7 @@ class CasaCase < ApplicationRecord
   scope :not_assigned, ->(casa_org) {
     where(casa_org_id: casa_org.id)
       .left_outer_joins(:case_assignments)
-      .where(case_assignments: {id: nil})
+      .where("case_assignments.id IS NULL OR NOT case_assignments.is_active")
       .order(:case_number)
   }
   scope :should_transition, -> {

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -91,11 +91,11 @@
               <% end %>
             </td>
             <td>
-              <% if @volunteer.active? && assignment.casa_case.active? %>
+              <% if @volunteer.active? && assignment.is_active && assignment.casa_case.active? %>
                 <%- if Pundit.policy(current_user, @volunteer).unassign_case? %>
                   <%= button_to 'Unassign Case',
-                                case_assignment_path(assignment, volunteer_id: @volunteer.id),
-                                method: :delete,
+                                unassign_case_assignment_path(assignment, volunteer_id: @volunteer.id),
+                                method: :patch,
                                 class: "btn btn-danger" %>
                 <%- end %>
               <% else %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -78,7 +78,7 @@
         </thead>
         <tbody>
         <% @volunteer.case_assignments_with_cases.each do |assignment| %>
-          <tr>
+          <tr id="<%= dom_id(assignment) %>">
             <td><%= link_to assignment.casa_case.case_number, casa_case_path(assignment.casa_case) %></td>
             <td><%= assignment.casa_case.decorate.transition_aged_youth_icon %></td>
             <td>

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -69,6 +69,32 @@ RSpec.describe CasaCase do
     end
   end
 
+  describe ".not_assigned" do
+    it "only returns cases NOT actively assigned to ANY volunteer" do
+      current_user = create(:volunteer)
+
+      never_assigned_case = create(:casa_case, casa_org: current_user.casa_org)
+
+      inactive_case = create(:casa_case, casa_org: current_user.casa_org)
+      create(:case_assignment, casa_case: inactive_case, volunteer: current_user, is_active: false)
+      active_cases = create_list(:casa_case, 2, casa_org: current_user.casa_org)
+      active_cases.each do |casa_case|
+        create(:case_assignment, casa_case: casa_case, volunteer: current_user, is_active: true)
+      end
+
+      other_user = create(:volunteer)
+      other_active_case = create(:casa_case, casa_org: other_user.casa_org)
+      other_inactive_case = create(:casa_case, casa_org: other_user.casa_org)
+      create(:case_assignment, casa_case: other_active_case, volunteer: other_user, is_active: true)
+      create(
+        :case_assignment,
+        casa_case: other_inactive_case, volunteer: other_user, is_active: false
+      )
+
+      expect(described_class.not_assigned(current_user.casa_org)).to contain_exactly(never_assigned_case, inactive_case, other_inactive_case)
+    end
+  end
+
   describe "#court_report_status=" do
     let(:casa_case) { build(:casa_case) }
     subject { casa_case.court_report_status = court_report_status }

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -126,6 +126,14 @@ RSpec.describe "volunteers/edit", type: :system do
         expect(page).to have_text(casa_case_2.case_number)
         expect(page).not_to have_button("Unassign Case")
       end
+
+      select casa_case_2.case_number, from: "Select a Case"
+      click_on "Assign Case"
+
+      within("#case_assignment_#{assignment2.id}") do
+        expect(page).to have_text(casa_case_2.case_number)
+        expect(page).to have_button("Unassign Case")
+      end
     end
   end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -102,6 +102,33 @@ RSpec.describe "volunteers/edit", type: :system do
     end
   end
 
+  context "with previously assigned cases" do
+    let(:casa_org) { create(:casa_org) }
+    let!(:supervisor) { create(:casa_admin, casa_org: casa_org) }
+    let!(:volunteer) { create(:volunteer, casa_org: casa_org, display_name: "AAA") }
+    let!(:casa_case_1) { create(:casa_case, casa_org: casa_org, case_number: "CINA1") }
+    let!(:casa_case_2) { create(:casa_case, casa_org: casa_org, case_number: "CINA2") }
+
+    it "shows the unassign button for assigned cases and not for unassigned cases" do
+      sign_in supervisor
+
+      assignment1 = volunteer.case_assignments.create(casa_case: casa_case_1, is_active: true)
+      assignment2 = volunteer.case_assignments.create(casa_case: casa_case_2, is_active: false)
+
+      visit edit_volunteer_path(volunteer)
+
+      within("#case_assignment_#{assignment1.id}") do
+        expect(page).to have_text(casa_case_1.case_number)
+        expect(page).to have_button("Unassign Case")
+      end
+
+      within("#case_assignment_#{assignment2.id}") do
+        expect(page).to have_text(casa_case_2.case_number)
+        expect(page).not_to have_button("Unassign Case")
+      end
+    end
+  end
+
   describe "inactive case visibility" do
     let!(:active_casa_case) { create(:casa_case, casa_org: organization, case_number: "ACTIVE") }
     let!(:inactive_casa_case) { create(:casa_case, casa_org: organization, active: false, case_number: "INACTIVE") }


### PR DESCRIPTION

### What github issue is this PR for, if any?

Resolves #1432 

### What changed, and why?
When an admin goes to edit a Volunteer, the list of cases available to assign included cases that had never been assigned but not cases that had inactive assignments (e.g. previously unassigned).

This PR fixes that.

In addition, the list of currently assigned cases would _include_ cases that had been unassigned.  

The solution in this PR is to leave inactive assignments in the list but not include the "Unassign Case" button.  This is consistent with the Case edit page that shows Volunteers that have been unassigned.  I leave it to a future PR to improve the list of Case Assignments on the Volunteer edit page.


### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Added new spec for `CasaCase.not_assigned` and system specs for the `volunteer/:id/edit` page assignments section.

### Screenshots please :)
<img width="1217" alt="Screen Shot 2020-12-15 at 2 58 13 PM" src="https://user-images.githubusercontent.com/3819249/102272387-4cfd4900-3ee6-11eb-9d6d-df7cd000a35b.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
