### PR TITLE
Adding a JS alert before the case_contact form is submitted to notify of invalid date selection

### DIFF
--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -74,18 +74,17 @@ window.onload = function () {
   }
 
   function validateOccurredAt () {
-    debugger
-      const msg = 'Case Contact Occurrences cannot be in the future.'
-      const today = new Date()
-      today.setHours(0,0,0,0)
+    const msg = 'Case Contact Occurrences cannot be in the future.'
+    const today = new Date()
+    today.setHours(0,0,0,0)
 
-      let caseDate = new Date(caseOccurredAt.value)
-      caseDate.setDate(caseDate.getDate())
-      caseDate.setHours(0,0,0,0)
+    let caseDate = new Date(caseOccurredAt.value)
+    caseDate.setDate(caseDate.getDate())
+    caseDate.setHours(0,0,0,0)
 
-      if (caseDate > today) {
-        alert(msg)
-      } 
+    if (caseDate > today) {
+      alert(msg)
+    } 
   }
 
   function validateNoteContent (e) {

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -7,6 +7,7 @@ window.onload = function () {
   const durationHourDisplay = document.getElementById('casa-contact-duration-hours-display')
   const durationMinutes = document.getElementById('case-contact-duration-minutes')
   const durationMinuteDisplay = document.getElementById('casa-contact-duration-minutes-display')
+  const caseOccurredAt = document.getElementById('case_contact_occurred_at')
   const caseContactSubmit = document.getElementById('case-contact-submit')
 
   milesDriven.onchange = function () {
@@ -17,6 +18,9 @@ window.onload = function () {
     }
   }
 
+  caseOccurredAt.onchange = function() {
+    validateOccurredAt()
+  }
   durationHours.onchange = function () {
     if (durationHourDisplay.value !== durationHours.value) {
       durationHourDisplay.value = durationHours.value
@@ -67,6 +71,21 @@ window.onload = function () {
     } else {
       durationMinutes.setCustomValidity('')
     }
+  }
+
+  function validateOccurredAt () {
+    debugger
+      const msg = 'Case Contact Occurrences cannot be in the future.'
+      const today = new Date()
+      today.setHours(0,0,0,0)
+
+      let caseDate = new Date(caseOccurredAt.value)
+      caseDate.setDate(caseDate.getDate())
+      caseDate.setHours(0,0,0,0)
+
+      if (caseDate > today) {
+        alert(msg)
+      } 
   }
 
   function validateNoteContent (e) {


### PR DESCRIPTION
Working PR and open to suggestions

### What github issue is this PR for, if any?
Resolves #1835

### What changed, and why?
Added in a JS function to create an alert if a future date is selected to potentially improve the 'new case contact' process.  Hopefully this will help users catch a quick mistake before an attempted form submission.  This warning does not currently prevent a future date from being selected after a user is notified.  Open to adding that feature, but wanted to keep my changes minimal initially.



### How is this tested? (please write tests!) 💖💪
As of now, no tests have been written.  Could use some advice and instruction in this area

### Screenshots please :)
![image](https://user-images.githubusercontent.com/61096269/111352494-9b8fc000-865a-11eb-9d82-c02615d97a2a.png)

