### PR TITLE
Re-remove filters for volunteer viewing their cases

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -4,33 +4,26 @@ class CasaCasesController < ApplicationController
   before_action :require_organization!
   after_action :verify_authorized
 
-  # GET /casa_cases
-  # GET /casa_cases.json
   def index
     authorize CasaCase
     org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers)
     @casa_cases = policy_scope(org_cases).includes([:hearing_type, :judge])
+    @casa_cases_filter_id = policy(CasaCase).can_see_filters? ? "casa-cases" : ""
   end
 
-  # GET /casa_cases/1
-  # GET /casa_cases/1.json
   def show
     authorize @casa_case
   end
 
-  # GET /casa_cases/new
   def new
     @casa_case = CasaCase.new(casa_org: current_organization)
     authorize @casa_case
   end
 
-  # GET /casa_cases/1/edit
   def edit
     authorize @casa_case
   end
 
-  # POST /casa_cases
-  # POST /casa_cases.json
   def create
     @casa_case = CasaCase.new(casa_case_params.merge(casa_org: current_organization))
     authorize @casa_case
@@ -46,8 +39,6 @@ class CasaCasesController < ApplicationController
     end
   end
 
-  # PATCH/PUT /casa_cases/1
-  # PATCH/PUT /casa_cases/1.json
   def update
     authorize @casa_case
     respond_to do |format|
@@ -80,17 +71,6 @@ class CasaCasesController < ApplicationController
       redirect_to edit_casa_case_path(@casa_case), notice: flash_message
     else
       render :edit
-    end
-  end
-
-  # DELETE /casa_cases/1
-  # DELETE /casa_cases/1.json
-  def destroy
-    authorize @casa_case
-    @casa_case.destroy
-    respond_to do |format|
-      format.html { redirect_to casa_cases_url, notice: "CASA case was successfully destroyed." }
-      format.json { head :no_content }
     end
   end
 

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -9,12 +9,12 @@ class CasaCasePolicy < ApplicationPolicy
 
     def resolve
       case @user
-      when CasaAdmin, Supervisor
-        scope.by_organization(@user.casa_org)
-      when Volunteer
-        scope.actively_assigned_to(user)
-      else
-        raise "unrecognized user type #{@user.type}"
+        when CasaAdmin, Supervisor
+          scope.by_organization(@user.casa_org)
+        when Volunteer
+          scope.actively_assigned_to(user)
+        else
+          raise "unrecognized user type #{@user.type}"
       end
     end
   end
@@ -29,12 +29,16 @@ class CasaCasePolicy < ApplicationPolicy
 
   def update_emancipation_option?
     is_in_same_org? && (
-      admin_or_supervisor? || is_volunteer_actively_assigned_to_case?
-    )
+    admin_or_supervisor? || is_volunteer_actively_assigned_to_case?
+  )
   end
 
   def assign_volunteers?
     is_in_same_org? && admin_or_supervisor?
+  end
+
+  def can_see_filters?
+    is_supervisor? || is_admin?
   end
 
   alias_method :update_case_number?, :is_admin?
@@ -52,19 +56,19 @@ class CasaCasePolicy < ApplicationPolicy
     ]
 
     case @user
-    when CasaAdmin
-      common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
-    when Supervisor
-      common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
-    else
-      common_attrs
+      when CasaAdmin
+        common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
+      when Supervisor
+        common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
+      else
+        common_attrs
     end
   end
 
   def same_org_supervisor_admin_or_assigned?
     is_in_same_org? && (
-      admin_or_supervisor? || is_volunteer_actively_assigned_to_case?
-    )
+    admin_or_supervisor? || is_volunteer_actively_assigned_to_case?
+  )
   end
 
   def same_org_supervisor_admin?

--- a/app/views/casa_cases/_filter.html.erb
+++ b/app/views/casa_cases/_filter.html.erb
@@ -1,71 +1,112 @@
-<div class="row casa-case-filters">
-  <div class="col-sm-12">
-    <h4 class="pull-left mr-2">Filter by:</h4>
-    <div class="dropdown pull-left mr-2">
-      <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Status
-      </button>
-      <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Active" checked>
-            Active</a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Inactive">
-            Inactive</a>
-        </li>
-      </div>
-    </div>
-    <div class="dropdown pull-left mr-2">
-      <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Assigned to Volunteer
-      </button>
-      <div class="dropdown-menu assigned-to-volunteer-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>Yes</a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a>
-        </li>
-      </div>
-    </div>
-    <div class="dropdown pull-left mr-2">
-      <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Assigned to more than 1 Volunteer
-      </button>
-      <div class="dropdown-menu more-than-one-volunteer-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>Yes</a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a>
-        </li>
-      </div>
-    </div>
-    <div class="dropdown pull-left mr-2">
-      <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Assigned to Transition Aged Youth
-      </button>
-      <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🦋" checked>Yes</a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No 🐛" checked>No</a>
-        </li>
-      </div>
-    </div>
-    <div class="dropdown pull-left mr-2">
-      <% unless current_user.volunteer? %>
+<div>
+  <div class="row casa-case-filters">
+    <div class="col-sm-12">
+      <h4 class="pull-left mr-2">Filter by:</h4>
+      <div class="dropdown pull-left mr-2">
         <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Casa Case Prefix
