### PR TITLE
Add Last Logged In At to all users and visible to all users Issue#1864

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -14,4 +14,8 @@ class UserDecorator < Draper::Decorator
   def formatted_updated_at
     I18n.l(object.updated_at, format: :standard, default: nil)
   end
+
+  def formatted_last_sign_in_at
+    I18n.l(object.last_sign_in_at, format: :standard, default: nil)
+  end
 end

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -16,6 +16,8 @@ end
 #
 #  id                     :bigint           not null, primary key
 #  active                 :boolean          default(TRUE)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
 #  display_name           :string           default("")
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
@@ -26,8 +28,11 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  sign_in_count          :integer
 #  type                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -13,6 +13,8 @@ end
 #
 #  id                     :bigint           not null, primary key
 #  active                 :boolean          default(TRUE)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
 #  display_name           :string           default("")
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
@@ -23,8 +25,11 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  sign_in_count          :integer
 #  type                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   include ByOrganizationScope
 
   has_paper_trail
-  devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable
+  devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, :trackable
 
   validates :email, presence: true
   validates :display_name, presence: true
@@ -147,6 +147,8 @@ end
 #
 #  id                     :bigint           not null, primary key
 #  active                 :boolean          default(TRUE)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
 #  display_name           :string           default("")
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
@@ -157,8 +159,11 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  sign_in_count          :integer
 #  type                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -99,6 +99,8 @@ end
 #
 #  id                     :bigint           not null, primary key
 #  active                 :boolean          default(TRUE)
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
 #  display_name           :string           default("")
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
@@ -109,8 +111,11 @@ end
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  invited_by_type        :string
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  sign_in_count          :integer
 #  type                   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -16,6 +16,11 @@
         <%= form.text_field :display_name, class: "form-control" %>
       </div>
 
+      <div class="field form-group">
+        <%= form.label "Last logged in at" %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: casa_admin.decorate.formatted_last_sign_in_at %>
+      </div>
+
       <% if casa_admin.persisted? %>
         <div class="field form-group">
           <% if casa_admin.active? %>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -24,6 +24,11 @@
         <% end %>
       </div>
 
+      <div class="field form-group">
+        <%= form.label "Last logged in at" %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: @supervisor.decorate.formatted_last_sign_in_at %>
+      </div>
+
       <div class="actions">
         <% if policy(@supervisor).update_supervisor_email? || policy(@supervisor).update_supervisor_name? %>
           <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,6 +17,12 @@
 
       <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
 
+      <div class="field form-group">
+        <%= form.label "Last logged in at" %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: current_user.decorate.formatted_last_sign_in_at %>
+      </div>
+
+      </br>
       <div class="actions">
         <%= form.submit "Update Profile", class: "btn btn-primary mb-3" %>
         <button class="btn btn-warning accordion mb-3" id="accordionExample" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -31,6 +31,11 @@
       </div>
 
       <div class="field form-group">
+        <%= form.label "Last logged in at" %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: @volunteer.decorate.formatted_last_sign_in_at %>
+      </div>
+
+      <div class="field form-group">
         <% if @volunteer.active? %>
           Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
           <% if policy(@volunteer).deactivate? %>

