### PR TITLE
Sort contact type groups and contact types by name

### DIFF
--- a/app/controllers/casa_orgs_controller.rb
+++ b/app/controllers/casa_orgs_controller.rb
@@ -36,7 +36,7 @@ class CasaOrgsController < ApplicationController
   end
 
   def set_contact_type_data
-    @contact_type_groups = @casa_org.contact_type_groups
+    @contact_type_groups = @casa_org.contact_type_groups.order(:name)
     @contact_types = ContactType.for_organization(@casa_org)
   end
 

--- a/app/controllers/casa_orgs_controller.rb
+++ b/app/controllers/casa_orgs_controller.rb
@@ -37,7 +37,7 @@ class CasaOrgsController < ApplicationController
 
   def set_contact_type_data
     @contact_type_groups = @casa_org.contact_type_groups.order(:name)
-    @contact_types = ContactType.for_organization(@casa_org)
+    @contact_types = ContactType.for_organization(@casa_org).order(:name)
   end
 
   def set_hearing_types

--- a/app/views/casa_orgs/_contact_type_groups.html.erb
+++ b/app/views/casa_orgs/_contact_type_groups.html.erb
@@ -15,7 +15,7 @@
   </thead>
 
   <tbody>
-  <% @contact_type_groups.each do |group| %>
+  <% contact_type_groups.each do |group| %>
     <tr id="group-<%= group.id %>">
       <td scope="row">
         <%= group.name %>

--- a/app/views/casa_orgs/_contact_types.html.erb
+++ b/app/views/casa_orgs/_contact_types.html.erb
@@ -16,7 +16,7 @@
   </thead>
 
   <tbody>
-  <% @contact_types.each do |contact_type| %>
+  <% contact_types.each do |contact_type| %>
     <tr id="contact_type-<%= contact_type.id %>">
       <td scope="row">
         <%= contact_type.name %>

--- a/app/views/casa_orgs/edit.html.erb
+++ b/app/views/casa_orgs/edit.html.erb
@@ -38,7 +38,7 @@
   <div class="card-body">
     <%= render "contact_type_groups", contact_type_groups: @contact_type_groups %>
 
-    <%= render "contact_types" %>
+    <%= render "contact_types", contact_types: @contact_types %>
   </div>
 </div>
 

--- a/app/views/casa_orgs/edit.html.erb
+++ b/app/views/casa_orgs/edit.html.erb
@@ -36,7 +36,7 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <%= render "contact_type_groups" %>
+    <%= render "contact_type_groups", contact_type_groups: @contact_type_groups %>
 
     <%= render "contact_types" %>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/1390

### What changed, and why?

Sorts contact type groups and contact types by name on the edit organization page.

### How will this affect user permissions?
NA

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

![image](https://user-images.githubusercontent.com/7039523/111237508-3b017400-85c3-11eb-8ce5-7d01a0cb96b0.png)
