### PR TITLE
Fixes notification title when it's a new followup

### DIFF
--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -17,6 +17,10 @@ class FollowupNotification < Noticed::Base
 
   # Define helper methods to make rendering easier.
   #
+  def title
+    t(".title")
+  end
+
   def message
     t(".message", created_by_name: params[:created_by_name])
   end

--- a/app/notifications/followup_resolved_notification.rb
+++ b/app/notifications/followup_resolved_notification.rb
@@ -17,6 +17,10 @@ class FollowupResolvedNotification < Noticed::Base
 
   # Define helper methods to make rendering easier.
   #
+  def title
+    t(".title")
+  end
+
   def message
     t(".message", created_by_name: params[:created_by_name])
   end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -14,7 +14,7 @@
         <div class="d-flex-shrink-0"><%= notification_icon(notification) %></div>
         <div class="ml-2 flex-grow-1">
           <div class="d-flex justify-content-between">
-            <h5 class="mb-1">Followup resolved</h5>
+            <h5 class="mb-1"><%= notification.to_notification.title %></h5>
             <small><%= time_ago_in_words(notification.updated_at) %> ago</small>
           </div>
           <p class="mb-1"><%= notification.to_notification.message %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,8 @@ en:
       short_date: "%-m/%d"
   notifications:
     followup_resolved_notification:
+      title: "Followup resolved"
       message: "%{created_by_name} resolved a follow up. Click to see more."
     followup_notification:
+      title: "New followup"
       message: "%{created_by_name} has flagged a Case Contact that needs follow up. Click to see more."

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "notifications/index", type: :system do
 
       notification_message = "#{volunteer.display_name} resolved a follow up. Click to see more."
       expect(page).to have_text(notification_message)
+      expect(page).to have_text("Followup resolved")
     end
   end
 
@@ -35,6 +36,7 @@ RSpec.describe "notifications/index", type: :system do
 
       notification_message = "#{admin.display_name} has flagged a Case Contact that needs follow up. Click to see more."
       expect(page).to have_text(notification_message)
+      expect(page).to have_text("New followup")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1618

### What changed, and why?
All notifications were showing "Followup resolved". I added a helper method for
`title` in each notification class and set the title locale appropriately.

### How is this tested? (please write tests!) 💖💪
Added check to make sure the title is correct for both notifications.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/113754/105922189-c61caf80-5fff-11eb-8690-3358e6acbc83.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`