### PR TITLE
Collapsible emancipation checklist

### DIFF
--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -20,16 +20,16 @@ class EmancipationsController < ApplicationController
       return
     end
 
-    unless params.key?("option_action")
-      render json: {error: "Missing param option_action"}
+    unless params.key?("check_item_action")
+      render json: {error: "Missing param check_item_action"}
       return
     end
 
-    if !params.key?("option_id")
-      render json: {error: "Missing param option_id"}
+    if !params.key?("check_item_id")
+      render json: {error: "Missing param check_item_id"}
       return
-    elsif !/\A\d+\z/.match(params[:option_id])
-      render json: {error: "Param option_id must be a positive integer"}
+    elsif !/\A\d+\z/.match(params[:check_item_id])
+      render json: {error: "Param check_item_id must be a positive integer"}
       return
     end
 
@@ -47,22 +47,22 @@ class EmancipationsController < ApplicationController
     end
 
     begin
-      case params[:option_action]
-      when "add"
-        current_case.add_emancipation_option(params[:option_id])
+      case params[:check_item_action]
+      when "add_option"
+        current_case.add_emancipation_option(params[:check_item_id])
         render json: "success".to_json
-      when "delete"
-        current_case.remove_emancipation_option(params[:option_id])
+      when "delete_option"
+        current_case.remove_emancipation_option(params[:check_item_id])
         render json: "success".to_json
-      when "set"
-        current_case.emancipation_options.delete(EmancipationOption.category_options(EmancipationOption.find(params[:option_id]).emancipation_category_id))
-        current_case.add_emancipation_option(params[:option_id])
+      when "set_option"
+        current_case.emancipation_options.delete(EmancipationOption.category_options(EmancipationOption.find(params[:check_item_id]).emancipation_category_id))
+        current_case.add_emancipation_option(params[:check_item_id])
         render json: "success".to_json
       else
-        render json: {error: "Param option_action did not contain a supported action"}
+        render json: {error: "Param check_item_action did not contain a supported action"}
       end
     rescue ActiveRecord::RecordNotFound
-      render json: {error: "Could not find option from id given by param option_id"}
+      render json: {error: "Could not find option from id given by param check_item_id"}
     rescue ActiveRecord::RecordNotUnique
       render json: {error: "Option already added to case"}
     rescue => error

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -75,8 +75,7 @@ class EmancipationsController < ApplicationController
     if exception.backtrace[1].end_with?("save'")
       render json: {error: "Sorry, you are not authorized to perform this action. Did the session expire?"}
     else
-      flash[:error] = "Sorry, you are not authorized to perform this action."
-      redirect_to(request.referrer || root_path)
+      super()
     end
   end
 end

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -48,24 +48,24 @@ class EmancipationsController < ApplicationController
 
     begin
       case params[:check_item_action]
-      when "add_category"
-        current_case.add_emancipation_category(params[:check_item_id])
-        render json: "success".to_json
-      when "add_option"
-        current_case.add_emancipation_option(params[:check_item_id])
-        render json: "success".to_json
-      when "delete_category"
-        current_case.remove_emancipation_category(params[:check_item_id])
-        render json: "success".to_json
-      when "delete_option"
-        current_case.remove_emancipation_option(params[:check_item_id])
-        render json: "success".to_json
-      when "set_option"
-        current_case.emancipation_options.delete(EmancipationOption.category_options(EmancipationOption.find(params[:check_item_id]).emancipation_category_id))
-        current_case.add_emancipation_option(params[:check_item_id])
-        render json: "success".to_json
-      else
-        render json: {error: "Param check_item_action did not contain a supported action"}
+        when "add_category"
+          current_case.add_emancipation_category(params[:check_item_id])
+          render json: "success".to_json
+        when "add_option"
+          current_case.add_emancipation_option(params[:check_item_id])
+          render json: "success".to_json
+        when "delete_category"
+          current_case.remove_emancipation_category(params[:check_item_id])
+          render json: "success".to_json
+        when "delete_option"
+          current_case.remove_emancipation_option(params[:check_item_id])
+          render json: "success".to_json
+        when "set_option"
+          current_case.emancipation_options.delete(EmancipationOption.category_options(EmancipationOption.find(params[:check_item_id]).emancipation_category_id))
+          current_case.add_emancipation_option(params[:check_item_id])
+          render json: "success".to_json
+        else
+          render json: {error: "Param check_item_action did not contain a supported action"}
       end
     rescue ActiveRecord::RecordNotFound
       render json: {error: "Could not find option from id given by param check_item_id"}

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -48,8 +48,14 @@ class EmancipationsController < ApplicationController
 
     begin
       case params[:check_item_action]
+      when "add_category"
+        current_case.add_emancipation_category(params[:check_item_id])
+        render json: "success".to_json
       when "add_option"
         current_case.add_emancipation_option(params[:check_item_id])
+        render json: "success".to_json
+      when "delete_category"
+        current_case.remove_emancipation_category(params[:check_item_id])
         render json: "success".to_json
       when "delete_option"
         current_case.remove_emancipation_option(params[:check_item_id])

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,13 +1,13 @@
 module EmancipationsHelper
-  def emancipation_category_checkbox_checked?(casa_case, emancipation_category)
+  def emancipation_category_checkbox_checked(casa_case, emancipation_category)
     casa_case.emancipation_categories.include?(emancipation_category) ? "checked" : nil
   end
 
-  def emancipation_category_collapse_hidden?(casa_case, emancipation_category)
+  def emancipation_category_collapse_hidden(casa_case, emancipation_category)
     casa_case.emancipation_categories.include?(emancipation_category) ? nil : "display: none;"
   end
 
-  def emancipation_option_checkbox_checked?(casa_case, emancipation_option)
+  def emancipation_option_checkbox_checked(casa_case, emancipation_option)
     casa_case.emancipation_options.include?(emancipation_option) ? "checked" : nil
   end
 end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,13 +1,23 @@
 module EmancipationsHelper
   def emancipation_category_checkbox_checked(casa_case, emancipation_category)
-    casa_case.emancipation_categories.include?(emancipation_category) ? "checked" : nil
+    case_contains_category?(casa_case, emancipation_category) ? "checked" : nil
   end
 
   def emancipation_category_collapse_hidden(casa_case, emancipation_category)
-    casa_case.emancipation_categories.include?(emancipation_category) ? nil : "display: none;"
+    case_contains_category?(casa_case, emancipation_category) ? nil : "display: none;"
+  end
+
+  def emancipation_category_collapse_icon(casa_case, emancipation_category)
+    case_contains_category?(casa_case, emancipation_category) ? "−" : "+"
   end
 
   def emancipation_option_checkbox_checked(casa_case, emancipation_option)
     casa_case.emancipation_options.include?(emancipation_option) ? "checked" : nil
+  end
+
+  private
+
+  def case_contains_category?(casa_case, emancipation_category)
+    casa_case.emancipation_categories.include?(emancipation_category)
   end
 end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,9 +1,13 @@
 module EmancipationsHelper
-  def emancipation_select_option_selected(casa_case, emancipation_option)
+  def emancipation_option_select_selected?(casa_case, emancipation_option)
     casa_case.emancipation_options.include?(emancipation_option) ? "selected" : nil
   end
 
-  def emancipation_checkbox_option_checked(casa_case, emancipation_option)
+  def emancipation_category_checkbox_checked?(casa_case, emancipation_category)
+    casa_case.emancipation_categories.include?(emancipation_category) ? "checked" : nil
+  end
+
+  def emancipation_option_checkbox_checked?(casa_case, emancipation_option)
     casa_case.emancipation_options.include?(emancipation_option) ? "checked" : nil
   end
 end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -3,6 +3,10 @@ module EmancipationsHelper
     casa_case.emancipation_categories.include?(emancipation_category) ? "checked" : nil
   end
 
