### PR TITLE
Adds Notification for volunteer on followups

### DIFF
--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -6,6 +6,9 @@ class CaseContacts::FollowupsController < ApplicationController
     case_contact = CaseContact.find(params[:case_contact_id])
 
     case_contact.followups.create(creator: current_user, status: :requested)
+    FollowupNotification
+      .with(followup: case_contact.requested_followup, created_by_name: current_user.display_name)
+      .deliver(case_contact.casa_case.assigned_volunteers)
 
     redirect_to casa_case_path(case_contact.casa_case)
   end

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -1,0 +1,27 @@
+# To deliver this notification:
+#
+# FollowupNotification.with(followup: @followup).deliver_later(current_user)
+# FollowupNotification.with(followup: @followup).deliver(current_user)
+
+class FollowupNotification < Noticed::Base
+  # Add your delivery methods
+  #
+  deliver_by :database
+  # deliver_by :email, mailer: "UserMailer"
+  # deliver_by :slack
+  # deliver_by :custom, class: "MyDeliveryMethod"
+
+  # Add required params
+  #
+  param :followup, :created_by_name
+
+  # Define helper methods to make rendering easier.
+  #
+  def message
+    t(".message", created_by_name: params[:created_by_name])
+  end
+
+  def url
+    edit_case_contact_path(params[:followup][:case_contact_id], notification_id: record.id)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,3 +65,5 @@ en:
   notifications:
     followup_resolved_notification:
       message: "%{created_by_name} resolved a follow up. Click to see more."
+    followup_notification:
+      message: "%{created_by_name} has flagged a Case Contact that needs follow up. Click to see more."

--- a/spec/requests/followups_spec.rb
+++ b/spec/requests/followups_spec.rb
@@ -87,5 +87,24 @@ RSpec.describe "/followups", type: :request do
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "notifications" do
+      context "supervisor/admin creates followup" do
+        let(:volunteer_2) { create(:volunteer) }
+        let(:unassigned_volunteer) { create(:volunteer) }
+
+        it "should create a notification for all assigned volunteers" do
+          casa_case = contact.casa_case
+          casa_case.assigned_volunteers = [volunteer, volunteer_2]
+          sign_in admin
+
+          post case_contact_followups_path(contact)
+
+          expect(volunteer.notifications.count).to eq(1)
+          expect(volunteer_2.notifications.count).to eq(1)
+          expect(unassigned_volunteer.notifications.count).to eq(0)
+        end
+      end
+    end
   end
 end

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -4,19 +4,37 @@ RSpec.describe "notifications/index", type: :system do
   let(:admin) { create(:casa_admin) }
   let(:volunteer) { create(:volunteer) }
   let(:case_contact) { create(:case_contact, creator: volunteer) }
-  let!(:followup) { create(:followup, creator: admin, case_contact: case_contact) }
 
-  it "lists my notifcations" do
-    casa_case = case_contact.casa_case
-    casa_case.assigned_volunteers << volunteer
-    sign_in volunteer
-    visit case_contacts_path
-    click_button "Resolve"
+  context "FollowupResolvedNotification" do
+    let!(:followup) { create(:followup, creator: admin, case_contact: case_contact) }
+    it "lists my notifcations" do
+      casa_case = case_contact.casa_case
+      casa_case.assigned_volunteers << volunteer
+      sign_in volunteer
+      visit case_contacts_path
+      click_button "Resolve"
 
-    sign_in admin
-    visit notifications_path
+      sign_in admin
+      visit notifications_path
 
-    notification_message = "#{volunteer.display_name} resolved a follow up. Click to see more."
-    expect(page).to have_text(notification_message)
+      notification_message = "#{volunteer.display_name} resolved a follow up. Click to see more."
+      expect(page).to have_text(notification_message)
+    end
+  end
+
+  context "FollowupNotification" do
+    it "lists my notifcations" do
+      casa_case = case_contact.casa_case
+      casa_case.assigned_volunteers << volunteer
+      sign_in admin
+      visit casa_case_path(casa_case)
+      click_button "Follow up"
+
+      sign_in volunteer
+      visit notifications_path
+
+      notification_message = "#{admin.display_name} has flagged a Case Contact that needs follow up. Click to see more."
+      expect(page).to have_text(notification_message)
+    end
   end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -147,4 +147,27 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
     end
   end
+
+  context "notifications" do
+    let(:user) { build_stubbed :volunteer }
+
+    it "displays badge when user has notifications" do
+      sign_in user
+      build_stubbed(:notification)
+      allow(user).to receive_message_chain(:notifications, :unread).and_return([:notification])
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to have_css("span.badge")
+    end
+
+    it "displays no badge when user has no unread notifications" do
+      sign_in user
+      allow(user).to receive_message_chain(:notifications, :unread).and_return([])
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).not_to have_css("span.badge")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1508

### What changed, and why?
When an admin/supervisor creates a followup, all volunteers assigned to the case
contact will now receive a notification. A badge will show up next to the Inbox
link if there are unread notifications. Clicking a notification, marks it as
read and takes the user to the edit page for the case contact.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Yes!


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`