### PR TITLE
Moved youth's birth month & year up on the page

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -12,6 +12,23 @@
         <% end %>
       </div>
 
+      <% if policy(casa_case).update_birth_month_year_youth? %>
+        <div class="field form-group">
+          <%= form.label :birth_month_year_youth, "Youth's Birth Month & Year" %>
+          <br>
+          <span class="datetime-year-month">
+            <%= form.date_select :birth_month_year_youth,
+                                 {
+                                     order: [:month, :year],
+                                     start_year: Date.current.year,
+                                     end_year: 1989,
+                                     prompt: {month: 'Month', year: 'Year'},
+                                     discard_day: true
+                                 }, class: "select2 date-input" %>
+          </span>
+        </div>
+      <% end %>
+
       <% if policy(casa_case).update_hearing_type? %>
         <div class="field form-group">
           <%= form.label :hearing_type_id %>
@@ -81,23 +98,6 @@
           </label>
         <% end %>
       </div>
-
-      <% if policy(casa_case).update_birth_month_year_youth? %>
-        <div class="field form-group">
-          <%= form.label :birth_month_year_youth, "Youth's Birth Month & Year" %>
-          <br>
-          <span class="datetime-year-month">
-            <%= form.date_select :birth_month_year_youth,
-                                 {
-                                     order: [:month, :year],
-                                     start_year: Date.current.year,
-                                     end_year: 1989,
-                                     prompt: {month: 'Month', year: 'Year'},
-                                     discard_day: true
-                                 }, class: "select2 date-input" %>
-          </span>
-        </div>
-      <% end %>
 
       <% if casa_case.new_record? %>
         <%# Only show the field when creating, but not when updating %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1707 .

### What changed, and why?
Moved youth's birth month & year up on the page so that it will be easier to find.  

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
