### PR TITLE
Changes is_active column name

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -6,13 +6,13 @@ class CaseAssignmentsController < ApplicationController
     authorize CaseAssignment
     case_assignments = case_assignment_parent.case_assignments
     existing_case_assignment = if params[:volunteer_id]
-      case_assignments.where(casa_case_id: case_assignment_params[:casa_case_id], is_active: false).first
+      case_assignments.where(casa_case_id: case_assignment_params[:casa_case_id], active: false).first
     else
-      case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], is_active: false).first
+      case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], active: false).first
     end
 
     if existing_case_assignment.present?
-      if existing_case_assignment.update(is_active: true)
+      if existing_case_assignment.update(active: true)
         flash.notice = "Volunteer reassigned to case"
       else
         errors = existing_case_assignment.errors.full_messages.join(". ")
@@ -45,7 +45,7 @@ class CaseAssignmentsController < ApplicationController
     volunteer = @case_assignment.volunteer
     flash_message = "Volunteer was unassigned from Case #{casa_case.case_number}."
 
-    if @case_assignment.update(is_active: false)
+    if @case_assignment.update(active: false)
       if params[:redirect_to_path] == "volunteer"
         redirect_to edit_volunteer_path(volunteer), notice: flash_message
       else

--- a/app/decorators/case_assignment_decorator.rb
+++ b/app/decorators/case_assignment_decorator.rb
@@ -3,6 +3,6 @@ class CaseAssignmentDecorator < Draper::Decorator
 
   def unassigned_in_past_week?
     this_week = Date.today - 7.days..Date.today
-    object.is_active == false && this_week.cover?(object.updated_at)
+    object.active == false && this_week.cover?(object.updated_at)
   end
 end

--- a/app/lib/importers/case_importer.rb
+++ b/app/lib/importers/case_importer.rb
@@ -65,8 +65,8 @@ class CaseImporter < FileImporter
 
       if assignment.empty?
         casa_case.volunteers << volunteer
-      elsif !assignment[0].is_active
-        assignment[0].update(is_active: true)
+      elsif !assignment[0].active
+        assignment[0].update(active: true)
       end
     end
   end

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -9,7 +9,7 @@ class CaseAssignment < ApplicationRecord
   validate :assignee_must_be_volunteer
   validate :casa_case_and_volunteer_must_belong_to_same_casa_org, if: -> { casa_case.present? && volunteer.present? }
 
-  scope :is_active, -> { where(is_active: true) }
+  scope :active, -> { where(active: true) }
 
   private
 
@@ -29,7 +29,7 @@ end
 # Table name: case_assignments
 #
 #  id           :bigint           not null, primary key
-#  is_active    :boolean          default(TRUE), not null
+#  active       :boolean          default(TRUE), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  casa_case_id :bigint           not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
   end
 
   def actively_assigned_and_active_cases
-    casa_cases.active.merge(CaseAssignment.is_active)
+    casa_cases.active.merge(CaseAssignment.active)
   end
 
   # all contacts this user has with this casa case
@@ -74,7 +74,7 @@ class User < ApplicationRecord
 
   def volunteers_serving_transition_aged_youth
     volunteers.includes(case_assignments: :casa_case)
