### PR TITLE
Supervisor weekly emails account for volunteers being unassinged from cases in part

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -29,6 +29,10 @@ class CasaCaseDecorator < Draper::Decorator
     object.case_contacts.max_by(&:occurred_at)
   end
 
+  def case_contacts_latest_before(date)
+    object.case_contacts.where("occurred_at < ?", date).max_by(&:occurred_at)
+  end
+
   def successful_contacts_this_week
     this_week = Date.today - 7.days..Date.today
     object.case_contacts.where(occurred_at: this_week).where(contact_made: true).count

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -38,9 +38,19 @@ class CasaCaseDecorator < Draper::Decorator
     object.case_contacts.where(occurred_at: this_week).where(contact_made: true).count
   end
 
+  def successful_contacts_this_week_before(date)
+    this_week_before_date = Date.today - 7.days..date
+    object.case_contacts.where(occurred_at: this_week_before_date).where(contact_made: true).count
+  end
+
   def unsuccessful_contacts_this_week
     this_week = Date.today - 7.days..Date.today
     object.case_contacts.where(occurred_at: this_week).where(contact_made: false).count
+  end
+
+  def unsuccessful_contacts_this_week_before(date)
+    this_week_before_date = Date.today - 7.days..date
+    object.case_contacts.where(occurred_at: this_week_before_date).where(contact_made: false).count
   end
 
   def court_report_select_option

--- a/app/decorators/case_assignment_decorator.rb
+++ b/app/decorators/case_assignment_decorator.rb
@@ -1,0 +1,8 @@
+class CaseAssignmentDecorator < Draper::Decorator
+  delegate_all
+
+  def unassigned_in_past_week?
+    this_week = Date.today - 7.days..Date.today
+    object.is_active == false && this_week.cover?(object.updated_at)
+  end
+end

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -24,12 +24,12 @@
           <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
             <b><%= "Summary for #{volunteer.display_name} Case #{casa_case.case_number}" %></b>
             <br>
-            <% successful_contacts = casa_case.decorate.successful_contacts_this_week %>
-            <% unsuccessful_contacts = casa_case.decorate.unsuccessful_contacts_this_week %>
+            <% successful_contacts = recently_unassigned ? casa_case.decorate.successful_contacts_this_week_before(case_assignment.updated_at) : casa_case.decorate.successful_contacts_this_week %>
+            <% unsuccessful_contacts = recently_unassigned ? casa_case.decorate.unsuccessful_contacts_this_week_before(case_assignment.updated_at) : casa_case.decorate.unsuccessful_contacts_this_week %>
             <% if successful_contacts + unsuccessful_contacts > 0 %>
-              <%= "Number of succesful case contacts made this week: #{successful_contacts}" %>
+              <%= "Number of successful case contacts made this week: #{successful_contacts}" %>
               <br>
-              <%= "Number of unsuccesful case contacts made this week: #{unsuccessful_contacts} " %>
+              <%= "Number of unsuccessful case contacts made this week: #{unsuccessful_contacts} " %>
               <br>
               <% recent_contact = recently_unassigned ? casa_case.decorate.case_contacts_latest_before(case_assignment.updated_at) : casa_case.decorate.case_contacts_latest %>
               <%= "Most recent contact attempted:" %>
@@ -51,7 +51,9 @@
             <% if recently_unassigned %>
               <br>
               This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
-              The above activity only describes the portion of the week when the case was still assigned to <% volunteer.display_name %>
+            <% if successful_contacts + unsuccessful_contacts > 0 %>
+                The above activity only describes the portion of the week when the case was still assigned to <% volunteer.display_name %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -17,41 +17,44 @@
   <% @supervisor.volunteers.each do |volunteer| %>
 
     <% volunteer.case_assignments_with_cases.each do |case_assignment| %>
-      <% casa_case = case_assignment.casa_case %>
-      <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
-        <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-          <b><%= "Summary for #{volunteer.display_name} Case #{casa_case.case_number}" %></b>
-          <br>
-          <% successful_contacts = casa_case.decorate.successful_contacts_this_week %>
-          <% unsuccessful_contacts = casa_case.decorate.unsuccessful_contacts_this_week %>
-          <% if successful_contacts + unsuccessful_contacts > 0 %>
-            <%= "Number of succesful case contacts made this week: #{successful_contacts}" %>
+      <% recently_unassigned = case_assignment.decorate.unassigned_in_past_week? %>
+      <% if case_assignment.is_active || recently_unassigned %>
+        <% casa_case = case_assignment.casa_case %>
+        <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
+          <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+            <b><%= "Summary for #{volunteer.display_name} Case #{casa_case.case_number}" %></b>
             <br>
