### PR TITLE
Change metadata that appears under header on case_contact cards

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -41,7 +41,6 @@ class CaseContactDecorator < Draper::Decorator
   def subheading
     [
       object.occurred_at.strftime(DateFormat::FULL),
-      contact_type_list,
       duration_minutes,
       contact_made,
       miles_traveled,
@@ -96,13 +95,5 @@ class CaseContactDecorator < Draper::Decorator
 
   def show_contact_type?(contact_type_id)
     object.case_contact_contact_type.map(&:contact_type_id).include?(contact_type_id)
-  end
-
-  private
-
-  def contact_type_list
-    object.contact_groups_with_types.map { |key, value|
-      "#{key}: #{value.join(", ")}"
-    }.join(" / ")
   end
 end

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -9,6 +9,8 @@
               <strong class="text-primary"><%= contact.contact_groups_with_types.keys.join(', ') %></strong>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">
+              <%= contact.decorate.contact_types %>
+              <br>
               <%= contact.decorate.subheading %>
             </h6>
             <div class="card-text">

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe CaseContactDecorator do
         case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | Group X: Type X | 1 hour 39 minutes | No Contact Made | 100 miles driven | Reimbursement"
+          "December 1, 2020 | 1 hour 39 minutes | No Contact Made | 100 miles driven | Reimbursement"
         )
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe CaseContactDecorator do
         case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | Group X: Type X | 1 hour 39 minutes | 100 miles driven | Reimbursement"
+          "December 1, 2020 | 1 hour 39 minutes | 100 miles driven | Reimbursement"
         )
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1500

### What changed, and why?

This PR updates how information is displayed in the case contact card based on acceptance criteria listed in issue #1500. These changes include:
- removing `contact_type_list` from the `subheading` decorator. 
- removing the `contact_type_list` method since we no longer make use of it. 
- call the already existing `contact_types` method to show the contact types in the first line. 


### Screenshots please :)
before:

<img width="998" alt="Screen Shot 2020-12-16 at 8 36 36 PM" src="https://user-images.githubusercontent.com/16447748/102444597-6c779d00-3fde-11eb-8794-e9cd14a25b55.png">


after:

<img width="861" alt="Screen Shot 2020-12-16 at 8 32 34 PM" src="https://user-images.githubusercontent.com/16447748/102444464-20c4f380-3fde-11eb-8349-c8667ad860d6.png">