-      .where(case_assignments: {is_active: true},
+      .where(case_assignments: {active: true},
              casa_cases: {active: true, transition_aged_youth: true}).size
   end
 
@@ -90,7 +90,7 @@ class User < ApplicationRecord
       .group("users.id, supervisor_volunteers_users.id, case_assignments.id")
       .where(active: true)
       .where(supervisor_volunteers: {is_active: true})
-      .where(case_assignments: {is_active: true})
+      .where(case_assignments: {active: true})
       .length
   end
 

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -36,7 +36,7 @@ class Volunteer < User
 
   def self.email_court_report_reminder
     active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|
-      volunteer.case_assignments.is_active.each do |case_assignment|
+      volunteer.case_assignments.active.each do |case_assignment|
         current_case = case_assignment.casa_case
         report_due_date = current_case.court_report_due_date
         if (report_due_date == Date.current + COURT_REPORT_SUBMISSION_REMINDER) && current_case.court_report_not_submitted?
@@ -56,7 +56,7 @@ class Volunteer < User
     transaction do
       updated = update(active: false)
       if updated
-        case_assignments.update_all(is_active: false)
+        case_assignments.update_all(active: false)
       end
 
       updated

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -98,6 +98,6 @@ class CasaCasePolicy < ApplicationPolicy
   end
 
   def is_volunteer_actively_assigned_to_case?
-    record.case_assignments.exists?(volunteer_id: user.id, is_active: true)
+    record.case_assignments.exists?(volunteer_id: user.id, active: true)
   end
 end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -21,6 +21,6 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def unassign?
-    record.is_active? && admin_or_supervisor?
+    record.active? && admin_or_supervisor?
   end
 end

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -25,7 +25,7 @@
               </td>
               <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
               <td data-test="assigned">
-                <% if assignment.is_active? %>
+                <% if assignment.active? %>
                   <span class='badge badge-success text-uppercase'>Assigned</span>
                 <% else %>
                     <span class="badge badge-danger text-uppercase">
@@ -35,7 +35,7 @@
               </td>
               <td data-test="assignment-start"><%= I18n.l(assignment.created_at, format: :full, default: nil) %></td>
               <td data-test="assignment-end">
-                <% unless assignment.is_active? %>
+                <% unless assignment.active? %>
                   <%= I18n.l(assignment.updated_at, format: :full, default: nil) %>
                 <% end %>
               </td>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -17,7 +17,7 @@
   <% @supervisor.volunteers.each do |volunteer| %>
     <% volunteer.case_assignments_with_cases.each do |case_assignment| %>
       <% recently_unassigned = case_assignment.decorate.unassigned_in_past_week? %>
-      <% if case_assignment.is_active || recently_unassigned %>
+      <% if case_assignment.active || recently_unassigned %>
         <% casa_case = case_assignment.casa_case %>
         <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
           <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -91,7 +91,7 @@
               <% end %>
             </td>
             <td>
-              <% if @volunteer.active? && assignment.is_active && assignment.casa_case.active? %>
+              <% if @volunteer.active? && assignment.active && assignment.casa_case.active? %>
                 <%- if Pundit.policy(current_user, @volunteer).unassign_case? %>
                   <%= button_to 'Unassign Case',
                                 unassign_case_assignment_path(assignment, volunteer_id: @volunteer.id),

--- a/db/migrate/20210308195135_change_is_active_name.rb
+++ b/db/migrate/20210308195135_change_is_active_name.rb
@@ -1,0 +1,5 @@
+class ChangeIsActiveName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :case_assignments, :is_active, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_133248) do
+ActiveRecord::Schema.define(version: 2021_03_08_195135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_133248) do
   create_table "case_assignments", force: :cascade do |t|
     t.bigint "casa_case_id", null: false
     t.bigint "volunteer_id", null: false
-    t.boolean "is_active", default: true, null: false
+    t.boolean "active", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["casa_case_id"], name: "index_case_assignments_on_casa_case_id"

--- a/spec/factories/case_assignment.rb
+++ b/spec/factories/case_assignment.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       casa_org { CasaOrg.first || create(:casa_org) }
     end
 
-    is_active { true }
+    active { true }
 
     casa_case do
       create(:casa_case, casa_org: @overrides[:volunteer].try(:casa_org) || casa_org)

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
     end
 
     context "when a supervisor has a volunteer who is unassigned from a casa case during the week" do
-      let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 2.days) }
+      let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false, updated_at: Date.today - 2.days) }
 
       it "shows a summary for a volunteer recently unassigned from the supervisor" do
         expect(mail.body.encoded).to match("Summary for #{volunteer.display_name}")
@@ -58,7 +58,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
     end
 
     it "does not show a summary for a volunteer unassigned from the supervisor before the week" do
