### PR TITLE
[#1759] Remove transition_aged_youth column from CSV file when importing a case

### DIFF
--- a/app/lib/importers/case_importer.rb
+++ b/app/lib/importers/case_importer.rb
@@ -50,7 +50,7 @@ class CaseImporter < FileImporter
     return {casa_case: casa_case, existing: true, deactivated: false} if casa_case.present?
 
     casa_case = CasaCase.new(casa_case_params)
-		casa_case.transition_aged_youth = casa_case.in_transition_age?
+    casa_case.transition_aged_youth = casa_case.in_transition_age?
     casa_case.casa_org_id = org_id
     casa_case.save!
 

--- a/app/lib/importers/case_importer.rb
+++ b/app/lib/importers/case_importer.rb
@@ -1,12 +1,12 @@
 class CaseImporter < FileImporter
-  IMPORT_HEADER = ["case_number", "transition_aged_youth", "case_assignment", "birth_month_year_youth"]
+  IMPORT_HEADER = ["case_number", "case_assignment", "birth_month_year_youth"]
 
   def self.import_cases(csv_filespec, org_id)
     new(csv_filespec, org_id).import_cases
   end
 
   def initialize(csv_filespec, org_id)
-    super(csv_filespec, org_id, "casa_cases", ["case_number", "transition_aged_youth", "case_assignment", "birth_month_year_youth"])
+    super(csv_filespec, org_id, "casa_cases", ["case_number", "case_assignment", "birth_month_year_youth"])
   end
 
   def import_cases
@@ -42,7 +42,7 @@ class CaseImporter < FileImporter
   private
 
   def create_casa_case(row_data)
-    casa_case_params = row_data.to_hash.slice(:case_number, :transition_aged_youth, :birth_month_year_youth)
+    casa_case_params = row_data.to_hash.slice(:case_number, :birth_month_year_youth)
     casa_case = CasaCase.find_by(casa_case_params)
 
     return {casa_case: casa_case, existing: true, deactivated: true} if casa_case.present? && !casa_case.active
@@ -50,6 +50,7 @@ class CaseImporter < FileImporter
     return {casa_case: casa_case, existing: true, deactivated: false} if casa_case.present?
 
     casa_case = CasaCase.new(casa_case_params)
+		casa_case.transition_aged_youth = casa_case.in_transition_age?
     casa_case.casa_org_id = org_id
     casa_case.save!
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -110,7 +110,7 @@ class CasaCase < ApplicationRecord
   end
 
   def in_transition_age?
-    birth_month_year_youth <= 14.years.ago
+    birth_month_year_youth.nil? ? false : birth_month_year_youth <= 14.years.ago
   end
 
   def has_transitioned?

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -109,6 +109,10 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   end
 
+	def in_transition_age?
+		birth_month_year_youth <= 14.years.ago
+	end
+
   def has_transitioned?
     transition_aged_youth
   end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -109,9 +109,9 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   end
 
-	def in_transition_age?
-		birth_month_year_youth <= 14.years.ago
-	end
+  def in_transition_age?
+    birth_month_year_youth <= 14.years.ago
+  end
 
   def has_transitioned?
     transition_aged_youth

--- a/public/casa_cases.csv
+++ b/public/casa_cases.csv
@@ -1,3 +1,3 @@
-﻿case_number,transition_aged_youth,case_assignment,birth_month_year_youth
-CINA-01-4347,TRUE,volunteer1@example.net,March 2010
-CINA-01-4348,FALSE,"volunteer2@example.net, volunteer3@example.net",September 2015
+﻿case_number,case_assignment,birth_month_year_youth
+CINA-01-4347,volunteer1@example.net,March 2010
+CINA-01-4348,"volunteer2@example.net, volunteer3@example.net",September 2015

--- a/spec/fixtures/casa_cases.csv
+++ b/spec/fixtures/casa_cases.csv
@@ -1,4 +1,4 @@
-﻿case_number,transition_aged_youth,case_assignment,birth_month_year_youth
-CINA-01-4347,TRUE,volunteer1@example.net,
-CINA-01-4348,FALSE,"volunteer2@example.net, volunteer3@example.net",February 2014
-CINA-01-4349,FALSE,,December 2016
+﻿case_number,case_assignment,birth_month_year_youth
+CINA-01-4347,volunteer1@example.net,
+CINA-01-4348,"volunteer2@example.net, volunteer3@example.net",February 2000
+CINA-01-4349,,December 2016

--- a/spec/fixtures/existing_casa_case.csv
+++ b/spec/fixtures/existing_casa_case.csv
@@ -1,2 +1,2 @@
-case_number,transition_aged_youth,case_assignment,birth_month_year_youth
-CINA-00-0000,TRUE,volunteer1@example.net,
+case_number,case_assignment,birth_month_year_youth
+CINA-00-0000,volunteer1@example.net,

--- a/spec/lib/importers/case_importer_spec.rb
+++ b/spec/lib/importers/case_importer_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe CaseImporter do
       expect { case_importer.import_cases }.to change(CasaCase, :count).by(3)
 
       # correctly imports true/false transition_aged_youth
-      expect(CasaCase.find_by(case_number: "CINA-01-4347").transition_aged_youth).to be_truthy
-      expect(CasaCase.find_by(case_number: "CINA-01-4348").transition_aged_youth).to be_falsey
+      expect(CasaCase.find_by(case_number: "CINA-01-4347").transition_aged_youth).to be_falsey # birth_month_year_youth is nil
+      expect(CasaCase.find_by(case_number: "CINA-01-4348").transition_aged_youth).to be_truthy
       expect(CasaCase.find_by(case_number: "CINA-01-4349").transition_aged_youth).to be_falsey
 
       # correctly imports birth_month_year_youth
       expect(CasaCase.find_by(case_number: "CINA-01-4347").birth_month_year_youth).to be_nil
-      expect(CasaCase.find_by(case_number: "CINA-01-4348").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2014-02-01"
+      expect(CasaCase.find_by(case_number: "CINA-01-4348").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2000-02-01"
       expect(CasaCase.find_by(case_number: "CINA-01-4349").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2016-12-01"
 
       # correctly adds volunteers


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1759

### What changed, and why?
When an admin imports Cases from a CSV file, they no longer have to (or can) specify the `transition_aged_youth` column.

When importing a case from a CSV file, `transition_aged_youth` is now calculated by checking if the youth is 14 years old or older.

The reference `casa_cases.csv` from the imports page has been updated and the column has been removed.

### How will this affect user permissions?
- Admin permissions: They can no longer specify a value for `transition_aged_youth` when importing a case from a CSV file, since it is now calculated automatically.

### How is this tested? (please write tests!) 💖💪
Since this is a minor change, I only updated the existing tests and fixtures. 

In the `casa_cases.csv` fixture I changed the `birth_month_year_youth` of one of the cases from 2014 to 2000, so we could test both values of `transition_aged_youth`.

### Screenshots please :)
Nothing in the UI was changed, but here is a screenshot of the sample CSV file before and after the change.

#### Before
![before](https://user-images.githubusercontent.com/72531802/108746407-0c8bfe00-751b-11eb-9112-fe2fd38da189.png)

#### After
![after](https://user-images.githubusercontent.com/72531802/108746417-10b81b80-751b-11eb-9e56-4a028b637582.png)
