### PR TITLE
volunteers_serving_transition_aged_youth ignores inactive and unassigned cases

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
 
   def volunteers_serving_transition_aged_youth
     volunteers.includes(case_assignments: :casa_case)
-      .where(case_assignments: {is_active: true}, 
+      .where(case_assignments: {is_active: true},
              casa_cases: {active: true, transition_aged_youth: true}).size
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,8 +68,9 @@ class User < ApplicationRecord
   end
 
   def volunteers_serving_transition_aged_youth
-    volunteers.includes(:casa_cases)
-      .where(casa_cases: {transition_aged_youth: true}).size # TODO filter for active?
+    volunteers.includes(case_assignments: :casa_case)
+      .where(case_assignments: {is_active: true}, 
+             casa_cases: {active: true, transition_aged_youth: true}).size
   end
 
   def no_contact_for_two_weeks

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,19 +63,30 @@ RSpec.describe User, type: :model do
 
   describe "supervisors" do
     describe "#volunteers_serving_transition_aged_youth" do
+      let(:casa_org) { create(:casa_org) }
+      let(:supervisor) { create(:supervisor, casa_org: casa_org) }
+
       it "returns the number of transition aged youth on a supervisor" do
-        casa_org = create(:casa_org)
         casa_cases = [
           create(:casa_case, casa_org: casa_org, transition_aged_youth: true),
           create(:casa_case, casa_org: casa_org, transition_aged_youth: true),
           create(:casa_case, casa_org: casa_org, transition_aged_youth: false)
         ]
-        supervisor = create(:supervisor, casa_org: casa_org)
+
         casa_cases.each do |casa_case|
           volunteer = create(:volunteer, supervisor: supervisor, casa_org: casa_org)
           volunteer.casa_cases << casa_case
         end
+
         expect(supervisor.volunteers_serving_transition_aged_youth).to eq(2)
+      end
+
+      it "ignores volunteers' inactive and unassgined cases" do
+        volunteer = create(:volunteer, supervisor: supervisor, casa_org: casa_org)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, active: false, transition_aged_youth: true), volunteer: volunteer)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, transition_aged_youth: true), is_active: false, volunteer: volunteer)
+
+        expect(supervisor.volunteers_serving_transition_aged_youth).to eq(0)
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1442

### What changed, and why?
`volunteers_serving_transition_aged_youth` does not count volunteers' transitioning cases if they are inactive and/or unassigned cases

### How is this tested? (please write tests!) 💖💪
added one test where a supervisor has a volunteer with one inactive case and one unassigned case expecting `volunteers_serving_transition_aged_youth` to return 0