### PR TITLE
Fix around action for rack attack specs

### DIFF
--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Rack::Attack do
     Rails.cache.clear
   end
 
-  around do
-    freeze_time
+  around do |example|
+    freeze_time(&example)
   end
 
   def app


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1492

### What changed, and why?
The around action was causing non-Docker specs to be marked as pending. Added proc.

- [x] Make sure GitHub Actions runs specs without marking them as pending