### PR TITLE
Remove unneeded configs within actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.1
 
       - name: Install PostgreSQL client
         run: |
@@ -56,7 +54,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -26,8 +26,6 @@ jobs:
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.1
 
     - name: install gem erb_lint
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.1
 
       - name: Install PostgreSQL client
         run: |
@@ -56,7 +54,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          bundle install
           skylight disable_dev_warning
           yarn
           bundle exec rake db:create
@@ -80,5 +77,4 @@ jobs:
           RAILS_ENV: test
         run: |
           RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
-
 

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -26,12 +26,6 @@ jobs:
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7.1
-
-    - name: install dependencies
-      run: |
-        bundle install
 
     - name: lint
       run: bundle exec standardrb

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,12 +26,6 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.1
-
-      - name: install dependencies
-        run: |
-          bundle install
 
       - name: brakeman
         run: bundle exec brakeman


### PR DESCRIPTION
Removed the ruby version and bundle install configs.

The ruby-setup action automatically uses the ruby version listed in the
.ruby-version file and installs the deps.


