### PR TITLE
Fixes case_contact filter in reports

### DIFF
--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -27,7 +27,7 @@ class CaseContactReport
       .contact_made(args[:contact_made])
       .has_transitioned(args[:has_transitioned])
       .want_driving_reimbursement(args[:want_driving_reimbursement])
-      .contact_type(args[:contact_type])
+      .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
   end
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe CaseContactReport, type: :model do
         contact = create(:case_contact, {occurred_at: 20.days.ago, creator_id: volunteer.id, contact_types: [court]})
         create(:case_contact, {occurred_at: 100.days.ago, creator_id: volunteer2.id, contact_types: [school]})
         create(:case_contact, {occurred_at: 100.days.ago})
-        report = CaseContactReport.new({contact_type: [court.id]})
+        report = CaseContactReport.new({contact_type_ids: [court.id]})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
         expect(contacts).to eq([contact])
@@ -335,15 +335,15 @@ RSpec.describe CaseContactReport, type: :model do
         contact6 = create(:case_contact, occurred_at: 20.days.ago, casa_case: transitioned_casa_case, contact_types: [therapist])
 
         aggregate_failures do
-          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [court.id]})
+          report_1 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type_ids: [court.id]})
           expect(report_1.case_contacts.length).to eq(2)
           expect((report_1.case_contacts - [contact1, contact5]).empty?).to eq(true)
 
-          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [school.id]})
+          report_2 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type_ids: [school.id]})
           expect(report_2.case_contacts.length).to eq(2)
           expect((report_2.case_contacts - [contact4, contact5]).empty?).to eq(true)
 
-          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type: [therapist.id]})
+          report_3 = CaseContactReport.new({start_date: 30.days.ago, end_date: 10.days.ago, has_transitioned: true, contact_type_ids: [therapist.id]})
           expect(report_3.case_contacts.length).to eq(1)
           expect(report_3.case_contacts.include?(contact6)).to eq(true)
         end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1555

### What changed, and why?
We were using `contact_type` inside of the `CaseContactReport` class but we
actually pass in `contact_type_ids` from the controller.

### How is this tested? (please write tests!) 💖💪
I only updated the tests which doesn't really gaurd against this happening in
the future. I'm wondering if we should have 1 system test that uses all these
attributes to generate a CSV and compare it to what we think it should be. I
don't have time right now but would be happy to look in to it.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`