### PR TITLE
Heroku review app configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "postdeploy": "bundle exec rake db:schema:load db:seed"
+    "postdeploy": "bundle exec rake db:migrate db:seed"
   },
   "stack": "heroku-18"
 }

--- a/db/seeds/casa_org_populator_presets.rb
+++ b/db/seeds/casa_org_populator_presets.rb
@@ -45,6 +45,6 @@ module CasaOrgPopulatorPresets
       "qa" => CasaOrgPopulatorPresets.large_dataset_options,
       "staging" => CasaOrgPopulatorPresets.large_dataset_options,
       "test" => CasaOrgPopulatorPresets.small_dataset_options
-    }[Rails.env]
+    }[ENV["APP_ENVIRONMENT"] || Rails.env]
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1238 

### What changed, and why?
- Use `db:migrate` instead of `schema:load` since `schema:load` is a destructive action on the database and requires an extra flag to run
- Running the seed file was causing an error since `production` was not available as an option for which dataset to use. Modified the seed code to use the `APP_ENVIRONMENT` environment variable to determine the dataset since we no longer have qa and staging environments. Set the review apps to have `APP_ENVIRONMENT` of "qa".