### PR TITLE
Sort Contact Type Groups in Edit page select field

### DIFF
--- a/app/models/contact_type_group.rb
+++ b/app/models/contact_type_group.rb
@@ -5,7 +5,10 @@ class ContactTypeGroup < ApplicationRecord
 
   validates :name, presence: true, uniqueness: {scope: :casa_org_id}
 
-  scope :for_organization, ->(org) { where(casa_org: org) }
+  scope :for_organization, ->(org) {
+    where(casa_org: org)
+      .order(:name)
+  }
 end
 
 # == Schema Information


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1255 

### What changed, and why?

Adds `.order(:name)` to the appropriate `scope` in the `ContactTypeGroup` model to sort the Select Field options on the `Edit Contact Type` view. i.e. `/contact_types/1/edit`

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a 

### How is this tested? (please write tests!) 💖💪

It's not 😢 . See issue #1391 
But I did verify that it's working manually. See Screenshot. 

### Screenshots please :)

![Screen Shot 2020-12-19 at 9 34 03 AM](https://user-images.githubusercontent.com/57697706/102693058-57b52800-41dd-11eb-9e24-c308ec3308c5.png)

### Feelings gif (optional)

Because I didn't write a test:
![shame](https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif)