-      create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false, updated_at: Date.today - 8.days)
+      create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false, updated_at: Date.today - 8.days)
       expect(mail.body.encoded).to_not match("Summary for #{volunteer.display_name}")
     end
   end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe CasaCase do
     it "only returns cases actively assigned to a volunteer" do
       current_user = create(:volunteer)
       inactive_case = create(:casa_case, casa_org: current_user.casa_org)
-      create(:case_assignment, casa_case: inactive_case, volunteer: current_user, is_active: false)
+      create(:case_assignment, casa_case: inactive_case, volunteer: current_user, active: false)
       active_cases = create_list(:casa_case, 2, casa_org: current_user.casa_org)
       active_cases.each do |casa_case|
-        create(:case_assignment, casa_case: casa_case, volunteer: current_user, is_active: true)
+        create(:case_assignment, casa_case: casa_case, volunteer: current_user, active: true)
       end
 
       other_user = create(:volunteer)
       other_active_case = create(:casa_case, casa_org: other_user.casa_org)
       other_inactive_case = create(:casa_case, casa_org: other_user.casa_org)
-      create(:case_assignment, casa_case: other_active_case, volunteer: other_user, is_active: true)
+      create(:case_assignment, casa_case: other_active_case, volunteer: other_user, active: true)
       create(
         :case_assignment,
-        casa_case: other_inactive_case, volunteer: other_user, is_active: false
+        casa_case: other_inactive_case, volunteer: other_user, active: false
       )
 
       assert_equal active_cases.map(&:case_number).sort, described_class.actively_assigned_to(current_user).map(&:case_number).sort
@@ -79,19 +79,19 @@ RSpec.describe CasaCase do
       never_assigned_case = create(:casa_case, casa_org: current_user.casa_org)
 
       inactive_case = create(:casa_case, casa_org: current_user.casa_org)
-      create(:case_assignment, casa_case: inactive_case, volunteer: current_user, is_active: false)
+      create(:case_assignment, casa_case: inactive_case, volunteer: current_user, active: false)
       active_cases = create_list(:casa_case, 2, casa_org: current_user.casa_org)
       active_cases.each do |casa_case|
-        create(:case_assignment, casa_case: casa_case, volunteer: current_user, is_active: true)
+        create(:case_assignment, casa_case: casa_case, volunteer: current_user, active: true)
       end
 
       other_user = create(:volunteer)
       other_active_case = create(:casa_case, casa_org: other_user.casa_org)
       other_inactive_case = create(:casa_case, casa_org: other_user.casa_org)
-      create(:case_assignment, casa_case: other_active_case, volunteer: other_user, is_active: true)
+      create(:case_assignment, casa_case: other_active_case, volunteer: other_user, active: true)
       create(
         :case_assignment,
-        casa_case: other_inactive_case, volunteer: other_user, is_active: false
+        casa_case: other_inactive_case, volunteer: other_user, active: false
       )
 
       expect(described_class.not_assigned(current_user.casa_org)).to contain_exactly(never_assigned_case, inactive_case, other_inactive_case)
@@ -290,7 +290,7 @@ RSpec.describe CasaCase do
 
       expect(casa_case.active_case_assignments).to eq case_assignments
 
-      case_assignments.first.update(is_active: false)
+      case_assignments.first.update(active: false)
       expect(casa_case.reload.active_case_assignments).to eq [case_assignments.last]
     end
   end
@@ -306,7 +306,7 @@ RSpec.describe CasaCase do
     it "only includes volunteers through active assignments" do
       expect(casa_case.assigned_volunteers.order(:id)).to eq [volunteer1, volunteer2].sort_by(&:id)
 
-      case_assignment1.update(is_active: false)
+      case_assignment1.update(active: false)
       expect(casa_case.reload.assigned_volunteers).to eq [volunteer2]
     end
 

--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe CaseAssignment do
     expect { volunteer_1.update(casa_org: casa_org_2) }.to change(case_assignment, :valid?).to false
   end
 
