### PR TITLE
Supervisor/admin can download already generated court reports #1398 (part 2)

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -14,14 +14,14 @@ class CaseCourtReportsController < ApplicationController
   # GET /case_court_reports/:id
   def show
     authorize CaseCourtReport
-    if !@casa_case || !@casa_case.court_report.attached?
+    if !@casa_case || !@casa_case.court_reports.attached?
       flash[:alert] = "Report #{params[:id]} is not found."
       redirect_to(case_court_reports_path) and return # rubocop:disable Style/AndOr
     end
 
     respond_to do |format|
       format.docx do
-        @casa_case.court_report.open do |file|
+        @casa_case.latest_court_report.open do |file|
           # TODO test this .read being present, we've broken it twice now
           send_data File.open(file.path).read, type: :docx, disposition: "attachment", status: :ok
         end
@@ -77,7 +77,7 @@ class CaseCourtReportsController < ApplicationController
     Tempfile.create do |t|
       t.binmode.write(report_data)
       t.rewind
-      casa_case.court_report.attach(
+      casa_case.court_reports.attach(
         io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
       )
     end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -82,7 +82,7 @@ class CasaCase < ApplicationRecord
   validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
 
   def latest_court_report
-    self.court_reports.last
+    self.court_reports.order("created_at").last
   end
 
   def court_report_status=(value)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -82,7 +82,7 @@ class CasaCase < ApplicationRecord
   validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
 
   def latest_court_report
-    self.court_reports.order("created_at").last
+    court_reports.order("created_at").last
   end
 
   def court_report_status=(value)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -27,7 +27,7 @@ class CasaCase < ApplicationRecord
   has_many :casa_cases_emancipation_options, dependent: :destroy
   has_many :emancipation_options, through: :casa_cases_emancipation_options
   has_many :past_court_dates, dependent: :destroy
-  has_one_attached :court_report
+  has_many_attached :court_reports
 
   validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true
   belongs_to :hearing_type, optional: true
@@ -80,6 +80,10 @@ class CasaCase < ApplicationRecord
 
   # Validation to check timestamp and submission status of a case
   validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
+
+  def latest_court_report
+    self.court_reports.last
+  end
 
   def court_report_status=(value)
     super

--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -1,7 +1,20 @@
 class PastCourtDate < ApplicationRecord
   belongs_to :casa_case
-end
 
+  # get reports associated with the case this belongs to before this court date but after the court date before this one
+  def associated_reports
+    prev = self.casa_case.past_court_dates.where("date < ?", self.date).order(:date).last
+    if prev
+      self.casa_case.court_reports.where("created_at > ?", prev.date).where("created_at < ?", self.date)
+    else
+      self.casa_case.court_reports.where("created_at < ?", self.date)
+    end
+  end
+
+  def latest_associated_report
+    self.associated_reports.order(:created_at).last
+  end
+end
 # == Schema Information
 #
 # Table name: past_court_dates

--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -3,16 +3,16 @@ class PastCourtDate < ApplicationRecord
 
   # get reports associated with the case this belongs to before this court date but after the court date before this one
   def associated_reports
-    prev = self.casa_case.past_court_dates.where("date < ?", self.date).order(:date).last
+    prev = casa_case.past_court_dates.where("date < ?", date).order(:date).last
     if prev
-      self.casa_case.court_reports.where("created_at > ?", prev.date).where("created_at < ?", self.date)
+      casa_case.court_reports.where("created_at > ?", prev.date).where("created_at < ?", date)
     else
-      self.casa_case.court_reports.where("created_at < ?", self.date)
+      casa_case.court_reports.where("created_at < ?", date)
     end
   end
 
   def latest_associated_report
-    self.associated_reports.order(:created_at).last
+    associated_reports.order(:created_at).last
   end
 end
 # == Schema Information

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -13,7 +13,13 @@
     <% if @casa_case.past_court_dates.size > 0 %>
       <ul>
         <% @casa_case.past_court_dates.each do |pcd| %>
-          <p><%= I18n.l(pcd.date, format: :full, default: nil) %></p>
+          <p>
+            <% if report = pcd.latest_associated_report %>
+              <%= link_to I18n.l(pcd.date, format: :full, default: nil), rails_blob_path(report, disposition: 'attachment') %>
+            <% else %>
+              <%= I18n.l(pcd.date, format: :full, default: nil) %>
+            <% end %>
+          </p>
         <% end %>
       </ul>
     <% else %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -52,8 +52,8 @@
     </p>
 
     <% unless @casa_case.court_report_not_submitted? %>
-      <% if @casa_case.court_report_submitted? && @casa_case.court_report.attached? %>
-        <%= link_to 'Click to download', rails_blob_path(@casa_case.court_report, disposition: 'attachment') %>
+      <% if @casa_case.court_report_submitted? && @casa_case.court_reports.attached? %>
+        <%= link_to 'Click to download', rails_blob_path(@casa_case.latest_court_report, disposition: 'attachment') %>
       <% end %>
       <p>
         <h6><strong>Court Report Submitted Date:</strong> <%= @casa_case.decorate.court_report_submitted_date %></h6>

--- a/spec/factories/past_court_date.rb
+++ b/spec/factories/past_court_date.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :past_court_date, class: "PastCourtDate" do
+    association :casa_case
+  end
+end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "/case_court_reports", type: :request do
 
       before do
         Tempfile.create do |t|
-          casa_case.court_report.attach(
+          casa_case.court_reports.attach(
             io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
           )
         end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "stringio"
 
 RSpec.describe "casa_cases/edit", type: :system do
   context "when admin" do
@@ -300,7 +301,38 @@ RSpec.describe "casa_cases/edit", type: :system do
     let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
+    let!(:court_dates) do
+      [10,30,31,90].map { |n| create(:past_court_date, casa_case: casa_case, date: n.days.ago) }
+    end
+
+    let!(:reports) do
+      [5,11,23,44,91].map do |n|
+        report = CaseCourtReport.new(
+          volunteer_id: volunteer.id,
+          case_id: casa_case.id,
+          path_to_template: "app/documents/templates/report_template_transition.docx"
+        )
+        casa_case.court_reports.attach(io: StringIO.new(report.generate_to_string), filename: "report#{n}.docx")
+        attached_report = casa_case.latest_court_report
+        attached_report.created_at = n.days.ago
+        attached_report.save!
+        attached_report
+      end
+    end
+
     before { sign_in volunteer }
+
+    it "views attached court reports" do
+      visit edit_casa_case_path(casa_case)
+
+      # test court dates with reports get the correct ones
+      [[0, 1], [2, 3], [3, 4]].each do |di, ri|
+        expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil),  href: rails_blob_path(reports[ri], disposition: 'attachment'))
+      end
+      # and that the one with no report doesn't get one
+      expect(page).not_to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))
+      expect(page).to have_text(I18n.l(court_dates[1].date, format: :full, default: nil))
+    end
 
     it "clicks back button after editing case" do
       visit edit_casa_case_path(casa_case)

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -302,11 +302,11 @@ RSpec.describe "casa_cases/edit", type: :system do
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
     let!(:court_dates) do
