### PR TITLE
Moves case contacts layout from table based view to card based view

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -40,7 +40,12 @@ class CaseContactDecorator < Draper::Decorator
 
   def subheading
     [
-      object.occurred_at.strftime(DateFormat::FULL), duration_minutes, contact_made, miles_traveled, reimbursement
+      contact_type_list,
+      object.occurred_at.strftime(DateFormat::FULL),
+      duration_minutes,
+      contact_made,
+      miles_traveled,
+      reimbursement
     ].compact.join(" | ")
   end
 
@@ -92,4 +97,13 @@ class CaseContactDecorator < Draper::Decorator
   def show_contact_type?(contact_type_id)
     object.case_contact_contact_type.map(&:contact_type_id).include?(contact_type_id)
   end
+
+  private
+
+  def contact_type_list
+    object.contact_groups_with_types.map do |key, value|
+      "#{key}: #{value.join(', ')}"
+    end.join(" / ")
+  end
+
 end

--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -64,24 +64,20 @@ class CaseContactDecorator < Draper::Decorator
     object.contact_types&.map { |ct| ct.name }&.join("|")
   end
 
-  def medium_type
-    object.medium_type.blank? ? "Unknown" : object.medium_type.titleize
-  end
-
-  def medium_type_icon
+  def medium_icon_classes
     case object.medium_type
     when CaseContact::IN_PERSON
-      "👥 #{object.medium_type}"
+      "fas fa-users"
     when CaseContact::TEXT_EMAIL
-      "🔤 #{object.medium_type}"
+      "fas fa-envelope"
     when CaseContact::VIDEO
-      "▶ #{object.medium_type}️"
+      "fas fa-video"
     when CaseContact::VOICE_ONLY
-      "📞 #{object.medium_type}"
+      "fas fa-phone-square-alt"
     when CaseContact::LETTER
-    "✉️ #{object.medium_type}️"
+      "fas fa-file-alt"
     else
-      object.medium_type
+      "fas fa-question"
     end
   end
 

--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -23,25 +23,41 @@ class CaseContactDecorator < Draper::Decorator
   end
 
   def miles_traveled
-    object.miles_driven.zero? ? "" : object.miles_driven
+    object.miles_driven.zero? ? nil : "#{object.miles_driven} miles driven"
   end
 
   def reimbursement
-    object.want_driving_reimbursement ? "Yes 🟢" : "No"
+    object.want_driving_reimbursement ? "Reimbursement" : nil
   end
 
   def contact_made
-    object.contact_made ? "Yes ✅" : "No ❌"
+    object.contact_made ? nil : "No Contact Made"
   end
 
   def report_contact_made
     object.contact_made
   end
 
+  def subheading
+    [
+      object.occurred_at.strftime(DateFormat::FULL), duration_minutes, contact_made, miles_traveled, reimbursement
+    ].compact.join(" | ")
+  end
+
+  def notes
+    if object.notes && object.notes.length > CaseContactDecorator::NOTES_WORD_LIMIT
+      helpers.content_tag(:p, limited_notes)
+    else
+      helpers.simple_format(full_notes)
+    end
+  end
+
   def contact_types
-    object.contact_types
-      &.map { |ct| ct.name }
-      &.to_sentence(last_word_connector: ", and ") || ""
+    if object.contact_types.any?
+      object.contact_types&.map { |ct| ct.name }&.to_sentence(last_word_connector: ", and ")
+    else
+      "No contact type specified"
+    end
   end
 
   def report_contact_types
@@ -63,7 +79,7 @@ class CaseContactDecorator < Draper::Decorator
     when CaseContact::VOICE_ONLY
       "📞 #{object.medium_type}"
     when CaseContact::LETTER
-      "✉️ #{object.medium_type}️"
+    "✉️ #{object.medium_type}️"
     else
       object.medium_type
     end

--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -101,9 +101,8 @@ class CaseContactDecorator < Draper::Decorator
   private
 
   def contact_type_list
-    object.contact_groups_with_types.map do |key, value|
-      "#{key}: #{value.join(', ')}"
-    end.join(" / ")
+    object.contact_groups_with_types.map { |key, value|
+      "#{key}: #{value.join(", ")}"
+    }.join(" / ")
   end
-
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -111,7 +111,7 @@ class CaseContact < ApplicationRecord
 
   def contact_groups_with_types
     hash = Hash.new { |h, k| h[k] = [] }
