### PR TITLE
New workflow to unassign inactive issues.

### DIFF
--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -1,7 +1,7 @@
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 * * * *'
+    - cron:  '0 0 * * *'
 
 jobs:
   unassign_issues:

--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+
+jobs:
+  unassign_issues:
+    runs-on: ubuntu-latest
+    name: Unassign issues
+    steps:
+      - name: Unassign issues
+        uses: bjthompson805/unassign-issues@v1
+        id: unassign-issues
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          unassign_inactive_in_hours: 168 # 7 days
+          warning_inactive_in_hours: 120 # 5 days


### PR DESCRIPTION
The workflow will run once per hour and will post a warning message in
issues that are older than 5 days telling the user that the issue will
be unassigned after 7 days. After 7 days it will be unassigned. The
algorithm to determine the time of inactivity will account for comments
made but not events.

### What github issue is this PR for, if any?
Resolves #1409

### What changed, and why?
A new workflow file was created in order to unassign inactive issues.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
I tested it manually in a test harness I created:

https://github.com/bjthompson805/hello-world-javascript-action

### Screenshots please :)
Here is what it looks like when the bot comments as well as unassigns the issue.
![image](https://user-images.githubusercontent.com/40772561/103254433-797f7f00-4942-11eb-974d-9f9fdaae8d96.png)

### Other comments
I suggest a code review of the action itself as well:

https://github.com/bjthompson805/unassign-issues

Also, you may want to fork this action and use it under the rubyforgood repo owner so it's not attached to my name. Let me know and I'll change the workflow file to use it.

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/hrdsOhSDozB0u5PQH9/giphy.gif)
