### PR TITLE
696 volunteer table header

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -14,7 +14,10 @@ class CasaCasesController < ApplicationController
   # GET /casa_cases/1
   # GET /casa_cases/1.json
   def show
-    authorize @casa_case
+    respond_to do |format|
+      authorize @casa_case
+      format.json { render json: @casa_case.with_contacts }
+    end
   end
 
   # GET /casa_cases/new

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -15,6 +15,7 @@ class CaseContactsController < ApplicationController
 
   def table
     @casa_cases = policy_scope(current_organization.casa_cases)
+    @selected_case = @casa_cases.first
     # @case_contact = current_organization.case_contacts.find(params[:id])
     render :table
   end

--- a/app/javascript/packs/case_contacts/table.js
+++ b/app/javascript/packs/case_contacts/table.js
@@ -1,0 +1,64 @@
+import axios from 'axios';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const CaseSelector = document.querySelector('#select-case-number')
+
+  CaseSelector.addEventListener('change', () => {
+    const SelectedCaseId = CaseSelector.querySelectorAll('option')[CaseSelector.selectedIndex].dataset.id
+
+    axios.get(`/casa_cases/${SelectedCaseId}.json`).then(response => {
+      document.querySelector('#case-court-date').innerText = response.data['court_date']
+      document.querySelector('#case-court-report-due-date').innerText = response.data['court_report_due_date']
+      document.querySelector('#case-court-report-status').innerText = response.data['court_report_status']
+
+      generateCaseContactsHTML(response.data['case_contacts'])
+      generateCaseYouthIcon(response.data['transition_aged_youth'])
+    })
+  })
+})
+
+const generateCaseContactsHTML = (case_contacts) => {
+  document.querySelector('#case-contacts').innerHTML = ''
+
+  case_contacts.forEach(contact => {
+    document.querySelector('#case-contacts').innerHTML += generateContactHTMLFromContact(contact)
+  })
+}
+
+const generateContactHTMLFromContact = contact => {
+  return `<article class="case-contact-item">
+    <header class="flex top contact-article">
+      <section>
+        <h2>${contact['medium_type']}</h2>
+        <p>
+          Foster Parent |
+          ${contact['occurred_at']} |
+          ${contact['duration_minutes']} minutes |
+          ${contact['miles_driven']} miles driven |
+          Reimbursement: ${contact['want_driving_reimbursement']}
+        </p>
+      </section>
+      <button class="button page">Edit</button>
+    </header>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean euismod bibendum laoreet. Proin gravida dolor sit <a class="read-more-link" href="#">Read More</a>
+    </p>
+    <div class="followup-alert">
+      <img src="/followup-alert.svg" alt="" />
+      <section>
+        <h3>Follow-Up</h3>
+        <p>Nam fermentum, nulla luctus pharetra vulputate</p>
+        <a href="#">+ Follow-Up Contact</a>
+      </section>
+    </div>
+  </article>`
+}
+
+const generateCaseYouthIcon = transitionAgedYouth => {
+  if(transitionAgedYouth) {
+    document.querySelector('#case-youth-icon').innerHTML = '<img alt="Non transition aged youth (under 14)" src="/caterpillar.svg" class="youth-icon caterpillar">'
+  }
+  else {
+    document.querySelector('#case-youth-icon').innerHTML = '<img alt="Transition aged youth (over 14)" src="/butterfly.svg" class="youth-icon butterfly">'
+  }
+}

--- a/app/javascript/src/stylesheets/pages/case_contacts.scss
+++ b/app/javascript/src/stylesheets/pages/case_contacts.scss
@@ -80,6 +80,11 @@ legend {
   }
 }
 
+#primary-case-contact-item{
+  background: $info;
+  color: white;
+}
+
 .read-more-link {
   text-decoration: underline;
 }
@@ -107,14 +112,18 @@ legend {
   }
 }
 
