### PR TITLE
Pretty print FactoryBot object creation stats

### DIFF
--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -43,6 +43,6 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     puts "How many objects did factory_bot create? (probably too many- let's tune some factories...)"
-    p factory_bot_results
+    pp factory_bot_results
   end
 end


### PR DESCRIPTION
### What changed, and why?

This is a super minor PR pretty-printing the stats from FactoryBot.

**Before**
![image](https://user-images.githubusercontent.com/7039523/111252390-07344780-85df-11eb-9d54-5e23d4138b00.png)

**After**

![image](https://user-images.githubusercontent.com/7039523/111252377-fc79b280-85de-11eb-94c0-88d472c04eb8.png)


### How will this affect user permissions?
NA
