### PR TITLE
Reduce repetition in tests

### DIFF
--- a/spec/controllers/emancipations_controller_spec.rb
+++ b/spec/controllers/emancipations_controller_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe EmancipationsController, type: :controller do
   end
 
   it "raises Missing param casa_case_id error message" do
-    post :save, params:{casa_case_id: 'string'}
+    post :save, params: {casa_case_id: "string"}
     expect(response.body).to eq({"error": "Param casa_case_id must be a positive integer"}.to_json)
   end
 
   it "raises add_option error message" do
-    post :save, params:{casa_case_id: '-1'}
+    post :save, params: {casa_case_id: "-1"}
     expect(response.body).to eq({"error": "Param casa_case_id must be a positive integer"}.to_json)
   end
-  
+
   context "empty params" do
     let(:params) { {} }
 
@@ -40,21 +40,21 @@ RSpec.describe EmancipationsController, type: :controller do
 
   describe "check_item_action" do
     it "raises missing param error message" do
-      post :save, params:{casa_case_id: '1'}
+      post :save, params: {casa_case_id: "1"}
       expect(response.body).to eq({"error": "Missing param check_item_action"}.to_json)
     end
   end
 
   it "raises param check_item_id error message" do
-    post :save, params:{casa_case_id: '1', check_item_action: '1'}
+    post :save, params: {casa_case_id: "1", check_item_action: "1"}
     expect(response.body).to eq({"error": "Missing param check_item_id"}.to_json)
   end
 
   it "raises must be positive integer error message" do
-    post :save, params:{casa_case_id: '1', check_item_action: '1', check_item_id: '-1'}
+    post :save, params: {casa_case_id: "1", check_item_action: "1", check_item_id: "-1"}
     expect(response.body).to eq({"error": "Param check_item_id must be a positive integer"}.to_json)
   end
-  
+
   context "non transitioning case" do
     let(:params) { {casa_case_id: volunteer.casa_cases.first.id} }
 

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -320,8 +320,7 @@ RSpec.describe CasaCase do
   describe "report submission" do
     # Creating a case whith a status other than not_submitted and a nil submission date
     it "rejects cases with a court report status, but no submission date" do
-      casa_org = create(:casa_org)
-      bad_case = create(:casa_case, casa_org: casa_org)
+      bad_case = create(:casa_case)
       bad_case.court_report_status = :in_review
       bad_case.court_report_submitted_at = nil
       bad_case.valid?
@@ -332,8 +331,7 @@ RSpec.describe CasaCase do
     end
 
     it "rejects cases with a submission date, but no status" do
-      casa_org = create(:casa_org)
-      bad_case = create(:casa_case, casa_org: casa_org)
+      bad_case = create(:casa_case)
       bad_case.court_report_status = :not_submitted
       bad_case.court_report_submitted_at = DateTime.now
       bad_case.valid?

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -147,28 +147,24 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     describe "case contact behavior" do
-      it "returns only the case contacts with where contact was made" do
+      before(:each) do
         create(:case_contact, {contact_made: true})
         create(:case_contact, {contact_made: false})
+      end
 
+      it "returns only the case contacts with where contact was made" do
         report = CaseContactReport.new({contact_made: true})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns only the case contacts with where contact was NOT made" do
-        create(:case_contact, {contact_made: true})
-        create(:case_contact, {contact_made: false})
-
         report = CaseContactReport.new({contact_made: false})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns only the case contacts with where contact was made or NOT made" do
-        create(:case_contact, {contact_made: true})
-        create(:case_contact, {contact_made: false})
-
         report = CaseContactReport.new({contact_made: [true, false]})
         contacts = report.case_contacts
         expect(contacts.length).to eq(2)
@@ -176,31 +172,27 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     describe "has transitioned behavior" do
-      it "returns only case contacts the youth has transitioned" do
-        case_case_1 = create(:casa_case, transition_aged_youth: false)
-        case_case_2 = create(:casa_case, transition_aged_youth: true)
+      let(:case_case_1) { create(:casa_case, transition_aged_youth: false) }
+      let(:case_case_2) { create(:casa_case, transition_aged_youth: true) }
+
+      before(:each) do
         create(:case_contact, {casa_case: case_case_1})
         create(:case_contact, {casa_case: case_case_2})
+      end
+
+      it "returns only case contacts the youth has transitioned" do
         report = CaseContactReport.new({has_transitioned: false})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns only case contacts the youth has transitioned" do
-        case_case_1 = create(:casa_case, transition_aged_youth: false)
-        case_case_2 = create(:casa_case, transition_aged_youth: true)
-        create(:case_contact, {casa_case: case_case_1})
-        create(:case_contact, {casa_case: case_case_2})
         report = CaseContactReport.new({has_transitioned: true})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns case contacts with both youth has transitioned and youth has not transitioned" do
