### PR TITLE
Better UX for Generate Reports multi selects

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import "shared/form";
 @import "shared/layout";
 @import "shared/navbar";
+@import "shared/select2";
 @import "shared/sidebar";
 @import "shared/typography";
 @import "shared/utilities";

--- a/app/javascript/src/stylesheets/shared/select2.scss
+++ b/app/javascript/src/stylesheets/shared/select2.scss
@@ -1,0 +1,5 @@
+.select2 {
+  input {
+    min-width: 250px;
+  }
+}

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -28,8 +28,8 @@
                   :supervisor_ids,
                   Supervisor.where(casa_org: current_user.casa_org),
                   :id, :display_name,
-                  {include_hidden: false, prompt: "-Select Supervisors-"},
-                  {class: "form-control", multiple: true}
+                  {include_hidden: false},
+                  {class: "form-control select2", data: {placeholder: "-Select Supervisors-"}, multiple: true}
               ) %>
         </div>
 
@@ -40,8 +40,8 @@
                   Volunteer.where(casa_org: current_user.casa_org),
                   :id,
                   :display_name,
-                  {include_hidden: false, prompt: "-Select Volunteers-"},
-                  {class: "form-control", multiple: true}
+                  {include_hidden: false},
+                  {class: "form-control select2", data: {placeholder: "-Select Volunteers-"}, multiple: true}
               ) %>
         </div>
 
@@ -52,8 +52,8 @@
                   ContactType.for_organization(current_user.casa_org),
                   :id,
                   :name,
-                  {include_hidden: false, prompt: "-Select Contact Types-"},
-                  {class: "form-control", multiple: true}
+                  {include_hidden: false},
+                  {class: "form-control select2", data: {placeholder: "-Select Contact Types-"}, multiple: true}
               ) %>
         </div>
 
@@ -64,8 +64,8 @@
                   ContactTypeGroup.for_organization(current_user.casa_org),
                   :id,
                   :name,
-                  {include_hidden: false, prompt: "-Select Contact Type Groups-"},
-                  {class: "form-control", multiple: true}
+                  {include_hidden: false},
+                  {class: "form-control select2", data: {placeholder: "-Select Contact Type Groups-"}, multiple: true}
               ) %>
         </div>
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
I couldn't find an issue for this.

### What changed, and why?
While I was fixing the report bugs I noticed it was a bit difficult to find and
select what I was looking for. This adds the `select2` class to the 4
multi-selects on this page. We're already using `select2` in some other forms.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
There is already tests for this selects so adding more seemed like overkill.


### Screenshots please :)
Before:
![image](https://user-images.githubusercontent.com/113754/104092536-2fec3980-524a-11eb-8b99-2af520d59378.png)

After:
![image](https://user-images.githubusercontent.com/113754/104092540-38447480-524a-11eb-9da9-44a0ee97e9b0.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`