### PR TITLE
join tables require unique two-id row combinations

### DIFF
--- a/app/models/casa_case_contact_type.rb
+++ b/app/models/casa_case_contact_type.rb
@@ -2,6 +2,8 @@ class CasaCaseContactType < ApplicationRecord
   has_paper_trail
   belongs_to :casa_case
   belongs_to :contact_type
+
+  validates :casa_case_id, uniqueness: {scope: :contact_type_id}
 end
 
 # == Schema Information

--- a/app/models/casa_case_emancipation_category.rb
+++ b/app/models/casa_case_emancipation_category.rb
@@ -1,6 +1,8 @@
 class CasaCaseEmancipationCategory < ApplicationRecord
   belongs_to :casa_case
   belongs_to :emancipation_category
+
+  validates :casa_case_id, uniqueness: {scope: :emancipation_category_id}
 end
 
 # == Schema Information

--- a/app/models/casa_cases_emancipation_option.rb
+++ b/app/models/casa_cases_emancipation_option.rb
@@ -1,6 +1,8 @@
 class CasaCasesEmancipationOption < ApplicationRecord
   belongs_to :casa_case
   belongs_to :emancipation_option
+
+  validates :casa_case_id, uniqueness: {scope: :emancipation_option_id}
 end
 
 # == Schema Information

--- a/app/models/case_contact_contact_type.rb
+++ b/app/models/case_contact_contact_type.rb
@@ -2,6 +2,8 @@ class CaseContactContactType < ApplicationRecord
   has_paper_trail
   belongs_to :case_contact
   belongs_to :contact_type
+
+  validates :case_contact_id, uniqueness: {scope: :contact_type_id}
 end
 
 # == Schema Information

--- a/spec/models/casa_case_contact_type_spec.rb
+++ b/spec/models/casa_case_contact_type_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe CasaCaseContactType, type: :model do
+  it "does not allow adding the same contact type twice to a case" do
+    expect {
+      casa_case = create(:casa_case)
+      contact_type = create(:contact_type)
+
+      casa_case.contact_types << contact_type
+      casa_case.contact_types << contact_type
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/models/casa_case_emancipation_category_spec.rb
+++ b/spec/models/casa_case_emancipation_category_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe CasaCaseEmancipationCategory, type: :model do
   it { is_expected.to belong_to(:casa_case) }
   it { is_expected.to belong_to(:emancipation_category) }
 
+  it "does not allow adding the same category twice to a case" do
+    expect {
+      casa_case = create(:casa_case)
+      emancipation_category = create(:emancipation_category)
+
+      casa_case.emancipation_categories << emancipation_category
+      casa_case.emancipation_categories << emancipation_category
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "has a valid factory" do
     case_category_association = build(:casa_case_emancipation_category)
     expect(case_category_association.valid?).to be true

--- a/spec/models/casa_cases_emancipation_option_spec.rb
+++ b/spec/models/casa_cases_emancipation_option_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe CasaCasesEmancipationOption, type: :model do
   it { is_expected.to belong_to(:casa_case) }
   it { is_expected.to belong_to(:emancipation_option) }
 
+  it "does not allow adding the same category twice to a case" do
+    expect {
+      casa_case = create(:casa_case)
+      emancipation_option = create(:emancipation_option)
+
+      casa_case.emancipation_options << emancipation_option
+      casa_case.emancipation_options << emancipation_option
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "has a valid factory" do
     case_option_association = build(:casa_cases_emancipation_option)
     expect(case_option_association.valid?).to be true

--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe CaseAssignment do
     expect(casa_case_2.reload.volunteers).to eq([volunteer_1])
   end
 
+  it "does not allow a volunteer to be double assigned" do
+    expect {
+      volunteer_1.casa_cases << casa_case_1
+      volunteer_1.casa_cases << casa_case_1
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "requires case and volunteer belong to the same organization" do
     case_assignment = casa_case_1.case_assignments.new(volunteer: volunteer_1)
     expect { volunteer_1.update(casa_org: casa_org_2) }.to change(case_assignment, :valid?).to false

--- a/spec/models/case_contact_contact_type_spec.rb
+++ b/spec/models/case_contact_contact_type_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe CaseContactContactType, type: :model do
+  it "does not allow adding the same contact type twice to a case contact" do
+    expect {
+      case_contact = create(:case_contact)
+      contact_type = create(:contact_type)
+
+      case_contact.contact_types << contact_type
+      case_contact.contact_types << contact_type
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/models/supervisor_volunteer_spec.rb
+++ b/spec/models/supervisor_volunteer_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe SupervisorVolunteer do
     expect { supervisor_2.volunteers << volunteer_1 }.to raise_error(StandardError)
   end
 
+  it "does not allow a volunteer to be double assigned" do
+    expect {
+      supervisor_1.volunteers << volunteer_1
+      supervisor_1.volunteers << volunteer_1
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it "requires supervisor and volunteer belong to same casa_org" do
     supervisor_volunteer = supervisor_1.supervisor_volunteers.new(volunteer: volunteer_1)
     expect { volunteer_1.update(casa_org: casa_org_2) }.to change(supervisor_volunteer, :valid?).to(false)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1564

### What changed, and why?
Added a unique constraint to some join tables because it didn't make sense  
 - to add the same contact type to a casa case twice and vice versa
 - to add the same emancipation option to a casa case twice and vice versa
 - to add the same emancipation category to a casa case twice and vice versa
 - to add the same case contact to a contact type twice and vice versa

### Testing
There are 2 existing constraints that are not tested in `supervisor_volunteer` and `case_assignment` so I did not add any tests. Let me know if tests are preferred. 