### PR TITLE
Add margin between buttons and card on case details page

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -14,18 +14,29 @@ label {
   font-weight: 900;
 }
 
-.fa-car, .fa-question-circle {
+.fa-car,
+.fa-question-circle {
   color: $primary;
 }
 
 .card.card-container {
-  box-shadow: 0 4px 12px 5px rgba(0,0,0,0.08);
+  box-shadow: 0 4px 12px 5px rgba(0, 0, 0, 0.08);
 }
 
+.casa-case-button {
+  margin: 0 0 12px 0;
+}
+
+
 /* ASSUMPTION: default screen size is desktop view (> 1024px) */
+
+
 /* As 'mobile-label' class is mobile only, not display them on desktop view */
+
 table.table {
-  span.mobile-label { display: none; }
+  span.mobile-label {
+    display: none;
+  }
 }
 
 #dropdownMenuButton {
@@ -33,35 +44,30 @@ table.table {
 }
 
 @media only screen and (max-width: 1024px) {
-
   .login-header {
     font-size: 0.75em !important;
   }
-
   .content {
     padding: 3rem 0;
     margin-left: 0;
   }
-
   .card-body {
     padding: 0.5rem;
   }
-
   table.table {
     thead {
       display: none;
     }
-
     tr {
       display: table;
       width: 100%;
       border-bottom: 1px solid #efefef;
-      > * {
+      >* {
         display: block;
       }
     }
-
-    th, td {
+    th,
+    td {
       border-top: none;
       font-size: 1.25rem;
       span.mobile-label {

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -6,13 +6,13 @@
     <%- if policy(:case_contact).new? & @casa_case.active? %>
       <%= link_to "New Case Contact",
                   new_case_contact_path(case_contact: {casa_case_id: @casa_case.id}),
-                  class: "btn btn-primary" %>
+                  class: "btn btn-primary casa-case-button" %>
     <%- end %>
     <% if @casa_case.active? %>
-      <%= link_to 'Edit Case Details', edit_casa_case_path(@casa_case), class: "btn btn-primary" %>
+      <%= link_to 'Edit Case Details', edit_casa_case_path(@casa_case), class: "btn btn-primary casa-case-button" %>
     <% end %>
     <% if @casa_case.has_transitioned? %>
-      <%= link_to 'Emancipation', casa_case_emancipation_path(@casa_case), class: "btn btn-primary" %>
+      <%= link_to 'Emancipation', casa_case_emancipation_path(@casa_case), class: "btn btn-primary casa-case-button" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1642

### What changed, and why?
Added some small margin between the buttons and card on the case details page when the page is smaller.

### Screenshots please :)

![CASA_Volunteer_Tracking](https://user-images.githubusercontent.com/10904005/106673846-47d08800-6580-11eb-8f5e-a4d9f98150e7.jpg)

When the page is super small the spacing was messed up if all the buttons didn't have the same margin added, this screenshot shows the spacing is working when the page is really compressed.
![CASA_Volunteer_Tracking](https://user-images.githubusercontent.com/10904005/106673868-51f28680-6580-11eb-8942-c0ff795be83d.jpg)
