### PR TITLE
Followup icons distinguishable by user role

### DIFF
--- a/app/helpers/followup_helper.rb
+++ b/app/helpers/followup_helper.rb
@@ -1,0 +1,6 @@
+module FollowupHelper
+  def followup_icon(creator)
+    return "fa-exclamation-circle text-warning" if creator.volunteer?
+    "fa-exclamation-triangle text-danger"
+  end
+end

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -30,24 +30,17 @@
           </div>
         </div>
       </div>
-      <div class="d-flex align-items-baseline flex-column flex-md-row-reverse">
+      <div class="row">
         <% if Pundit.policy(current_user, contact).update? %>
           <% if contact.created_in_current_quarter? %>
-            <%= link_to edit_case_contact_path(contact), class: 'btn btn-outline-primary' do %>
-              <strong>Edit</strong>
-            <% end %>
-            <% if contact.followup %>
-              <% if contact.followup.requested? %>
-                <%= button_to followups_path(contact_id: contact.id), class: "btn btn-success" do %>
-                  Resolve
-                <% end %>
-                <i class="fas fa-exclamation-triangle text-danger fa-lg"></i>
+
+            <%= render "case_contacts/followup", contact: contact, followup: contact.followup %>
+
+            <div class="col-sm-5">
+              <%= link_to edit_case_contact_path(contact), class: 'btn btn-outline-primary' do %>
+                <strong>Edit</strong>
               <% end %>
-            <% else %>
-              <%= link_to followups_path(contact_id: contact.id), method: "post", class: "btn btn-danger" do %>
-                Follow up
-              <% end %>
-            <% end %>
+            </div>
           <% else %>
             <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="This case contact was created in a previous quarter and is therefore no longer editable"></i>
           <% end %>

--- a/app/views/case_contacts/_followup.html.erb
+++ b/app/views/case_contacts/_followup.html.erb
@@ -1,0 +1,14 @@
+<% if followup %>
+  <% if followup.requested? %>
+    <div class="col-sm-2 pt-2">
+      <i class="fas fa-lg <%= followup_icon(followup.creator) %>"></i>
+    </div>
+    <div class="col-sm-5">
+      <%= button_to followups_path(contact_id: contact.id), class: "btn btn-success" do %>
+        Resolve
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <%= link_to 'Follow up', followups_path(contact_id: contact.id), method: "post", class: "btn btn-danger" %>
+<% end %>

--- a/spec/helpers/followup_helper_spec.rb
+++ b/spec/helpers/followup_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe FollowupHelper do
+  describe "#followup_icon" do
+    context "volunteer created followup" do
+      it "is orange circle with an exclamation point" do
+        creator = build_stubbed(:volunteer)
+        expect(helper.followup_icon(creator)).to include("exclamation-circle")
+      end
+    end
+
+    context "admin created followup" do
+      it "is orange circle with an exclamation point" do
+        creator = build_stubbed(:casa_admin)
+        expect(helper.followup_icon(creator)).to include("exclamation-triangle")
+      end
+    end
+  end
+end

--- a/spec/views/case_contacts/_followup.html.erb_spec.rb
+++ b/spec/views/case_contacts/_followup.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "case_contacts/_followup" do
+  let(:user) { build_stubbed(:casa_admin) }
+
+  describe "follow up icon" do
+    let(:case_contact) { build_stubbed(:case_contact) }
+
+    context "created by volunteer" do
+      it "should show orange circle with an exclamation point" do
+        volunteer = build_stubbed(:volunteer)
+        followup = build_stubbed(:followup, case_contact: case_contact, creator: volunteer)
+
+        render(partial: "case_contacts/followup", locals: {contact: case_contact, followup: followup})
+
+        expect(rendered).to include("fa-exclamation-circle text-warning")
+      end
+    end
+
+    context "created by admin" do
+      it "should show orange circle with an exclamation point" do
+        followup = build_stubbed(:followup, case_contact: case_contact, creator: user)
+
+        render(partial: "case_contacts/followup", locals: {contact: case_contact, followup: followup})
+
+        expect(rendered).to include("fa-exclamation-triangle text-danger")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1497

### What changed, and why?
Followups created by Volunteers will now dispaly with an orange circle with an
exclamation point in the middle. All other followups will dispaly with a red
triangle with an exclamation point.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added tests for the helper method and a view spec to verify the correct icon is
showing.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/113754/104107896-b96d2d00-5285-11eb-917b-03d1b40e5d47.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`