-    self.contact_types.each do |contact_type|
+    contact_types.each do |contact_type|
       hash[contact_type.contact_type_group.name] << contact_type.name
     end
     hash

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -108,6 +108,14 @@ class CaseContact < ApplicationRecord
   def has_casa_case_transitioned
     casa_case.has_transitioned?
   end
+
+  def contact_groups_with_types
+    hash = Hash.new { |h, k| h[k] = [] }
+    self.contact_types.each do |contact_type|
+      hash[contact_type.contact_type_group.name] << contact_type.name
+    end
+    hash
+  end
 end
 
 # == Schema Information

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -6,26 +6,8 @@
           <i class="mt-1 mr-3 text-primary <%= contact.decorate.medium_icon_classes %>"></i>
           <div class="media-body">
             <h5 class="mt-0 card-title">
-              <strong class="text-primary"><%= contact.decorate.contact_types %></strong>
+              <strong class="text-primary"><%= contact.contact_groups_with_types.keys.join(', ') %></strong>
             </h5>
-            <h6 class="card-subtitle mb-2 text-primary">
-              Created by: 
-              <% if policy(contact).edit? %>
-                <% if current_user.volunteer? %>
-                  <%= contact.creator&.display_name %>
-                <% else %>
-                  <% if contact.creator&.supervisor? %>
-                    <%= link_to contact.creator&.display_name, edit_supervisor_path(current_user) %>
-                  <% elsif contact.creator&.casa_admin? %>
-                    <%= link_to contact.creator&.display_name, edit_users_path %>
-                  <% else %>
-                    <%= link_to contact.creator&.display_name, edit_volunteer_path(contact.creator) %>
-                  <% end %>
-                <% end %>
-              <% else %>
-                <%= contact.creator&.display_name %>
-              <% end %>
-            </h6>
             <h6 class="card-subtitle mb-2 text-muted">
               <%= contact.decorate.subheading %>
             </h6>
@@ -59,22 +41,42 @@
       </div>
     </div>
   </div>
+  <div>
+    <h6 class="card-subtitle mb-2 text-primary float-right mr-2">
+      Created by:
+      <% if policy(contact).edit? %>
+        <% if current_user.volunteer? %>
+          <%= contact.creator&.display_name %>
+        <% else %>
+          <% if contact.creator&.supervisor? %>
+            <%= link_to contact.creator&.display_name, edit_supervisor_path(current_user) %>
+          <% elsif contact.creator&.casa_admin? %>
+            <%= link_to contact.creator&.display_name, edit_users_path %>
+          <% else %>
+            <%= link_to contact.creator&.display_name, edit_volunteer_path(contact.creator) %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= contact.creator&.display_name %>
+      <% end %>
+    </h6>
+  </div>
 </div>
 
 <script type="text/javascript">
-  function moreText (event) {
-    event.preventDefault()
-    const table_cell = event.target.closest('.card-text')
+function moreText (event) {
+  event.preventDefault()
+  const table_cell = event.target.closest('.card-text')
 
-    table_cell.querySelectorAll('.full-notes')[0].style.display = 'block'
-    table_cell.querySelectorAll('.limited-notes')[0].style.display = 'none'
-  }
+  table_cell.querySelectorAll('.full-notes')[0].style.display = 'block'
+  table_cell.querySelectorAll('.limited-notes')[0].style.display = 'none'
+}
 
-  function lessText (event) {
-    event.preventDefault()
-    const table_cell = event.target.closest('.card-text')
+function lessText (event) {
+  event.preventDefault()
+  const table_cell = event.target.closest('.card-text')
 
-    table_cell.querySelectorAll('.full-notes')[0].style.display = 'none'
-    table_cell.querySelectorAll('.limited-notes')[0].style.display = 'block'
-  }
+  table_cell.querySelectorAll('.full-notes')[0].style.display = 'none'
+  table_cell.querySelectorAll('.limited-notes')[0].style.display = 'block'
+}
 </script>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -1,81 +1,31 @@