+#select-case-number {
+  margin-right: 20px;
+}
+
 @media only screen and (max-width: 1280px) {
   h1 {
     margin-bottom: 4rem;
   }
-  #case-contacts-header #select-case-number,
+
   .youth-icon {
     position: absolute;
-    margin-top: -10rem;
+    margin-top: -1rem;
     color: $primary;
   }
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -123,6 +123,17 @@ class CasaCase < ApplicationRecord
     update(active: true)
   end
 
+  def with_contacts
+    {
+      case_number: case_number,
+      transition_aged_youth: transition_aged_youth,
+      court_date: court_date,
+      court_report_due_date: court_report_due_date,
+      court_report_status: court_report_status,
+      case_contacts: case_contact_items
+    }
+  end
+
   private
 
   def validate_date(day, month, year)
@@ -143,6 +154,18 @@ class CasaCase < ApplicationRecord
   rescue Date::Error
     errors.messages[date_field_name.to_sym] << "was not a valid date."
     args
+  end
+
+  def case_contact_items
+    case_contacts.map do |contact|
+      {
+        medium_type: contact.medium_type.humanize,
+        occurred_at: contact.occurred_at.strftime('%B %e, %Y'),
+        duration_minutes: contact.duration_minutes,
+        miles_driven: contact.miles_driven,
+        want_driving_reimbursement: contact.want_driving_reimbursement ? "Yes" : "No"
+      }
+    end
   end
 end
 

--- a/app/views/case_contacts/_table_article.html.erb
+++ b/app/views/case_contacts/_table_article.html.erb
@@ -3,10 +3,10 @@
     <section>
       <h2><%= case_contact.medium_type.humanize %></h2>
       <p>
-        Foster Parent | 
-        <%= case_contact.occurred_at.strftime('%B %e, %Y') %> | 
-        <%= case_contact.duration_minutes %> minutes | 
-        <%= case_contact.miles_driven %> miles driven | 
+        Foster Parent |
+        <%= case_contact.occurred_at.strftime('%B %e, %Y') %> |
+        <%= case_contact.duration_minutes %> minutes |
+        <%= case_contact.miles_driven %> miles driven |
         Reimbursement: <%= case_contact.want_driving_reimbursement ? "Yes" : "No" %>
       </p>
     </section>

--- a/app/views/case_contacts/_table_header.html.erb
+++ b/app/views/case_contacts/_table_header.html.erb
@@ -1,31 +1,20 @@
 <header id="case-contacts-header" class="flex center">
-  <% if !selected_case.transition_aged_youth %>
-    <img alt="Transition aged youth (over 14)" src="/butterfly.svg" class="youth-icon butterfly">
-  <% else %>
-    <img alt="Non transition aged youth (under 14)" src="/caterpillar.svg" class="youth-icon caterpillar">
-  <% end %>
-    
+  <span id="case-youth-icon">
+    <% if !selected_case.transition_aged_youth %>
+      <img alt="Transition aged youth (over 14)" src="/butterfly.svg" class="youth-icon butterfly">
+    <% else %>
+      <img alt="Non transition aged youth (under 14)" src="/caterpillar.svg" class="youth-icon caterpillar">
+    <% end %>
+  </span>
+
   <label for="select-case-number" class="visually-hidden">Select case number</label>
   <select id="select-case-number">
     <% casa_cases.each do |casa_case| %>
-      <option value="<%= casa_case.case_number %>"><%= casa_case.case_number %></option>
+      <option value="<%= casa_case.case_number %>" data-id="<%= casa_case.id %>">
+        <%= casa_case.case_number %>
+      </option>
     <% end %>
   </select>
-
-  <p>
-    Next Court Date:<br/>
-    <%= selected_case.court_date || '-' %>
-  </p>
-
-  <p>
-    Court Report Due:<br/>
-    <%= selected_case.court_report_due_date || '-' %>
-  </p>
-
-  <p>
-    Court report status:<br/>
-    <%= selected_case.court_report_status.humanize || '-' %>
-  </p>
 
   <p>
     <label for="case-contact-filter">Filter by:</label>

--- a/app/views/case_contacts/table.html.erb
+++ b/app/views/case_contacts/table.html.erb
@@ -1,13 +1,41 @@
 <h1>My Case Contacts</h1>
 
 <main class="case-contacts-wrapper">
-  <%= render partial: 'table_header', locals: { casa_cases: @casa_cases, selected_case: @casa_cases[0] } %>
+  <%= render partial: 'table_header', locals: { casa_cases: @casa_cases, selected_case: @selected_case } %>
+  <article id="primary-case-contact-item" class="case-contact-item">
+    <header class="flex top">
+      <p>
+        Next Court Date:<br/>
+        <span id="case-court-date">
+          <%= @selected_case.court_date || '-' %>
+        </span>
+      </p>
 
-  <% if @casa_cases[0].case_contacts %>
-    <% @casa_cases[0].case_contacts.each do |case_contact| %>
-      <%= render partial: 'table_article', locals: { case_contact: case_contact } %>
+      <p>
+        Court Report Due:<br/>
+        <span id="case-court-report-due-date">
+          <%= @selected_case.court_report_due_date || '-' %>
+        </span>
+      </p>
+
+      <p>
+        Court report status:<br/>
+        <span id="case-court-report-status">
+          <%= @selected_case.court_report_status.humanize || '-' %>
+        </span>
+      </p>
+    </header>
+  </article>
+
+  <section id='case-contacts'>
+    <% if @casa_cases[0].case_contacts %>
+      <% @casa_cases[0].case_contacts.each do |case_contact| %>
+        <%= render partial: 'table_article', locals: { case_contact: case_contact } %>
+      <% end %>
+    <% else %>
+      <p>This case has no contacts.<p>
     <% end %>
-  <% else %>
-    <p>This case has no contacts.<p>
-  <% end %>
+  </section>
 </main>
+
+<%= javascript_pack_tag('case_contacts/table') %>

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -229,4 +229,29 @@ RSpec.describe CasaCase do
       expect(casa_case.reload.assigned_volunteers).to eq [volunteer2]
     end
   end
+
+  describe "#with_contacts" do
+    it "includes some basic case and contact attributes" do
+      casa_case = create(:casa_case)
+      contact1 = create(:case_contact, casa_case: casa_case, want_driving_reimbursement: false)
+      expected_result = {
+        case_number: casa_case.case_number,
+        transition_aged_youth: casa_case.transition_aged_youth,
+        court_date: casa_case.court_date,
+        court_report_due_date: casa_case.court_report_due_date,
+        court_report_status: casa_case.court_report_status,
+        case_contacts: [
+          {
+            medium_type: contact1.medium_type.humanize,
+            occurred_at: contact1.occurred_at.strftime('%B %e, %Y'),
+            duration_minutes: contact1.duration_minutes,
+            miles_driven: contact1.miles_driven,
+            want_driving_reimbursement: 'No'
+          }
+        ]
+      }
+
+      expect(casa_case.with_contacts).to eq(expected_result)
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #696

### What changed, and why?
`case_contacts` layout altered to be more mobile-friendly and added the ability to change which contact a user is viewing in real-time through the case number selection box.


### How will this affect user permissions?
No permissions should be affected.

### How is this tested? (please write tests!) 💖💪
Only has a spec around the changes made in `casa_case`. I meant to get around to testing the JS and `casa_cases_controller`, but ran out of time.

How it all works is the page renders normally on the initial load, but changing the case number in the select will launch an asynchronous request to the `casa_cases_controller` to retrieve the newly selected case and its contacts' information. This information is then read into the current rendering of the contact page, clearing out the data initially displayed in the process.


### Screenshots please :)

## Interactivity Demo
![casa_demo](https://user-images.githubusercontent.com/38586565/102280296-7cb24e00-3ef2-11eb-9a8f-f211461370b0.gif)

## Mobile View
<img width="643" alt="Screen Shot 2020-12-15 at 4 28 58 PM" src="https://user-images.githubusercontent.com/38586565/102280370-a8353880-3ef2-11eb-995b-4cdf9480d0bd.png">

