### PR TITLE
add spring to speed up test and development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development do
   gem "letter_opener" # Opens emails in new tab for easier testing
   gem "listen", ">= 3.0.5", "< 3.6"
   gem "spring" # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem "spring-commands-rspec"
   gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0" # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,8 @@ GEM
     spoon (0.0.6)
       ffi
     spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -473,6 +475,7 @@ DEPENDENCIES
   simplecov (~> 0.21.2)
   skylight
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   standard (~> 1.0.4)
   tzinfo-data

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-require_relative '../config/boot'
-require 'rake'
-Rake.application.run
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "reports", type: :system do
 
   shared_examples "can view page" do
     it "downloads report", js: true do
-      expect(page).to have_text("Case Contacts Report") &
-        have_field("report_start_date", with: 6.months.ago.to_date) &
-        have_field("report_end_date", with: Date.today.to_date)
+      expect(page).to have_text("Case Contacts Report")
+      expect(page).to have_field("report_start_date", with: 6.months.ago.to_date)
+      expect(page).to have_field("report_end_date", with: Date.today.to_date)
       click_on "Download Report"
       expect(page).to have_button "Download Report"
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1715 

### What changed, and why?
- Generate `bin/rails`, `bin/rake`, `bin/rspec` to run with spring
- Adjust the `spec/system/reports/index_spec.rb:21` shared example (still wonder why it's failed with Spring)

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
Before
![Screen Shot 2021-04-03 at 2 27 42 AM](https://user-images.githubusercontent.com/42526152/113448078-5d99e680-9425-11eb-85c5-a1d71c8e220f.png)

After (with Spring)
![Screen Shot 2021-04-03 at 2 32 10 AM](https://user-images.githubusercontent.com/42526152/113448096-67234e80-9425-11eb-82a3-7a339807aade.png)

It's funny that in my Mac, the total time seems like the same :)))). But the files were loaded faster with Spring

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/LkOCoJy3KmRl8oHX0m/giphy.gif)
