### PR TITLE
Only create notification for case contact creator

### DIFF
--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -8,7 +8,7 @@ class CaseContacts::FollowupsController < ApplicationController
     case_contact.followups.create(creator: current_user, status: :requested)
     FollowupNotification
       .with(followup: case_contact.requested_followup, created_by_name: current_user.display_name)
-      .deliver(case_contact.casa_case.assigned_volunteers)
+      .deliver(case_contact.creator)
 
     redirect_to casa_case_path(case_contact.casa_case)
   end

--- a/spec/requests/followups_spec.rb
+++ b/spec/requests/followups_spec.rb
@@ -93,15 +93,16 @@ RSpec.describe "/followups", type: :request do
         let(:volunteer_2) { create(:volunteer) }
         let(:unassigned_volunteer) { create(:volunteer) }
 
-        it "should create a notification for all assigned volunteers" do
-          casa_case = contact.casa_case
+        it "should only create a notification for the user that created the case_contact" do
+          contact_created_by_volunteer = create(:case_contact, creator: volunteer)
+          casa_case = contact_created_by_volunteer.casa_case
           casa_case.assigned_volunteers = [volunteer, volunteer_2]
           sign_in admin
 
-          post case_contact_followups_path(contact)
+          post case_contact_followups_path(contact_created_by_volunteer)
 
           expect(volunteer.notifications.count).to eq(1)
-          expect(volunteer_2.notifications.count).to eq(1)
+          expect(volunteer_2.notifications.count).to eq(0)
           expect(unassigned_volunteer.notifications.count).to eq(0)
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1708

### What changed, and why?
We no longer want to create a notification for all volunteers assigned
to a casa case when a followup is created for one of the case's
contacts, just the creator of the case contact.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Changed the current test that was verifying all assigned volunteers received the
notification to verify just the creator gets one.


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`