### PR TITLE
Move unassigned issues from In Progress to To Do.

### DIFF
--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -10,8 +10,22 @@ jobs:
     steps:
       - name: Unassign issues
         uses: bjthompson805/unassign-issues@v1
-        id: unassign-issues
+        id: unassign_issues
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           unassign_inactive_in_hours: 168 # 7 days
           warning_inactive_in_hours: 120 # 5 days
+      - name: Print the unassigned issues
+        run: echo "Unassigned issues = ${{steps.unassign_issues.outputs.unassigned_issues}}"
+      - name: Print the warned issues
+        run: echo "Warned issues = ${{steps.unassign_issues.outputs.warned_issues}}"
+      - name: Move unassigned issues from In Progress to To Do
+        uses: bjthompson805/move-issues@v1
+        id: move_issues
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          issues: ${{steps.unassign_issues.outputs.unassigned_issues}}
+          from_column: '8461148'
+          to_column: '8461147'
+      - name: Print moved issues
+        run: echo "Moved issues = ${{steps.move_issues.outputs.moved_issues}}"


### PR DESCRIPTION
Issues found to be in the In Progress column will now be moved to the To
Do column. The unassign-issues action has been modified to output the
issues that were unassigned.

### What github issue is this PR for, if any?
Resolves #1541

### What changed, and why?
The issue-auto-unassign.yml file changed to retrieve the new outputs from the unassign-issues action and pass them to the new move-issues action. It also prints them out for better debugging.

Here is the new action: https://github.com/bjthompson805/move-issues

### How is this tested? (please write tests!) 💖💪
Tested manually in my test harness: https://github.com/bjthompson805/hello-world-javascript-action

### Screenshots please :)
Here, issue number 4 and number 6 were self-assigned, and the same workflow as in this PR was ran so that the issues were unassigned and then the move-issues action moved them from In Progress to To Do.
![image](https://user-images.githubusercontent.com/40772561/103492583-2f3a4a00-4de9-11eb-8967-8208632ad3b0.png)