-        case_case_1 = create(:casa_case, transition_aged_youth: false)
-        case_case_2 = create(:casa_case, transition_aged_youth: true)
-        create(:case_contact, {casa_case: case_case_1})
-        create(:case_contact, {casa_case: case_case_2})
         report = CaseContactReport.new({has_transitioned: ""})
         contacts = report.case_contacts
         expect(contacts.length).to eq(2)
@@ -208,31 +200,24 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     describe "wanting driving reimbursement functionality" do
-      it "returns only contacts that want reimbursement" do
-        # want_driving_reimbursement
+      before(:each) do
         create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
         create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
+      end
 
+      it "returns only contacts that want reimbursement" do
         report = CaseContactReport.new({want_driving_reimbursement: true})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns only contacts that DO NOT want reimbursement" do
-        # want_driving_reimbursement
-        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
-
         report = CaseContactReport.new({want_driving_reimbursement: false})
         contacts = report.case_contacts
         expect(contacts.length).to eq(1)
       end
 
       it "returns contacts that both want reimbursement and do not want reimbursement" do
-        # want_driving_reimbursement
-        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: true})
-        create(:case_contact, {miles_driven: 50, want_driving_reimbursement: false})
-
         report = CaseContactReport.new({want_driving_reimbursement: ""})
         contacts = report.case_contacts
         expect(contacts.length).to eq(2)

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -149,12 +149,13 @@ RSpec.describe CaseContact, type: :model do
     end
 
     describe ".has_transitioned" do
+      let(:casa_case_1) { create(:casa_case, transition_aged_youth: true) }
+      let(:casa_case_2) { create(:casa_case, transition_aged_youth: false) }
+
       context "with both option" do
         it "returns case contacts filtered by contact made option" do
-          case_case_1 = create(:casa_case, transition_aged_youth: true)
-          case_case_2 = create(:casa_case, transition_aged_youth: false)
-          case_contact_1 = create(:case_contact, {casa_case: case_case_1})
-          case_contact_2 = create(:case_contact, {casa_case: case_case_2})
+          case_contact_1 = create(:case_contact, {casa_case: casa_case_1})
+          case_contact_2 = create(:case_contact, {casa_case: casa_case_2})
 
           expect(CaseContact.has_transitioned("")).to match_array([case_contact_1, case_contact_2])
         end
@@ -162,10 +163,8 @@ RSpec.describe CaseContact, type: :model do
 
       context "with yes option" do
         it "returns case contacts filtered by contact made option" do
-          case_case_1 = create(:casa_case, transition_aged_youth: true)
-          case_case_2 = create(:casa_case, transition_aged_youth: false)
-          case_contact = create(:case_contact, {casa_case: case_case_1})
-          create(:case_contact, {casa_case: case_case_2})
+          case_contact = create(:case_contact, {casa_case: casa_case_1})
+          create(:case_contact, {casa_case: casa_case_2})
 
           expect(CaseContact.has_transitioned(true)).to match_array([case_contact])
         end
@@ -173,10 +172,8 @@ RSpec.describe CaseContact, type: :model do
 
       context "with no option" do
         it "returns case contacts filtered by contact made option" do
-          case_case_1 = create(:casa_case, transition_aged_youth: true)
-          case_case_2 = create(:casa_case, transition_aged_youth: false)
-          create(:case_contact, {casa_case: case_case_1})
-          case_contact = create(:case_contact, {casa_case: case_case_2})
+          create(:case_contact, {casa_case: casa_case_1})
+          case_contact = create(:case_contact, {casa_case: casa_case_2})
 
           expect(CaseContact.has_transitioned(false)).to match_array([case_contact])
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,19 +156,18 @@ RSpec.describe User, type: :model do
   end
 
   describe "#actively_assigned_and_active_cases" do
-    let(:casa_org) { create(:casa_org) }
-    let(:user) { create(:volunteer, casa_org: casa_org) }
+    let(:user) { create(:volunteer) }
     let!(:active_case_assignment_with_active_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org), volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), volunteer: user)
     end
     let!(:active_case_assignment_with_inactive_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, active: false), volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false), volunteer: user)
     end
     let!(:inactive_case_assignment_with_active_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org), is_active: false, volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), is_active: false, volunteer: user)
     end
     let!(:inactive_case_assignment_with_inactive_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, active: false), is_active: false, volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false), is_active: false, volunteer: user)
     end
 
     it "only returns the user's active cases with active case assignments" do

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "/all_casa_admins", type: :request do
+  let(:admin) { create(:all_casa_admin) }
+
+  before(:each) { sign_in admin }
+
   describe "GET /edit" do
     context "with a all_casa_admin signed in" do
       it "renders a successful response" do
