### PR TITLE
Upgrade postgres version for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '3'
+version: "3"
 
 services:
   web:
     build: .
     ports:
-      - '3000:3000'
-      - '4000:4000'
+      - "3000:3000"
+      - "4000:4000"
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
@@ -23,14 +23,14 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     ports:
-      - '5435:5432'
+      - "5435:5432"
 
   selenium_chrome:
     image: selenium/standalone-chrome-debug
     logging:
       driver: none
     ports:
-      - '5900:5900'
+      - "5900:5900"
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     tty: true
 
   database:
-    image: postgres:12.3
+    image: postgres:12.5
     env_file:
       - config/docker.env
     volumes:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1539 

### What changed, and why?
Production is now running version 12.5, so upgrading Docker dev environments to match.