+  def emancipation_category_collapse_hidden?(casa_case, emancipation_category)
+    casa_case.emancipation_categories.include?(emancipation_category) ? nil : "display: none;"
+  end
+
   def emancipation_option_checkbox_checked?(casa_case, emancipation_option)
     casa_case.emancipation_options.include?(emancipation_option) ? "checked" : nil
   end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,8 +1,4 @@
 module EmancipationsHelper
-  def emancipation_option_select_selected?(casa_case, emancipation_option)
-    casa_case.emancipation_options.include?(emancipation_option) ? "selected" : nil
-  end
-
   def emancipation_category_checkbox_checked?(casa_case, emancipation_category)
     casa_case.emancipation_categories.include?(emancipation_category) ? "checked" : nil
   end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,9 +1,9 @@
 module EmancipationsHelper
-  def emancipation_select_option_selected(casa_case, emancipation_option_id)
-    casa_case.contains_emancipation_option?(emancipation_option_id) ? "selected" : nil
+  def emancipation_select_option_selected(casa_case, emancipation_option)
+    casa_case.emancipation_options.include?(emancipation_option) ? "selected" : nil
   end
 
-  def emancipation_checkbox_option_checked(casa_case, emancipation_option_id)
-    casa_case.contains_emancipation_option?(emancipation_option_id) ? "checked" : nil
+  def emancipation_checkbox_option_checked(casa_case, emancipation_option)
+    casa_case.emancipation_options.include?(emancipation_option) ? "checked" : nil
   end
 end

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -87,10 +87,12 @@ function waitForAsyncOperation () {
 }
 
 // Adds or deletes an option from the current casa case
