### PR TITLE
Adds system test for CaseContact Report download

### DIFF
--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:case_number) { |n| "CINA-#{n}" }
     transition_aged_youth { false }
     birth_month_year_youth { 16.years.ago }
-    casa_org
+    casa_org { CasaOrg.first || create(:casa_org) }
     hearing_type
     judge
     court_report_status { :not_submitted }

--- a/spec/factories/contact_type_group.rb
+++ b/spec/factories/contact_type_group.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :contact_type_group do
-    association :casa_org
+    casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:name) { |n| "Group #{n}" }
   end
 end

--- a/spec/policies/casa_case_policy/scope_spec.rb
+++ b/spec/policies/casa_case_policy/scope_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe CasaCasePolicy::Scope do
     it "returns all CasaCases when user is admin" do
       user = create(:casa_admin, casa_org: organization)
       all_casa_cases = create_list(:casa_case, 2, casa_org: organization)
-      create_list(:casa_case, 2)
+      new_org = create(:casa_org)
+      create_list(:casa_case, 2, casa_org: new_org)
 
       scope = described_class.new(user, organization.casa_cases)
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -20,11 +20,16 @@ Capybara.register_driver :selenium_chrome_headless_in_container do |app|
 end
 
 Capybara.register_driver :selenium_chrome_headless do |app|
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    options: Selenium::WebDriver::Chrome::Options.new(
-      args: %w[--headless --disable-gpu --disable-site-isolation-trials --window-size=1280,900]
-    )
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << "--headless"
+    opts.args << "--disable-gpu"
+    opts.args << "--disable-site-isolation-trials"
+    opts.args << "--window-size=1280,900"
+  end
+  browser_options.add_preference(:download, prompt_for_download: false, default_directory: DownloadHelpers::PATH.to_s)
+
+  browser_options.add_preference(:browser, set_download_behavior: {behavior: "allow"})
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
 RSpec.configure do |config|
@@ -33,6 +38,8 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
+    config.include DownloadHelpers
+    clear_downloads
     if ENV["DOCKER"]
       driven_by :selenium_chrome_headless_in_container
       Capybara.server_host = "0.0.0.0"

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -1,0 +1,35 @@
+module DownloadHelpers
+  TIMEOUT = 10
+  PATH = Rails.root.join("tmp/downloads")
+
+  def downloads
+    Dir[PATH.join("*")]
+  end
+
+  def download
+    downloads.first
+  end
+
+  def download_content
+    wait_for_download
+    File.read(download)
+  end
+
+  def wait_for_download
+    Timeout.timeout(TIMEOUT) do
+      sleep 0.1 until downloaded?
+    end
+  end
+
+  def downloaded?
+    !downloading? && downloads.any?
+  end
+
+  def downloading?
+    downloads.grep(/\.crdownload$/).any?
+  end
+
+  def clear_downloads
+    FileUtils.rm_f(downloads)
+  end
+end

--- a/spec/system/reports/case_contact_reports_spec.rb
+++ b/spec/system/reports/case_contact_reports_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "case_contact_reports/index", type: :system do
+  let(:admin) { create(:casa_admin) }
+
+  it "filters report by date and selected contact type", js: true do
+    sign_in admin
+
+    contact_type_group = create(:contact_type_group)
+    court = create(:contact_type, name: "Court", contact_type_group: contact_type_group)
+    school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+
+    contact1 = create(:case_contact, occurred_at: 20.days.ago, contact_types: [court], notes: "Case Contact 1")
+    contact2 = create(:case_contact, occurred_at: 20.days.ago, contact_types: [court], notes: "Case Contact 2")
+    contact3 = create(:case_contact, occurred_at: 20.days.ago, contact_types: [court, school], notes: "Case Contact 3")
+
+    excluded_by_date = create(:case_contact, occurred_at: 40.days.ago, contact_types: [court], notes: "Excluded by date")
+    excluded_by_contact_type = create(:case_contact, occurred_at: 20.days.ago, contact_types: [school], notes: "Excluded by Contact Type")
+
+    visit reports_path
+    fill_in "report_start_date", with: 30.days.ago.to_date.strftime("%m/%d/%Y")
+    fill_in "report_end_date", with: 10.days.ago.to_date.strftime("%m/%d/%Y")
+    select court.name, from: "report_contact_type_ids"
+    click_button "Download Report"
+    wait_for_download
+
+    expect(download_content).to include(contact1.notes)
+    expect(download_content).to include(contact2.notes)
+    expect(download_content).to include(contact3.notes)
+
+    expect(download_content).not_to include(excluded_by_date.notes)
+    expect(download_content).not_to include(excluded_by_contact_type.notes)
+  end
+end

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe "casa_cases/index", type: :system do
 
     it "Only displays cases belonging to user's org" do
       org_cases = create_list :casa_case, 3, active: true, casa_org: organization
-      other_org_cases = create_list :casa_case, 3, active: true
+      new_org = create :casa_org
+      other_org_cases = create_list :casa_case, 3, active: true, casa_org: new_org
 
       visit casa_cases_path
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1565

### What changed, and why?
Adds system test for downloading the CaseContact Report. I only added one test
for now but it will give us a starting point to add others in the future.
I also changed the `CasaCase` and `ContactTypeGroup` factories to use the first
`casa_org` if it's available, or create a new one if it's not. This led to
needing to change a couple of tests.