### PR TITLE
Allow supervisors to edit a volunteer's email address

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -4,7 +4,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def update_volunteer_email?
-    is_admin?
+    admin_or_supervisor?
   end
 
   def unassign_case?

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe VolunteerPolicy do
 
     context "when user is a supervisor" do
       it "does not permit" do
-        is_expected.not_to permit(supervisor)
+        is_expected.to permit(supervisor)
       end
     end
 

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "volunteers/edit", type: :view do
+  it "allows an administrator to edit a volunteers email address" do
+    administrator = build_stubbed :casa_admin
+    enable_pundit(view, administrator)
+    allow(view).to receive(:current_user).and_return(administrator)
+
+    volunteer = create :volunteer
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field('volunteer_email', readonly: true)
+  end
+
+  it "allows a supervisor to edit a volunteers email address" do
+    supervisor = build_stubbed :supervisor
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(supervisor)
+
+    volunteer = create :volunteer
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field('volunteer_email', readonly: true)
+  end
+
+  it "does not allow a supervisor to edit a volunteers email address" do
+    supervisor = build_stubbed :supervisor
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(supervisor)
+
+    volunteer = create :volunteer
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field('volunteer_email', readonly: true)
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1805 

### What changed, and why?


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: can now edit a volunteer's email address
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
See unit tests included in this pull request

### Screenshots please :)
<img width="829" alt="Screen Shot 2021-03-04 at 9 04 11 PM" src="https://user-images.githubusercontent.com/838526/110056765-62d41a80-7d2d-11eb-93aa-a839daceaed9.png">