-        sign_in create(:all_casa_admin)
-
         get edit_all_casa_admins_path
 
         expect(response).to be_successful
@@ -16,9 +18,6 @@ RSpec.describe "/all_casa_admins", type: :request do
   describe "PATCH /update" do
     context "with valid parameters" do
       it "updates the all_casa_admin" do
-        admin = create(:all_casa_admin)
-        sign_in admin
-
         patch all_casa_admins_path, params: {all_casa_admin: {email: "newemail@example.com"}}
         expect(response).to have_http_status(:redirect)
 
@@ -28,8 +27,6 @@ RSpec.describe "/all_casa_admins", type: :request do
 
     context "with invalid parameters" do
       it "does not update the all_casa_admin" do
-        admin = create(:all_casa_admin)
-        sign_in admin
         other_admin = create(:all_casa_admin)
         patch all_casa_admins_path, params: {all_casa_admin: {email: other_admin.email}}
         expect(response).to have_http_status(:ok)
@@ -40,10 +37,6 @@ RSpec.describe "/all_casa_admins", type: :request do
   end
 
   describe "PATCH /update_password" do
-    let(:admin) { create(:all_casa_admin) }
-
-    before { sign_in admin }
-
     context "with valid parameters" do
       let(:params) do
         {

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -84,9 +84,10 @@ RSpec.describe "/case_contacts", type: :request do
     end
 
     describe "PATCH /update" do
+      let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+
       context "with valid parameters" do
         it "updates the requested case_contact and redirects to the root path" do
-          case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case)
           contact_type = create(:contact_type, name: "Attorney")
 
           patch case_contact_url(case_contact), params: {
@@ -107,7 +108,8 @@ RSpec.describe "/case_contacts", type: :request do
         it "does not allow update of case contacts created by other volunteers" do
           contact_type = create(:contact_type, name: "Attorney")
           contact_type2 = create(:contact_type, name: "Therapist")
-          case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case, contact_types: [contact_type])
+
+          case_contact.contact_types << contact_type
 
           patch case_contact_url(case_contact), params: {
             case_contact: {
@@ -123,7 +125,6 @@ RSpec.describe "/case_contacts", type: :request do
 
       context "with invalid parameters" do
         it "renders a successful response (i.e. to display the edit template)" do
-          case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case)
           patch case_contact_url(case_contact), params: {case_contact: invalid_attributes}
           expect(response).to be_successful
         end
@@ -133,6 +134,7 @@ RSpec.describe "/case_contacts", type: :request do
     describe "DELETE /destroy" do
       it "destroys the requested case_contact" do
         case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case)
+
         expect {
           delete case_contact_url(case_contact)
         }.to change(CaseContact, :count).by(-1)
@@ -140,6 +142,7 @@ RSpec.describe "/case_contacts", type: :request do
 
       it "redirects to the case_contacts list" do
         case_contact = create(:case_contact, creator: volunteer, casa_case: casa_case)
+
         delete case_contact_url(case_contact)
         expect(response).to redirect_to(case_contacts_url)
       end

--- a/spec/requests/emancipation_checklists_request_spec.rb
+++ b/spec/requests/emancipation_checklists_request_spec.rb
@@ -1,16 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "/emancipation_checklists", type: :request do
-  let(:organization) { create(:casa_org) }
-
   describe "GET /index" do
     before { sign_in volunteer }
 
     context "when viewing the page as a volunteer" do
-      let(:volunteer) { create(:volunteer, casa_org: organization) }
+      let(:volunteer) { create(:volunteer) }
 
       context "when viewing the page with exactly one transitioning case" do
-        let(:casa_case) { create(:casa_case, casa_org: organization, transition_aged_youth: true) }
+        let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org, transition_aged_youth: true) }
         let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
         it "redirects to the emancipation checklist page for that case" do
@@ -27,8 +25,8 @@ RSpec.describe "/emancipation_checklists", type: :request do
       end
 
       context "when viewing the page with more than one transitioning cases" do
-        let(:casa_case_a) { create(:casa_case, casa_org: organization, transition_aged_youth: true) }
-        let(:casa_case_b) { create(:casa_case, casa_org: organization, transition_aged_youth: true) }
+        let(:casa_case_a) { create(:casa_case, casa_org: volunteer.casa_org, transition_aged_youth: true) }
+        let(:casa_case_b) { create(:casa_case, casa_org: volunteer.casa_org, transition_aged_youth: true) }
         let!(:case_assignment_a) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case_a) }
         let!(:case_assignment_b) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case_b) }
 


### PR DESCRIPTION
### What changed, and why?
Some of the tests have repetitive lines so I just wrapped them in `before(:each)` or `let`  
Emancipation checklist request tests have been grouped by user type and is more similar to how casa case request tests are structured. 