-            <%= "Number of unsuccesful case contacts made this week: #{unsuccessful_contacts} " %>
-            <br>
-            <% recent_contact = casa_case.decorate.case_contacts_latest %>
-            <%= "Most recent contact attempted:" %>
-            <br>
-            <%= " - Date: #{I18n.l(recent_contact&.occurred_at, format: :full, default: nil)}" %>
-            <br>
-            <%= " - Type: #{recent_contact&.decorate.contact_types}" %>
-            <br>
-            <%= " - Duration: #{recent_contact&.duration_minutes}" %>
-            <br>
-            <%= " - Contact Made: #{recent_contact&.contact_made}" %>
-            <br>
-            <%= " - Medium Type: #{recent_contact&.medium_type}" %>
-            <br>
-            <%= " - Notes: #{recent_contact&.notes}" %>
-          <% else %>
-            No contact attempts were logged for this week.
-          <% end %>
-          <% if case_assignment.decorate.unassigned_in_past_week? %>
-            <br>
-            This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
-          <% end %>
-        </td>
-      </tr>
+            <% successful_contacts = casa_case.decorate.successful_contacts_this_week %>
+            <% unsuccessful_contacts = casa_case.decorate.unsuccessful_contacts_this_week %>
+            <% if successful_contacts + unsuccessful_contacts > 0 %>
+              <%= "Number of succesful case contacts made this week: #{successful_contacts}" %>
+              <br>
+              <%= "Number of unsuccesful case contacts made this week: #{unsuccessful_contacts} " %>
+              <br>
+              <% recent_contact = casa_case.decorate.case_contacts_latest %>
+              <%= "Most recent contact attempted:" %>
+              <br>
+              <%= " - Date: #{I18n.l(recent_contact&.occurred_at, format: :full, default: nil)}" %>
+              <br>
+              <%= " - Type: #{recent_contact&.decorate.contact_types}" %>
+              <br>
+              <%= " - Duration: #{recent_contact&.duration_minutes}" %>
+              <br>
+              <%= " - Contact Made: #{recent_contact&.contact_made}" %>
+              <br>
+              <%= " - Medium Type: #{recent_contact&.medium_type}" %>
+              <br>
+              <%= " - Notes: #{recent_contact&.notes}" %>
+            <% else %>
+              No contact attempts were logged for this week.
+            <% end %>
+            <% if recently_unassigned %>
+              <br>
+              This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
   <% end %>
 </table>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -51,6 +51,7 @@
             <% if recently_unassigned %>
               <br>
               This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
+              The above activity only describes the portion of the week when the case was still assigned to <% volunteer.display_name %>
             <% end %>
           </td>
         </tr>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -23,14 +23,20 @@
           <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
             <b><%= "Summary for #{volunteer.display_name} Case #{casa_case.case_number}" %></b>
             <br>
-            <% successful_contacts = recently_unassigned ? casa_case.decorate.successful_contacts_this_week_before(case_assignment.updated_at) : casa_case.decorate.successful_contacts_this_week %>
-            <% unsuccessful_contacts = recently_unassigned ? casa_case.decorate.unsuccessful_contacts_this_week_before(case_assignment.updated_at) : casa_case.decorate.unsuccessful_contacts_this_week %>
+            <% successful_contacts = recently_unassigned ?
+              casa_case.decorate.successful_contacts_this_week_before(case_assignment.updated_at) :
+              casa_case.decorate.successful_contacts_this_week %>
+            <% unsuccessful_contacts = recently_unassigned ?
+              casa_case.decorate.unsuccessful_contacts_this_week_before(case_assignment.updated_at) :
+              casa_case.decorate.unsuccessful_contacts_this_week %>
             <% if successful_contacts + unsuccessful_contacts > 0 %>
               <%= "Number of successful case contacts made this week: #{successful_contacts}" %>
               <br>
               <%= "Number of unsuccessful case contacts made this week: #{unsuccessful_contacts} " %>
               <br>
