### PR TITLE
Add deliver_now to mailer method

### DIFF
--- a/lib/tasks/send_supervisor_digest.rake
+++ b/lib/tasks/send_supervisor_digest.rake
@@ -2,7 +2,7 @@ desc "Send an email to supervisors each week to share an overview of their volun
 task send_supervisor_digest: :environment do
   if Time.now.monday?
     Supervisor.find_each do |supervisor|
-      SupervisorMailer.weekly_digest(supervisor)
+      SupervisorMailer.weekly_digest(supervisor).deliver_now
     end
   end
 end


### PR DESCRIPTION
### What changed, and why?

Supervisor weekly mailer wasn't going out since it was missing `deliver_now` or `deliver_later`
