### PR TITLE
Differentiate icon shown for transition_age_youth and non_transition_…

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -5,12 +5,12 @@ class CasaCaseDecorator < Draper::Decorator
     object.active ? "Active" : "Inactive"
   end
 
-  def transition_aged_youth_icon
-    object.transition_aged_youth ? "Yes 🐛🦋" : "No"
+  def transition_aged_youth
+    object.transition_aged_youth ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
-  def transition_aged_youth_only_icon
-    object.transition_aged_youth ? "🐛🦋" : ""
+  def transition_aged_youth_icon
+    object.transition_aged_youth ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def court_report_submission

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -145,7 +145,7 @@ $('document').ready(() => {
       },
       {
         name: 'has_transition_aged_youth_cases',
-        render: (data, type, row, meta) => row.has_transition_aged_youth_cases === 'true' ? 'Yes 🐛🦋' : 'No',
+        render: (data, type, row, meta) => row.has_transition_aged_youth_cases === 'true' ? 'Yes 🦋' : 'No 🐛',
         searchable: false
       },
       {

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -7,10 +7,14 @@ class CasaCase < ApplicationRecord
     hearing_type_name
     judge_name
     status
-    transition_aged_youth_icon
+    transition_aged_youth
     assigned_to
     actions
   ].freeze
+
+  TRANSITION_AGE_YOUTH_ICON = "🦋".freeze
+  NON_TRANSITION_AGE_YOUTH_ICON = "🐛".freeze
+
   has_paper_trail
 
   has_many :case_assignments, dependent: :destroy

--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -60,9 +60,9 @@
       </button>
       <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
         <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🐛🦋" checked>Yes</a>
+          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🦋" checked>Yes</a>
         </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a>
+        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No 🐛" checked>No</a>
         </li>
       </div>
     </div>
@@ -146,7 +146,7 @@
           <td><%= casa_case.hearing_type_name %></td>
           <td><%= casa_case.judge_name %></td>
           <td><%= casa_case.decorate.status %></td>
-          <td><%= casa_case.decorate.transition_aged_youth_icon %></td>
+          <td><%= casa_case.decorate.transition_aged_youth %></td>
           <td>
             <% if casa_case.active? %>
               <% if current_user.volunteer? %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-sm-12 form-header">
-    <h1><%= @casa_case.decorate.transition_aged_youth_only_icon %> CASA Case Details</h1>
+    <h1><%= @casa_case.decorate.transition_aged_youth_icon %> CASA Case Details</h1>
     <%- if policy(:case_contact).new? & @casa_case.active? %>
       <%= link_to "New Case Contact",
                   new_case_contact_path(case_contact: {casa_case_id: @casa_case.id}),
@@ -35,7 +35,7 @@
     </p>
 
     <p>
-    <h6><strong>Transition Aged Youth:</strong> <%= @casa_case.decorate.transition_aged_youth_icon %></h6>
+    <h6><strong>Transition Aged Youth:</strong> <%= @casa_case.decorate.transition_aged_youth %></h6>
     </p>
 
     <p>

--- a/app/views/case_assignments/index.html.erb
+++ b/app/views/case_assignments/index.html.erb
@@ -22,7 +22,7 @@
         </td>
         <td>
           <span class="mobile-label">Transition Aged Youth</span>
-          <%= assignment.casa_case.decorate.transition_aged_youth_icon %>
+          <%= assignment.casa_case.decorate.transition_aged_youth %>
         </td>
         <td>
           <%= button_to 'Unassign Case',

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -8,7 +8,7 @@
 <% @casa_cases.each do |casa_case| %>
   <div class="card card-container">
     <div class="card-body">
-      <h3><%= casa_case.case_number %></h3>
+      <h3><%= "#{casa_case.decorate.transition_aged_youth_icon} #{casa_case.case_number}" %></h3>
       <% casa_case.decorate.case_contacts_ordered_by_occurred_at.each do |contact| %>
         <%= render "case_contacts/case_contact", contact: contact %>
       <% end %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -80,7 +80,7 @@
         <% @volunteer.case_assignments_with_cases.each do |assignment| %>
           <tr id="<%= dom_id(assignment) %>">
             <td><%= link_to assignment.casa_case.case_number, casa_case_path(assignment.casa_case) %></td>
-            <td><%= assignment.casa_case.decorate.transition_aged_youth_icon %></td>
+            <td><%= assignment.casa_case.decorate.transition_aged_youth %></td>
             <td>
               <% if @volunteer.active? && assignment.casa_case.active? %>
                 Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -51,4 +51,32 @@ RSpec.describe CasaCaseDecorator do
 
     it { is_expected.to eq "12-09-2020" }
   end
+
+  describe "#transition_age_youth" do
+    it "returns transition age youth status with icon if transition age youth" do
+      casa_case = build(:casa_case, transition_aged_youth: true)
+      expect(casa_case.decorate.transition_aged_youth)
+        .to eq "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}"
+    end
+
+    it "returns non-transition age youth status with icon if not transition age youth" do
+      casa_case = build(:casa_case, transition_aged_youth: false)
+      expect(casa_case.decorate.transition_aged_youth)
+        .to eq "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    end
+  end
+
+  describe "#transition_age_youth_icon" do
+    it "returns transition age youth icon if transition age youth" do
+      casa_case = build(:casa_case, transition_aged_youth: true)
+      expect(casa_case.decorate.transition_aged_youth_icon)
+        .to eq CasaCase::TRANSITION_AGE_YOUTH_ICON
+    end
+
+    it "returns non-transition age youth icon if not transition age youth" do
+      casa_case = build(:casa_case, transition_aged_youth: false)
+      expect(casa_case.decorate.transition_aged_youth_icon)
+        .to eq CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1070 

### What changed, and why?

* Assigns butterfly and caterpillar emojis to `TRANSITION_AGE_YOUTH_ICON` and `NON_TRANSITION_AGE_YOUTH_ICON` so we can assign meaning to them.
* Renames existing methods in `CasaCaseDecorator` for clarity. `transition_aged_youth_icon` will return icon only, while `transition_aged_youth` will return status & icon. 
* Updates the decorator methods so that 🦋 is shown for transition aged youth and 🐛 is shown for non-transition aged youth. 

### How is this tested? (please write tests!) 💖💪
* `spec/decorators/casa_case_decorator_spec.rb` tests that the `#transition_age_youth` and `#transition_age_youth_icon` returns the expected icons.

### Screenshots please :)

<img width="970" alt="Screen Shot 2021-02-07 at 10 42 38 AM" src="https://user-images.githubusercontent.com/16447748/107156260-2a117300-6932-11eb-87e8-3c7099d536d9.png">

<img width="969" alt="Screen Shot 2021-02-07 at 10 42 08 AM" src="https://user-images.githubusercontent.com/16447748/107156258-27af1900-6932-11eb-95eb-424824a8f1ae.png">