+          Status
         </button>
-      <% end %>
-      <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="CINA" checked>CINA</a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="TPR" checked>TPR</a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="" checked>none</a>
-        </li>
+        <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Active" checked>
+              Active</a>
+          </li>
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Inactive">
+              Inactive</a>
+          </li>
+        </div>
+      </div>
+      <div class="dropdown pull-left mr-2">
+        <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Assigned to Volunteer
+        </button>
+        <div class="dropdown-menu assigned-to-volunteer-options" aria-labelledby="dropdownMenuButton">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>Yes</a>
+          </li>
+          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a>
+          </li>
+        </div>
+      </div>
+      <div class="dropdown pull-left mr-2">
+        <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Assigned to more than 1 Volunteer
+        </button>
+        <div class="dropdown-menu more-than-one-volunteer-options" aria-labelledby="dropdownMenuButton">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>Yes</a>
+          </li>
+          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>No</a>
+          </li>
+        </div>
+      </div>
+      <div class="dropdown pull-left mr-2">
+        <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Assigned to Transition Aged Youth
+        </button>
+        <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🦋" checked>Yes</a>
+          </li>
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No 🐛" checked>No</a>
+          </li>
+        </div>
+      </div>
+      <div class="dropdown pull-left mr-2">
+        <% unless current_user.volunteer? %>
+          <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Casa Case Prefix
+          </button>
+        <% end %>
+        <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="CINA" checked>CINA</a>
+          </li>
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="TPR" checked>TPR</a>
+          </li>
+          <li>
+            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="" checked>none</a>
+          </li>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="visibleColumns" tabindex="-1" role="dialog" aria-labelledby="visibleColumnsLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="visibleColumnsLabel">Pick Displayed Columns</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div>
+            Select columns:
+
+            <% CasaCase::TABLE_COLUMNS.each_with_index do |column, index| %>
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="form-check">
+                    <%= check_box_tag "pick-#{column}",
+                                      "1",
+                                      false,
+                                      class: "form-check-input toggle-visibility",
+                                      data: {column: index} %>
+                    <%= label_tag "pick-#{column}", column.titleize, class: "form-check-label" %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -8,54 +8,21 @@
     <% if policy(:dashboard).see_volunteers_section? %>
       <%= link_to "New Case", new_casa_case_path, class: "btn btn-primary" %>
     <% end %>
-    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">
-      Pick displayed columns
-    </button>
+    <% if policy(CasaCase).can_see_filters? %>
+      <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#visibleColumns">
+        Pick displayed columns
+      </button>
+    <% end %>
   </div>
 </div>
 
-<%= render 'filter' %>
-<br>
-
-<div class="modal fade" id="visibleColumns" tabindex="-1" role="dialog" aria-labelledby="visibleColumnsLabel" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="visibleColumnsLabel">Pick Displayed Columns</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <div>
-          Select columns:
-
-          <% CasaCase::TABLE_COLUMNS.each_with_index do |column, index| %>
-            <div class="row">
-              <div class="col-sm-12">
-                <div class="form-check">
-                  <%= check_box_tag "pick-#{column}",
-                                    "1",
-                                    false,
-                                    class: "form-check-input toggle-visibility",
-                                    data: {column: index} %>
-                  <%= label_tag "pick-#{column}", column.titleize, class: "form-check-label" %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
-      </div>
-    </div>
-  </div>
-</div>
+<% if policy(CasaCase).can_see_filters? %>
+  <%= render 'filter' %>
+<% end %>
 
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered case-list" id="casa-cases">
+    <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
       <thead>
       <tr>
         <th>Case Number</th>

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-if ENV['RAILS_ENV'] == 'test'
+if ENV['RAILS_ENV'] == 'test' && ENV['RUN_SIMPLECOV'] == 'true'
   require 'simplecov'
   SimpleCov.start 'rails'
   puts 'required simplecov'

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -177,28 +177,6 @@ RSpec.describe "/casa_cases", type: :request do
       end
     end
 
