### PR TITLE
Add seeding for hearing types

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -45,6 +45,7 @@ class DbPopulator
 
     create_users(casa_org, options, prefix)
     create_cases(casa_org, options, prefix)
+    create_hearing_types(casa_org)
     casa_org
   end
 
@@ -147,6 +148,34 @@ class DbPopulator
       random_case_contact_count.times do
         create_case_contact(new_casa_case, prefix)
       end
+    end
+  end
+
+  def create_hearing_types(casa_org)
+    active_hearing_type_names = [
+      "emergency hearing",
+      "trial on the merits",
+      "scheduling conference",
+      "uncontested hearing",
+      "pendente lite hearing",
+      "pretrial conference",
+    ]
+    inactive_hearing_type_names = [
+      "deprecated hearing",
+    ]
+    active_hearing_type_names.each do | hearing_type_name |
+      HearingType.create!(
+        casa_org_id: casa_org.id,
+        name: hearing_type_name,
+        active: true
+      )
+    end
+    inactive_hearing_type_names.each do | hearing_type_name |
+      HearingType.create!(
+        casa_org_id: casa_org.id,
+        name: hearing_type_name,
+        active: false
+      )
     end
   end
 end

--- a/spec/seeds/seeds_spec.rb
+++ b/spec/seeds/seeds_spec.rb
@@ -14,6 +14,7 @@ def empty_ar_classes
     Supervisor,
     SupervisorVolunteer,
     User,
+    HearingType,
     Volunteer
   ]
   ar_classes.select { |klass| klass.count == 0 }.map(&:name)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1048

### What changed, and why?
`rails db:seed` now creates hearing types for each organization. For each organization it will create the following active hearing types (per [this discussion](https://github.com/rubyforgood/casa/issues/928#issuecomment-703988917))

- emergency hearing
- trial on the merits
- scheduling conference
- uncontested hearing
- pendente lite hearing
- pretrial conference

Along with an inactive hearing type titled "deprecated hearing".

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Ran `rails db:seed` and checked that seeds were created. Added HearingType to list of models tests expect to be seeded.
