### PR TITLE
Add Tests for Creating and Editing Contact Types

### DIFF
--- a/app/controllers/contact_types_controller.rb
+++ b/app/controllers/contact_types_controller.rb
@@ -1,5 +1,4 @@
 class ContactTypesController < ApplicationController
-  before_action :set_group_options, only: [:new, :edit, :update]
   before_action :set_contact_type, except: [:new, :create]
   after_action :verify_authorized
 
@@ -35,10 +34,6 @@ class ContactTypesController < ApplicationController
   end
 
   private
-
-  def set_group_options
-    @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }
-  end
 
   def set_contact_type
     @contact_type = ContactType.find(params[:id])

--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -1,8 +1,6 @@
 # Helper methods for new contact type form
 module ContactTypesHelper
-    def set_group_options
-        @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }
-    end
-  
+  def set_group_options
+    @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }
   end
-  
+end

--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -1,0 +1,8 @@
+# Helper methods for new contact type form
+module ContactTypesHelper
+    def set_group_options
+        @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }
+    end
+  
+  end
+  

--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -1,4 +1,4 @@
-# Helper methods for new contact type form
+# Helper methods for new/edit contact type form
 module ContactTypesHelper
   def set_group_options
     @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }

--- a/app/views/casa_orgs/_contact_type_groups.html.erb
+++ b/app/views/casa_orgs/_contact_type_groups.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<table class="table table-striped table-bordered">
+<table class="table table-striped table-bordered" id="contact-type-groups">
   <thead>
   <tr>
     <th>Name</th>

--- a/app/views/casa_orgs/_contact_types.html.erb
+++ b/app/views/casa_orgs/_contact_types.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<table class="table table-striped table-bordered">
+<table class="table table-striped table-bordered" id="contact-types">
   <thead>
   <tr>
     <th>Name</th>

--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -12,7 +12,7 @@
       </div>
       <div class="field form-group">
         <%= form.label :contact_type_group %>
-        <%= form.select :contact_type_group_id, group_options, class: "form-control" %>
+        <%= form.select :contact_type_group_id, set_group_options, class: "form-control" %>
       </div>
       <div class="field form-group">
         <%= form.check_box :active %>

--- a/app/views/contact_types/edit.html.erb
+++ b/app/views/contact_types/edit.html.erb
@@ -1,2 +1,2 @@
 <%= render partial: "form",
-           locals: {title: "Edit Contact Type", contact_type: @contact_type, group_options: @group_options} %>
+           locals: {title: "Edit Contact Type", contact_type: @contact_type} %>

--- a/app/views/contact_types/new.html.erb
+++ b/app/views/contact_types/new.html.erb
@@ -1,2 +1,2 @@
 <%= render partial: "form",
-           locals: {title: "New Contact Type", contact_type: @contact_type, group_options: @group_options} %>
+           locals: {title: "New Contact Type", contact_type: @contact_type} %>

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ContactType, type: :model do
+  # let(:casa_org) { create(:casa_org) }
+  # let(:contact_type_group) { create(:contact_type_group, {name: "Test1", casa_org_id: casa_org.id}) }
+  let(:contact_type) { create(:contact_type, name: "Name") }
+  
+  describe "#create"  do
+    it "does have a name" do
+        # contact_type = create(:contact_type, name: nil)
+        # create_contact_type = -> { create(:contact_type, name: nil) }
+        # create_contact_type.call
+        # expect(create_contact_type.call).to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+        # expect(contact_type.errors.message[:name]).to eq["Name can't be blank"]
+        is_expected.to validate_presence_of(:name)
+      # expect(contact_type).to_not be_valid
+    end
+  end
+
+  describe "#update" do
+    it "can update to a valid name" do
+      contact_type.name = "New name"
+      contact_type.save
+      expect(contact_type.name).to eq("New name")
+    end
+
+    it "can't update to an invalid name" do
+      contact_type.name = nil
+      # expect(contact_type.errors.messages[:name]).to eq(["Name can't be blank"])
+      expect {contact_type.save!}.to  raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+    end
+
+    it "can update contact type group" do
+      new_group = create(:contact_type_group, name: "New contact group")
+      contact_type.contact_type_group_id = new_group.id
+      expect(contact_type.contact_type_group.name).to eq("New contact group")
+      # expect {contact_type.save!}.to  raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+    end
+
+    it "can deactivate contact type " do
+      contact_type.active = false
+      expect(contact_type.active?).to be_falsey
+    end
+
+  end
+end

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -1,19 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ContactType, type: :model do
-  # let(:casa_org) { create(:casa_org) }
-  # let(:contact_type_group) { create(:contact_type_group, {name: "Test1", casa_org_id: casa_org.id}) }
   let(:contact_type) { create(:contact_type, name: "Name") }
 
   describe "#create" do
     it "does have a name" do
