### PR TITLE
[#1733] Add option to remove Court Mandates

### DIFF
--- a/app/controllers/case_court_mandates_controller.rb
+++ b/app/controllers/case_court_mandates_controller.rb
@@ -8,6 +8,8 @@ class CaseCourtMandatesController < ApplicationController
     @case_court_mandate.destroy
   end
 
+  private
+
   def set_case_court_mandate
     @case_court_mandate = CaseCourtMandate.find(params[:id])
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/case_court_mandates_controller.rb
+++ b/app/controllers/case_court_mandates_controller.rb
@@ -1,0 +1,16 @@
+class CaseCourtMandatesController < ApplicationController
+  before_action :set_case_court_mandate, only: %i[destroy]
+  before_action :require_organization!
+  after_action :verify_authorized
+
+  def destroy
+    authorize @case_court_mandate
+    @case_court_mandate.destroy
+  end
+
+  def set_case_court_mandate
+    @case_court_mandate = CaseCourtMandate.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+end

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -10,11 +10,12 @@ id="casa_case_case_court_mandates_attributes_1_mandate_text">\
   $(list).children(':last').trigger('focus')
 }
 
-function remove_mandate_with_confirmation() {
+function remove_mandate_with_confirmation () {
   Swal.fire({
     icon: 'warning',
     title: 'Delete mandate?',
-    text: 'Are you sure you want to remove this court mandate? Doing so will delete all records of it unless it was included in a previous court report.',
+    text: 'Are you sure you want to remove this court mandate? Doing so will \
+delete all records of it unless it was included in a previous court report.',
 
     showCloseButton: true,
     showCancelButton: true,
@@ -32,35 +33,38 @@ function remove_mandate_with_confirmation() {
   })
 }
 
-function remove_mandate_action(ctx) {
-  id = get_mandate_id(ctx)
+function remove_mandate_action (ctx) {
+  id_element = get_mandate_id_element(ctx)
+  id = id_element.val()
 
   $.ajax({
     url: `/case_court_mandates/${id}`,
-    method: "delete",
+    method: 'delete',
     success: () => {
       remove_mandate_entry(ctx)
+      id_element.remove() // Remove form element since this mandate has been deleted
+
       Swal.fire({
         icon: 'success',
         text: 'Court mandate has been removed.',
-        showCloseButton: true,
+        showCloseButton: true
       })
     },
     error: () => {
       Swal.fire({
         icon: 'error',
         text: 'Something went wrong when attempting to delete this court mandate.',
-        showCloseButton: true,
+        showCloseButton: true
       })
     }
   })
 }
 
-function get_mandate_id(ctx) {
-  return ctx.parent().next('input[type="hidden"]').val()
+function get_mandate_id_element (ctx) {
+  return ctx.parent().next('input[type="hidden"]')
 }
 
-function remove_mandate_entry(ctx) {
+function remove_mandate_entry (ctx) {
   ctx.parent().remove()
 }
 

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -10,6 +10,61 @@ id="casa_case_case_court_mandates_attributes_1_mandate_text">\
   $(list).children(':last').trigger('focus')
 }
 
+function remove_mandate_with_confirmation() {
+  Swal.fire({
+    icon: 'warning',
+    title: 'Delete mandate?',
+    text: 'Are you sure you want to remove this court mandate? Doing so will delete all records of it unless it was included in a previous court report.',
+
+    showCloseButton: true,
+    showCancelButton: true,
+    focusConfirm: false,
+
+    confirmButtonColor: '#d33',
+    cancelButtonColor: '#39c',
+
+    confirmButtonText: 'Delete',
+    cancelButtonText: 'Go back'
+  }).then((result) => {
+    if (result.isConfirmed) {
+      remove_mandate_action($(this))
+    }
+  })
+}
+
+function remove_mandate_action(ctx) {
+  id = get_mandate_id(ctx)
+
+  $.ajax({
+    url: `/case_court_mandates/${id}`,
+    method: "delete",
+    success: () => {
+      remove_mandate_entry(ctx)
+      Swal.fire({
+        icon: 'success',
+        text: 'Court mandate has been removed.',
+        showCloseButton: true,
+      })
+    },
+    error: () => {
+      Swal.fire({
+        icon: 'error',
+        text: 'Something went wrong when attempting to delete this court mandate.',
+        showCloseButton: true,
+      })
+    }
+  })
+}
+
+function get_mandate_id(ctx) {
+  return ctx.parent().next('input[type="hidden"]').val()
+}
+
+function remove_mandate_entry(ctx) {
+  ctx.parent().remove()
+}
+
 $('document').ready(() => {
   $('button#add-mandate-button').on('click', add_court_mandate_input)
+  $('button.remove-mandate-button').on('click', remove_mandate_with_confirmation)
 })

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -34,14 +34,14 @@ delete all records of it unless it was included in a previous court report.',
 }
 
 function remove_mandate_action (ctx) {
-  id_element = get_mandate_id_element(ctx)
+  id_element = ctx.parent().next('input[type="hidden"]')
   id = id_element.val()
 
   $.ajax({
     url: `/case_court_mandates/${id}`,
     method: 'delete',
     success: () => {
-      remove_mandate_entry(ctx)
+      ctx.parent().remove()
       id_element.remove() // Remove form element since this mandate has been deleted
 
       Swal.fire({
@@ -58,14 +58,6 @@ function remove_mandate_action (ctx) {
       })
     }
   })
-}
-
-function get_mandate_id_element (ctx) {
-  return ctx.parent().next('input[type="hidden"]')
-}
-
-function remove_mandate_entry (ctx) {
-  ctx.parent().remove()
 }
 
 $('document').ready(() => {

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -13,7 +13,7 @@ id="casa_case_case_court_mandates_attributes_1_mandate_text">\
 function remove_mandate_with_confirmation () {
   Swal.fire({
     icon: 'warning',
-    title: 'Delete mandate?',
+    title: 'Delete court mandate?',
     text: 'Are you sure you want to remove this court mandate? Doing so will \
 delete all records of it unless it was included in a previous court report.',
 

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -38,19 +38,37 @@ body.casa_cases {
     gap: 10px;
   }
 
-  #add-mandate-button {
-    background-color: #{$primary};
+  #add-mandate-button, .remove-mandate-button {
     color: white;
+    border: none;
 
     font-size: 1.25em;
-
-    padding: 0.25em 1.5em;
-    border-radius: 10px;
-    border: none;
 
     :hover {
       cursor: pointer;
     }
+  }
+
+  .court-mandate-entry {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .remove-mandate-button {
+      background-color: #{$red};
+
+      border-radius: 100%;
+
+      max-width: 30px;
+      max-height: 30px;
+    }
+  }
+
+  #add-mandate-button {
+    background-color: #{$primary};
+
+    padding: 0.25em 1.5em;
+    border-radius: 10px;
   }
 }
 

--- a/app/policies/case_court_mandate_policy.rb
+++ b/app/policies/case_court_mandate_policy.rb
@@ -1,0 +1,3 @@
+class CaseCourtMandatePolicy < ApplicationPolicy
+  alias_method :destroy?, :admin_or_supervisor?
+end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -122,7 +122,12 @@
           <% if policy(casa_case).update_court_mandates? %>
             <div id="mandates-list-container">
               <%= form.fields_for :case_court_mandates do |ff| %>
-                <%= ff.text_area :mandate_text %>
+                <div class="court-mandate-entry">
+                  <%= ff.text_area :mandate_text %>
+                  <button type="button" class="remove-mandate-button">
+                    <i class="fa fa-minus" aria-hidden="true"></i>
+                  </button>
+                </div>
               <% end %>
             </div>
             <div class="add-court-mandate-container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
       patch :unassign
     end
   end
+  resources :case_court_mandates, only: %i[destroy]
 
   namespace :all_casa_admins do
     resources :casa_orgs, only: [:new, :create, :show] do

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -19,6 +19,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_one_court_mandate do
+      after(:create) do |casa_case|
+        casa_case.case_court_mandates << build(:case_court_mandate)
+        casa_case.save
+      end
+    end
+
     trait :active do
       active { true }
     end

--- a/spec/requests/case_court_mandates_spec.rb
+++ b/spec/requests/case_court_mandates_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "/case_court_mandates", type: :request do
+  subject(:delete_request) { delete case_court_mandate_url(case_court_mandate) }
   let(:case_court_mandate) { build(:case_court_mandate) }
-  let(:delete_request) { delete case_court_mandate_url(case_court_mandate) }
 
   before do
     sign_in user

--- a/spec/requests/case_court_mandates_spec.rb
+++ b/spec/requests/case_court_mandates_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "/case_court_mandates", type: :request do
+  let(:case_court_mandate) { build(:case_court_mandate) }
+  let(:delete_request) { delete case_court_mandate_url(case_court_mandate) }
+
+  before do
+    sign_in user
+    casa_case = create(:casa_case)
+    casa_case.case_court_mandates << case_court_mandate
+  end
+
+  describe "as an admin" do
+    let(:user) { create(:casa_admin) }
+
+    describe "DELETE /destroy" do
+      it "renders a successful response" do
+        delete_request
+        expect(response).to be_successful
+      end
+
+      it "deletes the court mandate" do
+        expect { delete_request }.to change(CaseCourtMandate, :count).from(1).to(0)
+      end
+    end
+  end
+
+  describe "as a supervisor" do
+    let(:user) { create(:supervisor) }
+
+    describe "DELETE /destroy" do
+      it "renders a successful response" do
+        delete_request
+        expect(response).to be_successful
+      end
+
+      it "deletes the court mandate" do
+        expect { delete_request }.to change(CaseCourtMandate, :count).from(1).to(0)
+      end
+    end
+  end
+
+  describe "as a volunteer" do
+    let(:user) { create(:volunteer) }
+
+    describe "DELETE /destroy" do
+      it "renders a successful response" do
+        delete_request
+        # CASA will attempt to redirect to another page
+        expect(response.status).to be(302)
+      end
+
+      it "deletes the court mandate" do
+        expect { delete_request }.to_not change(CaseCourtMandate, :count)
+      end
+    end
+  end
+end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -303,6 +303,33 @@ RSpec.describe "casa_cases/edit", type: :system do
         expect(page).to have_text(volunteer_2.display_name)
       end
     end
+
+    context "deleting court mandates", js: true do
+      let(:casa_case) { create(:casa_case) }
+      let(:mandate) { build(:case_court_mandate) }
+
+      before do
+        casa_case.case_court_mandates << mandate
+      end
+
+      it "can delete a court mandate" do
+        visit edit_casa_case_path(casa_case.id)
+
+        expect(page).to have_text(mandate.mandate_text)
+
+        find("i.fa-minus").click
+        expect(page).to have_text("Are you sure you want to remove this court mandate? Doing so will delete all records \
+of it unless it was included in a previous court report.")
+
+        click_on "Delete"
+        expect(page).to have_text("Court mandate has been removed.")
+        click_on "OK"
+        expect(page).to_not have_text(mandate.mandate_text)
+
+        click_on "Update CASA Case"
+        expect(page).to_not have_text(mandate.mandate_text)
+      end
+    end
   end
 
   context "when volunteer" do

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -305,17 +305,13 @@ RSpec.describe "casa_cases/edit", type: :system do
     end
 
     context "deleting court mandates", js: true do
-      let(:casa_case) { create(:casa_case) }
-      let(:mandate) { build(:case_court_mandate) }
-
-      before do
-        casa_case.case_court_mandates << mandate
-      end
+      let(:casa_case) { create(:casa_case, :with_one_court_mandate) }
+      let(:mandate_text) { casa_case.case_court_mandates.first.mandate_text }
 
       it "can delete a court mandate" do
         visit edit_casa_case_path(casa_case.id)
 
-        expect(page).to have_text(mandate.mandate_text)
+        expect(page).to have_text(mandate_text)
 
         find("i.fa-minus").click
         expect(page).to have_text("Are you sure you want to remove this court mandate? Doing so will delete all records \
@@ -324,10 +320,10 @@ of it unless it was included in a previous court report.")
         click_on "Delete"
         expect(page).to have_text("Court mandate has been removed.")
         click_on "OK"
-        expect(page).to_not have_text(mandate.mandate_text)
+        expect(page).to_not have_text(mandate_text)
 
         click_on "Update CASA Case"
-        expect(page).to_not have_text(mandate.mandate_text)
+        expect(page).to_not have_text(mandate_text)
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1733

### What changed, and why?
When implementing #1795 I added an option to add and edit Court Mandates in the CASA Case Edit page.
Now I've implemented a way to delete Court Mandates that have already been saved in the database.

* The saved court mandates in the CASA Case Edit page now have a (-) (minus) button beside them.
* Clicking on it will show a dialog box with the requested confirmation text
* Deviating a little bit from what was requested, instead of adding a "Remove" and a "Return" button I added a "Delete" and "Go back" button instead.
* Clicking in the "Go back" button or the X button will close the dialog box and do nothing.
* Clicking in the "Delete" button will send an AJAX request to the server to delete the specified Court Mandate
* Instead of showing a notice (which most likely would require the page to be reloaded) I opted for showing another dialog box showing success (or failure, in case of any errors)
* After that, the court mandate disappears from the edit page

To "delete" a court mandate that has not been saved yet, the process remains the same: just empty the field.


### How will this affect user permissions?
- Volunteer permissions: Cannot delete court mandates
- Supervisor permissions: Can delete court mandates
- Admin permissions: Can delete court mandates

### How is this tested? (please write tests!) 💖💪
#### Automated tests
##### Request specs
For each type of user in the system (volunteers, admins and supervisors) I tested:
* Whether or not they could actually delete a court mandate
* Correct reponse from the server

##### Frontend specs
* The delete button shows a dialog box
* Clicking "Delete" removes the court mandate from the page
* The "success" dialog box shows up
* Clicking on Update CASA Case works perfectly, without any errors

#### Manual testing
* Log-in as admin/supervisor
* Go to a CASA case, add some court mandates and click Update to save the data
* Click on the minus button
* Check if the dialog box shows up and displays the correct message and buttons
* Click on the "Delete" button
* Check if the success dialog box shows up
* Check if the court mandate is actually gone in the page
* Update the page, check if no errors occurred and if the court mandate is actually gone

### Screenshots please :)
Overview
![01-overview](https://user-images.githubusercontent.com/72531802/109684445-091df580-7b5f-11eb-9ed4-6b8e46736830.png)
Dialog box
![02-dialog-box-delete](https://user-images.githubusercontent.com/72531802/109684448-09b68c00-7b5f-11eb-92b2-762997a0c23f.png)
Success message
![03-dialog-box-success](https://user-images.githubusercontent.com/72531802/109684451-09b68c00-7b5f-11eb-8cb8-a60ec05ea212.png)
After deletion
![04-after](https://user-images.githubusercontent.com/72531802/109684453-0a4f2280-7b5f-11eb-9465-90b67ddd0377.png)
Mobile view
![05-mobile-view](https://user-images.githubusercontent.com/72531802/109684456-0a4f2280-7b5f-11eb-86f8-c7f88d674827.png)
Mobile view of the dialog box
![06-dialog-box-mobile](https://user-images.githubusercontent.com/72531802/109684457-0ae7b900-7b5f-11eb-9825-c3ef84bad168.png)
Mobile view of the success dialog box
![07-dialog-box-success-mobile](https://user-images.githubusercontent.com/72531802/109684461-0ae7b900-7b5f-11eb-8ce3-c7da7f7be0ba.png)

