### PR TITLE
Let admin edit contact types like a supervisor

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -1,6 +1,6 @@
 class CasaCasesController < ApplicationController
   before_action :set_casa_case, only: %i[show edit update destroy deactivate reactivate]
-  before_action :set_contact_types, only: %i[new edit update create]
+  before_action :set_contact_types, only: %i[new edit update create deactivate]
   before_action :require_organization!
   after_action :verify_authorized
 

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -20,7 +20,7 @@ class CasaCasePolicy < ApplicationPolicy
   end
 
   def update_contact_types?
-    is_supervisor?
+    is_supervisor? || is_admin?
   end
 
   def update_birth_month_year_youth?

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -118,7 +118,6 @@
       <% if Pundit.policy(current_user, casa_case).update_contact_types? %>
         <div id="contact-type-form" class="field contact-type form-group">
           <h2 id="contact-type-label"><%= form.label :contact_types %></h2>
-
           <% @contact_types.each_with_index do |contact_type, index| %>
             <div class="form-check">
               <%= check_box_tag "casa_case[casa_case_contact_types_attributes][][contact_type_id]",

--- a/spec/policies/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe CasaCasePolicy do
     end
   end
 
+  permissions :update_contact_types? do
+    context "when user is an admin" do
+      it "allow update" do
+        is_expected.to permit(casa_admin, casa_case)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it "does allow update" do
+        is_expected.to permit(supervisor, casa_case)
+      end
+    end
+
+    context "when user is a volunteer" do
+      it "does not allow update" do
+        is_expected.not_to permit(volunteer, casa_case)
+      end
+    end
+  end
+
   permissions :assign_volunteers? do
     context "when user is an admin" do
       it "does allow volunteer assignment" do

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "casa_cases/edit" do
 
   before do
     enable_pundit(view, user)
+    assign :contact_types, []
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1699

### What changed, and why?
Updated policy to allow both supervisor and admins to edit contact types 

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: Same as before, can edit contact types 
- Admin permissions: Can edit contact types

### How is this tested? (please write tests!) 💖💪
- New test in `spec/policies/casa_case_policy_spec.rb`.

### Screenshots please :)
Admin: 
<img width="1562" alt="Screen Shot 2021-02-16 at 7 49 17 PM" src="https://user-images.githubusercontent.com/16447748/108153823-c523ee80-7090-11eb-8de8-b1fad37b8550.png">