-//  @param    {string}            optionAction
-//    'add_option'     to add an option to the case
-//    'delete_option'  to remove an option from the case
-//    'set_option'     to set the option for a mutually exclusive category
+//  @param    {string}  action One of the following:
+//    'add_category'    to add a category to the case
+//    'add_option'      to add an option to the case
+//    'delete_category' to remove a category from the case
+//    'delete_option'   to remove an option from the case
+//    'set_option'      to set the option for a mutually exclusive category
 //  @param    {integer | string}  checkItemId The id of either an emancipation option or an emancipation category to perform an action on
 //  @returns  {array} a jQuery jqXHR object. See https://api.jquery.com/jQuery.ajax/#jqXHR
 //  @throws   {TypeError}  for a parameter of the incorrect type

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -124,27 +124,14 @@ function saveCheckState (action, checkItemId) {
 }
 
 $('document').ready(() => {
-  emancipationPage.emancipationSelects = $('.emancipation-select')
   emancipationPage.notifications = $('#async-notifications')
   emancipationPage.asyncSuccessIndicator = emancipationPage.notifications.find('#async-success-indicator')
   emancipationPage.asyncWaitIndicator = emancipationPage.notifications.find('#async-waiting-indicator')
 
-  emancipationPage.emancipationSelects.each(function () {
-    const thisSelect = $(this)
+  $('.emancipation-radio-button').change(function (data) {
+    const thisRadioButton = $(this)
 
-    thisSelect.data('prev', thisSelect.val())
-  })
-
-  emancipationPage.emancipationSelects.change(function (data) {
-    const thisSelect = $(this)
-
-    if (thisSelect.val()) {
-      saveCheckState('set_option', thisSelect.val())
-    } else {
-      saveCheckState('delete_option', thisSelect.data().prev)
-    }
-
-    thisSelect.data('prev', thisSelect.val())
+    saveCheckState('set_option', thisRadioButton.val())
   })
 
   $('.emancipation-check-box').change(function () {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -128,13 +128,18 @@ $('document').ready(() => {
   emancipationPage.asyncSuccessIndicator = emancipationPage.notifications.find('#async-success-indicator')
   emancipationPage.asyncWaitIndicator = emancipationPage.notifications.find('#async-waiting-indicator')
 
+  $('.emancipation-category').click(function () {
+    categoryCheckbox = $(this).find('input[type="checkbox"]')
+    categoryCheckbox.prop('checked', !categoryCheckbox.is(':checked'))
+  })
+
   $('.emancipation-radio-button').change(function (data) {
     const thisRadioButton = $(this)
 
     saveCheckState('set_option', thisRadioButton.val())
   })
 
-  $('.emancipation-check-box').change(function () {
+  $('.emancipation-option-check-box').change(function () {
     const thisCheckBox = $(this)
 
     if (thisCheckBox.prop('checked')) {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -131,15 +131,18 @@ $('document').ready(() => {
   $('.emancipation-category').click(function () {
     category = $(this)
     categoryCheckbox = category.find('input[type="checkbox"]')
+    categoryCollapseIcon = category.find('span')
     categoryCheckboxChecked = categoryCheckbox.is(':checked')
 
     categoryCheckbox.prop('checked', !categoryCheckboxChecked)
 
     if (categoryCheckboxChecked) {
       category.siblings('.category-options').hide()
+      categoryCollapseIcon.text('+')
       saveCheckState('delete_category', categoryCheckbox.val())
     } else {
       category.siblings('.category-options').show()
+      categoryCollapseIcon.text('−')
       saveCheckState('add_category', categoryCheckbox.val())
     }
   })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -134,7 +134,14 @@ $('document').ready(() => {
     categoryCheckboxChecked = categoryCheckbox.is(':checked')
 
     categoryCheckbox.prop('checked', !categoryCheckboxChecked)
-    categoryCheckboxChecked ? category.siblings('.category-options').hide() : category.siblings('.category-options').show()
+
+    if (categoryCheckboxChecked) {
+      category.siblings('.category-options').hide()
+      saveCheckState('delete_category', categoryCheckbox.val())
+    } else {
+      category.siblings('.category-options').show()
+      saveCheckState('add_category', categoryCheckbox.val())
+    }
   })
 
   $('.emancipation-radio-button').change(function (data) {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -164,7 +164,11 @@ $('document').ready(() => {
         }).each(function() {
           let checkbox = $(this)
 
+          checkbox.prop('checked', false)
           saveCheckState('delete_option', checkbox.val())
+          .fail(function() {
+            checkbox.prop('checked', false)
+          })
           notify('Unchecked ' + checkbox.next().text(), 'info')
         })
 
@@ -199,15 +203,25 @@ $('document').ready(() => {
     const thisRadioButton = $(this)
 
     saveCheckState('set_option', thisRadioButton.val())
+    .fail(function() {
+      thisRadioButton.prop('checked', false)
+    })
   })
 
   $('.emancipation-option-check-box').change(function () {
     const thisCheckBox = $(this)
 
-    if (thisCheckBox.prop('checked')) {
-      saveCheckState('add_option', thisCheckBox.val())
+    let originallyChecked = thisCheckBox.prop('checked')
+    let asyncCall
+
+    if (originallyChecked) {
+      asyncCall = saveCheckState('add_option', thisCheckBox.val())
     } else {
-      saveCheckState('delete_option', thisCheckBox.val())
+      asyncCall = saveCheckState('delete_option', thisCheckBox.val())
     }
+
+    asyncCall.fail(function() {
+      thisCheckBox.prop('checked', originallyChecked)
+    })
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -79,28 +79,28 @@ function waitForAsyncOperation () {
 
 // Adds or deletes an option from the current casa case
 //  @param    {string}            optionAction
-//    'add'     to add an option to the case
-//    'delete'  to remove an option from the case
-//    'set'     to set the option for a mutually exclusive category
-//  @param    {integer | string}  optionId The id of the emancipation option to add or delete
+//    'add_option'     to add an option to the case
+//    'delete_option'  to remove an option from the case
+//    'set_option'     to set the option for a mutually exclusive category
+//  @param    {integer | string}  checkItemId The id of either an emancipation option or an emancipation category to perform an action on
 //  @returns  {array} a jQuery jqXHR object. See https://api.jquery.com/jQuery.ajax/#jqXHR
 //  @throws   {TypeError}  for a parameter of the incorrect type
 //  @throws   {RangeError} if optionId is negative
-function changeOptions (optionAction, optionId) {
+function saveCheckState (action, checkItemId) {
   // Input check
-  if (typeof optionId === 'string') {
-    const optionIdAsNum = parseInt(optionId)
+  if (typeof checkItemId === 'string') {
+    const checkItemIdAsNum = parseInt(checkItemId)
 
-    if (!optionIdAsNum) {
-      throw new TypeError('Param optionId is not an integer')
-    } else if (optionIdAsNum < 0) {
-      throw new RangeError('Param optionId cannot be negative')
+    if (!checkItemIdAsNum) {
+      throw new TypeError('Param checkItemId is not an integer')
+    } else if (checkItemIdAsNum < 0) {
+      throw new RangeError('Param checkItemId cannot be negative')
     }
   } else {
-    if (!Number.isInteger(optionId)) {
-      throw new TypeError('Param optionId is not an integer')
-    } else if (optionId < 0) {
-      throw new RangeError('Param optionId cannot be negative')
+    if (!Number.isInteger(checkItemId)) {
+      throw new TypeError('Param checkItemId is not an integer')
+    } else if (checkItemId < 0) {
+      throw new RangeError('Param checkItemId cannot be negative')
     }
   }
 
@@ -108,8 +108,8 @@ function changeOptions (optionAction, optionId) {
 
   // Post request
   return $.post(emancipationPage.savePath, {
-    option_action: optionAction,
-    option_id: optionId
+    check_item_action: action,
+    check_item_id: checkItemId
   }).done(function (response, textStatus) {
     if (response.error) {
       resolveAsyncOperation(response.error)
@@ -139,9 +139,9 @@ $('document').ready(() => {
     const thisSelect = $(this)
 
     if (thisSelect.val()) {
-      changeOptions('set', thisSelect.val())
+      saveCheckState('set_option', thisSelect.val())
     } else {
-      changeOptions('delete', thisSelect.data().prev)
+      saveCheckState('delete_option', thisSelect.data().prev)
     }
 
     thisSelect.data('prev', thisSelect.val())
@@ -151,9 +151,9 @@ $('document').ready(() => {
     const thisCheckBox = $(this)
 
     if (thisCheckBox.prop('checked')) {
-      changeOptions('add', thisCheckBox.val())
+      saveCheckState('add_option', thisCheckBox.val())
     } else {
-      changeOptions('delete', thisCheckBox.val())
+      saveCheckState('delete_option', thisCheckBox.val())
     }
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -129,8 +129,12 @@ $('document').ready(() => {
   emancipationPage.asyncWaitIndicator = emancipationPage.notifications.find('#async-waiting-indicator')
 
   $('.emancipation-category').click(function () {
-    categoryCheckbox = $(this).find('input[type="checkbox"]')
-    categoryCheckbox.prop('checked', !categoryCheckbox.is(':checked'))
+    category = $(this)
+    categoryCheckbox = category.find('input[type="checkbox"]')
+    categoryCheckboxChecked = categoryCheckbox.is(':checked')
+
+    categoryCheckbox.prop('checked', !categoryCheckboxChecked)
+    categoryCheckboxChecked ? category.siblings('.category-options').hide() : category.siblings('.category-options').show()
   })
 
   $('.emancipation-radio-button').change(function (data) {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -134,16 +134,35 @@ $('document').ready(() => {
     categoryCollapseIcon = category.find('span')
     categoryCheckboxChecked = categoryCheckbox.is(':checked')
 
-    categoryCheckbox.prop('checked', !categoryCheckboxChecked)
+    if (!category.data("disabled")) {
+      category.data("disabled", true)
+      category.addClass("disabled")
+      categoryCheckbox.prop('checked', !categoryCheckboxChecked)
+      categoryCheckbox.prop("disabled", "disabled")
 
-    if (categoryCheckboxChecked) {
-      category.siblings('.category-options').hide()
-      categoryCollapseIcon.text('+')
-      saveCheckState('delete_category', categoryCheckbox.val())
-    } else {
-      category.siblings('.category-options').show()
-      categoryCollapseIcon.text('−')
-      saveCheckState('add_category', categoryCheckbox.val())
+      if (categoryCheckboxChecked) {
+        saveCheckState('delete_category', categoryCheckbox.val())
+        .done(function () {
+          category.siblings('.category-options').hide()
+          categoryCollapseIcon.text('+')
+        })
+        .always(function () {
+          category.data("disabled", false)
+          category.removeClass("disabled")
+          categoryCheckbox.prop("disabled", false)
+        })
+      } else {
+        saveCheckState('add_category', categoryCheckbox.val())
+        .done(function () {
+          category.siblings('.category-options').show()
+          categoryCollapseIcon.text('−')
+        })
+        .always(function () {
+          category.data("disabled", false)
+          category.removeClass("disabled")
+          categoryCheckbox.prop("disabled", false)
+        })
+      }
     }
   })
 

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -46,3 +46,26 @@
     }
   }
 }
+
+.emancipation-category {
+  border-bottom: 2px solid #bfe3ff;
+  padding: .5em;
+
+  label {
+    margin: 0
+  }
+}
+
+.emancipation-category:hover {
+  background-color: #f5f5f5;
+  cursor: pointer;
+
+  input, label{
+    cursor: pointer
+  }
+}
+
+.category-options {
+  margin-left: 2em;
+  margin-bottom: 1em;
+}

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -56,6 +56,10 @@
   border-bottom: 2px solid #bfe3ff;
   padding: .5em;
 
+  input[type="checkbox"] {
+    pointer-events: none;
+  }
+
   label {
     margin: 0
   }
@@ -72,9 +76,21 @@
   background-color: #f5f5f5;
   cursor: pointer;
 
-  input, label{
+  input[type="checkbox"], label{
     cursor: pointer
   }
+}
+
+.emancipation-category.disabled {
+  cursor: default;
+
+  span, label{
+    color: #757575;
+  }
+}
+
+.emancipation-category.disabled:hover{
+  background-color: unset;
 }
 
 .no-select {

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -24,7 +24,7 @@
     color: white;
   }
   
-  #async-success-indicator {
+  .async-success-indicator {
     background-color: #28a745;
     color: white;
   }

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -47,6 +47,11 @@
   }
 }
 
+.category-options {
+  margin-left: 2em;
+  margin-bottom: 1em;
+}
+
 .emancipation-category {
   border-bottom: 2px solid #bfe3ff;
   padding: .5em;
@@ -65,7 +70,12 @@
   }
 }
 
-.category-options {
-  margin-left: 2em;
-  margin-bottom: 1em;
+.no-select {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Edge, Opera and Firefox */
 }

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -59,6 +59,13 @@
   label {
     margin: 0
   }
+
+  span {
+    color: #00447c;
+    float: right;
+    font-weight: bold;
+    font-size: 18pt;
+  }
 }
 
 .emancipation-category:hover {

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -18,6 +18,8 @@ class CasaCase < ApplicationRecord
   has_many :active_case_assignments, -> { is_active }, class_name: "CaseAssignment"
   has_many :assigned_volunteers, -> { active }, through: :active_case_assignments, source: :volunteer, class_name: "Volunteer"
   has_many :case_contacts, dependent: :destroy
+  has_many :casa_case_emancipation_categories, dependent: :destroy
+  has_many :emancipation_categories, through: :casa_case_emancipation_categories
   has_many :casa_cases_emancipation_options, dependent: :destroy
   has_many :emancipation_options, through: :casa_cases_emancipation_options
   has_many :past_court_dates, dependent: :destroy
@@ -105,6 +107,10 @@ class CasaCase < ApplicationRecord
     emancipation_options.find_by(id: option_id).present?
   end
 
+  def add_emancipation_category(category_id)
+    emancipation_categories << EmancipationCategory.find(category_id)
+  end
+
   def add_emancipation_option(option_id)
     option_category = EmancipationOption.find(option_id).emancipation_category
 
@@ -113,6 +119,10 @@ class CasaCase < ApplicationRecord
     else
       raise "Attempted adding multiple options belonging to a mutually exclusive category"
     end
+  end
+
+  def remove_emancipation_category(category_id)
+    emancipation_categories.destroy(EmancipationCategory.find(category_id))
   end
 
   def remove_emancipation_option(option_id)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -103,10 +103,6 @@ class CasaCase < ApplicationRecord
     transition_aged_youth
   end
 
-  def contains_emancipation_option?(option_id)
-    emancipation_options.find_by(id: option_id).present?
-  end
-
   def add_emancipation_category(category_id)
     emancipation_categories << EmancipationCategory.find(category_id)
   end

--- a/app/models/casa_case_emancipation_category.rb
+++ b/app/models/casa_case_emancipation_category.rb
@@ -1,0 +1,25 @@
+class CasaCaseEmancipationCategory < ApplicationRecord
+  belongs_to :casa_case
+  belongs_to :emancipation_category
+end
+
+# == Schema Information
+#
+# Table name: casa_case_emancipation_categories
+#
+#  id                       :bigint           not null, primary key
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  casa_case_id             :bigint           not null
+#  emancipation_category_id :bigint           not null
+#
+# Indexes
+#
+#  index_casa_case_emancipation_categories_on_casa_case_id         (casa_case_id)
+#  index_case_emancipation_categories_on_emancipation_category_id  (emancipation_category_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (casa_case_id => casa_cases.id)
+#  fk_rails_...  (emancipation_category_id => emancipation_categories.id)
+#

--- a/app/models/emancipation_category.rb
+++ b/app/models/emancipation_category.rb
@@ -1,4 +1,6 @@
 class EmancipationCategory < ApplicationRecord
+  has_many :casa_cases_emancipation_categories, dependent: :destroy
+  has_many :casa_cases, through: :casa_cases_emancipation_categories
   has_many :emancipation_options
   validates :name, presence: true
   validates :mutually_exclusive, inclusion: {in: [true, false]}

--- a/app/models/emancipation_category.rb
+++ b/app/models/emancipation_category.rb
@@ -1,6 +1,6 @@
 class EmancipationCategory < ApplicationRecord
-  has_many :casa_cases_emancipation_categories, dependent: :destroy
-  has_many :casa_cases, through: :casa_cases_emancipation_categories
+  has_many :casa_case_emancipation_categories, dependent: :destroy
+  has_many :casa_cases, through: :casa_case_emancipation_categories
   has_many :emancipation_options
   validates :name, presence: true
   validates :mutually_exclusive, inclusion: {in: [true, false]}

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -17,7 +17,7 @@
           <select id="C<%= category.id %>" class="emancipation-select">
             <option value="" disabled selected>Select One</option>
             <% category.emancipation_options.each do |option| %>
-              <option value="<%= option.id %>" <%= emancipation_select_option_selected(@current_case, option.id) %>>
+              <option value="<%= option.id %>" <%= emancipation_select_option_selected(@current_case, option) %>>
                 <%= option.name %>
               </option>
             <% end %>
@@ -31,7 +31,7 @@
             id="O<%= option.id %>"
             class="emancipation-check-box"
             value="<%= option.id %>"
-            <%= emancipation_checkbox_option_checked(@current_case, option.id) %>>
+            <%= emancipation_checkbox_option_checked(@current_case, option) %>>
           <label for="O<%= option.id %>"><%= option.name %></label>
           <br>
         <% end %>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -9,21 +9,18 @@
 <div class="card card-container">
   <div class="card-body">
     <% @emancipation_form_data.each do |category| %>
-      <% if category.mutually_exclusive %>
-        <h6><strong> <%= category.name %> </strong></h6>
-          <% category.emancipation_options.each do |option| %>
-            <input
-              type="radio"
-              id="O<%= option.id %>"
-              class="emancipation-radio-button"
-              name="C<%= category.id %>"
-              value="<%= option.id %>"
-              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
-            <label for="O<%= option.id %>"><%= option.name %></label><br>
-          <% end %>
-      <% else %>
-        <h6><strong> <%= category.name %> </strong></h6>
-        <% category.emancipation_options.each do |option| %>
+      <h6><strong> <%= category.name %> </strong></h6>
+      <% category.emancipation_options.each do |option| %>
+        <% if category.mutually_exclusive %>
+          <input
+            type="radio"
+            id="O<%= option.id %>"
+            class="emancipation-radio-button"
+            name="C<%= category.id %>"
+            value="<%= option.id %>"
+            <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+          <label for="O<%= option.id %>"><%= option.name %></label><br>
+        <% else %>
           <input
             type="checkbox"
             id="O<%= option.id %>"

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -19,7 +19,9 @@
             <%= emancipation_category_checkbox_checked?(@current_case, category) %>>
           <label for="C<%= category.id %>"><%= category.name %></label>
         </h6>
-        <div class="category-options">
+        <div
+          class="category-options"
+          style="<%= emancipation_category_collapse_hidden?(@current_case, category) %>">
           <% category.emancipation_options.each do |option| %>
             <% if category.mutually_exclusive %>
               <input

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -18,6 +18,7 @@
             value="<%= category.id %>"
             <%= emancipation_category_checkbox_checked(@current_case, category) %>>
           <label for="C<%= category.id %>"><%= category.name %></label>
+          <span><%= emancipation_category_collapse_icon(@current_case, category) %></span>
         </h6>
         <div
           class="category-options"

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -16,12 +16,12 @@
             id="C<%= category.id %>"
             class="emancipation-category-check-box"
             value="<%= category.id %>"
-            <%= emancipation_category_checkbox_checked?(@current_case, category) %>>
+            <%= emancipation_category_checkbox_checked(@current_case, category) %>>
           <label for="C<%= category.id %>"><%= category.name %></label>
         </h6>
         <div
           class="category-options"
-          style="<%= emancipation_category_collapse_hidden?(@current_case, category) %>">
+          style="<%= emancipation_category_collapse_hidden(@current_case, category) %>">
           <% category.emancipation_options.each do |option| %>
             <% if category.mutually_exclusive %>
               <input
@@ -30,7 +30,7 @@
                 class="emancipation-radio-button"
                 name="C<%= category.id %>"
                 value="<%= option.id %>"
-                <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+                <%= emancipation_option_checkbox_checked(@current_case, option) %>>
               <label for="O<%= option.id %>"><%= option.name %></label>
               <br>
             <% else %>
@@ -39,7 +39,7 @@
                 id="O<%= option.id %>"
                 class="emancipation-option-check-box"
                 value="<%= option.id %>"
-                <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+                <%= emancipation_option_checkbox_checked(@current_case, option) %>>
               <label for="O<%= option.id %>"><%= option.name %></label>
               <br>
             <% end %>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -17,7 +17,7 @@
           <select id="C<%= category.id %>" class="emancipation-select">
             <option value="" disabled selected>Select One</option>
             <% category.emancipation_options.each do |option| %>
-              <option value="<%= option.id %>" <%= emancipation_select_option_selected(@current_case, option) %>>
+              <option value="<%= option.id %>" <%= emancipation_option_select_selected?(@current_case, option) %>>
                 <%= option.name %>
               </option>
             <% end %>
@@ -31,7 +31,7 @@
             id="O<%= option.id %>"
             class="emancipation-check-box"
             value="<%= option.id %>"
-            <%= emancipation_checkbox_option_checked(@current_case, option) %>>
+            <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
           <label for="O<%= option.id %>"><%= option.name %></label>
           <br>
         <% end %>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -13,11 +13,10 @@
         <h6 class="emancipation-category no-select">
           <input
             type="checkbox"
-            id="C<%= category.id %>"
             class="emancipation-category-check-box"
             value="<%= category.id %>"
             <%= emancipation_category_checkbox_checked(@current_case, category) %>>
-          <label for="C<%= category.id %>"><%= category.name %></label>
+          <label><%= category.name %></label>
           <span><%= emancipation_category_collapse_icon(@current_case, category) %></span>
         </h6>
         <div

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -9,38 +9,40 @@
 <div class="card card-container">
   <div class="card-body">
     <% @emancipation_form_data.each do |category| %>
-      <h6 class="emancipation-category no-select">
-        <input
-          type="checkbox"
-          id="C<%= category.id %>"
-          class="emancipation-category-check-box"
-          value="<%= category.id %>"
-          <%= emancipation_category_checkbox_checked?(@current_case, category) %>>
-        <label for="C<%= category.id %>"><%= category.name %></label>
-      </h6>
-      <div class="category-options">
-        <% category.emancipation_options.each do |option| %>
-          <% if category.mutually_exclusive %>
-            <input
-              type="radio"
-              id="O<%= option.id %>"
-              class="emancipation-radio-button"
-              name="C<%= category.id %>"
-              value="<%= option.id %>"
-              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
-            <label for="O<%= option.id %>"><%= option.name %></label>
-            <br>
-          <% else %>
-            <input
-              type="checkbox"
-              id="O<%= option.id %>"
-              class="emancipation-option-check-box"
-              value="<%= option.id %>"
-              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
-            <label for="O<%= option.id %>"><%= option.name %></label>
-            <br>
+      <div>
+        <h6 class="emancipation-category no-select">
+          <input
+            type="checkbox"
+            id="C<%= category.id %>"
+            class="emancipation-category-check-box"
+            value="<%= category.id %>"
+            <%= emancipation_category_checkbox_checked?(@current_case, category) %>>
+          <label for="C<%= category.id %>"><%= category.name %></label>
+        </h6>
+        <div class="category-options">
+          <% category.emancipation_options.each do |option| %>
+            <% if category.mutually_exclusive %>
+              <input
+                type="radio"
+                id="O<%= option.id %>"
+                class="emancipation-radio-button"
+                name="C<%= category.id %>"
+                value="<%= option.id %>"
+                <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+              <label for="O<%= option.id %>"><%= option.name %></label>
+              <br>
+            <% else %>
+              <input
+                type="checkbox"
+                id="O<%= option.id %>"
+                class="emancipation-option-check-box"
+                value="<%= option.id %>"
+                <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+              <label for="O<%= option.id %>"><%= option.name %></label>
+              <br>
+            <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -9,7 +9,7 @@
 <div class="card card-container">
   <div class="card-body">
     <% @emancipation_form_data.each do |category| %>
-      <h6 class="emancipation-category">
+      <h6 class="emancipation-category no-select">
         <input
           type="checkbox"
           id="C<%= category.id %>"

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -9,28 +9,39 @@
 <div class="card card-container">
   <div class="card-body">
     <% @emancipation_form_data.each do |category| %>
-      <h6><strong> <%= category.name %> </strong></h6>
-      <% category.emancipation_options.each do |option| %>
-        <% if category.mutually_exclusive %>
-          <input
-            type="radio"
-            id="O<%= option.id %>"
-            class="emancipation-radio-button"
-            name="C<%= category.id %>"
-            value="<%= option.id %>"
-            <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
-          <label for="O<%= option.id %>"><%= option.name %></label><br>
-        <% else %>
-          <input
-            type="checkbox"
-            id="O<%= option.id %>"
-            class="emancipation-check-box"
-            value="<%= option.id %>"
-            <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
-          <label for="O<%= option.id %>"><%= option.name %></label>
-          <br>
+      <h6 class="emancipation-category">
+        <input
+          type="checkbox"
+          id="C<%= category.id %>"
+          class="emancipation-category-check-box"
+          value="<%= category.id %>"
+          <%= emancipation_category_checkbox_checked?(@current_case, category) %>>
+        <label for="C<%= category.id %>"><%= category.name %></label>
+      </h6>
+      <div class="category-options">
+        <% category.emancipation_options.each do |option| %>
+          <% if category.mutually_exclusive %>
+            <input
+              type="radio"
+              id="O<%= option.id %>"
+              class="emancipation-radio-button"
+              name="C<%= category.id %>"
+              value="<%= option.id %>"
+              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+            <label for="O<%= option.id %>"><%= option.name %></label>
+            <br>
+          <% else %>
+            <input
+              type="checkbox"
+              id="O<%= option.id %>"
+              class="emancipation-option-check-box"
+              value="<%= option.id %>"
+              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+            <label for="O<%= option.id %>"><%= option.name %></label>
+            <br>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -31,8 +31,6 @@
                 name="C<%= category.id %>"
                 value="<%= option.id %>"
                 <%= emancipation_option_checkbox_checked(@current_case, option) %>>
-              <label for="O<%= option.id %>"><%= option.name %></label>
-              <br>
             <% else %>
               <input
                 type="checkbox"
@@ -40,9 +38,9 @@
                 class="emancipation-option-check-box"
                 value="<%= option.id %>"
                 <%= emancipation_option_checkbox_checked(@current_case, option) %>>
-              <label for="O<%= option.id %>"><%= option.name %></label>
-              <br>
             <% end %>
+            <label for="O<%= option.id %>"><%= option.name %></label>
+            <br>
           <% end %>
         </div>
       </div>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -10,19 +10,17 @@
   <div class="card-body">
     <% @emancipation_form_data.each do |category| %>
       <% if category.mutually_exclusive %>
-        <h6>
-          <label for="C<%= category.id %>">
-            <strong> <%= category.name %> </strong>
-          </label>
-          <select id="C<%= category.id %>" class="emancipation-select">
-            <option value="" disabled selected>Select One</option>
-            <% category.emancipation_options.each do |option| %>
-              <option value="<%= option.id %>" <%= emancipation_option_select_selected?(@current_case, option) %>>
-                <%= option.name %>
-              </option>
-            <% end %>
-          </select>
-        <h6>
+        <h6><strong> <%= category.name %> </strong></h6>
+          <% category.emancipation_options.each do |option| %>
+            <input
+              type="radio"
+              id="O<%= option.id %>"
+              class="emancipation-radio-button"
+              name="C<%= category.id %>"
+              value="<%= option.id %>"
+              <%= emancipation_option_checkbox_checked?(@current_case, option) %>>
+            <label for="O<%= option.id %>"><%= option.name %></label><br>
+          <% end %>
       <% else %>
         <h6><strong> <%= category.name %> </strong></h6>
         <% category.emancipation_options.each do |option| %>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -54,7 +54,7 @@
   <div id="async-waiting-indicator" style="display: none">
     Saving <div class="load-spinner"></div>
   </div>
-  <div id="async-success-indicator" style="display: none">
+  <div id="async-success-indicator" class="async-success-indicator" style="display: none">
     Saved
   </div>
 </div>

--- a/db/migrate/20201226024029_create_casa_case_emancipation_categories.rb
+++ b/db/migrate/20201226024029_create_casa_case_emancipation_categories.rb
@@ -1,0 +1,10 @@
+class CreateCasaCaseEmancipationCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :casa_case_emancipation_categories do |t|
+      t.references :casa_case, null: false, foreign_key: true
+      t.references :emancipation_category, null: false, foreign_key: true, index: { name: 'index_case_emancipation_categories_on_emancipation_category_id' }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201226024029_create_casa_case_emancipation_categories.rb
+++ b/db/migrate/20201226024029_create_casa_case_emancipation_categories.rb
@@ -2,7 +2,7 @@ class CreateCasaCaseEmancipationCategories < ActiveRecord::Migration[6.1]
   def change
     create_table :casa_case_emancipation_categories do |t|
       t.references :casa_case, null: false, foreign_key: true
-      t.references :emancipation_category, null: false, foreign_key: true, index: { name: 'index_case_emancipation_categories_on_emancipation_category_id' }
+      t.references :emancipation_category, null: false, foreign_key: true, index: {name: "index_case_emancipation_categories_on_emancipation_category_id"}
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_125442) do
+ActiveRecord::Schema.define(version: 2020_12_26_024029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,15 @@ ActiveRecord::Schema.define(version: 2020_12_22_125442) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["casa_case_id"], name: "index_casa_case_contact_types_on_casa_case_id"
     t.index ["contact_type_id"], name: "index_casa_case_contact_types_on_contact_type_id"
+  end
+
+  create_table "casa_case_emancipation_categories", force: :cascade do |t|
+    t.bigint "casa_case_id", null: false
+    t.bigint "emancipation_category_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["casa_case_id"], name: "index_casa_case_emancipation_categories_on_casa_case_id"
+    t.index ["emancipation_category_id"], name: "index_case_emancipation_categories_on_emancipation_category_id"
   end
 
   create_table "casa_cases", force: :cascade do |t|
@@ -257,6 +266,8 @@ ActiveRecord::Schema.define(version: 2020_12_22_125442) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "casa_case_emancipation_categories", "casa_cases"
+  add_foreign_key "casa_case_emancipation_categories", "emancipation_categories"
   add_foreign_key "casa_cases", "casa_orgs"
   add_foreign_key "casa_cases_emancipation_options", "casa_cases"
   add_foreign_key "casa_cases_emancipation_options", "emancipation_options"

--- a/spec/factories/casa_case_emancipation_categories.rb
+++ b/spec/factories/casa_case_emancipation_categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :casa_case_emancipation_category do
+    casa_case { nil }
+    emancipation_category { nil }
+  end
+end

--- a/spec/factories/casa_case_emancipation_categories.rb
+++ b/spec/factories/casa_case_emancipation_categories.rb
@@ -1,6 +1,11 @@
 FactoryBot.define do
   factory :casa_case_emancipation_category do
-    casa_case { nil }
-    emancipation_category { nil }
+    casa_case do
+      create(:casa_case)
+    end
+
+    emancipation_category do
+      create(:emancipation_category)
+    end
   end
 end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -39,6 +39,19 @@ RSpec.describe EmancipationsHelper, type: :helper do
     end
   end
 
+  describe "#emancipation_category_collapse_icon" do
+    let(:emancipation_category) { create(:emancipation_category, name: "another unique name") }
+
+    it "returns nil when passed an associated casa case and emancipation category" do
+      create(:casa_case_emancipation_category, casa_case_id: casa_case.id, emancipation_category_id: emancipation_category.id)
+      expect(helper.emancipation_category_collapse_icon(casa_case, emancipation_category)).to eq("−")
+    end
+
+    it "returns \"display: none;\" when passed an unassociated casa case and emancipation category" do
+      expect(helper.emancipation_category_collapse_icon(casa_case, emancipation_category)).to eq("+")
+    end
+  end
+
   describe "#emancipation_option_checkbox_checked" do
     let(:emancipation_option) { create(:emancipation_option) }
 

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe EmancipationsHelper, type: :helper do
 
     it "returns \"checked\" when passed an associated casa case and emancipation category" do
       create(:casa_case_emancipation_category, casa_case_id: casa_case.id, emancipation_category_id: emancipation_category.id)
-      expect(helper.emancipation_category_checkbox_checked?(casa_case, emancipation_category)).to eq("checked")
+      expect(helper.emancipation_category_checkbox_checked(casa_case, emancipation_category)).to eq("checked")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation category" do
-      expect(helper.emancipation_category_checkbox_checked?(casa_case, emancipation_category)).to eq(nil)
+      expect(helper.emancipation_category_checkbox_checked(casa_case, emancipation_category)).to eq(nil)
     end
   end
 
@@ -31,11 +31,11 @@ RSpec.describe EmancipationsHelper, type: :helper do
 
     it "returns nil when passed an associated casa case and emancipation category" do
       create(:casa_case_emancipation_category, casa_case_id: casa_case.id, emancipation_category_id: emancipation_category.id)
-      expect(helper.emancipation_category_collapse_hidden?(casa_case, emancipation_category)).to eq(nil)
+      expect(helper.emancipation_category_collapse_hidden(casa_case, emancipation_category)).to eq(nil)
     end
 
     it "returns \"display: none;\" when passed an unassociated casa case and emancipation category" do
-      expect(helper.emancipation_category_collapse_hidden?(casa_case, emancipation_category)).to eq("display: none;")
+      expect(helper.emancipation_category_collapse_hidden(casa_case, emancipation_category)).to eq("display: none;")
     end
   end
 
@@ -44,11 +44,11 @@ RSpec.describe EmancipationsHelper, type: :helper do
 
     it "returns \"checked\" when passed an associated casa case and emancipation option" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_option_checkbox_checked?(casa_case, emancipation_option)).to eq("checked")
+      expect(helper.emancipation_option_checkbox_checked(casa_case, emancipation_option)).to eq("checked")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_option_checkbox_checked?(casa_case, emancipation_option)).to eq(nil)
+      expect(helper.emancipation_option_checkbox_checked(casa_case, emancipation_option)).to eq(nil)
     end
   end
 end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -12,10 +12,24 @@ require "rails_helper"
 # end
 RSpec.describe EmancipationsHelper, type: :helper do
   let(:casa_case) { create(:casa_case, transition_aged_youth: true) }
-  let(:emancipation_option) { create(:emancipation_option) }
 
-  describe "#emancipation_checkbox_option_checked" do
-    it "returns \"checked\" when passed an associated casa case and emancipation option id" do
+  describe "#emancipation_category_checkbox_checked" do
+    let(:emancipation_category) { create(:emancipation_category, name: "unique name") }
+
+    it "returns \"checked\" when passed an associated casa case and emancipation category" do
+      create(:casa_case_emancipation_category, casa_case_id: casa_case.id, emancipation_category_id: emancipation_category.id)
+      expect(helper.emancipation_category_checkbox_checked?(casa_case, emancipation_category)).to eq("checked")
+    end
+
+    it "returns nil when passed an unassociated casa case and emancipation category" do
+      expect(helper.emancipation_category_checkbox_checked?(casa_case, emancipation_category)).to eq(nil)
+    end
+  end
+
+  describe "#emancipation_option_checkbox_checked" do
+    let(:emancipation_option) { create(:emancipation_option) }
+
+    it "returns \"checked\" when passed an associated casa case and emancipation option" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
       expect(helper.emancipation_option_checkbox_checked?(casa_case, emancipation_option)).to eq("checked")
     end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -17,22 +17,22 @@ RSpec.describe EmancipationsHelper, type: :helper do
   describe "#emancipation_select_option_selected" do
     it "returns \"selected\" when passed an associated casa case and emancipation option id" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option.id)).to eq("selected")
+      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option)).to eq("selected")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option.id)).to eq(nil)
+      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option)).to eq(nil)
     end
   end
 
   describe "#emancipation_checkbox_option_checked" do
     it "returns \"checked\" when passed an associated casa case and emancipation option id" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option.id)).to eq("checked")
+      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option)).to eq("checked")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option.id)).to eq(nil)
+      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option)).to eq(nil)
     end
   end
 end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -17,22 +17,22 @@ RSpec.describe EmancipationsHelper, type: :helper do
   describe "#emancipation_select_option_selected" do
     it "returns \"selected\" when passed an associated casa case and emancipation option id" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option)).to eq("selected")
+      expect(helper.emancipation_option_select_selected?(casa_case, emancipation_option)).to eq("selected")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_select_option_selected(casa_case, emancipation_option)).to eq(nil)
+      expect(helper.emancipation_option_select_selected?(casa_case, emancipation_option)).to eq(nil)
     end
   end
 
   describe "#emancipation_checkbox_option_checked" do
     it "returns \"checked\" when passed an associated casa case and emancipation option id" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option)).to eq("checked")
+      expect(helper.emancipation_option_checkbox_checked?(casa_case, emancipation_option)).to eq("checked")
     end
 
     it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_checkbox_option_checked(casa_case, emancipation_option)).to eq(nil)
+      expect(helper.emancipation_option_checkbox_checked?(casa_case, emancipation_option)).to eq(nil)
     end
   end
 end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe EmancipationsHelper, type: :helper do
     end
   end
 
+  describe "#emancipation_category_collapse_hidden" do
+    let(:emancipation_category) { create(:emancipation_category, name: "another unique name") }
+
+    it "returns nil when passed an associated casa case and emancipation category" do
+      create(:casa_case_emancipation_category, casa_case_id: casa_case.id, emancipation_category_id: emancipation_category.id)
+      expect(helper.emancipation_category_collapse_hidden?(casa_case, emancipation_category)).to eq(nil)
+    end
+
+    it "returns \"display: none;\" when passed an unassociated casa case and emancipation category" do
+      expect(helper.emancipation_category_collapse_hidden?(casa_case, emancipation_category)).to eq("display: none;")
+    end
+  end
+
   describe "#emancipation_option_checkbox_checked" do
     let(:emancipation_option) { create(:emancipation_option) }
 

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe EmancipationsHelper, type: :helper do
   let(:casa_case) { create(:casa_case, transition_aged_youth: true) }
   let(:emancipation_option) { create(:emancipation_option) }
 
-  describe "#emancipation_select_option_selected" do
-    it "returns \"selected\" when passed an associated casa case and emancipation option id" do
-      create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
-      expect(helper.emancipation_option_select_selected?(casa_case, emancipation_option)).to eq("selected")
-    end
-
-    it "returns nil when passed an unassociated casa case and emancipation option id" do
-      expect(helper.emancipation_option_select_selected?(casa_case, emancipation_option)).to eq(nil)
-    end
-  end
-
   describe "#emancipation_checkbox_option_checked" do
     it "returns \"checked\" when passed an associated casa case and emancipation option id" do
       create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)

--- a/spec/models/casa_case_emancipation_category_spec.rb
+++ b/spec/models/casa_case_emancipation_category_spec.rb
@@ -1,5 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CasaCaseEmancipationCategory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to belong_to(:casa_case) }
+  it { is_expected.to belong_to(:emancipation_category) }
+
+  it "has a valid factory" do
+    case_category_association = build(:casa_case_emancipation_category)
+    expect(case_category_association.valid?).to be true
+  end
 end

--- a/spec/models/casa_case_emancipation_category_spec.rb
+++ b/spec/models/casa_case_emancipation_category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CasaCaseEmancipationCategory, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -181,6 +181,17 @@ RSpec.describe CasaCase do
     end
   end
 
+  context "#add_emancipation_category" do
+    let(:casa_case) { create(:casa_case) }
+    let(:emancipation_category) { create(:emancipation_category) }
+
+    it "associates an emacipation category with the case when passed the id of the category" do
+      expect {
+        casa_case.add_emancipation_category(emancipation_category.id)
+      }.to change { casa_case.emancipation_categories.count }.from(0).to(1)
+    end
+  end
+
   context "#add_emancipation_option" do
     let(:casa_case) { create(:casa_case) }
     let(:emancipation_category) { create(:emancipation_category, mutually_exclusive: true) }
@@ -198,6 +209,19 @@ RSpec.describe CasaCase do
         casa_case.add_emancipation_option(emancipation_option_a.id)
         casa_case.add_emancipation_option(emancipation_option_b.id)
       }.to raise_error("Attempted adding multiple options belonging to a mutually exclusive category")
+    end
+  end
+
+  context "#remove_emancipation_category" do
+    let(:casa_case) { create(:casa_case) }
+    let(:emancipation_category) { create(:emancipation_category) }
+
+    it "dissociates an emancipation category with the case when passed the id of the category" do
+      casa_case.emancipation_categories << emancipation_category
+
+      expect {
+        casa_case.remove_emancipation_category(emancipation_category.id)
+      }.to change { casa_case.emancipation_categories.count }.from(1).to(0)
     end
   end
 

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe CasaCase do
 
   it { is_expected.to have_many(:case_assignments).dependent(:destroy) }
   it { is_expected.to belong_to(:casa_org) }
+  it { is_expected.to have_many(:casa_case_emancipation_categories).dependent(:destroy) }
+  it { is_expected.to have_many(:emancipation_categories).through(:casa_case_emancipation_categories) }
   it { is_expected.to have_many(:casa_cases_emancipation_options).dependent(:destroy) }
   it { is_expected.to have_many(:emancipation_options).through(:casa_cases_emancipation_options) }
   it { is_expected.to belong_to(:hearing_type).optional }

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -181,20 +181,6 @@ RSpec.describe CasaCase do
     end
   end
 
-  context "#contains_emancipation_option?" do
-    let(:casa_case) { create(:casa_case) }
-    let(:emancipation_option) { create(:emancipation_option) }
-
-    it "returns true when passed the id of an emancipation option associated with the case" do
-      casa_case.emancipation_options << emancipation_option
-      expect(casa_case.contains_emancipation_option?(emancipation_option.id)).to eq(true)
-    end
-
-    it "returns false when passed the id of an emancipation option not associated with the case" do
-      expect(casa_case.contains_emancipation_option?(emancipation_option.id)).to eq(false)
-    end
-  end
-
   context "#add_emancipation_option" do
     let(:casa_case) { create(:casa_case) }
     let(:emancipation_category) { create(:emancipation_category, mutually_exclusive: true) }

--- a/spec/models/casa_cases_emancipation_option_spec.rb
+++ b/spec/models/casa_cases_emancipation_option_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe CasaCasesEmancipationOption, type: :model do
+  it { is_expected.to belong_to(:casa_case) }
+  it { is_expected.to belong_to(:emancipation_option) }
+
   it "has a valid factory" do
     case_option_association = build(:casa_cases_emancipation_option)
     expect(case_option_association.valid?).to be true

--- a/spec/models/emancipation_category_spec.rb
+++ b/spec/models/emancipation_category_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe EmancipationCategory, type: :model do
+  it { is_expected.to have_many(:casa_case_emancipation_categories).dependent(:destroy) }
+  it { is_expected.to have_many(:casa_cases).through(:casa_case_emancipation_categories) }
   it { is_expected.to have_many(:emancipation_options) }
   it { is_expected.to validate_presence_of(:name) }
 

--- a/spec/requests/emancipations_request_spec.rb
+++ b/spec/requests/emancipations_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         it "renders an unauthorized error" do
           get casa_case_emancipation_path(casa_case)
           expect(response).to_not be_successful
-          expect(flash[:error]).to match(/you are not authorized/)
+          expect(flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
         end
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         it "renders an unauthorized error" do
           get casa_case_emancipation_path(casa_case)
           expect(response).to_not be_successful
-          expect(flash[:error]).to match(/you are not authorized/)
+          expect(flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
         end
       end
 
@@ -59,7 +59,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         it "renders an unauthorized error" do
           get casa_case_emancipation_path(casa_case)
           expect(response).to_not be_successful
-          expect(flash[:error]).to match(/you are not authorized/)
+          expect(flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
         end
       end
 
@@ -68,7 +68,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         it "renders an unauthorized error" do
           get casa_case_emancipation_path(casa_case)
           expect(response).to_not be_successful
-          expect(flash[:error]).to match(/you are not authorized/)
+          expect(flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
         end
       end
     end

--- a/spec/requests/emancipations_request_spec.rb
+++ b/spec/requests/emancipations_request_spec.rb
@@ -184,10 +184,30 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         expect(JSON.parse(response.body)["error"]).to match(/not marked as transitioning/)
       end
 
+      it "associates an emancipation category with a case when passed \"add\" and the category id" do
+        expect {
+          post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_category", check_item_id: mutually_exclusive_category.id}
+        }.to change { casa_case.emancipation_categories.count }.from(0).to(1)
+
+        expect(response.header["Content-Type"]).to match(/application\/json/)
+        expect(JSON.parse(response.body)).to eq "success"
+      end
+
       it "associates an emancipation option with a case when passed \"add\" and the option id" do
         expect {
           post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
         }.to change { casa_case.emancipation_options.count }.from(0).to(1)
+
+        expect(response.header["Content-Type"]).to match(/application\/json/)
+        expect(JSON.parse(response.body)).to eq "success"
+      end
+
+      it "removes an emancipation category from a case when passed \"delete\" and the category id" do
+        casa_case.emancipation_categories << mutually_exclusive_category
+
+        expect {
+          post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "delete_category", check_item_id: mutually_exclusive_category.id}
+        }.to change { casa_case.emancipation_categories.count }.from(1).to(0)
 
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(JSON.parse(response.body)).to eq "success"

--- a/spec/requests/emancipations_request_spec.rb
+++ b/spec/requests/emancipations_request_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as an admin" do
           let(:user) { create(:casa_admin, casa_org: organization) }
           it "allows the admin to make changes" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(JSON.parse(response.body)).to eq "success"
           end
@@ -94,7 +94,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as a supervisor" do
           let(:user) { create(:supervisor, casa_org: organization) }
           it "allows the supervisor to make changes" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(JSON.parse(response.body)).to eq "success"
           end
@@ -104,7 +104,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
           let(:user) { create(:volunteer, casa_org: organization) }
           let!(:case_assignment) { create(:case_assignment, volunteer: user, casa_case: casa_case) }
           it "allows the volunteer to make changes" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(JSON.parse(response.body)).to eq "success"
           end
@@ -113,7 +113,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as a volunteer not assigned to the associated case" do
           let(:user) { create(:volunteer, casa_org: organization) }
           it "sends an unauthorized error" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(response.body).to_not be_nil
             expect(JSON.parse(response.body)).to have_key("error")
@@ -126,7 +126,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as an admin" do
           let(:user) { create(:casa_admin, casa_org: organization_different) }
           it "sends an unauthorized error" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(response.body).to_not be_nil
             expect(JSON.parse(response.body)).to have_key("error")
@@ -137,7 +137,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as a supervisor" do
           let(:user) { create(:supervisor, casa_org: organization_different) }
           it "sends an unauthorized error" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(response.body).to_not be_nil
             expect(JSON.parse(response.body)).to have_key("error")
@@ -148,7 +148,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         context "as a volunteer" do
           let(:user) { create(:volunteer, casa_org: organization_different) }
           it "sends an unauthorized error" do
-            post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+            post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
             expect(response.header["Content-Type"]).to match(/application\/json/)
             expect(response.body).to_not be_nil
             expect(JSON.parse(response.body)).to have_key("error")
@@ -169,24 +169,24 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
       let!(:case_assignment_non_transitioning_case) { create(:case_assignment, volunteer: user, casa_case: non_transitioning_casa_case) }
 
       it "sends an error when a required parameter is missing" do
-        post casa_case_emancipation_path(casa_case) + "/save", params: {option_id: option_a.id}
+        post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_id: option_a.id}
         expect(JSON.parse(response.body)).to have_key("error")
         expect(JSON.parse(response.body)["error"]).to match(/Missing param/)
 
-        post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add"}
+        post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option"}
         expect(JSON.parse(response.body)).to have_key("error")
         expect(JSON.parse(response.body)["error"]).to match(/Missing param/)
       end
 
       it "sends an error when attempting to perform an action on a case that is not tranitioning" do
-        post casa_case_emancipation_path(non_transitioning_casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+        post casa_case_emancipation_path(non_transitioning_casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
         expect(JSON.parse(response.body)).to have_key("error")
         expect(JSON.parse(response.body)["error"]).to match(/not marked as transitioning/)
       end
 
       it "associates an emancipation option with a case when passed \"add\" and the option id" do
         expect {
-          post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "add", option_id: option_a.id}
+          post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option", check_item_id: option_a.id}
         }.to change { casa_case.emancipation_options.count }.from(0).to(1)
 
         expect(response.header["Content-Type"]).to match(/application\/json/)
@@ -197,7 +197,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         casa_case.emancipation_options << option_a
 
         expect {
-          post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "delete", option_id: option_a.id}
+          post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "delete_option", check_item_id: option_a.id}
         }.to change { casa_case.emancipation_options.count }.from(1).to(0)
 
         expect(response.header["Content-Type"]).to match(/application\/json/)
@@ -207,7 +207,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
       it "removes all emancipation options from the case belonging to the same category before adding the new option when passed \"set\" and the option id" do
         casa_case.emancipation_options << mutex_option_a
 
-        post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "set", option_id: mutex_option_b.id}
+        post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "set_option", check_item_id: mutex_option_b.id}
 
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(JSON.parse(response.body)).to eq "success"
@@ -220,7 +220,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
         casa_case.emancipation_options << mutex_option_a
         casa_case.emancipation_options << option_a
 
-        post casa_case_emancipation_path(casa_case) + "/save", params: {option_action: "set", option_id: mutex_option_b.id}
+        post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "set_option", check_item_id: mutex_option_b.id}
 
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(JSON.parse(response.body)).to eq "success"

--- a/spec/system/casa_cases/emancipation/show_spec.rb
+++ b/spec/system/casa_cases/emancipation/show_spec.rb
@@ -18,9 +18,5 @@ RSpec.describe "casa_cases/show", type: :system do
     it "sees title" do
       expect(page).to have_content("Emancipation Checklist")
     end
-
-    it "sees that 'Select One' is chosen" do
-      expect(page).to have_content("Select One")
-    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1494

### What changed, and why?
Users can check emancipation categories
Checking emancipation categories expands emancipation options into view
Unchecking emancipation categories removes all emancipation category options from the case
When checkbox actions fail server side, the client side ui won't change.
Some refactoring

### How will this affect user permissions?
Users can now associate emancipation categories with cases

### Screenshots
![image](https://user-images.githubusercontent.com/8918762/103451878-fa19e480-4c8e-11eb-88d6-e36161994e81.png)
![image](https://user-images.githubusercontent.com/8918762/103451862-e40c2400-4c8e-11eb-82fe-2a65e3e07725.png)
![image](https://user-images.githubusercontent.com/8918762/103451884-07cf6a00-4c8f-11eb-95d2-70d014b9a02a.png)