-<tr>
-  <td data-sort="<%= contact.occurred_at.strftime(DateFormat::CONTACT_OCCURRED_AT) %>">
-    <%= contact.occurred_at.strftime(DateFormat::FULL) %>
-  </td>
-  <td>
-    <span class="mobile-label">Duration</span>
-    <%= contact.decorate.duration_minutes %>
-  </td>
-  <td>
-    <span class="mobile-label">Contact Made?</span>
-    <%= contact.decorate.contact_made %>
-  </td>
-  <td>
-    <span class="mobile-label">Contact Medium</span>
-    <%= contact.decorate.medium_type_icon %>
-  </td>
-  <td>
-    <span class="mobile-label">Type</span>
-    <%= contact.decorate.contact_types %>
-  </td>
-  <td>
-    <span class="mobile-label">Miles Driven</span>
-    <%= contact.decorate.miles_traveled %>
-    <% unless contact.decorate.miles_traveled.blank? %>
-      <%= " " %>
-      <i class="fa fa-car" aria-hidden="true"></i>
-    <% end %>
-  </td>
-  <td>
-    <span class="mobile-label">Want Reimbursement?</span>
-    <%= contact.decorate.reimbursement %>
-  </td>
-  <td>
-    <span class="mobile-label">Creator</span>
-    <% if policy(contact).edit? %>
-      <% if current_user.volunteer? %>
-        <%= contact.creator&.display_name %>
-      <% else %>
-        <% if contact.creator&.supervisor? %>
-          <%= link_to contact.creator&.display_name, edit_supervisor_path(current_user) %>
-        <% elsif contact.creator&.casa_admin? %>
-          <%= link_to contact.creator&.display_name, edit_users_path %>
-        <% else %>
-          <%= link_to contact.creator&.display_name, edit_volunteer_path(contact.creator) %>
+<div class="card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between">
+      <div>
+        <h5 class="card-title">
+          <strong class="text-primary"><%= contact.decorate.contact_types %></strong>
+        </h5>
+        <h6 class="card-subtitle mb-2 text-muted">
+          <%= contact.decorate.subheading %>
+        </h6>
+      </div>
+      <div>
+        <% if Pundit.policy(current_user, contact).update? %>
+          <% if contact.created_in_current_quarter? %>
+            <%= link_to edit_case_contact_path(contact), class: 'btn btn-outline-primary' do %>
+              <strong>Edit</strong>
+            <% end %>
+          <% else %>
+            <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="This case contact was created in a previous quarter and is therefore no longer editable"></i>
+          <% end %>
         <% end %>
-      <% end %>
-    <% else %>
-      <%= contact.creator&.display_name %>
-    <% end %>
-  </td>
-  <td class="read-more">
-    <span class="mobile-label">Notes</span>
-    <%- if contact.notes && contact.notes.length > CaseContactDecorator::NOTES_WORD_LIMIT %>
-      <div class="limited-notes" style="display: block;">
-        <%= simple_format(contact.decorate.limited_notes) %>
-        <span><a role="button" href="#" onClick="moreText(event)">Read more</a></span>
       </div>
-      <div class="full-notes" style="display: none;">
-        <%= simple_format(contact.decorate.full_notes) %>
-        <span><a role="button" href="#" onClick="lessText(event)">Hide</a></span>
-      </div>
-    <%- else %>
-      <%= simple_format(contact.decorate.full_notes) %>
-    <%- end %>
-  </td>
-  <td>
-    <% if Pundit.policy(current_user, contact).update? %>
-      <% if contact.created_in_current_quarter? %>
-        <%= link_to 'Edit', edit_case_contact_path(contact) %>
-      <% else %>
-        <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="This case contact was created in a previous quarter and is therefore no longer editable"></i>
-      <% end %>
-    <% end %>
-  </td>
-</tr>
+    </div>
+    <p class="card-text"><%= contact.decorate.notes %></p>
+  </div>
+</div>
 
 <script type="text/javascript">
