### PR TITLE
supervisor/admin can download already-generated court reports

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -23,6 +23,8 @@ class CasaCase < ApplicationRecord
   has_many :casa_cases_emancipation_options, dependent: :destroy
   has_many :emancipation_options, through: :casa_cases_emancipation_options
   has_many :past_court_dates, dependent: :destroy
+  has_one_attached :court_report
+
   validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true
   belongs_to :hearing_type, optional: true
   belongs_to :judge, optional: true

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -52,8 +52,12 @@
     </p>
 
     <% unless @casa_case.court_report_not_submitted? %>
+      <% if @casa_case.court_report_submitted? && @casa_case.court_report.attached? %>
+        <%= link_to 'Click to download', rails_blob_path(@casa_case.court_report, disposition: 'attachment') %>
+      <% end %>
       <p>
-      <h6><strong>Court Report Submitted Date:</strong> <%= @casa_case.decorate.court_report_submitted_date %></h6></p>
+        <h6><strong>Court Report Submitted Date:</strong> <%= @casa_case.decorate.court_report_submitted_date %></h6>
+      </p>
     <% end %>
 
     <div>

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "/case_court_reports", type: :request do
       let(:casa_case) { volunteer.casa_cases.first }
 
       before do
+        Tempfile.create do |t|
+          casa_case.court_report.attach(
+            io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
+          )
+        end
         get case_court_report_path(casa_case.case_number, format: "docx")
       end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves Part 1 of #1398

### What changed, and why?

* Introduces a [has_one_attached] :court_report to the `CasaCase` model which allows an attachment to be associated with a `casa_case` record.
* Currently a court report doc is generated on `Click to download` but does not get persisted anywhere. This PR updates `app/controllers/case_court_reports_controller.rb` so that the court report is generated and persisted on `Generate report` (which I think is what we'd expect).
* Allows the persisted court report to be downloaded from the `Casa Case Details` page ONLY when the `court_report_status` is `submitted`. 

[has_one_attached]: https://apidock.com/rails/ActiveStorage/Attached/Macros/has_one_attached

### How will this affect user permissions?
- Volunteer permissions: Allows volunteer to download most recently generated report.
- Supervisor permissions: Allows supervisor to download most recently generated report by volunteer.
- Admin permissions: Allows admin to download most recently generated report by volunteer.

### How is this tested? (please write tests!) 💖💪
- This is tested via unit tests in `spec/requests/case_court_reports_spec.rb` and integration tests in `spec/system/case_court_reports/index_spec.rb`. 

### Screenshots please :)
<img width="847" alt="Screen Shot 2021-01-29 at 8 40 50 PM" src="https://user-images.githubusercontent.com/16447748/106347298-506c4a00-6272-11eb-88b9-ff7537091fcc.png">



