### PR TITLE
Fixes Case Contact checkboxes

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -32,16 +32,16 @@
             <% group.contact_types.filter do |ct|
                 @selected_case_contact_types.blank? ||
                     @selected_case_contact_types.include?(ct)
-              end.each_with_index do |contact_type, index| %>
+              end.each do |contact_type| %>
               <div class="form-check">
                 <%=
                   check_box_tag "case_contact[case_contact_contact_type_attributes][][contact_type_id]",
-                                contact_type.id,
-                                @case_contact.decorate.show_contact_type?(contact_type.id),
-                                id: "case_contact_contact_types_#{index}",
-                                class: ["form-check-input", "case-contact-contact-type"]
-                %>
-                <label class="form-check-label" for="case_contact_contact_types_<%= index %>">
+                    contact_type.id,
+                    @case_contact.decorate.show_contact_type?(contact_type.id),
+                    id: dom_id(contact_type, :case_contact),
+                    class: ["form-check-input", "case-contact-contact-type"]
+                  %>
+                <label class="form-check-label" for="<%= dom_id(contact_type, :case_contact) %>">
                   <%= contact_type.name %>
                 </label>
               </div>

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -105,6 +105,27 @@ RSpec.describe "case_contacts/new", type: :system do
     end
   end
 
+  context "mutliple contact type groups" do
+    let(:organization) { create(:casa_org) }
+    let(:admin) { create(:casa_admin, casa_org: organization) }
+    let(:casa_case) { create(:casa_case, casa_org: organization) }
+
+    before do
+      sign_in admin
+    end
+
+    it "should check the correct box when clicking the label" do
+      group_1 = create(:contact_type_group, casa_org: organization)
+      create(:contact_type, name: "School", contact_type_group: group_1)
+      group_2 = create(:contact_type_group, casa_org: organization)
+      create(:contact_type, name: "Parent", contact_type_group: group_2)
+
+      visit new_case_contact_path(casa_case.id)
+
+      expect { check "Parent" }.not_to raise_error
+    end
+  end
+
   context "when volunteer" do
     let(:organization) { create(:casa_org) }
     let!(:empty) { create(:contact_type_group, name: "Empty", casa_org: organization) }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1395

### What changed, and why?
Clicking certain case contact types caused the wrong checkbox to be selected.
This was caused by the index being added to the `for`. Because the index was
already in a loop, elements were getting duplicate names.

Changed from using index to `dom_id`


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added a test to will raise an exception if there are duplicate checkboxes found
in the future.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`