### PR TITLE
[#1623] Sort Supervisor fields as numbers

### DIFF
--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -23,24 +23,24 @@ function notify (message, level) {
           Error: ${message}
           <button class="btn btn-danger btn-sm">×</button>
         </div>`)
-      .find('.async-failure-indicator button').click(function () {
-        $(this).parent().remove()
-      })
-      break;
-   case 'info':
+        .find('.async-failure-indicator button').click(function () {
+          $(this).parent().remove()
+        })
+      break
+    case 'info':
       emancipationPage.notifications.append(`
         <div class="async-success-indicator">
           ${message}
           <button class="btn btn-success btn-sm">×</button>
         </div>`)
-      .find('.async-success-indicator button').click(function () {
-        $(this).parent().remove()
-      })
+        .find('.async-success-indicator button').click(function () {
+          $(this).parent().remove()
+        })
 
-      break;
-  default:
+      break
+    default:
       throw new RangeError('Unsupported option for param level')
-      break;
+      break
   }
 }
 
@@ -122,20 +122,20 @@ function saveCheckState (action, checkItemId) {
     check_item_action: action,
     check_item_id: checkItemId
   })
-  .then(function (response, textStatus, jqXHR) {
-    if (response.error) {
-      return $.Deferred().reject(jqXHR, textStatus, response.error);
-    } else if (response === 'success') {
-      resolveAsyncOperation()
-    } else {
-      resolveAsyncOperation('Unknown response')
-    }
+    .then(function (response, textStatus, jqXHR) {
+      if (response.error) {
+        return $.Deferred().reject(jqXHR, textStatus, response.error)
+      } else if (response === 'success') {
+        resolveAsyncOperation()
+      } else {
+        resolveAsyncOperation('Unknown response')
+      }
 
-    return response
-  })
-  .fail(function (jqXHR, textStatus, error) {
-    resolveAsyncOperation(error)
-  })
+      return response
+    })
+    .fail(function (jqXHR, textStatus, error) {
+      resolveAsyncOperation(error)
+    })
 }
 
 $('document').ready(() => {
@@ -150,27 +150,27 @@ $('document').ready(() => {
     categoryCheckboxChecked = categoryCheckbox.is(':checked')
     categoryOptionsContainer = category.siblings('.category-options')
 
-    if (!category.data("disabled")) {
-      category.data("disabled", true)
-      category.addClass("disabled")
-      categoryCheckbox.prop("disabled", "disabled")
+    if (!category.data('disabled')) {
+      category.data('disabled', true)
+      category.addClass('disabled')
+      categoryCheckbox.prop('disabled', 'disabled')
 
       let saveAction,
-          collapseIcon,
-          doneCallback
+        collapseIcon,
+        doneCallback
 
       if (categoryCheckboxChecked) {
         // Uncheck all category options
         categoryOptionsContainer.children().filter(function () {
           return $(this).prop('checked')
-        }).each(function() {
-          let checkbox = $(this)
+        }).each(function () {
+          const checkbox = $(this)
 
           checkbox.prop('checked', false)
           saveCheckState('delete_option', checkbox.val())
-          .fail(function() {
-            checkbox.prop('checked', false)
-          })
+            .fail(function () {
+              checkbox.prop('checked', false)
+            })
           notify('Unchecked ' + checkbox.next().text(), 'info')
         })
 
@@ -188,16 +188,16 @@ $('document').ready(() => {
       }
 
       saveCheckState(saveAction, categoryCheckbox.val())
-      .done(function () {
-        doneCallback()
-        categoryCheckbox.prop('checked', !categoryCheckboxChecked)
-        categoryCollapseIcon.text(collapseIcon)
-      })
-      .always(function () {
-        category.data("disabled", false)
-        category.removeClass("disabled")
-        categoryCheckbox.prop("disabled", false)
-      })
+        .done(function () {
+          doneCallback()
+          categoryCheckbox.prop('checked', !categoryCheckboxChecked)
+          categoryCollapseIcon.text(collapseIcon)
+        })
+        .always(function () {
+          category.data('disabled', false)
+          category.removeClass('disabled')
+          categoryCheckbox.prop('disabled', false)
+        })
     }
   })
 
@@ -205,15 +205,15 @@ $('document').ready(() => {
     const thisRadioButton = $(this)
 
     saveCheckState('set_option', thisRadioButton.val())
-    .fail(function() {
-      thisRadioButton.prop('checked', false)
-    })
+      .fail(function () {
+        thisRadioButton.prop('checked', false)
+      })
   })
 
   $('.emancipation-option-check-box').change(function () {
     const thisCheckBox = $(this)
 
-    let originallyChecked = thisCheckBox.prop('checked')
+    const originallyChecked = thisCheckBox.prop('checked')
     let asyncCall
 
     if (originallyChecked) {
@@ -222,7 +222,7 @@ $('document').ready(() => {
       asyncCall = saveCheckState('delete_option', thisCheckBox.val())
     }
 
-    asyncCall.fail(function() {
+    asyncCall.fail(function () {
       thisCheckBox.prop('checked', originallyChecked)
     })
   })

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -13,7 +13,7 @@ var defineSupervisorsDataTable = function () {
   $('table#supervisors').DataTable(
     {
       columnDefs: [
-        { orderable: false, targets: 4 },
+        { orderable: false, targets: 4 }
       ],
       autoWidth: false,
       searching: false,

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,8 +8,7 @@
   <% @notifications.each do | notification | %>
     <a
       href="<%= notification.to_notification.url %>"
-      class="<%= notification_row_class(notification) %> list-group-item list-group-item-action flex-column align-items-start"
-      >
+      class="<%= notification_row_class(notification) %> list-group-item list-group-item-action flex-column align-items-start">
       <div class="d-flex flex-row">
         <div class="d-flex-shrink-0"><%= notification_icon(notification) %></div>
         <div class="ml-2 flex-grow-1">

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -27,18 +27,25 @@
             <span class="mobile-label">Supervisor Name</span>
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
-          <td id="volunteer-assignments-<%= supervisor.id %>">
+
+          <% total_volunteers = supervisor.volunteers.size %>
+          <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= total_volunteers %>">
             <span class="mobile-label">Volunteer Assignments</span>
-            <%= supervisor.volunteers.size %>
+            <%= total_volunteers %>
           </td>
-          <td id="serving-transition-aged-youth-<%= supervisor.id %>">
+
+          <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
+          <td id="serving-transition-aged-youth-<%= supervisor.id %>" data-order="<%= transition_volunteers %>">
             <span class="mobile-label">Serving Transition Aged Youth</span>
-            <%= supervisor.volunteers_serving_transition_aged_youth %>
+            <%= transition_volunteers %>
           </td>
-          <td id="no-contact-<%= supervisor.id %>">
+
+          <% no_contact_volunteers = supervisor.no_contact_for_two_weeks %>
+          <td id="no-contact-<%= supervisor.id %>" data-order="<%= no_contact_volunteers %>">
             <span class="mobile-label">No Contact (14 days)</span>
-            <%= supervisor.no_contact_for_two_weeks %>
+            <%= no_contact_volunteers %>
           </td>
+
           <td>
             <span class="mobile-label">Actions</span>
             <%= link_to 'Edit', edit_supervisor_path(supervisor) %>

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -33,4 +33,58 @@ RSpec.describe "supervisors/index", type: :system do
 
     expect(page).to have_text("Editing Supervisor")
   end
+
+  describe "can sort table columns" do
+    def verify_numeric_sort(column)
+      expect(page).to have_selector("tr:nth-child(1)", text: "11")
+
+      find("th", text: column).click
+
+      expect(page).to have_selector("th.sorting_asc", text: column)
+      expect(page).to have_selector("tr:nth-child(1)", text: "9")
+    end
+
+    let!(:first_supervisor) { create(:supervisor, display_name: "First Supervisor", casa_org: organization) }
+    let!(:last_supervisor) { create(:supervisor, display_name: "Last Supervisor", casa_org: organization) }
+
+    before(:each) do
+      # Stub our `@supervisors` collection so we've got control over column values for sorting.
+      allow_any_instance_of(SupervisorPolicy::Scope).to receive(:resolve).and_return(
+        [first_supervisor, last_supervisor]
+      )
+
+      allow(first_supervisor).to receive(:volunteers).and_return(Array.new(9))
+      allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
+      allow(first_supervisor).to receive(:no_contact_for_two_weeks).and_return(9)
+
+      allow(last_supervisor).to receive(:volunteers).and_return(Array.new(11))
+      allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
+      allow(last_supervisor).to receive(:no_contact_for_two_weeks).and_return(11)
+
+      sign_in user
+      visit supervisors_path
+    end
+
+    it "by supervisor name", js: true do
+      expect(page).to have_selector("th.sorting_desc", text: "Supervisor Name")
+      expect(page).to have_selector("tr:nth-child(1)", text: "Last Supervisor")
+
+      find("th", text: "Supervisor Name").click
+
+      expect(page).to have_selector("th.sorting_asc", text: "Supervisor Name")
+      expect(page).to have_selector("tr:nth-child(1)", text: "First Supervisor")
+    end
+
+    it "by volunteer count", js: true do
+      verify_numeric_sort("Volunteer Assignments")
+    end
+
+    it "by transition-aged youth", js: true do
+      verify_numeric_sort("Serving Transition Aged Youth")
+    end
+
+    it "by no-contact count", js: true do
+      verify_numeric_sort("No Contact (14 days)")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1623

### What changed, and why?
Recent changes (https://github.com/rubyforgood/casa/pull/1584) made the Supervisors dashboard columns sortable, but didn't account for different data types. No wories, DataTable includes a `num` type to fix that...right? 😬 

Unfortunately, because we also include hidden mobile labels in each cell, `num` sorting also fails. The solution is to add a `data-order` attribute to each table cell. This lets us specify exactly which value we want to order against, and DataTable does the rest. 😌 

> This change includes a [handful of autocorrections](https://github.com/rubyforgood/casa/commit/2eabd1f5f612a214a04c1dfd2f39fa1fd119cfd9) from the linters recommended in [CONTRIBUTING.md](https://github.com/rubyforgood/casa/blob/main/doc/CONTRIBUTING.md). I'm happy to roll this commit back if the updates are just too noisy! 🙈 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Because this feature requires JavaScript, new system tests are added to confirm sorting works for each column (including the originally-updated "Name").

### Screenshots please :)
_Before_
![image](https://user-images.githubusercontent.com/4934682/106347396-26278600-628c-11eb-90ef-37b0c4342992.png)

_After_
<img width="1164" alt="Screen Shot 2021-01-29 at 11 44 23 PM" src="https://user-images.githubusercontent.com/4934682/106347393-17d96a00-628c-11eb-909d-cd2c6ec34ffc.png">


### Feelings gif (optional)
:joy:
![Judge shouting "Order" in a courtroom](https://media.giphy.com/media/tJMVcTfzDdL1pOGxlk/giphy.gif)