-              <% recent_contact = recently_unassigned ? casa_case.decorate.case_contacts_latest_before(case_assignment.updated_at) : casa_case.decorate.case_contacts_latest %>
+              <% recent_contact = recently_unassigned ?
+                casa_case.decorate.case_contacts_latest_before(case_assignment.updated_at) :
+                casa_case.decorate.case_contacts_latest %>
               <%= "Most recent contact attempted:" %>
               <br>
               <%= " - Date: #{I18n.l(recent_contact&.occurred_at, format: :full, default: nil)}" %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -31,7 +31,7 @@
               <br>
               <%= "Number of unsuccesful case contacts made this week: #{unsuccessful_contacts} " %>
               <br>
-              <% recent_contact = casa_case.decorate.case_contacts_latest %>
+              <% recent_contact = recently_unassigned ? casa_case.decorate.case_contacts_latest_before(case_assignment.updated_at) : casa_case.decorate.case_contacts_latest %>
               <%= "Most recent contact attempted:" %>
               <br>
               <%= " - Date: #{I18n.l(recent_contact&.occurred_at, format: :full, default: nil)}" %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -15,7 +15,6 @@
     </td>
   </tr>
   <% @supervisor.volunteers.each do |volunteer| %>
-
     <% volunteer.case_assignments_with_cases.each do |case_assignment| %>
       <% recently_unassigned = case_assignment.decorate.unassigned_in_past_week? %>
       <% if case_assignment.is_active || recently_unassigned %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -46,6 +46,10 @@
           <% else %>
             No contact attempts were logged for this week.
           <% end %>
+          <% if case_assignment.decorate.unassigned_in_past_week? %>
+            <br>
+            This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -56,8 +56,8 @@
             <% if recently_unassigned %>
               <br>
               This case was unassigned from <%= volunteer.display_name %> on <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
-            <% if successful_contacts + unsuccessful_contacts > 0 %>
-                The above activity only describes the portion of the week when the case was still assigned to <% volunteer.display_name %>
+              <% if successful_contacts + unsuccessful_contacts > 0 %>
+                The above activity only describes the part of the week when the case was still assigned to <% volunteer.display_name %>
               <% end %>
             <% end %>
           </td>

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe SupervisorMailer, :type => :mailer do
+  describe ".weekly_digest" do
+    let(:supervisor) { create(:supervisor) }
+    let(:volunteer) { create(:volunteer, supervisor: supervisor) }
+    let(:mail) { SupervisorMailer.weekly_digest(supervisor) }
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Here's a summary of what happened with your volunteers this last week.")
+    end
+  end
+end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -4,34 +4,62 @@ RSpec.describe SupervisorMailer, :type => :mailer do
   describe ".weekly_digest" do
     let(:supervisor) { build(:supervisor) }
     let(:volunteer) { build(:volunteer, casa_org: supervisor.casa_org, supervisor: supervisor) }
+    let(:casa_case) { build(:casa_case, casa_org: supervisor.casa_org) }
     
     let(:mail) { SupervisorMailer.weekly_digest(supervisor) }
 
     context "when a supervisor has volunteer assigned to a casa case" do
-      let!(:case_assignment) { create(:case_assignment, casa_case: build(:casa_case, casa_org: supervisor.casa_org), volunteer: volunteer) }
+      let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
+
       it "shows a summary for a volunteer assigned to the supervisor" do
         expect(mail.body.encoded).to match("Summary for #{ volunteer.display_name }")
       end
 
       it "does not show a case contact that did not occurr in the week" do
+        create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 8.days)
+        expect(mail.body.encoded).to_not match("Most recent contact attempted:")
       end
 
       it "shows the latest case contact that occurred in the week" do
+        most_recent_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 1.days, notes: "AAAAAAAAAAAAAAAAAAAAAAAA")
+        other_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 3.days, notes: "BBBBBBBBBBBBBBBBBBBB")
+
+        expect(mail.body.encoded).to match("Notes: #{ most_recent_contact.notes }")
+        expect(mail.body.encoded).to_not match("Notes: #{ other_contact.notes }")
       end
     end
 
     context "when a supervisor has a volunteer who is unassigned from a casa case during the week" do
