### PR TITLE
fix up supervisors view

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -12,8 +12,10 @@ var defineCaseContactsTable = function () {
 var defineSupervisorsDataTable = function () {
   $('table#supervisors').DataTable(
     {
+      columnDefs: [
+        { orderable: false, targets: 4 },
+      ],
       autoWidth: false,
-      scrollX: true,
       searching: false,
       order: [[0, 'desc']]
     }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1600 #1599

### What changed, and why?
Tune the parameters to DataTable call used to add sorting to the supervisors view so that the horizontal scrolling is disabled and you can't sort by the actions column anymore.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: None changed.

### How is this tested? (please write tests!) 💖💪
I just changed stuff and checked that it looked ok. Not sure how you'd unit test it though.

### Screenshots please :)
![Capture](https://user-images.githubusercontent.com/23124989/105113107-eb527080-5a89-11eb-9789-b92fe915664d.PNG)

