### PR TITLE
Fix error handling when importing casa cases, supervisors and volunteers

### DIFF
--- a/app/lib/importers/supervisor_importer.rb
+++ b/app/lib/importers/supervisor_importer.rb
@@ -10,45 +10,35 @@ class SupervisorImporter < FileImporter
   end
 
   def import_supervisors
-    failures = []
-
     import do |row|
       supervisor_params = row.to_hash.slice(:display_name, :email).compact
 
-      if !supervisor_params.key?(:email)
-        failures << "ERROR: The row \n  #{row}\n  does not contain an email address"
-        next
+      unless supervisor_params.key?(:email)
+        raise "Row does not contain e-mail address."
       end
 
-      begin
-        supervisor = Supervisor.find_by(email: supervisor_params[:email])
-        volunteer_assignment_list = email_addresses_to_users(Volunteer, String(row[:supervisor_volunteers]))
+      supervisor = Supervisor.find_by(email: supervisor_params[:email])
+      volunteer_assignment_list = email_addresses_to_users(Volunteer, String(row[:supervisor_volunteers]))
 
-        if volunteer_assignment_list.count != String(row[:supervisor_volunteers]).split(",").count
-          failures << "ERROR: The row \n  #{row}\n  contains unimported volunteers"
-          next
-        end
-
-        if supervisor # Supervisor exists try to update it
-          update_supervisor(supervisor, supervisor_params, volunteer_assignment_list)
-        else # Supervisor doesn't exist try to create a new supervisor
-          supervisor = create_user_record(Supervisor, supervisor_params)
-        end
-
-        volunteer_assignment_list.each do |volunteer|
-          if volunteer.supervisor
-            next if volunteer.supervisor == supervisor
-
-            failures << "Volunteer #{volunteer.email} already has a supervisor"
-          else
-            supervisor.volunteers << volunteer
-          end
-        end
-      rescue => error
-        failures << error.to_s
+      if volunteer_assignment_list.count != String(row[:supervisor_volunteers]).split(",").count
+        raise "Row contains unimported volunteers."
       end
 
-      raise failures.join("\n") unless failures.empty?
+      if supervisor # Supervisor exists try to update it
+        update_supervisor(supervisor, supervisor_params, volunteer_assignment_list)
+      else # Supervisor doesn't exist try to create a new supervisor
+        supervisor = create_user_record(Supervisor, supervisor_params)
+      end
+
+      volunteer_assignment_list.each do |volunteer|
+        if volunteer.supervisor
+          next if volunteer.supervisor == supervisor
+
+          failures << "Volunteer #{volunteer.email} already has a supervisor"
+        else
+          supervisor.volunteers << volunteer
+        end
+      end
     end
   end
 

--- a/app/lib/importers/volunteer_importer.rb
+++ b/app/lib/importers/volunteer_importer.rb
@@ -10,29 +10,20 @@ class VolunteerImporter < FileImporter
   end
 
   def import_volunteers
-    failures = []
-
     import do |row|
       volunteer_params = row.to_hash.slice(:display_name, :email).compact
 
-      if !volunteer_params.key?(:email)
-        failures << "ERROR: The row \n  #{row}\n  does not contain an email address"
-        next
+      unless volunteer_params.key?(:email)
+        raise "Row does not contain an e-mail address."
       end
 
-      begin
-        volunteer = Volunteer.find_by(email: volunteer_params[:email])
+      volunteer = Volunteer.find_by(email: volunteer_params[:email])
 
-        if volunteer # Volunteer exists try to update it
-          update_volunteer(volunteer, volunteer_params)
-        else # Volunteer doesn't exist try to create a new supervisor
-          create_user_record(Volunteer, volunteer_params)
-        end
-      rescue => error
-        failures << error.to_s
+      if volunteer # Volunteer exists try to update it
+        update_volunteer(volunteer, volunteer_params)
+      else # Volunteer doesn't exist try to create a new supervisor
+        create_user_record(Volunteer, volunteer_params)
       end