-
   function moreText (event) {
     event.preventDefault()
     const table_cell = event.target.closest('td')

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -2,12 +2,49 @@
   <div class="card-body">
     <div class="d-flex justify-content-between">
       <div>
-        <h5 class="card-title">
-          <strong class="text-primary"><%= contact.decorate.contact_types %></strong>
-        </h5>
-        <h6 class="card-subtitle mb-2 text-muted">
-          <%= contact.decorate.subheading %>
-        </h6>
+        <div class="media">
+          <i class="mt-1 mr-3 text-primary <%= contact.decorate.medium_icon_classes %>"></i>
+          <div class="media-body">
+            <h5 class="mt-0 card-title">
+              <strong class="text-primary"><%= contact.decorate.contact_types %></strong>
+            </h5>
+            <h6 class="card-subtitle mb-2 text-primary">
+              Created by: 
+              <% if policy(contact).edit? %>
+                <% if current_user.volunteer? %>
+                  <%= contact.creator&.display_name %>
+                <% else %>
+                  <% if contact.creator&.supervisor? %>
+                    <%= link_to contact.creator&.display_name, edit_supervisor_path(current_user) %>
+                  <% elsif contact.creator&.casa_admin? %>
+                    <%= link_to contact.creator&.display_name, edit_users_path %>
+                  <% else %>
+                    <%= link_to contact.creator&.display_name, edit_volunteer_path(contact.creator) %>
+                  <% end %>
+                <% end %>
+              <% else %>
+                <%= contact.creator&.display_name %>
+              <% end %>
+            </h6>
+            <h6 class="card-subtitle mb-2 text-muted">
+              <%= contact.decorate.subheading %>
+            </h6>
+            <div class="card-text">
+              <% if contact.notes && contact.notes.length > CaseContactDecorator::NOTES_WORD_LIMIT %>
+                <div class="limited-notes" style="display: block;">
+                  <%= simple_format(contact.decorate.limited_notes) %>
+                  <span><a role="button" href="#" onClick="moreText(event)">Read more</a></span>
+                </div>
+                <div class="full-notes" style="display: none;">
+                  <%= simple_format(contact.decorate.full_notes) %>
+                  <span><a role="button" href="#" onClick="lessText(event)">Hide</a></span>
+                </div>
+              <% else %>
+                <%= simple_format(contact.decorate.full_notes) %>
+              <% end %>
+            </div>
+          </div>
+        </div>
       </div>
       <div>
         <% if Pundit.policy(current_user, contact).update? %>
@@ -21,14 +58,13 @@
         <% end %>
       </div>
     </div>
-    <p class="card-text"><%= contact.decorate.notes %></p>
   </div>
 </div>
 
 <script type="text/javascript">
   function moreText (event) {
     event.preventDefault()
-    const table_cell = event.target.closest('td')
+    const table_cell = event.target.closest('.card-text')
 
     table_cell.querySelectorAll('.full-notes')[0].style.display = 'block'
     table_cell.querySelectorAll('.limited-notes')[0].style.display = 'none'
@@ -36,7 +72,7 @@
 
   function lessText (event) {
     event.preventDefault()
-    const table_cell = event.target.closest('td')
+    const table_cell = event.target.closest('.card-text')
 
     table_cell.querySelectorAll('.full-notes')[0].style.display = 'none'
     table_cell.querySelectorAll('.limited-notes')[0].style.display = 'block'

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -9,22 +9,6 @@
   <div class="card card-container">
     <div class="card-body">
       <h3><%= casa_case.case_number %></h3>
-      <table class="table case-contacts-table" id="case_contacts">
-        <thead>
-        <tr>
-          <th>Date</th>
-          <th>Duration</th>
-          <th>Contact Made</th>
-          <th>Contact Medium</th>
-          <th>Type</th>
-          <th>Miles Driven</th>
-          <th>Want reimbursement?</th>
-          <th>Created by</th>
-          <th>Notes</th>
-          <th>Actions</th>
-        </tr>
-        </thead>
-        <tbody>
         <% casa_case.decorate.case_contacts_ordered_by_occurred_at.each do |contact| %>
           <%= render "case_contacts/case_contact", contact: contact %>
         <% end %>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -9,12 +9,9 @@
   <div class="card card-container">
     <div class="card-body">
       <h3><%= casa_case.case_number %></h3>
-        <% casa_case.decorate.case_contacts_ordered_by_occurred_at.each do |contact| %>
-          <%= render "case_contacts/case_contact", contact: contact %>
-        <% end %>
-        </tbody>
-      </table>
+      <% casa_case.decorate.case_contacts_ordered_by_occurred_at.each do |contact| %>
+        <%= render "case_contacts/case_contact", contact: contact %>
+      <% end %>
     </div>
   </div>
-  <br>
 <% end %>

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -128,20 +128,26 @@ RSpec.describe CaseContactDecorator do
   describe "#subheading" do
     context "when all information is available" do
       it "returns a properly formatted string" do
+        contact_group = create(:contact_type_group, name: 'Group X')
+        contact_type = create(:contact_type, contact_type_group: contact_group, name: 'Type X')
         case_contact = create(:case_contact, occurred_at: "2020-12-01", duration_minutes: 99, contact_made: false, miles_driven: 100, want_driving_reimbursement: true)
+        case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | 1 hour 39 minutes | No Contact Made | 100 miles driven | Reimbursement"
+          "Group X: Type X | December 1, 2020 | 1 hour 39 minutes | No Contact Made | 100 miles driven | Reimbursement"
         )
       end
     end
 
     context "when some information is missing" do
       it "returns a properly formatted string without extra pipes" do
+        contact_group = create(:contact_type_group, name: 'Group X')
+        contact_type = create(:contact_type, contact_type_group: contact_group, name: 'Type X')
         case_contact = create(:case_contact, occurred_at: "2020-12-01", duration_minutes: 99, contact_made: true, miles_driven: 100, want_driving_reimbursement: true)
+        case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | 1 hour 39 minutes | 100 miles driven | Reimbursement"
+          "Group X: Type X | December 1, 2020 | 1 hour 39 minutes | 100 miles driven | Reimbursement"
         )
       end
     end

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe CaseContactDecorator do
   describe "#subheading" do
     context "when all information is available" do
       it "returns a properly formatted string" do
-        contact_group = create(:contact_type_group, name: 'Group X')
-        contact_type = create(:contact_type, contact_type_group: contact_group, name: 'Type X')
+        contact_group = create(:contact_type_group, name: "Group X")
+        contact_type = create(:contact_type, contact_type_group: contact_group, name: "Type X")
         case_contact = create(:case_contact, occurred_at: "2020-12-01", duration_minutes: 99, contact_made: false, miles_driven: 100, want_driving_reimbursement: true)
         case_contact.contact_types = [contact_type]
 
@@ -141,8 +141,8 @@ RSpec.describe CaseContactDecorator do
 
     context "when some information is missing" do
       it "returns a properly formatted string without extra pipes" do
-        contact_group = create(:contact_type_group, name: 'Group X')
-        contact_type = create(:contact_type, contact_type_group: contact_group, name: 'Type X')
+        contact_group = create(:contact_type_group, name: "Group X")
+        contact_type = create(:contact_type, contact_type_group: contact_group, name: "Type X")
         case_contact = create(:case_contact, occurred_at: "2020-12-01", duration_minutes: 99, contact_made: true, miles_driven: 100, want_driving_reimbursement: true)
         case_contact.contact_types = [contact_type]
 

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -75,20 +75,52 @@ RSpec.describe CaseContactDecorator do
     end
   end
 
-  describe "#medium_type" do
-    context "when medium_type is nil" do
-      it "returns Unknown" do
-        case_contact = build(:case_contact, medium_type: nil)
+  describe "#medium_icon_classes" do
+    context "when medium type is in-person" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "in-person").decorate
 
