### PR TITLE
Improve client side sync for emancipation checklist

### DIFF
--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -56,6 +56,7 @@ class EmancipationsController < ApplicationController
           render json: "success".to_json
         when "delete_category"
           current_case.remove_emancipation_category(params[:check_item_id])
+          current_case.emancipation_options.delete(EmancipationOption.category_options(params[:check_item_id]))
           render json: "success".to_json
         when "delete_option"
           current_case.remove_emancipation_option(params[:check_item_id])

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -159,11 +159,12 @@ $('document').ready(() => {
         doneCallback
 
       if (categoryCheckboxChecked) {
+          console.log(categoryOptionsContainer.children())
         // Uncheck all category options
         categoryOptionsContainer.children().filter(function () {
-          return $(this).prop('checked')
+          return $(this).find('input').prop('checked')
         }).each(function () {
-          const checkbox = $(this)
+          const checkbox = $(this).find('input')
 
           checkbox.prop('checked', false)
           notify('Unchecked ' + checkbox.next().text(), 'info')

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -167,10 +167,6 @@ $('document').ready(() => {
           const checkbox = $(this)
 
           checkbox.prop('checked', false)
-          saveCheckState('delete_option', checkbox.val())
-            .fail(function () {
-              checkbox.prop('checked', false)
-            })
           notify('Unchecked ' + checkbox.next().text(), 'info')
         })
 
@@ -203,41 +199,60 @@ $('document').ready(() => {
 
   $('.check-item').click(function() {
     const checkComponent = $(this)
+    const checkElement = checkComponent.find('input')
 
-    if (!checkComponent.data("disabled")) {
-      const checkElement = $(this).find('input')
+    if (checkComponent.data("disabled")) {
+      return
+    }
 
-      if (!(checkElement.attr('type') === 'radio' && checkElement.prop('checked'))) {
-        checkComponent.data("disabled", true)
-        checkComponent.addClass("disabled")
-        checkElement.prop("disabled", "disabled")
-
-        if (checkElement.attr('type') === 'radio') {
-          saveCheckState('set_option', checkElement.val())
-          .done(function() {
-            checkComponent.data("disabled", false)
-            checkComponent.removeClass("disabled")
-            checkElement.prop('checked', true)
-            checkElement.prop("disabled", false)
-          })
-        } else {// Expecting type=checkbox
-          let originallyChecked = checkElement.prop('checked')
-          let asyncCall
-
-          if (!originallyChecked) {
-            asyncCall = saveCheckState('add_option', checkElement.val())
-          } else {
-            asyncCall = saveCheckState('delete_option', checkElement.val())
-          }
-
-          asyncCall.done(function() {
-            checkComponent.data("disabled", false)
-            checkComponent.removeClass("disabled")
-            checkElement.prop('checked', !originallyChecked)
-            checkElement.prop("disabled", false)
-          })
-        }
+    if (checkElement.attr('type') === 'radio') {
+      if (checkElement.prop('checked')) {
+        return
       }
+
+      const radioButtons = checkComponent.parent().children()
+
+      radioButtons.each(function () {
+        const radioComponent = $(this)
+        const radioInput = radioComponent.find('input')
+
+        radioComponent.data("disabled", true)
+        radioComponent.addClass("disabled")
+        radioInput.prop("disabled", "disabled")
+      })
+
+      saveCheckState('set_option', checkElement.val())
+      .done(function() {
+        checkElement.prop('checked', true)
+        radioButtons.each(function () {
+          const radioComponent = $(this)
+          const radioInput = radioComponent.find('input')
+
+          radioComponent.data("disabled", false)
+          radioComponent.removeClass("disabled")
+          radioInput.prop("disabled", false)
+        })
+      })
+    } else {// Expecting type=checkbox
+      checkComponent.data("disabled", true)
+      checkComponent.addClass("disabled")
+      checkElement.prop("disabled", "disabled")
+
+      let originallyChecked = checkElement.prop('checked')
+      let asyncCall
+
+      if (!originallyChecked) {
+        asyncCall = saveCheckState('add_option', checkElement.val())
+      } else {
+        asyncCall = saveCheckState('delete_option', checkElement.val())
+      }
+
+      asyncCall.done(function() {
+        checkComponent.data("disabled", false)
+        checkComponent.removeClass("disabled")
+        checkElement.prop('checked', !originallyChecked)
+        checkElement.prop("disabled", false)
+      })
     }
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -40,7 +40,6 @@ function notify (message, level) {
       break
     default:
       throw new RangeError('Unsupported option for param level')
-      break
   }
 }
 
@@ -144,11 +143,11 @@ $('document').ready(() => {
   emancipationPage.asyncWaitIndicator = emancipationPage.notifications.find('#async-waiting-indicator')
 
   $('.emancipation-category').click(function () {
-    let category = $(this)
-    let categoryCheckbox = category.find('input[type="checkbox"]')
-    let categoryCollapseIcon = category.find('span')
-    let categoryCheckboxChecked = categoryCheckbox.is(':checked')
-    let categoryOptionsContainer = category.siblings('.category-options')
+    const category = $(this)
+    const categoryCheckbox = category.find('input[type="checkbox"]')
+    const categoryCollapseIcon = category.find('span')
+    const categoryCheckboxChecked = categoryCheckbox.is(':checked')
+    const categoryOptionsContainer = category.siblings('.category-options')
 
     if (!category.data('disabled')) {
       category.data('disabled', true)
@@ -197,11 +196,11 @@ $('document').ready(() => {
     }
   })
 
-  $('.check-item').click(function() {
+  $('.check-item').click(function () {
     const checkComponent = $(this)
     const checkElement = checkComponent.find('input')
 
-    if (checkComponent.data("disabled")) {
+    if (checkComponent.data('disabled')) {
       return
     }
 
@@ -216,29 +215,29 @@ $('document').ready(() => {
         const radioComponent = $(this)
         const radioInput = radioComponent.find('input')
 
-        radioComponent.data("disabled", true)
-        radioComponent.addClass("disabled")
-        radioInput.prop("disabled", "disabled")
+        radioComponent.data('disabled', true)
+        radioComponent.addClass('disabled')
+        radioInput.prop('disabled', 'disabled')
       })
 
       saveCheckState('set_option', checkElement.val())
-      .done(function() {
-        checkElement.prop('checked', true)
-        radioButtons.each(function () {
-          const radioComponent = $(this)
-          const radioInput = radioComponent.find('input')
+        .done(function () {
+          checkElement.prop('checked', true)
+          radioButtons.each(function () {
+            const radioComponent = $(this)
+            const radioInput = radioComponent.find('input')
 
-          radioComponent.data("disabled", false)
-          radioComponent.removeClass("disabled")
-          radioInput.prop("disabled", false)
+            radioComponent.data('disabled', false)
+            radioComponent.removeClass('disabled')
+            radioInput.prop('disabled', false)
+          })
         })
-      })
-    } else {// Expecting type=checkbox
-      checkComponent.data("disabled", true)
-      checkComponent.addClass("disabled")
-      checkElement.prop("disabled", "disabled")
+    } else { // Expecting type=checkbox
+      checkComponent.data('disabled', true)
+      checkComponent.addClass('disabled')
+      checkElement.prop('disabled', 'disabled')
 
-      let originallyChecked = checkElement.prop('checked')
+      const originallyChecked = checkElement.prop('checked')
       let asyncCall
 
       if (!originallyChecked) {
@@ -247,11 +246,11 @@ $('document').ready(() => {
         asyncCall = saveCheckState('delete_option', checkElement.val())
       }
 
-      asyncCall.done(function() {
-        checkComponent.data("disabled", false)
-        checkComponent.removeClass("disabled")
+      asyncCall.done(function () {
+        checkComponent.data('disabled', false)
+        checkComponent.removeClass('disabled')
         checkElement.prop('checked', !originallyChecked)
-        checkElement.prop("disabled", false)
+        checkElement.prop('disabled', false)
       })
     }
   })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -159,20 +159,19 @@ $('document').ready(() => {
         doneCallback
 
       if (categoryCheckboxChecked) {
-          console.log(categoryOptionsContainer.children())
-        // Uncheck all category options
-        categoryOptionsContainer.children().filter(function () {
-          return $(this).find('input').prop('checked')
-        }).each(function () {
-          const checkbox = $(this).find('input')
-
-          checkbox.prop('checked', false)
-          notify('Unchecked ' + checkbox.next().text(), 'info')
-        })
-
         collapseIcon = '+'
         doneCallback = () => {
           categoryOptionsContainer.hide()
+
+          // Uncheck all category options
+          categoryOptionsContainer.children().filter(function () {
+            return $(this).find('input').prop('checked')
+          }).each(function () {
+            const checkbox = $(this).find('input')
+
+            checkbox.prop('checked', false)
+            notify('Unchecked ' + checkbox.next().text(), 'info')
+          })
         }
         saveAction = 'delete_category'
       } else {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -221,26 +221,23 @@ $('document').ready(() => {
             checkElement.prop("disabled", false)
           })
         } else {// Expecting type=checkbox
+          let originallyChecked = checkElement.prop('checked')
+          let asyncCall
 
+          if (!originallyChecked) {
+            asyncCall = saveCheckState('add_option', checkElement.val())
+          } else {
+            asyncCall = saveCheckState('delete_option', checkElement.val())
+          }
+
+          asyncCall.done(function() {
+            checkComponent.data("disabled", false)
+            checkComponent.removeClass("disabled")
+            checkElement.prop('checked', !originallyChecked)
+            checkElement.prop("disabled", false)
+          })
         }
       }
     }
-  })
-
-  $('.emancipation-option-check-box').change(function () {
-    const thisCheckBox = $(this)
-
-    const originallyChecked = thisCheckBox.prop('checked')
-    let asyncCall
-
-    if (originallyChecked) {
-      asyncCall = saveCheckState('add_option', thisCheckBox.val())
-    } else {
-      asyncCall = saveCheckState('delete_option', thisCheckBox.val())
-    }
-
-    asyncCall.fail(function () {
-      thisCheckBox.prop('checked', originallyChecked)
-    })
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -144,11 +144,11 @@ $('document').ready(() => {
   emancipationPage.asyncWaitIndicator = emancipationPage.notifications.find('#async-waiting-indicator')
 
   $('.emancipation-category').click(function () {
-    category = $(this)
-    categoryCheckbox = category.find('input[type="checkbox"]')
-    categoryCollapseIcon = category.find('span')
-    categoryCheckboxChecked = categoryCheckbox.is(':checked')
-    categoryOptionsContainer = category.siblings('.category-options')
+    let category = $(this)
+    let categoryCheckbox = category.find('input[type="checkbox"]')
+    let categoryCollapseIcon = category.find('span')
+    let categoryCheckboxChecked = categoryCheckbox.is(':checked')
+    let categoryOptionsContainer = category.siblings('.category-options')
 
     if (!category.data('disabled')) {
       category.data('disabled', true)
@@ -201,13 +201,30 @@ $('document').ready(() => {
     }
   })
 
-  $('.emancipation-radio-button').change(function (data) {
-    const thisRadioButton = $(this)
+  $('.check-item').click(function() {
+    const checkComponent = $(this)
 
-    saveCheckState('set_option', thisRadioButton.val())
-      .fail(function () {
-        thisRadioButton.prop('checked', false)
-      })
+    if (!checkComponent.data("disabled")) {
+      const checkElement = $(this).find('input')
+
+      if (!(checkElement.attr('type') === 'radio' && checkElement.prop('checked'))) {
+        checkComponent.data("disabled", true)
+        checkComponent.addClass("disabled")
+        checkElement.prop("disabled", "disabled")
+
+        if (checkElement.attr('type') === 'radio') {
+          saveCheckState('set_option', checkElement.val())
+          .done(function() {
+            checkComponent.data("disabled", false)
+            checkComponent.removeClass("disabled")
+            checkElement.prop('checked', true)
+            checkElement.prop("disabled", false)
+          })
+        } else {// Expecting type=checkbox
+
+        }
+      }
+    }
   })
 
   $('.emancipation-option-check-box').change(function () {

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -1,6 +1,10 @@
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg)
+  }
+  100% {
+    transform: rotate(360deg)
+  }
 }
 
 #async-notifications {
@@ -16,17 +20,17 @@
     margin: .25em;
     margin-left: auto;
     margin-right: 0;
-    padding: .5em;
+    padding: .5em
   }
 
   .async-failure-indicator {
     background-color: #b71c1c;
-    color: white;
+    color: white
   }
   
   .async-success-indicator {
     background-color: #28a745;
-    color: white;
+    color: white
   }
 
   #async-waiting-indicator {
@@ -42,7 +46,7 @@
       height: 1em;
       margin: 0;
       padding: 0;
-      width: 1em;
+      width: 1em
     }
   }
 }
@@ -57,7 +61,7 @@
   padding: .5em;
 
   input[type="checkbox"] {
-    pointer-events: none;
+    pointer-events: none
   }
 
   label {
@@ -68,7 +72,7 @@
     color: #00447c;
     float: right;
     font-weight: bold;
-    font-size: 18pt;
+    font-size: 18pt
   }
 }
 
@@ -85,12 +89,12 @@
   cursor: default;
 
   span, label{
-    color: #757575;
+    color: #757575
   }
 }
 
 .emancipation-category.disabled:hover{
-  background-color: unset;
+  background-color: unset
 }
 
 .no-select {

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -54,6 +54,14 @@
 .category-options {
   margin-left: 2em;
   margin-bottom: 1em;
+
+  input[type="checkbox"], input[type="radio"] {
+    pointer-events: none
+  }
+}
+
+.category-options.disabled {
+
 }
 
 .emancipation-category {

--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -60,8 +60,12 @@
   }
 }
 
-.category-options.disabled {
+.check-item.disabled {
+  cursor: default;
 
+  label {
+    color: #757575
+  }
 }
 
 .emancipation-category {

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -23,6 +23,7 @@
           class="category-options"
           style="<%= emancipation_category_collapse_hidden(@current_case, category) %>">
           <% category.emancipation_options.each do |option| %>
+            <div class="check-item">
             <% if category.mutually_exclusive %>
               <input
                 type="radio"
@@ -39,8 +40,8 @@
                 value="<%= option.id %>"
                 <%= emancipation_option_checkbox_checked(@current_case, option) %>>
             <% end %>
-            <label for="O<%= option.id %>"><%= option.name %></label>
-            <br>
+            <label><%= option.name %></label>
+            </div>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
### What changed, and why?
 - Checking an emancipation option will disable the element until the request is complete. (Before it never disabled)
 - An emancipation option will only appear checked after the sent request returns with a successful response. (Before it would appear checked and uncheck itself on error responses)
 - Auto deleting emancipation options is now handled by a single request. (Before multiple requests would be sent quickly)