+      let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 2.days) }
+
       it "shows a summary for a volunteer recently unassigned from the supervisor" do
+        expect(mail.body.encoded).to match("Summary for #{ volunteer.display_name }")
+      end
+
+      it "shows a disclaimer for a volunteer recently unassigned from the supervisor" do
+        expect(mail.body.encoded).to match("This case was unassigned from #{ volunteer.display_name }")
       end
 
       it "does not show a case contact that occurred past the unassignment date in the week" do
+        contact_past_unassignment = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 1.days, notes: "AAAAAAAAAAAAAAAAAAAAAAAA")
+
+        expect(mail.body.encoded).to_not match("Notes: #{ contact_past_unassignment.notes }")
       end
 
       it "shows the latest case contact that occurred in the week before the unassignment date" do
+        contact_past_unassignment = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 1.days, notes: "AAAAAAAAAAAAAAAAAAAAAAAA")
+        most_recent_contact_before_unassignment = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 3.days, notes: "BBBBBBBBBBBBBBBBBB")
+        older_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 4.days, notes: "CCCCCCCCCCCCCCCCCCCC")
+
+        expect(mail.body.encoded).to match("Notes: #{ most_recent_contact_before_unassignment.notes }")
+        expect(mail.body.encoded).to_not match("Notes: #{ contact_past_unassignment.notes }")
+        expect(mail.body.encoded).to_not match("Notes: #{ older_contact.notes }")
       end
     end
 
     it "does not show a summary for a volunteer unassigned from the supervisor before the week" do
+      create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 8.days)
+      expect(mail.body.encoded).to_not match("Summary for #{ volunteer.display_name }")
     end
   end
 end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -2,12 +2,36 @@ require "rails_helper"
 
 RSpec.describe SupervisorMailer, :type => :mailer do
   describe ".weekly_digest" do
-    let(:supervisor) { create(:supervisor) }
-    let(:volunteer) { create(:volunteer, supervisor: supervisor) }
+    let(:supervisor) { build(:supervisor) }
+    let(:volunteer) { build(:volunteer, casa_org: supervisor.casa_org, supervisor: supervisor) }
+    
     let(:mail) { SupervisorMailer.weekly_digest(supervisor) }
 
-    it "renders the body" do
-      expect(mail.body.encoded).to match("Here's a summary of what happened with your volunteers this last week.")
+    context "when a supervisor has volunteer assigned to a casa case" do
+      let!(:case_assignment) { create(:case_assignment, casa_case: build(:casa_case, casa_org: supervisor.casa_org), volunteer: volunteer) }
+      it "shows a summary for a volunteer assigned to the supervisor" do
+        expect(mail.body.encoded).to match("Summary for #{ volunteer.display_name }")
+      end
+
+      it "does not show a case contact that did not occurr in the week" do
+      end
+
+      it "shows the latest case contact that occurred in the week" do
+      end
+    end
+
+    context "when a supervisor has a volunteer who is unassigned from a casa case during the week" do
+      it "shows a summary for a volunteer recently unassigned from the supervisor" do
+      end
+
+      it "does not show a case contact that occurred past the unassignment date in the week" do
+      end
+
+      it "shows the latest case contact that occurred in the week before the unassignment date" do
+      end
+    end
+
+    it "does not show a summary for a volunteer unassigned from the supervisor before the week" do
     end
   end
 end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
-RSpec.describe SupervisorMailer, :type => :mailer do
+RSpec.describe SupervisorMailer, type: :mailer do
   describe ".weekly_digest" do
     let(:supervisor) { build(:supervisor) }
     let(:volunteer) { build(:volunteer, casa_org: supervisor.casa_org, supervisor: supervisor) }
     let(:casa_case) { build(:casa_case, casa_org: supervisor.casa_org) }
-    
+
     let(:mail) { SupervisorMailer.weekly_digest(supervisor) }
 
     context "when a supervisor has volunteer assigned to a casa case" do
       let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
 
       it "shows a summary for a volunteer assigned to the supervisor" do
-        expect(mail.body.encoded).to match("Summary for #{ volunteer.display_name }")
+        expect(mail.body.encoded).to match("Summary for #{volunteer.display_name}")
       end
 
       it "does not show a case contact that did not occurr in the week" do
