### PR TITLE
add sorting to supervisors dashboard

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -9,6 +9,17 @@ var defineCaseContactsTable = function () {
   )
 }
 
+var defineSupervisorsDataTable = function () {
+  $('table#supervisors').DataTable(
+    {
+      autoWidth: false,
+      scrollX: true,
+      searching: false,
+      order: [[0, 'desc']]
+    }
+  )
+}
+
 $('document').ready(() => {
   $.fn.dataTable.ext.search.push(
     function (settings, data, dataIndex) {
@@ -239,6 +250,8 @@ $('document').ready(() => {
 
   defineCaseContactsTable()
 
+  defineSupervisorsDataTable()
+
   function filterOutUnassignedVolunteers (checked) {
     $('.supervisor-options').find('input[type="checkbox"]').not('#unassigned-vol-filter').each(function () {
       this.checked = checked
@@ -274,4 +287,4 @@ $('document').ready(() => {
   })
 })
 
-export { defineCaseContactsTable }
+export { defineCaseContactsTable, defineSupervisorsDataTable }

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -9,7 +9,7 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered" id="supervisors">
+    <table class="table table-striped table-bordered supervisors-list" id="supervisors">
       <thead>
       <tr>
         <th>Supervisor Name</th>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #001

### What changed, and why?
Uses the DataTable function in dashboard.js to make the table used for displaying the supervisors index sortable. See #1573 for motivation.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: No change

### How is this tested? (please write tests!) 💖💪
Manually tested that sorting is applied to the table, and DataTable itself already has unit tests.

### Screenshots please :)
![Capture](https://user-images.githubusercontent.com/23124989/104516945-d0c85500-55ba-11eb-949f-ac6890ad862f.PNG)
