### PR TITLE
Fixes issue where case contacts have no contact types.

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -134,6 +134,7 @@ class DbPopulator
 
   def create_cases(casa_org, options, prefix)
     volunteers = Volunteer.where(active: true).to_a
+    ContactTypePopulator.populate
     options.case_count.times do
       new_casa_case = CasaCase.create!(
         casa_org_id: casa_org.id,

--- a/lib/tasks/data_post_processors/case_contact_populator.rb
+++ b/lib/tasks/data_post_processors/case_contact_populator.rb
@@ -1,25 +1,9 @@
 module CaseContactPopulator
   def self.populate
-    code_to_name_mapping = {
-      attorney: "Attorney",
-      bio_parent: "Bio Parent",
-      court: "Court",
-      dss_worker: "DSS Worker",
-      foster_parent: "Foster Parent",
-      medical_professional: "Medical Professional",
-      other_family: "Other Family",
-      other_support_worker: "Other Support Worker",
-      school: "School",
-      social_worker: "Social Worker",
-      supervisor: "Supervisor",
-      therapist: "Therapist",
-      youth: "Youth"
-    }
-
     CaseContact.find_each do |case_contact|
       casa_org = case_contact.casa_case.casa_org
       case_contact.contact_types&.each do |contact_type|
-        ct_name = code_to_name_mapping[contact_type.to_sym]
+        ct_name = contact_type.name;
         cts_by_name = ContactType.where(name: ct_name)
         ct = cts_by_name.find { |ct| ct.contact_type_group.casa_org == casa_org }
         unless ct

--- a/lib/tasks/data_post_processors/case_contact_populator.rb
+++ b/lib/tasks/data_post_processors/case_contact_populator.rb
@@ -3,7 +3,7 @@ module CaseContactPopulator
     CaseContact.find_each do |case_contact|
       casa_org = case_contact.casa_case.casa_org
       case_contact.contact_types&.each do |contact_type|
-        ct_name = contact_type.name;
+        ct_name = contact_type.name
         cts_by_name = ContactType.where(name: ct_name)
         ct = cts_by_name.find { |ct| ct.contact_type_group.casa_org == casa_org }
         unless ct


### PR DESCRIPTION
The ContactType data was not being inserted prior to the CaseContact
data being created, which caused case contacts to not have any contact
types associated with it. I've added a new statement to insert the
ContactType data prior to CaseContact data being created.

### What github issue is this PR for, if any?
Resolves #1505

### What changed, and why?
I added a line to insert the ContactType data into the tables prior to the CaseContact data being created, so that the CaseContact data can be associated with contact types instead of having no contact types.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
I've tested it on my local machine and confirmed that all of the case contact data have 2 contact types associated with each of them.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/40772561/103380261-908ab200-4aa5-11eb-9fc3-35425b480edf.png)