-      [10,30,31,90].map { |n| create(:past_court_date, casa_case: casa_case, date: n.days.ago) }
+      [10, 30, 31, 90].map { |n| create(:past_court_date, casa_case: casa_case, date: n.days.ago) }
     end
 
     let!(:reports) do
-      [5,11,23,44,91].map do |n|
+      [5, 11, 23, 44, 91].map do |n|
         report = CaseCourtReport.new(
           volunteer_id: volunteer.id,
           case_id: casa_case.id,
@@ -327,7 +327,7 @@ RSpec.describe "casa_cases/edit", type: :system do
 
       # test court dates with reports get the correct ones
       [[0, 1], [2, 3], [3, 4]].each do |di, ri|
-        expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil),  href: rails_blob_path(reports[ri], disposition: 'attachment'))
+        expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil), href: rails_blob_path(reports[ri], disposition: "attachment"))
       end
       # and that the one with no report doesn't get one
       expect(page).not_to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1398

### What changed, and why?
Allows a CasaCase to have multiple attached court reports. Links to these will show up on the case's edit view for all users who can access this. 

### How will this affect user permissions?
- volunteer/supervisor/admin previously had access to the report attached to a case, now that there are more than one they have access to those too.

### How is this tested? (please write tests!) 💖💪
Edit case view test now creates some past court dates and reports attached to the case, and checks to see that the correct links are generated in the page.

### Screenshots please :)
![Capture](https://user-images.githubusercontent.com/23124989/107830050-a51ec300-6d50-11eb-9f19-2b457844bc6c.PNG)

### Feelings gif (optional)
![me trying to understand this workflow](https://media.giphy.com/media/yTzwdWHe1VxQt4sfiD/giphy.gif)