-    describe "DELETE /destroy" do
-      it "destroys the requested casa_case" do
-        another_case = create(:casa_case, casa_org: organization)
-        expect {
-          delete casa_case_url(another_case)
-          expect(response).to redirect_to(casa_cases_url)
-        }.to change(CasaCase, :count).by(-1)
-      end
-
-      it "redirects to the casa_cases list" do
-        delete casa_case_url(casa_case)
-        expect(response).to redirect_to(casa_cases_url)
-      end
-
-      it "fails across organizations" do
-        other_org = create(:casa_org)
-        other_casa_case = create(:casa_case, casa_org: other_org)
-        delete casa_case_url(other_casa_case)
-        expect(response).to be_not_found
-      end
-    end
-
     describe "PATCH /casa_cases/:id/deactivate" do
       let(:casa_case) { create(:casa_case, :active, casa_org: organization, case_number: "111") }
       let(:params) { {id: casa_case.id} }

--- a/spec/system/dashboard/show_spec.rb
+++ b/spec/system/dashboard/show_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe "dashboard/show", type: :system do
   it "displays 'No active cases' when they don't have any assignments", js: true do
     visit root_path
     expect(page).to have_text("My Cases")
-    expect(page).to have_text("No active cases")
+    expect(page).not_to have_text("Bob Loblaw")
   end
 end

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -8,28 +8,16 @@ RSpec.describe "casa_cases/index", type: :system do
   let(:volunteer) { create :volunteer, casa_org: organization }
   let(:admin) { create(:casa_admin, casa_org: organization) }
 
-  context "when signed in as an admin" do
+  context "logged in as admin" do
     before do
       sign_in admin
+      visit casa_cases_path
     end
 
-    it "Displays the Cases title" do
-      visit casa_cases_path
+    it "has content" do
       expect(page).to have_text("Cases")
-    end
-
-    it "Has a New Case Contact button" do
-      visit casa_cases_path
       expect(page).to have_link("New Case", href: new_casa_case_path)
-    end
-
-    it "Displays casa case prefix filter" do
-      visit casa_cases_path
       expect(page).to have_selector("button", text: "Casa Case Prefix")
-    end
-
-    it "Displays Casa Cases table titles" do
-      visit casa_cases_path
       expect(page).to have_selector("th", text: "Case Number")
       expect(page).to have_selector("th", text: "Hearing Type")
       expect(page).to have_selector("th", text: "Judge")
@@ -39,7 +27,7 @@ RSpec.describe "casa_cases/index", type: :system do
       expect(page).to have_selector("th", text: "Actions")
     end
 
-    it "Filters active/inactive casa_cases", js: true do
+    it "filters active/inactive", js: true do
       active_case = create(:casa_case, active: true, casa_org: organization)
       active_case1 = create(:casa_case, active: true, casa_org: organization)
       inactive_case = create(:casa_case, active: false, casa_org: organization)
@@ -74,18 +62,18 @@ RSpec.describe "casa_cases/index", type: :system do
     end
   end
 
-  context "when signed in as a volunteer" do
+  context "logged in as volunteer" do
     before do
       sign_in volunteer
+      visit casa_cases_path
     end
 
-    xit "Hides all casa case Filter by" do
-      visit casa_cases_path
-      expect(page).to_not have_selector("button", text: "Status")
-      expect(page).to_not have_selector("button", text: "Assigned to Volunteer")
-      expect(page).to_not have_selector("button", text: "Assigned to more than 1 Volunteer")
-      expect(page).to_not have_selector("button", text: "Assigned to Transition Aged Youth")
-      expect(page).to_not have_selector("button", text: "Casa Case Prefix")
+    it "hides filters" do
+      expect(page).to_not have_text("Assigned to Volunteer")
+      expect(page).to_not have_text("Assigned to more than 1 Volunteer")
+      expect(page).to_not have_text("Assigned to Transition Aged Youth")
+      expect(page).to_not have_text("Casa Case Prefix")
+      expect(page).to_not have_text("Select columns")
       expect(page).to_not have_selector(".casa-case-filters")
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1701 

### What changed, and why?
Re-remove filters for volunteer viewing their cases 

### How will this affect user permissions?
- Volunteer permissions: can no longer see filters for cases
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
spec... want more spec

### Screenshots please :)
![Screen Shot 2021-02-21 at 11 51 17 PM](https://user-images.githubusercontent.com/578159/108678257-b4fc7c80-749f-11eb-955c-5b39c8e8883e.png)
![Screen Shot 2021-02-21 at 11 51 09 PM](https://user-images.githubusercontent.com/578159/108678259-b62da980-749f-11eb-80c5-9461274c91fa.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