-  describe ".is_active" do
+  describe ".active" do
     it "only includes active case assignments" do
       casa_case = create(:casa_case)
       case_assignments = 2.times.map { create(:case_assignment, casa_case: casa_case, volunteer: create(:volunteer, casa_org: casa_case.casa_org)) }
-      expect(CaseAssignment.is_active).to eq case_assignments
+      expect(CaseAssignment.active).to eq case_assignments
 
-      case_assignments.first.update(is_active: false)
-      expect(CaseAssignment.is_active).to eq [case_assignments.last]
+      case_assignments.first.update(active: false)
+      expect(CaseAssignment.active).to eq [case_assignments.last]
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe User, type: :model do
     end
 
     it "does not return case_contacts neither unassigned cases or inactive cases" do
-      inactive_case_assignment = create(:case_assignment, casa_case: create(:casa_case, casa_org: volunteer.casa_org), is_active: false, volunteer: volunteer)
+      inactive_case_assignment = create(:case_assignment, casa_case: create(:casa_case, casa_org: volunteer.casa_org), active: false, volunteer: volunteer)
       case_assignment_to_inactve_case = create(:case_assignment, casa_case: create(:casa_case, active: false, casa_org: volunteer.casa_org), volunteer: volunteer)
 
       expect {
@@ -86,7 +86,7 @@ RSpec.describe User, type: :model do
       it "ignores volunteers' inactive and unassgined cases" do
         volunteer = create(:volunteer, supervisor: supervisor, casa_org: casa_org)
         create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, active: false, transition_aged_youth: true), volunteer: volunteer)
-        create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, transition_aged_youth: true), is_active: false, volunteer: volunteer)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: casa_org, transition_aged_youth: true), active: false, volunteer: volunteer)
 
         expect(supervisor.volunteers_serving_transition_aged_youth).to eq(0)
       end
@@ -131,8 +131,8 @@ RSpec.describe User, type: :model do
         case_of_interest_2 = volunteer_1.casa_cases.last
         case_assignment_1 = case_of_interest_1.case_assignments.find_by(volunteer: volunteer_1)
         case_assignment_2 = case_of_interest_2.case_assignments.find_by(volunteer: volunteer_1)
-        case_assignment_1.update!(is_active: false)
-        case_assignment_2.update!(is_active: false)
+        case_assignment_1.update!(active: false)
+        case_assignment_2.update!(active: false)
 
         expect(supervisor.no_contact_for_two_weeks).to eq(0)
       end
@@ -164,10 +164,10 @@ RSpec.describe User, type: :model do
       create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false), volunteer: user)
     end
     let!(:inactive_case_assignment_with_active_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), is_active: false, volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org), active: false, volunteer: user)
     end
     let!(:inactive_case_assignment_with_inactive_case) do
-      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false), is_active: false, volunteer: user)
+      create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, active: false), active: false, volunteer: user)
     end
 
     it "only returns the user's active cases with active case assignments" do
@@ -204,7 +204,7 @@ RSpec.describe User, type: :model do
 
     context "when the user is unassigned from a transition-aged-youth case" do
       it "is false" do
-        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: true), volunteer: user, is_active: false)
+        create(:case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: true), volunteer: user, active: false)
 
         expect(user).not_to be_serving_transition_aged_youth
       end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Volunteer, type: :model do
     let(:case_assignment1) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case1) }
     let(:case_assignment2) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case2) }
     let(:case_assignment3) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case3) }
-    let(:case_assignment_unassigned) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case4, is_active: false) }
+    let(:case_assignment_unassigned) { build(:case_assignment, casa_org: casa_org, casa_case: casa_case4, active: false) }
     let!(:v1) { create(:volunteer, casa_org: casa_org, case_assignments: [case_assignment1, case_assignment2, case_assignment3]) }
     let!(:v2) { create(:volunteer, casa_org: casa_org, active: false) }
     let!(:v3) { create(:volunteer, casa_org: casa_org) }
@@ -66,7 +66,7 @@ RSpec.describe Volunteer, type: :model do
       volunteer.deactivate
 
       case_contacts.each { |c| c.reload }