@@ -24,8 +24,8 @@ RSpec.describe SupervisorMailer, :type => :mailer do
         most_recent_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 1.days, notes: "AAAAAAAAAAAAAAAAAAAAAAAA")
         other_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 3.days, notes: "BBBBBBBBBBBBBBBBBBBB")
 
-        expect(mail.body.encoded).to match("Notes: #{ most_recent_contact.notes }")
-        expect(mail.body.encoded).to_not match("Notes: #{ other_contact.notes }")
+        expect(mail.body.encoded).to match("Notes: #{most_recent_contact.notes}")
+        expect(mail.body.encoded).to_not match("Notes: #{other_contact.notes}")
       end
     end
 
@@ -33,17 +33,17 @@ RSpec.describe SupervisorMailer, :type => :mailer do
       let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 2.days) }
 
       it "shows a summary for a volunteer recently unassigned from the supervisor" do
-        expect(mail.body.encoded).to match("Summary for #{ volunteer.display_name }")
+        expect(mail.body.encoded).to match("Summary for #{volunteer.display_name}")
       end
 
       it "shows a disclaimer for a volunteer recently unassigned from the supervisor" do
-        expect(mail.body.encoded).to match("This case was unassigned from #{ volunteer.display_name }")
+        expect(mail.body.encoded).to match("This case was unassigned from #{volunteer.display_name}")
       end
 
       it "does not show a case contact that occurred past the unassignment date in the week" do
         contact_past_unassignment = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 1.days, notes: "AAAAAAAAAAAAAAAAAAAAAAAA")
 
-        expect(mail.body.encoded).to_not match("Notes: #{ contact_past_unassignment.notes }")
+        expect(mail.body.encoded).to_not match("Notes: #{contact_past_unassignment.notes}")
       end
 
       it "shows the latest case contact that occurred in the week before the unassignment date" do
@@ -51,15 +51,15 @@ RSpec.describe SupervisorMailer, :type => :mailer do
         most_recent_contact_before_unassignment = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 3.days, notes: "BBBBBBBBBBBBBBBBBB")
         older_contact = create(:case_contact, casa_case: casa_case, occurred_at: Date.today - 4.days, notes: "CCCCCCCCCCCCCCCCCCCC")
 
-        expect(mail.body.encoded).to match("Notes: #{ most_recent_contact_before_unassignment.notes }")
-        expect(mail.body.encoded).to_not match("Notes: #{ contact_past_unassignment.notes }")
-        expect(mail.body.encoded).to_not match("Notes: #{ older_contact.notes }")
+        expect(mail.body.encoded).to match("Notes: #{most_recent_contact_before_unassignment.notes}")
+        expect(mail.body.encoded).to_not match("Notes: #{contact_past_unassignment.notes}")
+        expect(mail.body.encoded).to_not match("Notes: #{older_contact.notes}")
       end
     end
 
     it "does not show a summary for a volunteer unassigned from the supervisor before the week" do
       create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 8.days)
-      expect(mail.body.encoded).to_not match("Summary for #{ volunteer.display_name }")
+      expect(mail.body.encoded).to_not match("Summary for #{volunteer.display_name}")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1438
in part

### What changed, and why?
#### Problem  
A volunteer is unassigned from a casa_case but the supervisor will still see the case in their weekly email every week after they've been unassigned. If the case is transferred to a different volunteer, and it starts receiving case contacts, it will appear as though the volunteer who the case was unassigned from has handled the new case contacts.  
  
#### Changes  
Supervisors will no longer see cases their volunteer have been unassigned from past the week they are unassigned  
Supervisors will see "This case was unassigned from VOLUNTEER on DATE" if the volunteer was unassigned from the case during the week.  
Supervisors will only see the latest case contact on a case that has been unassigned from a volunteer before the unassignment time.  
If a volunteer handled a case contact in the week before they were unassigned, there will be a disclaimer saying that the case activity only describes the portion of the week before the volunteer was unassigned.  

#### Further problems  
This PR does not solve:  
If a case has been reassigned to a new volunteer and they have not had any case contacts but the previous volunteer handled a case contact in the past week, it will appear as though the new volunteer handled the case contact of the previous volunteer. 