### PR TITLE
removed unnecessary emancipation options

### DIFF
--- a/app/models/emancipation_category.rb
+++ b/app/models/emancipation_category.rb
@@ -6,7 +6,11 @@ class EmancipationCategory < ApplicationRecord
   validates :mutually_exclusive, inclusion: {in: [true, false]}
 
   def add_option(option_name)
-    emancipation_options.create(name: option_name)
+    emancipation_options.where(name: option_name).first_or_create
+  end
+
+  def delete_option(option_name)
+    emancipation_options.find_by(name: option_name)&.destroy
   end
 end
 

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -18,7 +18,9 @@
             value="<%= category.id %>"
             <%= emancipation_category_checkbox_checked(@current_case, category) %>>
           <label><%= category.name %></label>
-          <span><%= emancipation_category_collapse_icon(@current_case, category) %></span>
+          <% if category.emancipation_options.count > 0 %>
+            <span><%= emancipation_category_collapse_icon(@current_case, category) %></span>
+          <% end %>
         </h6>
         <div
           class="category-options"

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -51,8 +51,8 @@
                         class: "btn btn-outline-success" %>
           <% end %>
         <% end %>
-        <% if (current_user.supervisor? || 
-              current_user.casa_admin?) && 
+        <% if (current_user.supervisor? ||
+              current_user.casa_admin?) &&
               @volunteer.invitation_accepted_at == nil %>
         <%= link_to "Resend Invitation",
                     resend_invitation_volunteer_path(@volunteer),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,3 +97,4 @@ end
 SeederMain.new.seed
 
 load(Rails.root.join("db", "seeds", "emancipation_data.rb"))
+load(Rails.root.join("db", "seeds", "emancipation_options_prune.rb"))

--- a/db/seeds/emancipation_data.rb
+++ b/db/seeds/emancipation_data.rb
@@ -14,24 +14,20 @@ category_income.add_option("SSDI")
 category_income.add_option("Inheritance/survivors benefits")
 
 category_budget = EmancipationCategory.where(name: "Youth has completed a budget.").first_or_create(mutually_exclusive: false)
-category_budget.add_option("Completed budget")
 
 category_employment = EmancipationCategory.where(name: "Youth is employed.").first_or_create(mutually_exclusive: true)
-category_employment.add_option("Not employed")
 category_employment.add_option("Part-time job")
 category_employment.add_option("Full-time job")
 category_employment.add_option("Apprenticeship or paid internship")
 category_employment.add_option("Self-employed")
 
 category_continuing_education = EmancipationCategory.where(name: "Youth is attending an educational or vocational program.").first_or_create(mutually_exclusive: true)
-category_continuing_education.add_option("Not attending")
 category_continuing_education.add_option("High school")
 category_continuing_education.add_option("Post-secondary/college")
 category_continuing_education.add_option("Vocational")
 category_continuing_education.add_option("GED program")
 
 category_high_school_diploma = EmancipationCategory.where(name: "Youth has a high school diploma or equivalency.").first_or_create(mutually_exclusive: true)
-category_high_school_diploma.add_option("No")
 category_high_school_diploma.add_option("Traditional")
 category_high_school_diploma.add_option("Out of school program")
 category_high_school_diploma.add_option("GED")
