### PR TITLE
All casa admin can see casa org overview key metrics #1086

### DIFF
--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -23,6 +23,10 @@ class CasaOrg < ApplicationRecord
     Volunteer.in_organization(self)
   end
 
+  def cases
+    CasaCase.where(casa_org_id: id)
+  end
+
   def case_contacts
     CaseContact.where(
       casa_case_id: CasaCase.where(casa_org_id: id)

--- a/app/views/all_casa_admins/casa_orgs/show.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/show.html.erb
@@ -30,3 +30,30 @@
     </table>
   </div>
 </div>
+
+<div class="card card-container">
+  <div class="card-body">
+    <div class="card-title">
+      <h3>Details</h3>
+    </div>
+    <ul class="list-group list-group-flush">
+      <%{
+        "Number of admins" => selected_organization.casa_admins.count,
+        "Number of supervisors" => selected_organization.supervisors.count,
+        "Number of active volunteers" => selected_organization
+          .volunteers.where(active: true).count,
+        "Number of inactive volunteers" => selected_organization
+          .volunteers.where(active: false).count,
+        "Number of active cases" => selected_organization
+          .cases.where(active: true).count,
+        "Number of inactive cases" => selected_organization
+          .cases.where(active: false).count,
+      }.each do |item_description, item_value|%>
+        <li class="list-group-item">
+          <strong><%=item_description%>:</strong>
+          <%=item_value%>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "all_casa_admins/casa_orgs/show", type: :view do
+  context "All casa admin organization dashboard" do
+    let(:organization) {create :casa_org }
+  
+    let(:org_info) {
+      [
+        {
+          type: :casa_admin,
+          number: 3,
+          active: true,
+          description: "admin",
+        },
+        {
+          type: :supervisor,
+          number: 7,
+          active: true,
+          description: "supervisor",
+        },
+        {
+          type: :volunteer,
+          number: 20,
+          active: true,
+          description: "active volunteer",
+        },
+        {
+          type: :volunteer,
+          number: 7,
+          active: false,
+          description: "inactive volunteer",
+        },
+        {
+          type: :casa_case,
+          number: 50,
+          active: true,
+          description: "active case",
+        },
+        {
+          type: :casa_case,
+          number: 11,
+          active: false,
+          description: "inactive case",
+        },
+      ]
+    }
+
+    before do
+      # seed the organization
+      org_info.each do |group|
+        group[:number].times do
+          create group[:type], casa_org: organization, active: group[:active]
+        end
+      end
+      allow(view).to receive(:selected_organization).and_return(organization)
+      render
+    end
+
+    it "shows stats about the organization" do
+      org_info.each do |group|
+        expect(rendered).to have_text(
+          "Number of #{group[:description]}s: #{group[:number]}",
+          normalize_ws: true,
+        )
+      end
+    end
+  end
+end

--- a/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
@@ -2,46 +2,46 @@ require "rails_helper"
 
 RSpec.describe "all_casa_admins/casa_orgs/show", type: :view do
   context "All casa admin organization dashboard" do
-    let(:organization) {create :casa_org }
-  
+    let(:organization) { create :casa_org }
+
     let(:org_info) {
       [
         {
           type: :casa_admin,
           number: 3,
           active: true,
-          description: "admin",
+          description: "admin"
         },
         {
           type: :supervisor,
           number: 7,
           active: true,
-          description: "supervisor",
+          description: "supervisor"
         },
         {
           type: :volunteer,
           number: 20,
           active: true,
-          description: "active volunteer",
+          description: "active volunteer"
         },
         {
           type: :volunteer,
           number: 7,
           active: false,
-          description: "inactive volunteer",
+          description: "inactive volunteer"
         },
         {
           type: :casa_case,
           number: 50,
           active: true,
-          description: "active case",
+          description: "active case"
         },
         {
           type: :casa_case,
           number: 11,
           active: false,
-          description: "inactive case",
-        },
+          description: "inactive case"
+        }
       ]
     }
 
@@ -60,7 +60,7 @@ RSpec.describe "all_casa_admins/casa_orgs/show", type: :view do
       org_info.each do |group|
         expect(rendered).to have_text(
           "Number of #{group[:description]}s: #{group[:number]}",
-          normalize_ws: true,
+          normalize_ws: true
         )
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1086

### What changed, and why?
Added stats to the casa org dashboard.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A
- All Casa Admin permissions: just collects information they already had access to.

### How is this tested? (please write tests!) 💖💪
Cappybara test that generates the page with a mocked organization and then tests that it displays the "correct" statistics for the mocked organization.

### Screenshots please :)
![Capture](https://user-images.githubusercontent.com/23124989/106658269-b0a90780-6562-11eb-9e49-2cb41ada6e8f.PNG)

### Feelings gif (optional)

![Capybara doesn't work on WSL](https://media.giphy.com/media/12bVDtXPOzYwda/giphy.gif)

 (Capybara doesn't work on WSL 😢 )
