### PR TITLE
Update language for weekly digest when no case contacts have been logged

### DIFF
--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -40,7 +40,7 @@
             <br>
             <%= " - Notes: #{recent_contact&.notes}" %>
           <% else %>
-            No contact attempts for this week.
+            No contact attempts were logged for this week.
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
Small update to the language of the supervisor weekly digest email as discussed at the casa meeting.  Just want to be clear that nothing was logged, we're not sure if contacts were made but not logged.

@Zrrrpy for added info, I looked it up and in the email we show any contacts that have an `occured_at` this week.  So if they logged it this week for a contact they made last week it won't show up.  If we want to we could show anything that was created this week OR we could show anything created/updated this week regardless of when the contact was made.  Thanks for getting clarification from the pg casa folks.