### PR TITLE
Fix user inactive case lists

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
   end
 
   def serving_transition_aged_youth?
-    casa_cases.where(transition_aged_youth: true).any? # TODO filter for active?
+    actively_assigned_and_active_cases.where(transition_aged_youth: true).any?
   end
 
   def admin_self_deactivated?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -181,5 +181,21 @@ RSpec.describe User, type: :model do
         expect(user).not_to be_serving_transition_aged_youth
       end
     end
+
+    context "when the user's only transition-aged-youth case is inactive" do
+      it "is false" do
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false, transition_aged_youth: true), volunteer: user)
+
+        expect(user).not_to be_serving_transition_aged_youth
+      end
+    end
+
+    context "when the user is unassigned from a transition-aged-youth case" do
+      it "is false" do
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: true), volunteer: user, is_active: false)
+
+        expect(user).not_to be_serving_transition_aged_youth
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -164,18 +164,14 @@ RSpec.describe User, type: :model do
   end
 
   describe "#serving_transition_aged_youth?" do
-    let(:casa_org) { create(:casa_org) }
-    let(:user) { create(:volunteer, casa_org: casa_org) }
-    let(:case_assignment_with_a_transition_aged_youth) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, transition_aged_youth: true), volunteer: user)
-    end
+    let(:user) { create(:volunteer) }
     let!(:case_assignment_without_transition_aged_youth) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, transition_aged_youth: false), volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: false), volunteer: user)
     end
 
     context "when the user has a transition-aged-youth case" do
       it "is true" do
-        case_assignment_with_a_transition_aged_youth.inspect
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: true), volunteer: user)
         expect(user).to be_serving_transition_aged_youth
       end
     end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "layout/sidebar", type: :view do
     end
 
     context "when the volunteer does not have a transitioning case" do
-      it "does not renders emancipation checklist(s)" do
+      it "does not render emancipation checklist(s)" do
         sign_in user
 
         # 0 Cases
@@ -87,6 +87,21 @@ RSpec.describe "layout/sidebar", type: :view do
         # 1 Non transitioning case
         casa_case = create(:casa_case, casa_org: organization, transition_aged_youth: false)
         create(:case_assignment, volunteer: user, casa_case: casa_case)
+
+        render partial: "layouts/sidebar"
+        expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
+      end
+    end
+
+    context "when the user has only inactive or unassigned transiting cases" do
+      it "does not render emancipation checklist(s)" do
+        sign_in user
+
+        inactive_case = create(:casa_case, casa_org: organization, transition_aged_youth: true, active: false)
+        create(:case_assignment, volunteer: user, casa_case: inactive_case)
+
+        unassigned_case = create(:casa_case, casa_org: organization, transition_aged_youth: true)
+        create(:case_assignment, volunteer: user, casa_case: unassigned_case, is_active: false)
 
         render partial: "layouts/sidebar"
         expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1443

### What changed, and why?
`user.rb`'s `serving_transition_aged_youth?` function ignores inactive and unassigned cases

### How is this tested? (please write tests!) 💖💪
one test for inactive cases
one test for unassigned cases
a view test for emancipation checklist(s) appearing in the sidebar