### PR TITLE
Redirect to the volunteer edit page after creating a volunteer

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -25,7 +25,7 @@ class VolunteersController < ApplicationController
 
     if @volunteer.save
       @volunteer.invite!
-      redirect_to volunteers_path
+      redirect_to edit_volunteer_path(@volunteer)
     else
       render :new
     end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "/volunteers", type: :request do
         volunteer = Volunteer.last
         expect(volunteer.email).to eq("volunteer1@example.com")
         expect(volunteer.display_name).to eq("Example")
-        expect(response).to redirect_to volunteers_path
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
       end
 
       it "sends an account_setup email" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/1700

### What changed, and why?

Previously, the admin was redirected to the volunteers page after creating a volunteer. This PR redirects the admin to the volunteer edit page instead.

### How will this affect user permissions?

NA

### How is this tested? (please write tests!) 💖💪

Updated the existing request spec to assert the redirect path.