### PR TITLE
Allows any supervisor to edit/update case_contact

### DIFF
--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -4,7 +4,7 @@ class CaseContactPolicy < ApplicationPolicy
   end
 
   def is_creator_or_supervisor_or_casa_admin?
-    is_admin? || is_creator? || is_creator_supervisor?
+    is_creator? || admin_or_supervisor?
   end
 
   alias_method :index?, :admin_or_supervisor_or_volunteer?
@@ -36,10 +36,6 @@ class CaseContactPolicy < ApplicationPolicy
   end
 
   private
-
-  def is_creator_supervisor?
-    record.creator&.supervisor == user
-  end
 
   def is_creator?
     record.creator == user

--- a/spec/policies/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy_spec.rb
@@ -47,25 +47,8 @@ RSpec.describe CaseContactPolicy do
       is_expected.to permit(casa_admin, case_contact)
     end
 
-    context "when supervisor" do
-      let(:case_contact) { create(:case_contact, creator: supervisor) }
-
-      it "allows if is creator" do
-        is_expected.to permit(supervisor, case_contact)
-      end
-
-      it "does not allow if is not the creator" do
-        is_expected.to_not permit(supervisor, create(:case_contact, creator: create(:supervisor)))
-      end
-
-      it "allows if is supervisor of the creator" do
-        is_expected.to permit(supervisor, create(:case_contact, creator: create(:volunteer, supervisor: supervisor)))
-      end
-
-      it "does not allow if is not supervisor of the creator" do
-        is_expected.to_not permit(create(:supervisor),
-          create(:case_contact, creator: create(:volunteer, supervisor: create(:supervisor))))
-      end
+    it "allows supervisors" do
+      is_expected.to permit(supervisor, case_contact)
     end
 
     context "when volunteer is assigned" do
@@ -98,29 +81,12 @@ RSpec.describe CaseContactPolicy do
       is_expected.to permit(casa_admin, case_contact)
     end
 
-    it "does not allow volunteers" do
-      is_expected.not_to permit(volunteer, case_contact)
+    it "allows supervisors" do
+      is_expected.to permit(supervisor, case_contact)
     end
 
-    context "when supervisor" do
-      it "allows if is creator" do
-        supervisor = create(:supervisor)
-        is_expected.to permit(supervisor, create(:case_contact, creator: supervisor))
-      end
-
-      it "does not allow if is not the creator" do
-        is_expected.to_not permit(create(:supervisor), create(:case_contact, creator: create(:supervisor)))
-      end
-
-      it "allows if is supervisor of the creator" do
-        supervisor = create(:supervisor)
-        is_expected.to permit(supervisor, create(:case_contact, creator: create(:volunteer, supervisor: supervisor)))
-      end
-
-      it "does not allow if is not supervisor of the creator" do
-        is_expected.to_not permit(create(:supervisor),
-          create(:case_contact, creator: create(:volunteer, supervisor: create(:supervisor))))
-      end
+    it "does not allow volunteers" do
+      is_expected.not_to permit(volunteer, case_contact)
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1709

### What changed, and why?
Before we were only allow supervisors to edit/update `case_contacts` if the
volunteer who created the `case_conact` was assigned to the logged in
supervisor. This caused some problems with notifications, making the
notification not clickable if the volunteer was unassigned from the supervisor.

This will now allow any supervisor the ability to edit/update any
`case_contact`.


### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: All supervisors can now edit/update any
  `case_contact`.
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Mostly whacked tests around supervisors only being able to edit/update that
their volunteers created.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`