-      # contact_type = create(:contact_type, name: nil)
-      # create_contact_type = -> { create(:contact_type, name: nil) }
-      # create_contact_type.call
-      # expect(create_contact_type.call).to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
-      # expect(contact_type.errors.message[:name]).to eq["Name can't be blank"]
       is_expected.to validate_presence_of(:name)
-      # expect(contact_type).to_not be_valid
     end
   end
 
@@ -26,7 +18,6 @@ RSpec.describe ContactType, type: :model do
 
     it "can't update to an invalid name" do
       contact_type.name = nil
-      # expect(contact_type.errors.messages[:name]).to eq(["Name can't be blank"])
       expect { contact_type.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
     end
 
@@ -34,7 +25,6 @@ RSpec.describe ContactType, type: :model do
       new_group = create(:contact_type_group, name: "New contact group")
       contact_type.contact_type_group_id = new_group.id
       expect(contact_type.contact_type_group.name).to eq("New contact group")
-      # expect {contact_type.save!}.to  raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
     end
 
     it "can deactivate contact type " do

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe ContactType, type: :model do
   # let(:casa_org) { create(:casa_org) }
   # let(:contact_type_group) { create(:contact_type_group, {name: "Test1", casa_org_id: casa_org.id}) }
   let(:contact_type) { create(:contact_type, name: "Name") }
-  
-  describe "#create"  do
+
+  describe "#create" do
     it "does have a name" do
-        # contact_type = create(:contact_type, name: nil)
-        # create_contact_type = -> { create(:contact_type, name: nil) }
-        # create_contact_type.call
-        # expect(create_contact_type.call).to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
-        # expect(contact_type.errors.message[:name]).to eq["Name can't be blank"]
-        is_expected.to validate_presence_of(:name)
+      # contact_type = create(:contact_type, name: nil)
+      # create_contact_type = -> { create(:contact_type, name: nil) }
+      # create_contact_type.call
+      # expect(create_contact_type.call).to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+      # expect(contact_type.errors.message[:name]).to eq["Name can't be blank"]
+      is_expected.to validate_presence_of(:name)
       # expect(contact_type).to_not be_valid
     end
   end
@@ -27,7 +27,7 @@ RSpec.describe ContactType, type: :model do
     it "can't update to an invalid name" do
       contact_type.name = nil
       # expect(contact_type.errors.messages[:name]).to eq(["Name can't be blank"])
-      expect {contact_type.save!}.to  raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
+      expect { contact_type.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name can't be blank")
     end
 
     it "can update contact type group" do
@@ -41,6 +41,5 @@ RSpec.describe ContactType, type: :model do
       contact_type.active = false
       expect(contact_type.active?).to be_falsey
     end
-
   end
 end

--- a/spec/system/casa_orgs/edit_spec.rb
+++ b/spec/system/casa_orgs/edit_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "casa_orgs/edit", type: :system do
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let!(:contact_type_group) { create(:contact_type_group, casa_org: organization, name: "Contact type group 1") }
+  let!(:contact_type) { create(:contact_type, name: "Contact type 1") }
   let!(:hearing_type) { create(:hearing_type, casa_org: organization, name: "Spec Test Hearing Type") }
   let!(:judge) { create(:judge, casa_org: organization, name: "Joey Tom") }
 
@@ -15,6 +17,38 @@ RSpec.describe "casa_orgs/edit", type: :system do
   it "loads casa org edit page" do
     expect(page).to have_text "Editing CASA Organization"
     expect(page).to_not have_text "sign in before continuing"
+  end
+
+  it "has contact type groups content" do
+    expect(page).to have_text("Contact type group 1")
+    expect(page).to have_text(contact_type_group.name)
+  end
+
+  it "has contact type groups table", js: true do
+    scroll_to(page.find("table#contact-type-groups", visible: false))
+    expect(page).to have_table(
+      id: "contact-type-groups",
+      with_rows:
+      [
+        ["Contact type group 1", "Yes", "Edit"]
+      ]
+    )
+  end
+
+  it "has contact types content" do
+    expect(page).to have_text("Contact type 1")
+    expect(page).to have_text(contact_type.name)
+  end
+
+  it "has contact types table", js: true do
+    scroll_to(page.find("table#contact-types", visible: false))
+    expect(page).to have_table(
+      id: "contact-types",
+      with_rows:
+      [
+        ["Contact type 1", "Yes", "Edit"]
+      ]
+    )
   end
 
   it "has hearing types content" do

--- a/spec/system/contact_types/edit_spec.rb
+++ b/spec/system/contact_types/edit_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "contact_types/edit", type: :system do
+  let!(:organization) { create(:casa_org) }
+  let!(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let!(:contact_type_group) { create(:contact_type_group, casa_org: organization, name: "Contact type group 1") }
+  let!(:contact_type) { create(:contact_type, name: "Contact type 1") }
+
+  before do
+    sign_in admin
+
+    visit edit_contact_type_path(contact_type)
+  end
+
+  it 'errors with invalid name' do
+    fill_in 'Name', with: ''
+    click_on 'Submit'
+
+    expect(page).to have_text("Name can't be blank")
+  end
+
+  it "creates with valid data" do
+    fill_in "Name", with: "Edit Contact Type test"
+    click_on "Submit"
+
+    expect(page).to have_text("Contact Type was successfully updated.")
+  end
+end

--- a/spec/system/contact_types/edit_spec.rb
+++ b/spec/system/contact_types/edit_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "contact_types/edit", type: :system do
     visit edit_contact_type_path(contact_type)
   end
 
-  it 'errors with invalid name' do
-    fill_in 'Name', with: ''
-    click_on 'Submit'
+  it "errors with invalid name" do
+    fill_in "Name", with: ""
+    click_on "Submit"
 
     expect(page).to have_text("Name can't be blank")
   end

--- a/spec/system/contact_types/new_spec.rb
+++ b/spec/system/contact_types/new_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "contact_types/new", type: :system do
+  let!(:organization) { create(:casa_org) }
+  let!(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let!(:contact_type_group) { create(:contact_type_group, casa_org: organization, name: "Contact type group 1") }
+  let!(:contact_type) { create(:contact_type, name: "Contact type 1") }
+
+  before do
+    sign_in admin
+
+    visit new_contact_type_path(contact_type)
+  end
+
+  it 'errors with invalid name' do
+    fill_in 'Name', with: ''
+    click_on 'Submit'
+
+    expect(page).to have_text("Name can't be blank")
+  end
+
+  it "creates with valid data" do
+    fill_in "Name", with: "New Contact Type test"
+    click_on "Submit"
+
+    expect(page).to have_text("Contact Type was successfully created.")
+  end
+end

--- a/spec/system/contact_types/new_spec.rb
+++ b/spec/system/contact_types/new_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "contact_types/new", type: :system do
     visit new_contact_type_path(contact_type)
   end
 
-  it 'errors with invalid name' do
-    fill_in 'Name', with: ''
-    click_on 'Submit'
+  it "errors with invalid name" do
+    fill_in "Name", with: ""
+    click_on "Submit"
 
     expect(page).to have_text("Name can't be blank")
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1391

### What changed, and why?
Removed the filter `before_action :set_group_options, only: [:new, :edit, :update]` in ContactTypesController and created a helper to faciliate the testing.
Added IDs to some tables to easily test the views.
Added some model tests for creating and editing contact types.


### How will this affect user permissions?
Permissions coninue the same.

### How is this tested? (please write tests!) 💖💪
This PR is about tests. :)


### Screenshots please :)
Sorry, I don't think screenshots of the tests are useful.


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt_text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
