### PR TITLE
Fix court report case contact date filtering to know that cc court date is in the FUTURE

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -22,7 +22,8 @@ class CaseCourtReportsController < ApplicationController
     respond_to do |format|
       format.docx do
         @casa_case.court_report.open do |file|
-          send_data File.open(file.path), type: :docx, disposition: "attachment", status: :ok
+          # TODO test this .read being present, we've broken it twice now
+          send_data File.open(file.path).read, type: :docx, disposition: "attachment", status: :ok
         end
       end
     end
@@ -65,7 +66,7 @@ class CaseCourtReportsController < ApplicationController
 
     type = report_type(casa_case)
     court_report = CaseCourtReport.new(
-      volunteer_id: current_user.id,
+      volunteer_id: current_user.id, # ??? not a volunteer ? linda
       case_id: casa_case.id,
       path_to_template: path_to_template(type)
     )

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -18,6 +18,30 @@ RSpec.describe CaseCourtReport, type: :model do
       )
     end
 
+    describe "with court date in the furure" do
+      let!(:far_past_case_contact) { create :case_contact, occurred_at: 5.days.ago, casa_case_id: casa_case_with_contacts.id }
+
+      before do
+        casa_case_with_contacts.update!(court_date: 1.day.from_now)
+      end
+
+      describe "without past court date" do
+        it "has all case contacts ever created for the youth" do
+          expect(report.context[:case_contacts].length).to eq(5)
+        end
+      end
+
+      describe "with past court date" do
+        # TODO make a factory for PastCourtDate
+        let!(:past_court_date) { PastCourtDate.create!(date: 2.days.ago, casa_case_id: casa_case_with_contacts.id) }
+
+        it "has all case contacts created since the previous court date" do
+          expect(casa_case_with_contacts.past_court_dates.length).to eq(1)
+          expect(report.context[:case_contacts].length).to eq(4)
+        end
+      end
+    end
+
     describe "has valid @path_to_template" do
       it "is existing" do
         path = report.template.instance_variable_get(:@path)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1674

### What changed, and why?
When filtering case contacts for a court report, filter out contacts from before the most recent court date, NOT contacts before the upcoming court date
This is related to a use who emailed in on 2 Feb 2020 from PG casa

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
rspec

### Screenshots please :)
aaaaa

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
