### PR TITLE
Filter contact type groups and contact types based on selected cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :test do
   gem "capybara-screenshot"
   gem "database_cleaner-active_record", "~> 1.8.0"
   gem "rake"
+  gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "simplecov", "~> 0.17.1", require: false # 0.17.1 pinned as a workaround for https://github.com/codeclimate/test-reporter/issues/418
   gem "webdrivers", require: false # Easy installation and use of web drivers to run system tests with browsers; do not initially require as causes conflict with Docker setup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.0)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -405,6 +409,7 @@ DEPENDENCIES
   pundit
   rack-attack
   rails (~> 6.1.0)
+  rails-controller-testing
   rake
   rspec-rails (~> 4.0.2)
   sablon

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -30,7 +30,18 @@ class CaseContactsController < ApplicationController
     # By default the first case is selected
     @selected_cases = @casa_cases[0, 1]
 
-    @current_organization_groups = current_organization.contact_type_groups.joins(:contact_types).where(contact_types: {active: true}).uniq
+    @selected_case_contact_types = @selected_cases.flat_map(&:contact_types)
+
+    @current_organization_groups =
+      if @selected_case_contact_types.present?
+        @selected_case_contact_types.map(&:contact_type_group).uniq
+      else
+        current_organization
+          .contact_type_groups
+          .joins(:contact_types)
+          .where(contact_types: {active: true})
+          .uniq
+      end
   end
 
   def create

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -29,7 +29,10 @@
         <% @current_organization_groups.each do |group| %>
           <td style="display:inline-block; vertical-align:top; padding-right:50px; padding-bottom:20px">
             <h5> <%= group.name %> </h5>
-            <% group.contact_types.each_with_index do |contact_type, index| %>
+            <% group.contact_types.filter do |ct|
+                @selected_case_contact_types.blank? ||
+                    @selected_case_contact_types.include?(ct)
+              end.each_with_index do |contact_type, index| %>
               <div class="form-check">
                 <%=
                   check_box_tag "case_contact[case_contact_contact_type_attributes][][contact_type_id]",

--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe CaseContactsController, type: :controller do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
+  let(:case_id) { volunteer.casa_cases.first.id }
+  let!(:contact_type_group_one) do
+    create(:contact_type_group, casa_org: organization).tap do |group|
+      create(:contact_type, contact_type_group: group, name: "Attorney")
+    end
+  end
+  let!(:contact_type_group_two) do
+    create(:contact_type_group, casa_org: organization).tap do |group|
+      create(:contact_type, contact_type_group: group, name: "Therapist")
+    end
+  end
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+    allow(controller).to receive(:current_user).and_return(volunteer)
+  end
+
+  describe "GET new" do
+    context "when the case has specific contact types assigned" do
+      before do
+        casa_case = volunteer.casa_cases.first
+        casa_case.contact_types = contact_type_group_one.contact_types
+        casa_case.save
+      end
+
+      it "only assigns that contact types groups to @current_organization_groups" do
+        get :new, params: {case_contact: {casa_case_id: case_id}}
+        expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+      end
+    end
+
+    context "when the case does not have specific contact types assigned" do
+      it "assigns all the organizations contact type groups to @current_organization_groups" do
+        get :new, params: {case_contact: {casa_case_id: case_id}}
+        expect(assigns(:current_organization_groups)).to eq([contact_type_group_one, contact_type_group_two])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #859

### Questions
What's the expected behavior of the case has not had contact types defined for it by a supervisor? Does that ever happen or is it never supposed to happen? If it does happen, what contact types should be shown? Show all contact types?

I have assumed that:

1. it is possible that a case will not have been set up by a supervisor so that only some contact types are defined for it
2. when that happens, we show all possible contact types for the current organization

If these assumptions are wrong, please let me know, and I will update this PR.

### What changed, and why?
Filter the contact type groups and the contact types based on the contact types that are assigned to a case.

### How will this affect user permissions?
No effect

### How is this tested? (please write tests!) 💖💪
I'm open to guidance on where to add tests for this. Please be specific about which spec you think it should be added to. The ones for the view right now assign empty data to the contact type groups that are in the view and, from what I can tell, do not set up contact types for the cases that are in the test. See [here](https://github.com/rubyforgood/casa/blob/main/spec/views/case_contacts/new.html.erb_spec.rb#L7-L12)

### Screenshots please :)
Here are screenshots for two cases. One case (with an id of 840) has no contact types assigned. For that case, all of the organization's contact types are displayed on the form. One case (with an id of 848) has two contact types assigned, both of which are in the "Family" group. For that case, only the assigned types are displayed on the form.

Here is the data for these two cases. 

```sql

casa_development=# select cc.id, cc.case_number, ct.name as "contact type", ctg.name as "group"
casa_development-# from casa_cases cc
casa_development-# left join casa_case_contact_types ccct
casa_development-# on cc.id = ccct.casa_case_id
casa_development-# left join contact_types ct
casa_development-# on ct.id = ccct.contact_type_id
casa_development-# left join contact_type_groups ctg
casa_development-# on ctg.id = ct.contact_type_group_id
casa_development-# where cc.id in (840, 848);
 id  |     case_number     | contact type | group  
-----+---------------------+--------------+--------
 840 | CINA-13-1002 org1MM |              | 
 848 | CINA-09-1010 org1MM | Parent       | Family
 848 | CINA-09-1010 org1MM | Grandparent  | Family
(3 rows)
```

Here are the screenshots

This one is for the case that has no contact types assigned to it, and so all types are displayed. In other words, this behaves like things currently behave.

![all-contact-types-when-case-has-no-specific-ones-assigned](https://user-images.githubusercontent.com/3824492/103382244-e2d2cf80-4ab3-11eb-993d-cc555e560d0b.png)


This one is for the case that has two contact types assigned to it, and so only those two types and their group are displayed. This is where the change is noticeable.

![contact-types-filtered-when-case-has-specific-types](https://user-images.githubusercontent.com/3824492/103382238-dd758500-4ab3-11eb-9a48-d4c3f15528d8.png)


