### PR TITLE
Fix factory bot lint workflow and job names

### DIFF
--- a/.github/workflows/factory_bot_lint.yml
+++ b/.github/workflows/factory_bot_lint.yml
@@ -1,4 +1,4 @@
-name: rspec
+name: factory bot lint
 
 on:
   push:
@@ -17,8 +17,7 @@ on:
       - 'bin/*'
 
 jobs:
-  rspec:
-
+  lint:
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
### What changed, and why?

This is a minor PR fixing the factory bot lint workflow which uses the same workflow name and job name as the `rspec` workflow.

**Before**

![image](https://user-images.githubusercontent.com/7039523/111261336-5171f480-85f0-11eb-9883-96b6eda86929.png)

**After**

![image](https://user-images.githubusercontent.com/7039523/111261715-e8d74780-85f0-11eb-98e3-1aff9c8d46a2.png)

### How will this affect user permissions?
NA
