### PR TITLE
Issue#1827

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -71,6 +71,14 @@ class VolunteersController < ApplicationController
     end
   end
 
+  def resend_invitation
+    authorize @volunteer
+    volunteer = Volunteer.find(params[:id])
+    volunteer.invite!
+
+    redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
+  end
+
   private
 
   def set_volunteer

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -10,4 +10,5 @@ class VolunteerPolicy < UserPolicy
   alias_method :update?, :index?
   alias_method :activate?, :index?
   alias_method :deactivate?, :index?
+  alias_method :resend_invitation?, :index?
 end

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -51,6 +51,12 @@
                         class: "btn btn-outline-success" %>
           <% end %>
         <% end %>
+        <% if current_user.supervisor? && @volunteer.invitation_accepted_at == nil%>
+        <%= link_to "Resend Invitation",
+                    resend_invitation_volunteer_path(@volunteer),
+                    method: :patch,
+                    class: "btn btn-outline-danger" %>
+        <% end %>
       </div>
 
       <div class="actions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     member do
       patch :activate
       patch :deactivate
+      patch :resend_invitation
     end
   end
   resources :case_assignments, only: %i[create destroy] do

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -179,4 +179,21 @@ RSpec.describe "volunteers/edit", type: :system do
       expect(page).not_to have_content(inactive_casa_case.case_number)
     end
   end
+
+  describe "resend invite" do
+    let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+    it "allows an admin resend invitation to a volunteer" do
+      volunteer = create(:volunteer, casa_org_id: organization.id)
+          
+      sign_in supervisor
+
+      visit edit_volunteer_path(volunteer)
+
+      click_on "Resend Invitation"
+
+      expect(page).to have_content("Resend Invitation")
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+  end
 end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
     it "allows an admin resend invitation to a volunteer" do
       volunteer = create(:volunteer, casa_org_id: organization.id)
-          
+
       sign_in supervisor
 
       visit edit_volunteer_path(volunteer)

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -45,4 +45,19 @@ RSpec.describe "volunteers/edit", type: :view do
 
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
   end
+
+  it "resend invitation" do
+    supervisor = build_stubbed :supervisor
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(supervisor)
+
+    volunteer = create :volunteer
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to have_content("Resend Invitation")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1827

### What changed, and why?
Added a button to resend invitation for this I needed to create an action to be called with the button. The button is only visible for supervisors and if the volunteer, which is being edited, have never accepted the invitation.


### How will this affect user permissions?
It will not affect.


### How is this tested? (please write tests!) 💖💪
I have created 2 tests, one for checking the presence of the button for supervisor and the other testing the sending the e-mail process.

### Screenshots please :)
Volunteer accepted the invitation. 
![Screenshot from 2021-03-16 17-51-34](https://user-images.githubusercontent.com/61836657/111385425-8e3dfa00-8689-11eb-943f-d100afa9fd2a.png)

Volunteer have not accepted the invitation yet.
![Screenshot from 2021-03-16 17-50-23](https://user-images.githubusercontent.com/61836657/111385475-a01f9d00-8689-11eb-905d-8706e3673b57.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