--- a/db/migrate/20210330182538_add_devise_trackable_columns_to_users.rb
+++ b/db/migrate/20210330182538_add_devise_trackable_columns_to_users.rb
@@ -1,0 +1,9 @@
+class AddDeviseTrackableColumnsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_195135) do
+ActiveRecord::Schema.define(version: 2021_03_30_182538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,6 +267,11 @@ ActiveRecord::Schema.define(version: 2021_03_08_195135) do
     t.integer "invitations_count", default: 0
     t.string "type"
     t.boolean "active", default: true
+    t.integer "sign_in_count"
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["casa_org_id"], name: "index_users_on_casa_org_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -56,4 +56,10 @@ RSpec.describe "casa_admins/edit", type: :system do
     expect(page).to have_text("Admin was deactivated.")
     expect(another.reload.active).to be_falsey
   end
+
+  it "is not able to edit last sign in" do
+    visit edit_casa_admin_path(admin)
+
+    expect(page).to have_field("casa_admin_last_sign_in_at", disabled: true)
+  end
 end

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(page).to have_text("There are no active, unassigned volunteers available")
     end
 
+    it "can go to the supervisor edit page and see last sign in" do
+      supervisor = create :supervisor, casa_org: organization
+
+      sign_in user
+
+      visit edit_supervisor_path(supervisor)
+
+      expect(page).to have_field("supervisor_last_sign_in_at", disabled: true)
+    end
+
     context "when entering valid information" do
       it "updates the e-mail address successfully" do
         sign_in user
@@ -97,6 +107,10 @@ RSpec.describe "supervisors/edit", type: :system do
       it "does not have a submit button" do
         expect(page).not_to have_selector(:link_or_button, "Submit")
       end
+
+      it "sees last sign in" do
+        expect(page).to have_field("supervisor_last_sign_in_at", disabled: true)
+      end
     end
 
     context "when editing own page" do
@@ -107,6 +121,10 @@ RSpec.describe "supervisors/edit", type: :system do
         visit edit_supervisor_path(supervisor)
 
         expect(page).to have_selector(:link_or_button, "Submit")
+      end
+
+      it "sees last sign in" do
+        expect(page).to have_field("supervisor_last_sign_in_at", disabled: true)
       end
 
       context "when no volunteers exist" do

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe "users/edit", type: :system do
     it "is not able to update the email if user is a volunteer" do
       expect(page).to have_field("Email", disabled: true)
     end
+
+    it "is not able to edit last sign in" do
+      expect(page).to have_field("user_last_sign_in_at", disabled: true)
+    end
   end
 
   context "supervisor user" do
@@ -48,6 +52,10 @@ RSpec.describe "users/edit", type: :system do
 
     it "is not able to update the email if user is a supervisor" do
       expect(page).to have_field("Email", disabled: true)
+    end
+
+    it "is not able to edit last sign in" do
+      expect(page).to have_field("user_last_sign_in_at", disabled: true)
     end
   end
 
@@ -70,6 +78,10 @@ RSpec.describe "users/edit", type: :system do
       expect(page).to have_text("Profile was successfully updated.")
       expect(page).to have_text("new_admin@example.com")
       assert_equal "new_admin@example.com", admin.reload.email
+    end
+
+    it "is not able to edit last sign in" do
+      expect(page).to have_field("user_last_sign_in_at", disabled: true)
     end
   end
 end

--- a/spec/views/casa_admins/edit.html.erb_spec.rb
+++ b/spec/views/casa_admins/edit.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "casa_admins/edit", type: :view do
+  describe "does not allow" do
+    let(:admin) { build_stubbed :casa_admin }
+
+    it "an admin to edit an admin last sign in" do
+      enable_pundit(view, admin)
+      allow(view).to receive(:current_user).and_return(admin)
+
+      assign :casa_admin, admin
+
+      render template: "casa_admins/edit"
+
+      expect(rendered).to have_field("casa_admin_last_sign_in_at", disabled: true)
+    end
+  end
+end

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -36,4 +36,36 @@ RSpec.describe "supervisors/edit", type: :view do
     expect(rendered).to_not include(unassign_supervisor_volunteer_path(volunteer))
     expect(rendered).to include("Unassigned")
   end
+
+  describe "does not allow" do
+    let(:volunteer) { create :volunteer }
+    let(:supervisor) { build_stubbed :supervisor }
+    let(:admin) { build_stubbed :casa_admin }
+
+    it "a supervisor to edit a supervisor last sign in" do
+      enable_pundit(view, supervisor)
+      allow(view).to receive(:current_user).and_return(supervisor)
+
+      assign :supervisor, supervisor
+      assign :all_volunteers_ever_assigned, [volunteer]
+      assign :available_volunteers, []
+
+      render template: "supervisors/edit"
+
+      expect(rendered).to have_field("supervisor_last_sign_in_at", disabled: true)
+    end
+
+    it "an admin to edit a supervisor last sign in" do
+      enable_pundit(view, supervisor)
+      allow(view).to receive(:current_user).and_return(admin)
+
+      assign :supervisor, supervisor
+      assign :all_volunteers_ever_assigned, [volunteer]
+      assign :available_volunteers, []
+
+      render template: "supervisors/edit"
+
+      expect(rendered).to have_field("supervisor_last_sign_in_at", disabled: true)
+    end
+  end
 end

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -42,6 +42,36 @@ RSpec.describe "volunteers/edit", type: :view do
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
   end
 
+  describe "does not allow" do
+    let(:volunteer) { create :volunteer }
+    let(:supervisor) { build_stubbed :supervisor }
+    let(:admin) { build_stubbed :casa_admin }
+
+    it "a supervisor to edit a volunteers last sign in" do
+      enable_pundit(view, supervisor)
+      allow(view).to receive(:current_user).and_return(supervisor)
+
+      assign :volunteer, volunteer
+      assign :supervisors, []
+
+      render template: "volunteers/edit"
+
+      expect(rendered).to have_field("volunteer_last_sign_in_at", disabled: true)
+    end
+
+    it "an admin to edit a volunteers last sign in" do
+      enable_pundit(view, supervisor)
+      allow(view).to receive(:current_user).and_return(admin)
+
+      assign :volunteer, volunteer
+      assign :supervisors, []
+
+      render template: "volunteers/edit"
+
+      expect(rendered).to have_field("volunteer_last_sign_in_at", disabled: true)
+    end
+  end
+
   context "The user has not accepted their invitation" do
     it "shows a string stating that the user has not recieved there invation yet" do
       expect("#{volunteer.display_name},


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1864

### What changed, and why?
Added the trackable module of devise to have the field "last signed in at" so now volunteers, supervisors and administrators can see the correspondent information.


### How will this affect user permissions?
- Volunteer permissions: Can only see their own "last logged in at" in the edit profile view.
- Supervisor permissions: Can see other supervisors and volunteers "last logged in at"
- Admin permissions: Can see "last logged in at" from everyone.

### How is this tested? (please write tests!) 💖💪
Added some tests checking if the field is present and not editable.

### Screenshots please :)
Editing a volunteer which has never logged in:
![Screenshot from 2021-03-31 13-20-02](https://user-images.githubusercontent.com/61836657/113178660-2d83f500-9225-11eb-8a8b-7556961eb688.png)

Editing a supervisor:
![Screenshot from 2021-03-31 13-19-50](https://user-images.githubusercontent.com/61836657/113178658-2c52c800-9225-11eb-9173-31caad69f67b.png)

Editing an admin:
![Screenshot from 2021-03-31 13-21-13](https://user-images.githubusercontent.com/61836657/113178663-2d83f500-9225-11eb-8988-9a888b049d74.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
