### PR TITLE
made_contact_with_all_cases_in_days? no longer considers inactive and unassigned cases

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -78,10 +78,10 @@ class Volunteer < User
   # false if volunteer has any case with no contact in the past 30 days
   def made_contact_with_all_cases_in_days?(num_days = CONTACT_MADE_IN_DAYS_NUM)
     # TODO this should do the same thing as no_contact_for_two_weeks but for a volunteer
-    total_cases_count = casa_cases.size
-    return true if total_cases_count.zero?
+    total_active_case_count = actively_assigned_and_active_cases.size
+    return true if total_active_case_count.zero?
     current_contact_cases_count = cases_where_contact_made_in_days(num_days).count
-    current_contact_cases_count == total_cases_count
+    current_contact_cases_count == total_active_case_count
   end
 
   private

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -112,52 +112,54 @@ RSpec.describe Volunteer, type: :model do
 
   describe "#made_contact_with_all_cases_in_days?" do
     let(:volunteer) { create(:volunteer) }
-    let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
-    let(:create_case_contact) do
-      lambda { |occurred_at, contact_made|
-        create(:case_contact, casa_case: casa_case, creator: volunteer, occurred_at: occurred_at, contact_made: contact_made)
-      }
-    end
 
-    before do
-      create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: true)
-    end
-
-    context "when volunteer has made recent contact" do
-      it "returns true" do
-        create_case_contact.call(Date.current, true)
-        expect(volunteer.made_contact_with_all_cases_in_days?).to eq(true)
+    context "when a volunteer is assigned to an active case" do
+      let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
+      let(:create_case_contact) do
+        lambda { |occurred_at, contact_made|
+          create(:case_contact, casa_case: casa_case, creator: volunteer, occurred_at: occurred_at, contact_made: contact_made)
+        }
       end
-    end
 
-    context "when volunteer has made recent contact attempt but no contact made" do
-      it "returns true" do
-        create_case_contact.call(Date.current, false)
-        expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+      before do
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer)
       end
-    end
 
-    context "when volunteer has not made recent contact" do
-      it "returns false" do
-        create_case_contact.call(Date.current - 60.days, true)
-        expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+      context "when volunteer has made recent contact" do
+        it "returns true" do
+          create_case_contact.call(Date.current, true)
+          expect(volunteer.made_contact_with_all_cases_in_days?).to eq(true)
+        end
       end
-    end
 
-    context "when volunteer has not made recent contact in just one case" do
-      it "returns false" do
-        casa_case2 = create(:casa_case, casa_org: volunteer.casa_org)
-        create(:case_assignment, casa_case: casa_case2, volunteer: volunteer, is_active: true)
-        create(:case_contact, casa_case: casa_case2, creator: volunteer, occurred_at: Date.current - 60.days, contact_made: true)
-        create_case_contact.call(Date.current, true)
-        expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+      context "when volunteer has made recent contact attempt but no contact made" do
+        it "returns true" do
+          create_case_contact.call(Date.current, false)
+          expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+        end
+      end
+
+      context "when volunteer has not made recent contact" do
+        it "returns false" do
+          create_case_contact.call(Date.current - 60.days, true)
+          expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+        end
+      end
+
+      context "when volunteer has not made recent contact in just one case" do
+        it "returns false" do
+          casa_case2 = create(:casa_case, casa_org: volunteer.casa_org)
+          create(:case_assignment, casa_case: casa_case2, volunteer: volunteer, is_active: true)
+          create(:case_contact, casa_case: casa_case2, creator: volunteer, occurred_at: Date.current - 60.days, contact_made: true)
+          create_case_contact.call(Date.current, true)
+          expect(volunteer.made_contact_with_all_cases_in_days?).to eq(false)
+        end
       end
     end
 
     context "when volunteer has no case assignments" do
       it "returns true" do
-        volunteer2 = create(:volunteer)
-        expect(volunteer2.made_contact_with_all_cases_in_days?).to eq(true)
+        expect(volunteer.made_contact_with_all_cases_in_days?).to eq(true)
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1439 

### What changed, and why?
`volunteer.rb` 's `made_contact_with_all_cases_in_days?` no longer considers inactive and unassigned cases

### How is this tested? (please write tests!) 💖💪
wrote a test where a volunteer has an inactive case checking that the inactive case does not factor into the output of the function
wrote a test where a volunteer has an unassigned case checking that the unassigned case does not factor into the output of the function