-        expect(case_contact.decorate.medium_type).to eq "Unknown"
+        expect(case_contact.medium_icon_classes).to eql("fas fa-users")
       end
     end
 
-    context "when medium_type is not nil" do
-      it "returns the titleized medium_type" do
-        case_contact = create(:case_contact, medium_type: "in-person")
+    context "when medium type is text/email" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "text/email").decorate
 
-        expect(case_contact.decorate.medium_type).to eq "In Person"
+        expect(case_contact.medium_icon_classes).to eql("fas fa-envelope")
+      end
+    end
+
+    context "when medium type is video" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "video").decorate
+
+        expect(case_contact.medium_icon_classes).to eql("fas fa-video")
+      end
+    end
+
+    context "when medium type is voice-only" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "voice-only").decorate
+
+        expect(case_contact.medium_icon_classes).to eql("fas fa-phone-square-alt")
+      end
+    end
+
+    context "when medium type is letter" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "letter").decorate
+
+        expect(case_contact.medium_icon_classes).to eql("fas fa-file-alt")
+      end
+    end
+
+    context "when medium type is anything else" do
+      it "returns the proper font-awesome classes" do
+        case_contact = create(:case_contact, medium_type: "foo").decorate
+
+        expect(case_contact.medium_icon_classes).to eql("fas fa-question")
       end
     end
   end
@@ -111,27 +143,6 @@ RSpec.describe CaseContactDecorator do
         expect(case_contact.decorate.subheading).to eq(
           "December 1, 2020 | 1 hour 39 minutes | 100 miles driven | Reimbursement"
         )
-      end
-    end
-  end
-
-  describe "#notes" do
-    context "when notes exceed NOTES_WORD_LIMIT" do
-      it "truncates the notes" do
-        note = "A" * 500
-        expected_note = "A" * 97
-
-        case_contact = create(:case_contact, notes: note)
-
-        expect(case_contact.decorate.notes).to eq("<p>#{expected_note}...</p>")
-      end
-
-      it "does NOT truncate when less than NOTES_WORD_LIMIT" do
-        note = "A" * 50
-
-        case_contact = create(:case_contact, notes: note)
-
-        expect(case_contact.decorate.notes).to eq("<p>#{note}</p>")
       end
     end
   end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -215,11 +215,11 @@ RSpec.describe CaseContact, type: :model do
 
   describe "#contact_groups_with_types" do
     it "returns the groups with their associated case types" do