-
-      raise failures.join("\n") unless failures.empty?
     end
   end
 

--- a/spec/fixtures/casa_cases_without_case_number.csv
+++ b/spec/fixtures/casa_cases_without_case_number.csv
@@ -1,0 +1,3 @@
+case_number,case_assignment,birth_month_year_youth
+,volunteer1@example.net,
+CINA-01-4348,"volunteer2@example.net, volunteer3@example.net",February 2000

--- a/spec/fixtures/supervisors_without_email.csv
+++ b/spec/fixtures/supervisors_without_email.csv
@@ -1,0 +1,3 @@
+﻿email,display_name,supervisor_volunteers
+supervisor1@example.net,Supervisor One,volunteer1@example.net
+,Supervisor Two,"volunteer2@example.net, volunteer3@example.net"

--- a/spec/fixtures/volunteers_without_email.csv
+++ b/spec/fixtures/volunteers_without_email.csv
@@ -1,0 +1,3 @@
+﻿display_name,email
+Volunteer One,volunteer1@example.net
+Volunteer Two,

--- a/spec/lib/importers/case_importer_spec.rb
+++ b/spec/lib/importers/case_importer_spec.rb
@@ -74,5 +74,17 @@ RSpec.describe CaseImporter do
         expect { case_importer.import_cases }.to change(CasaCase, :count).by(0)
       end
     end
+
+    context "when there's no case number" do
+      let(:import_file_path) { Rails.root.join("spec", "fixtures", "casa_cases_without_case_number.csv") }
+
+      it "returns an error message if row does not contain a case number" do
+        alert = case_importer.import_cases
+
+        expect(alert[:type]).to eq(:error)
+        expect(alert[:message]).to eq("You successfully imported 1 casa_cases. Not all rows were imported.")
+        expect(alert[:exported_rows]).to include("Row does not contain a case number.")
+      end
+    end
   end
 end

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe SupervisorImporter do
     end
   end
 
+  context "when row doesn't have e-mail address" do
+    let(:import_file_path) { Rails.root.join("spec", "fixtures", "supervisors_without_email.csv") }
+
+    it "returns an error message" do
+      alert = supervisor_importer.import_supervisors
+
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to eq("You successfully imported 1 supervisors. Not all rows were imported.")
+      expect(alert[:exported_rows]).to include("Row does not contain e-mail address.")
+    end
+  end
+
   specify "static and instance methods have identical results" do
     SupervisorImporter.new(import_file_path, casa_org_id).import_supervisors
     data_using_instance = Supervisor.pluck(:email).sort

--- a/spec/lib/importers/volunteer_importer_spec.rb
+++ b/spec/lib/importers/volunteer_importer_spec.rb
@@ -49,4 +49,16 @@ RSpec.describe VolunteerImporter do
       }.to change(existing_volunteer, :display_name).to("Volunteer One")
     end
   end
+
+  context "when row doesn't have e-mail address" do
+    let(:import_file_path) { Rails.root.join("spec", "fixtures", "volunteers_without_email.csv") }
+
+    it "returns an error message" do
+      alert = volunteer_importer.call
+
+      expect(alert[:type]).to eq(:error)
+      expect(alert[:message]).to eq("You successfully imported 1 volunteers. Not all rows were imported.")
+      expect(alert[:exported_rows]).to include("Row does not contain an e-mail address.")
+    end
+  end
 end


### PR DESCRIPTION
I noticed that there was not test coverage for missing case number and missing e-mail validations when importing cases, supervisors and volunteers. When I wrote the tests I figured out that the error handling for this validations were wrong. It was adding the error to an array that wasn't used and the process returned as success.

I've changed the method to raise errors, because when you raise an error for a row it is automatically handled by the `FileImporter`

### Screenshots please :)

Message after this change:

![image](https://user-images.githubusercontent.com/1084729/111458692-810c2400-86f8-11eb-9af8-af07ff410538.png)