-      expect(case_contacts).to all(satisfy { |c| !c.is_active })
+      expect(case_contacts).to all(satisfy { |c| !c.active })
     end
   end
 
@@ -175,7 +175,7 @@ RSpec.describe Volunteer, type: :model do
 
     context "when a volunteer has only an unassigned case where contact was not made recently" do
       it "returns true" do
-        create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false)
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false)
         create(:case_contact, casa_case: casa_case, creator: volunteer, occurred_at: Date.current - 60.days, contact_made: true)
 
         expect(volunteer.made_contact_with_all_cases_in_days?).to eq(true)

--- a/spec/policies/case_assignment_policy_spec.rb
+++ b/spec/policies/case_assignment_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CaseAssignmentPolicy do
   let(:casa_case) { create(:casa_case, casa_org: organization) }
   let(:volunteer) { create(:volunteer, casa_org: organization) }
   let(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
-  let(:case_assignment_inactive) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, is_active: false) }
+  let(:case_assignment_inactive) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
   let(:casa_admin) { create(:casa_admin, casa_org: organization) }
 

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "/case_assignments", type: :request do
   describe "POST /create" do
     context "when the volunteer has been previously assigned to the casa_case" do
       it "reassigns the volunteer to the casa_case" do
-        create(:case_assignment, is_active: false, volunteer: volunteer, casa_case: casa_case)
+        create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
 
         sign_in admin
 
         expect {
           post case_assignments_url(casa_case_id: casa_case.id),
             params: {case_assignment: {volunteer_id: volunteer.id}}
-        }.to change { casa_case.case_assignments.first.is_active }.from(false).to(true)
+        }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
 
         expect(response).to redirect_to edit_casa_case_path(casa_case)
       end
@@ -130,7 +130,7 @@ RSpec.describe "/case_assignments", type: :request do
 
         expect {
           patch unassign_case_assignment_url(assignment, redirect_to_path: "volunteer")
-        }.to change { assignment.reload.is_active? }.to(false)
+        }.to change { assignment.reload.active? }.to(false)
 
         expect(response).to redirect_to edit_volunteer_path(volunteer)
       end
@@ -144,7 +144,7 @@ RSpec.describe "/case_assignments", type: :request do
 
         expect {
           patch unassign_case_assignment_url(assignment)
-        }.to change { assignment.reload.is_active? }.to(false)
+        }.to change { assignment.reload.active? }.to(false)
 
         expect(response).to redirect_to edit_casa_case_path(casa_case)
       end
@@ -158,7 +158,7 @@ RSpec.describe "/case_assignments", type: :request do
 
         expect {
           patch unassign_case_assignment_url(assignment)
-        }.not_to change { assignment.reload.is_active? }
+        }.not_to change { assignment.reload.active? }
 
         expect(response).to be_not_found
       end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe "volunteers/edit", type: :system do
     it "shows the unassign button for assigned cases and not for unassigned cases" do
       sign_in supervisor
 
-      assignment1 = volunteer.case_assignments.create(casa_case: casa_case_1, is_active: true)
-      assignment2 = volunteer.case_assignments.create(casa_case: casa_case_2, is_active: false)
+      assignment1 = volunteer.case_assignments.create(casa_case: casa_case_1, active: true)
+      assignment2 = volunteer.case_assignments.create(casa_case: casa_case_2, active: false)
 
       visit edit_volunteer_path(volunteer)
 

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "layout/sidebar", type: :view do
         create(:case_assignment, volunteer: user, casa_case: inactive_case)
 
         unassigned_case = create(:casa_case, casa_org: organization, transition_aged_youth: true)
-        create(:case_assignment, volunteer: user, casa_case: unassigned_case, is_active: false)
+        create(:case_assignment, volunteer: user, casa_case: unassigned_case, active: false)
 
         render partial: "layouts/sidebar"
         expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")


### PR DESCRIPTION
Resolves #1776

Changes the column case_assignment.is_active  to case_assignment.active  to match the others columns

This change won't affect user permissions

All tests which were working with .is_active now work as .active