-      group1 = create(:contact_type_group, name: 'Family')
-      group2 = create(:contact_type_group, name: 'Health')
-      contact_type1 = create(:contact_type, contact_type_group: group1, name: 'Parent')
-      contact_type2 = create(:contact_type, contact_type_group: group2, name: 'Medical Professional')
-      contact_type3 = create(:contact_type, contact_type_group: group2, name: 'Other Therapist')
+      group1 = create(:contact_type_group, name: "Family")
+      group2 = create(:contact_type_group, name: "Health")
+      contact_type1 = create(:contact_type, contact_type_group: group1, name: "Parent")
+      contact_type2 = create(:contact_type, contact_type_group: group2, name: "Medical Professional")
+      contact_type3 = create(:contact_type, contact_type_group: group2, name: "Other Therapist")
       case_contact_types = [contact_type1, contact_type2, contact_type3]
       case_contact = create(:case_contact)
       case_contact.contact_types = case_contact_types

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -212,4 +212,26 @@ RSpec.describe CaseContact, type: :model do
       end
     end
   end
+
+  describe "#contact_groups_with_types" do
+    it "returns the groups with their associated case types" do
+      group1 = create(:contact_type_group, name: 'Family')
+      group2 = create(:contact_type_group, name: 'Health')
+      contact_type1 = create(:contact_type, contact_type_group: group1, name: 'Parent')
+      contact_type2 = create(:contact_type, contact_type_group: group2, name: 'Medical Professional')
+      contact_type3 = create(:contact_type, contact_type_group: group2, name: 'Other Therapist')
+      case_contact_types = [contact_type1, contact_type2, contact_type3]
+      case_contact = create(:case_contact)
+      case_contact.contact_types = case_contact_types
+
+      groups_with_types = case_contact.contact_groups_with_types
+
+      expect(groups_with_types).to eql(
+        {
+          "Family" => ["Parent"],
+          "Health" => ["Medical Professional", "Other Therapist"]
+        }
+      )
+    end
+  end
 end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "case_contacts/index", type: :system do
   end
 
   it "displays the contact type groups" do
-    within('.card-title') do
+    within(".card-title") do
       expect(page).to have_text(case_contact.contact_groups_with_types.keys.first)
     end
   end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe "case_contacts/index", type: :system do
   it "can navigate to edit volunteer page" do
     expect(page).to have_no_link("Bob Loblaw")
   end
+
+  it "displays the contact type groups" do
+    within('.card-title') do
+      expect(page).to have_text(case_contact.contact_groups_with_types.keys.first)
+    end
+  end
 end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "case_contacts/index", type: :system do
     visit case_contacts_path
   end
 
-  it "can see case creator in table" do
+  it "can see case creator in card" do
     expect(page).to have_text("Bob Loblaw")
   end
 

--- a/spec/views/case_contacts/index.html.erb_spec.rb
+++ b/spec/views/case_contacts/index.html.erb_spec.rb
@@ -19,9 +19,4 @@ RSpec.describe "case_contacts/index" do
   it "Has a New Case Contact button" do
     expect(rendered).to have_link("New Case Contact", href: new_case_contact_path)
   end
-
-  it "Displays case contact table titles" do
-    expect(rendered).to have_selector("th", text: "Contact Made")
-    expect(rendered).to have_selector("th", text: "Miles Driven")
-  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/735  (#735 appeared to have 2 parts - one to convert the view into a card-view and one to move it into tabs.  We were able to get the view converted into using cards but ran out of time for the tab part.  I may submit a future PR to do this).

### What changed, and why?
This changes the case contact index page from a table-view to a card-view.

### How will this affect user permissions?
This should not affect any user permissions.

### How is this tested? (please write tests!) 💖💪
We have a variety of unit and system tests that cover this new functionality.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/6797093/102283805-b5edbc80-3ef8-11eb-91d7-8b3e8abdca2d.png)

This was based on this mockup: 
![image](https://user-images.githubusercontent.com/6797093/102283847-c9992300-3ef8-11eb-97a2-ef4ccfab8616.png)

### Feelings gif (optional)
![alt text](https://media.giphy.com/media/iJbJDBPby4Mfzk8zeN/giphy.gif)
