### PR TITLE
Add a message to the supervisor weekly email if they have no volunteers

### DIFF
--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -1,6 +1,6 @@
 class SupervisorMailer < ApplicationMailer
   def weekly_digest(supervisor)
     @supervisor = supervisor
-    mail(to: @supervisor.email, subject: "Weekly summary of volunteer's activities for the week of #{Date.today - 7.days}")
+    mail(to: @supervisor.email, subject: "Weekly summary of volunteers' activities for the week of #{Date.today - 7.days}")
   end
 end

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -7,7 +7,11 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+    <% if @supervisor.volunteers.length == 0 %>
+      You have no volunteers with assigned cases at the moment. When you do, you will see their status here.
+    <% else %>
       Here's a summary of what happened with your volunteers this last week.
+    <% end %>
     </td>
   </tr>
   <% @supervisor.volunteers.each do |volunteer| %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/1628

### What changed, and why?
- Adds a message to the supervisor weekly email if they have no volunteers
- Fixes apostrophe in a plural noun

### How will this affect user permissions?
It won't.

### How is this tested? (please write tests!) 💖💪

Manually, using mailer previews.

### Screenshots please :)

![image](https://user-images.githubusercontent.com/7039523/108150622-f4435b80-70a2-11eb-8d5b-7be699725b76.png)

