### PR TITLE
Adjusts PR#1845

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -73,8 +73,8 @@ class VolunteersController < ApplicationController
 
   def resend_invitation
     authorize @volunteer
-    volunteer = Volunteer.find(params[:id])
-    volunteer.invite!
+    @volunteer = Volunteer.find(params[:id])
+    @volunteer.invite!
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
   end

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -51,7 +51,9 @@
                         class: "btn btn-outline-success" %>
           <% end %>
         <% end %>
-        <% if current_user.supervisor? && @volunteer.invitation_accepted_at == nil%>
+        <% if (current_user.supervisor? || 
+              current_user.casa_admin?) && 
+              @volunteer.invitation_accepted_at == nil %>
         <%= link_to "Resend Invitation",
                     resend_invitation_volunteer_path(@volunteer),
                     method: :patch,

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -183,9 +183,7 @@ RSpec.describe "volunteers/edit", type: :system do
   describe "resend invite" do
     let(:supervisor) { create(:supervisor, casa_org: organization) }
 
-    it "allows an admin resend invitation to a volunteer" do
-      volunteer = create(:volunteer, casa_org_id: organization.id)
-
+    it "allows a supervisor resend invitation to a volunteer" do
       sign_in supervisor
 
       visit edit_volunteer_path(volunteer)
@@ -195,5 +193,16 @@ RSpec.describe "volunteers/edit", type: :system do
       expect(page).to have_content("Resend Invitation")
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
+  end
+
+  it "allows an administrator resend invitation to a volunteer" do
+    sign_in admin
+
+    visit edit_volunteer_path(volunteer)
+
+    click_on "Resend Invitation"
+
+    expect(page).to have_content("Resend Invitation")
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
 end

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -46,12 +46,26 @@ RSpec.describe "volunteers/edit", type: :view do
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
   end
 
-  it "resend invitation" do
-    supervisor = build_stubbed :supervisor
+  describe "shows resend invitation "
+  let(:volunteer) { create :volunteer }
+  let(:supervisor) { build_stubbed :supervisor }
+  let(:admin) { build_stubbed :casa_admin }
+
+  it "allows an administrator resend invitation to a volunteer" do
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(admin)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to have_content("Resend Invitation")
+  end
+
+  it "allows a supervisor resend invitation to a volunteer" do
     enable_pundit(view, supervisor)
     allow(view).to receive(:current_user).and_return(supervisor)
-
-    volunteer = create :volunteer
 
     assign :volunteer, volunteer
     assign :supervisors, []


### PR DESCRIPTION
### What github issue is this PR for, if any?
Make some adjustments to PR#1845.

### What changed, and why?
Now administrators can resend invitation for volunteers just like supervisors. Added some tests.

### How will this affect user permissions?
Only supervisors and administrators have permission to resend invitation.

### How is this tested? (please write tests!) 💖💪
There are tests showing that administrators and supervisor have access to edit a volunteer and resend invitation, regular users does not have access to that page.

### Screenshots please :)
Administrator:
![Screenshot from 2021-03-18 11-23-55](https://user-images.githubusercontent.com/61836657/111642220-a96d4e80-87dc-11eb-9b6f-c215bcd59ff4.png)


Supervisor:
![Screenshot from 2021-03-18 11-25-07](https://user-images.githubusercontent.com/61836657/111642259-affbc600-87dc-11eb-860d-2dde0ddbdb4d.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? 
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
