### PR TITLE
user should remain on Edit Volunteer page after editing a volunteer

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -5,9 +5,12 @@ class SupervisorVolunteersController < ApplicationController
     authorize :supervisor_volunteer
     supervisor_volunteer = supervisor_volunteer_parent.supervisor_volunteers.find_or_create_by!(supervisor_volunteer_params)
     supervisor_volunteer.is_active = true unless supervisor_volunteer&.is_active?
+    volunteer = supervisor_volunteer.volunteer
+    supervisor = supervisor_volunteer.supervisor
     supervisor_volunteer.save
+    flash_message = "#{volunteer.display_name} successfully assigned to #{supervisor.display_name}."
 
-    redirect_to after_action_path(supervisor_volunteer_parent)
+    redirect_to edit_volunteer_path(volunteer), notice: flash_message
   end
 
   def unassign

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -10,7 +10,7 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.save
     flash_message = "#{volunteer.display_name} successfully assigned to #{supervisor.display_name}."
 
-    redirect_to edit_volunteer_path(volunteer), notice: flash_message
+    redirect_to request.referrer, notice: flash_message
   end
 
   def unassign
@@ -22,21 +22,13 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.save!
     flash_message = "#{volunteer.display_name} was unassigned from #{supervisor.display_name}."
 
-    redirect_to after_action_path(supervisor), notice: flash_message
+    redirect_to request.referrer, notice: flash_message
   end
 
   private
 
   def supervisor_volunteer_params
     params.require(:supervisor_volunteer).permit(:supervisor_id, :volunteer_id)
-  end
-
-  def after_action_path(resource)
-    if resource.supervisor?
-      edit_supervisor_path(resource)
-    else
-      edit_volunteer_path(resource)
-    end
   end
 
   def supervisor_volunteer_parent

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: "#{edit_volunteer_path(volunteer)}"  }
+          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.to change(SupervisorVolunteer, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
-
       end
     end
 
@@ -41,7 +40,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
+          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.not_to change(SupervisorVolunteer, :count)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -69,7 +68,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
+          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.to change(SupervisorVolunteer, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -96,7 +95,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
+          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.not_to change(SupervisorVolunteer, :count)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -116,7 +115,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in admin
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer), headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
+          patch unassign_supervisor_volunteer_path(volunteer), headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload
@@ -130,7 +129,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in supervisor
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer), headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
+          patch unassign_supervisor_volunteer_path(volunteer), headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
   let!(:volunteer) { create(:volunteer, casa_org: casa_org) }
 
   context "POST /create" do
-    context "when no pre-existing association between supervisr and volunteer exists" do
+    context "when no pre-existing association between supervisor and volunteer exists" do
       it "creates a new supervisor_volunteers association" do
         valid_parameters = {
           supervisor_volunteer: {volunteer_id: volunteer.id},
@@ -16,9 +16,10 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters
+          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: "#{edit_volunteer_path(volunteer)}"  }
         }.to change(SupervisorVolunteer, :count).by(1)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
+
       end
     end
 
@@ -40,9 +41,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters
+          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
         }.not_to change(SupervisorVolunteer, :count)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
 
         association.reload
         expect(association.is_active?).to be(true)
@@ -68,9 +69,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters
+          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
         }.to change(SupervisorVolunteer, :count).by(1)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
 
         expect(previous_association.reload.is_active?).to be(false)
         expect(SupervisorVolunteer.where(supervisor: supervisor, volunteer: volunteer).exists?).to be(true)
@@ -95,9 +96,9 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters
+          post supervisor_volunteers_url, params: valid_parameters, headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
         }.not_to change(SupervisorVolunteer, :count)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
 
         association.reload
         expect(association.is_active?).to be(true)
@@ -115,12 +116,12 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in admin
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer)
+          patch unassign_supervisor_volunteer_path(volunteer), headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload
         expect(association.is_active?).to be(false)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
       end
     end
 
@@ -129,13 +130,13 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in supervisor
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer)
+          patch unassign_supervisor_volunteer_path(volunteer), headers: { "HTTP_REFERER" => "#{edit_volunteer_path(volunteer)}"  }
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload
 
         expect(association.is_active?).to be(false)
-        expect(response).to redirect_to edit_supervisor_path(supervisor)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
       end
     end
 

--- a/spec/requests/supervisor_volunteers_spec.rb
+++ b/spec/requests/supervisor_volunteers_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          post supervisor_volunteers_url, params: valid_parameters, headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.to change(SupervisorVolunteer, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
       end
@@ -40,7 +40,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          post supervisor_volunteers_url, params: valid_parameters, headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.not_to change(SupervisorVolunteer, :count)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -68,7 +68,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          post supervisor_volunteers_url, params: valid_parameters, headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.to change(SupervisorVolunteer, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -95,7 +95,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in(admin)
 
         expect {
-          post supervisor_volunteers_url, params: valid_parameters, headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          post supervisor_volunteers_url, params: valid_parameters, headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.not_to change(SupervisorVolunteer, :count)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
 
@@ -115,7 +115,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in admin
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer), headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          patch unassign_supervisor_volunteer_path(volunteer), headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload
@@ -129,7 +129,7 @@ RSpec.describe "/supervisor_volunteers", type: :request do
         sign_in supervisor
 
         expect {
-          patch unassign_supervisor_volunteer_path(volunteer), headers: { HTTP_REFERER: edit_volunteer_path(volunteer).to_s }
+          patch unassign_supervisor_volunteer_path(volunteer), headers: {HTTP_REFERER: edit_volunteer_path(volunteer).to_s}
         }.not_to change(supervisor.volunteers, :count)
 
         association.reload


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1806

### What changed, and why?
Changed the redirection after assigning/unassigning a supervisor to a volunteer, now remains in the current page. Also now show a success message after the assignment.


### How will this affect user permissions?
It will not affect permissions.

### How is this tested? (please write tests!) 💖💪
The specs which was testing the redirection, now test if  the page remains in the current page.

### Screenshots please :)
https://user-images.githubusercontent.com/61836657/110702537-66eeb500-81d1-11eb-9a11-60018d64b2e1.mp4




### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
'![alt-text](https://media.giphy.com/media/q6RoNkLlFNjaw/giphy.gif)'
