### PR TITLE
let volunteer download their own case contacts

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -16,6 +16,14 @@ class CasaCasesController < ApplicationController
   # GET /casa_cases/1.json
   def show
     authorize @casa_case
+    respond_to do |format|
+      format.html {}
+      format.csv do
+        case_contacts = @casa_case.decorate.case_contacts_ordered_by_occurred_at.decorate
+        csv = CaseContactsExportCsvService.new(case_contacts).perform
+        send_data csv, filename: "volunteer-#{current_user.id}-case-contacts-#{Time.zone.now.to_i}.csv"
+      end
+    end
   end
 
   # GET /casa_cases/new

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -6,14 +6,8 @@ class CaseContactReport
   end
 
   def to_csv
-    CSV.generate(headers: true) do |csv|
-      csv << full_data(nil).keys.map(&:to_s).map(&:titleize)
-      if @case_contacts.present?
-        @case_contacts.includes(:creator).decorate.each do |case_contact|
-          csv << full_data(case_contact).values
-        end
-      end
-    end
+    case_contacts_for_csv = @case_contacts.includes(:creator).decorate
+    CaseContactsExportCsvService.new(case_contacts_for_csv).perform
   end
 
   private
@@ -29,26 +23,5 @@ class CaseContactReport
       .want_driving_reimbursement(args[:want_driving_reimbursement])
       .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
-  end
-
-  def full_data(case_contact)
-    # Note: these header labels are for stakeholders and do not match the
-    # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
-    {
-      internal_contact_number: case_contact&.id,
-      duration_minutes: case_contact&.report_duration_minutes,
-      contact_types: case_contact&.report_contact_types,
-      contact_made: case_contact&.report_contact_made,
-      contact_medium: case_contact&.medium_type,
-      occurred_at: I18n.l(case_contact&.occurred_at, format: :full, default: nil),
-      added_to_system_at: case_contact&.created_at,
-      miles_driven: case_contact&.miles_driven,
-      wants_driving_reimbursement: case_contact&.want_driving_reimbursement,
-      casa_case_number: case_contact&.casa_case&.case_number,
-      creator_email: case_contact&.creator&.email,
-      creator_name: case_contact&.creator&.display_name,
-      supervisor_name: case_contact&.creator&.supervisor&.display_name,
-      case_contact_notes: case_contact&.notes
-    }
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -1,0 +1,43 @@
+require "csv"
+
+class CaseContactsExportCsvService
+  attr_reader :case_contacts
+
+  def initialize(case_contacts)
+    @case_contacts = case_contacts
+  end
+
+  def perform
+    CSV.generate(headers: true) do |csv|
+      csv << full_data.keys.map(&:to_s).map(&:titleize)
+      if case_contacts.present?
+        case_contacts.each do |case_contact|
+          csv << full_data(case_contact).values
+        end
+      end
+    end
+  end
+
+  private
+
+  def full_data(case_contact = nil)
+    # Note: these header labels are for stakeholders and do not match the
+    # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
+    {
+      internal_contact_number: case_contact&.id,
+      duration_minutes: case_contact&.report_duration_minutes,
+      contact_types: case_contact&.report_contact_types,
+      contact_made: case_contact&.report_contact_made,
+      contact_medium: case_contact&.medium_type,
+      occurred_at: I18n.l(case_contact&.occurred_at, format: :full, default: nil),
+      added_to_system_at: case_contact&.created_at,
+      miles_driven: case_contact&.miles_driven,
+      wants_driving_reimbursement: case_contact&.want_driving_reimbursement,
+      casa_case_number: case_contact&.casa_case&.case_number,
+      creator_email: case_contact&.creator&.email,
+      creator_name: case_contact&.creator&.display_name,
+      supervisor_name: case_contact&.creator&.supervisor&.display_name,
+      case_contact_notes: case_contact&.notes
+    }
+  end
+end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -67,6 +67,10 @@
       <% end %>
       <br>
 
+      <div class="text-right mb-2">
+        <%= link_to "Download All", casa_case_path(params[:id], format: :csv) , class: "btn btn-success" %>
+      </div>
+
       <div>
         <% @casa_case.decorate.case_contacts_ordered_by_occurred_at.each do |contact| %>
           <%= render "case_contacts/case_contact", contact: contact %>

--- a/spec/controllers/casa_cases_controller_spec.rb
+++ b/spec/controllers/casa_cases_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe CasaCasesController, type: :controller do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, :with_cases_and_contacts, casa_org: organization) }
+
+  describe "#show" do
+    context "when logged in as volunteer" do
+      before do
+        allow(controller).to receive(:authenticate_user!).and_return(true)
+        allow(controller).to receive(:current_user).and_return(volunteer)
+      end
+
+      it "should export csv successfully" do
+        case_id = volunteer.casa_cases.first.id
+
+        get :show, params: {id: case_id, format: :csv}
+        expect(response).to have_http_status(:ok)
+        # TODO: add more test cases to cover the amount of data that's exported
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1838 

### What changed, and why?
- Add format csv for `casa_cases_controller.rb#show` to allow volunteers to download all their case contacts
- Create a new service to reuse the functionality from `CaseContractsReport` because I don't want to just spread the same code all over the place 🌵 🌵 🌵 
- Add a button `Download All` in casa_cases show page

### How will this affect user permissions?
- Volunteer permissions: the same
- Supervisor permissions: the same
- Admin permissions: the same

### How is this tested? (please write tests!) 💖💪
I created the `casa_cases_controller_spec.rb` already, but right now it just covers the http_status.
I already check that the data is exported correctly, and a TODO message to add more test cases to cover in the future. :bow:

### Screenshots please :)
![casa-1838](https://user-images.githubusercontent.com/42526152/113197597-0f52df00-928f-11eb-9d59-090047ea5888.jpg)

### Feelings gif (optional)
What gif best describes your feeling working on this issue?
![alt text](https://pa1.narvii.com/6504/60d31226d1ff241f043d6ca36dea9dd8bcacdb12_hq.gif)