@@ -44,7 +40,6 @@ category_medical_insurance.add_option("Knows that dental insurance ends at age 2
 category_medical_insurance.add_option("Has plan for dental care")
 
 category_allies = EmancipationCategory.where(name: "Youth can identify permanent family and/or adult connections.").first_or_create(mutually_exclusive: false)
-category_allies.add_option("Has connections")
 
 category_community = EmancipationCategory.where(name: "Youth is accessing community activities.").first_or_create(mutually_exclusive: false)
 category_community.add_option("Arts activities (e.g., singing, dancing, theater)")
@@ -73,7 +68,6 @@ category_adult_criminal_cases.add_option("All adult criminal cases have been res
 category_adult_criminal_cases.add_option("All eligible adult criminal records have been expunged.")
 
 category_civil_cases = EmancipationCategory.where(name: "Youth has been or is involved in civil or family cases.").first_or_create(mutually_exclusive: false)
-category_civil_cases.add_option("All civil or family cases have been resolved.")
 
 category_bank_account = EmancipationCategory.where(name: "Youth has a bank account in good standing.").first_or_create(mutually_exclusive: false)
 category_bank_account.add_option("Checking")
@@ -84,7 +78,5 @@ category_credit.add_option("An adult has reviewed the credit report with Youth."
 category_credit.add_option("Issues or concerns")
 
 category_values = EmancipationCategory.where(name: "Youth can identify his/her/their core values.").first_or_create(mutually_exclusive: false)
-category_values.add_option("Identified values")
 
 category_assessment = EmancipationCategory.where(name: "Youth has completed the Ansell Casey Assessment.").first_or_create(mutually_exclusive: false)
-category_assessment.add_option("Threshold for self-sufficiency was met.")

--- a/db/seeds/emancipation_data.rb
+++ b/db/seeds/emancipation_data.rb
@@ -13,7 +13,7 @@ category_income.add_option("SSI")
 category_income.add_option("SSDI")
 category_income.add_option("Inheritance/survivors benefits")
 
-category_budget = EmancipationCategory.where(name: "Youth has completed a budget.").first_or_create(mutually_exclusive: false)
+EmancipationCategory.where(name: "Youth has completed a budget.").first_or_create(mutually_exclusive: false)
 
 category_employment = EmancipationCategory.where(name: "Youth is employed.").first_or_create(mutually_exclusive: true)
 category_employment.add_option("Part-time job")
@@ -39,7 +39,7 @@ category_medical_insurance.add_option("Knows how to continue insurance coverage"
 category_medical_insurance.add_option("Knows that dental insurance ends at age 21")
 category_medical_insurance.add_option("Has plan for dental care")
 
-category_allies = EmancipationCategory.where(name: "Youth can identify permanent family and/or adult connections.").first_or_create(mutually_exclusive: false)
+EmancipationCategory.where(name: "Youth can identify permanent family and/or adult connections.").first_or_create(mutually_exclusive: false)
 
 category_community = EmancipationCategory.where(name: "Youth is accessing community activities.").first_or_create(mutually_exclusive: false)
 category_community.add_option("Arts activities (e.g., singing, dancing, theater)")
@@ -67,7 +67,7 @@ category_adult_criminal_cases = EmancipationCategory.where(name: "Youth has been
 category_adult_criminal_cases.add_option("All adult criminal cases have been resolved.")
 category_adult_criminal_cases.add_option("All eligible adult criminal records have been expunged.")
 
-category_civil_cases = EmancipationCategory.where(name: "Youth has been or is involved in civil or family cases.").first_or_create(mutually_exclusive: false)
+EmancipationCategory.where(name: "Youth has been or is involved in civil or family cases.").first_or_create(mutually_exclusive: false)
 
 category_bank_account = EmancipationCategory.where(name: "Youth has a bank account in good standing.").first_or_create(mutually_exclusive: false)
 category_bank_account.add_option("Checking")
@@ -77,6 +77,5 @@ category_credit = EmancipationCategory.where(name: "Youth has obtained a copy of
 category_credit.add_option("An adult has reviewed the credit report with Youth.")
 category_credit.add_option("Issues or concerns")
 
-category_values = EmancipationCategory.where(name: "Youth can identify his/her/their core values.").first_or_create(mutually_exclusive: false)
-
-category_assessment = EmancipationCategory.where(name: "Youth has completed the Ansell Casey Assessment.").first_or_create(mutually_exclusive: false)
+EmancipationCategory.where(name: "Youth can identify his/her/their core values.").first_or_create(mutually_exclusive: false)
+EmancipationCategory.where(name: "Youth has completed the Ansell Casey Assessment.").first_or_create(mutually_exclusive: false)

--- a/db/seeds/emancipation_options_prune.rb
+++ b/db/seeds/emancipation_options_prune.rb
@@ -1,0 +1,13 @@
+def get_category_by_name(category_name)
+  EmancipationCategory.where(name: category_name)&.first
+end
+
+get_category_by_name("Youth has completed a budget.")&.delete_option("Completed budget")
+get_category_by_name("Youth is employed.")&.delete_option("Not employed")
+get_category_by_name("Youth is attending an educational or vocational program.")&.delete_option("Not attending")
+get_category_by_name("Youth has a high school diploma or equivalency.")&.delete_option("No")
+get_category_by_name("Youth can identify permanent family and/or adult connections.")&.delete_option("Has connections")
+get_category_by_name("Youth has been or is involved in civil or family cases.")&.delete_option("All civil or family cases have been resolved.")
+get_category_by_name("Youth can identify his/her/their core values.")&.delete_option("Identified values")
+get_category_by_name("Youth has completed the Ansell Casey Assessment.")&.delete_option("Threshold for self-sufficiency was met.")
+get_category_by_name("Youth has completed the Ansell Casey Assessment.")&.update_attribute(:name, "Youth has completed the Ansell Casey Assessment and threshold for self-sufficiency was met.")

--- a/spec/models/emancipation_category_spec.rb
+++ b/spec/models/emancipation_category_spec.rb
@@ -24,11 +24,30 @@ RSpec.describe EmancipationCategory, type: :model do
       EmancipationOption.category_options(emancipation_category.id).destroy_all
     end
 
-    it "should call EmancipationOption.create" do
+    it "should create an option" do
       option_name = "test option"
 
-      expect(emancipation_category.emancipation_options).to receive(:create).with(name: option_name)
+      expect {
+        emancipation_category.add_option(option_name)
+      }.to change(EmancipationOption, :count).by(1)
+    end
+  end
+
+  context "#delete_option" do
+    let(:emancipation_category) { create(:emancipation_category) }
+
+    after(:each) do
+      EmancipationOption.category_options(emancipation_category.id).destroy_all
+    end
+
+    it "should delete an existing option" do
+      option_name = "test option"
+
       emancipation_category.add_option(option_name)
+
+      expect {
+        emancipation_category.delete_option(option_name)
+      }.to change(EmancipationOption, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1703

### What changed, and why?
added a script: `db/seeds/emancipation_options_prune.rb`
`load(Rails.root.join("db", "seeds", "emancipation_options_prune.rb"))` in seeds.rb can be removed after running it

created delete option method for emancipation category
made delete and add option methods for category idempotent
updated test to match new methods

### Screenshots please :)
Before 
![image](https://user-images.githubusercontent.com/8918762/112266217-b4dbd200-8c41-11eb-925b-72e5b98070aa.png)
![image](https://user-images.githubusercontent.com/8918762/112266001-6fb7a000-8c41-11eb-81dc-3ba912fb36e0.png)
![image](https://user-images.githubusercontent.com/8918762/112266251-befdd080-8c41-11eb-8ca3-14445ecf40d0.png)

After
![image](https://user-images.githubusercontent.com/8918762/112548496-553d0e00-8d8a-11eb-9779-f3d22e655de1.png)
![image](https://user-images.githubusercontent.com/8918762/112354977-3744b000-8c9b-11eb-9e86-2ae1da318bf3.png)
