### PR TITLE
Move read more JS code from partial

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -29,6 +29,7 @@ require('src/select')
 require('src/dashboard')
 require('src/sidebar')
 require('src/sessions')
+require('src/readMore')
 
 // Uncomment to copy all static images under ../images to the output folder and
 // reference them with the image_pack_tag or asset_pack_path helpers in views.

--- a/app/javascript/src/readMore.js
+++ b/app/javascript/src/readMore.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('click', (event) => {
+    if (event.target.matches('.js-read-more')) {
+      return handleReadMore(event)
+    }
+
+    if (event.target.matches('.js-read-less')) {
+      return handleReadLess(event)
+    }
+  })
+})
+
+const handleReadMore = (event) => {
+  event.preventDefault()
+
+  const wrapper = event.target.closest('.js-read-more-text-wrapper')
+  wrapper.querySelector('.js-full-text').style.display = 'block'
+  wrapper.querySelector('.js-truncated-text').style.display = 'none'
+}
+
+const handleReadLess = (event) => {
+  event.preventDefault()
+
+  const wrapper = event.target.closest('.js-read-more-text-wrapper')
+  wrapper.querySelector('.js-truncated-text').style.display = 'block'
+  wrapper.querySelector('.js-full-text').style.display = 'none'
+}

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -13,15 +13,15 @@
               <br>
               <%= contact.decorate.subheading %>
             </h6>
-            <div class="card-text">
+            <div class="card-text js-read-more-text-wrapper">
               <% if contact.notes && contact.notes.length > CaseContactDecorator::NOTES_CHARACTER_LIMIT %>
-                <div class="limited-notes" style="display: block;">
+                <div class="js-truncated-text" style="display: block;">
                   <%= simple_format(contact.decorate.limited_notes) %>
-                  <span><a role="button" href="#" onClick="moreText(event)">Read more</a></span>
+                  <span><a role="button" href="#" class="js-read-more">Read more</a></span>
                 </div>
-                <div class="full-notes" style="display: none;">
+                <div class="js-full-text" style="display: none;">
                   <%= simple_format(contact.decorate.full_notes) %>
-                  <span><a role="button" href="#" onClick="lessText(event)">Hide</a></span>
+                  <span><a role="button" href="#" class="js-read-less">Hide</a></span>
                 </div>
               <% else %>
                 <%= simple_format(contact.decorate.full_notes) %>
@@ -69,21 +69,3 @@
     </h6>
   </div>
 </div>
-
-<script type="text/javascript">
-function moreText (event) {
-  event.preventDefault()
-  const table_cell = event.target.closest('.card-text')
-
-  table_cell.querySelectorAll('.full-notes')[0].style.display = 'block'
-  table_cell.querySelectorAll('.limited-notes')[0].style.display = 'none'
-}
-
-function lessText (event) {
-  event.preventDefault()
-  const table_cell = event.target.closest('.card-text')
-
-  table_cell.querySelectorAll('.full-notes')[0].style.display = 'none'
-  table_cell.querySelectorAll('.limited-notes')[0].style.display = 'block'
-}
-</script>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/1259

### What changed, and why?

Moves read more JS code from a partial which was being rendered N times. Uses vanilla JS event delegation to handle read more and read less link clicks. We can reuse this feature in other views by using the`.js-*` classes the script expects.
### How will this affect user permissions?
NA

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
