### PR TITLE
add tests for case contact view delete and undelete buttons

### DIFF
--- a/spec/factories/case_contact.rb
+++ b/spec/factories/case_contact.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     contact_made { false }
     medium_type { CaseContact::CONTACT_MEDIUMS.first }
     want_driving_reimbursement { false }
+    deleted_at { nil }
 
     trait :multi_line_note do
       notes { "line1\nline2\nline3" }

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -1,50 +1,129 @@
 require "rails_helper"
 
 RSpec.describe "case_contacts/case_contact", type: :view do
-  let(:user) { build_stubbed(:casa_admin) }
+  let(:admin) { build_stubbed(:casa_admin) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+  let(:supervisor) { build_stubbed(:supervisor) }
 
-  before do
-    enable_pundit(view, user)
-    allow(view).to receive(:current_user).and_return(user)
+  describe "edit and follow up buttons" do
+    before do
+      enable_pundit(view, admin)
+      allow(view).to receive(:current_user).and_return(admin)
+    end
+
+    context "occured_at is before the last day of the month in the quarter that the case contact was created" do
+      let(:case_contact) { create(:case_contact) }
+      let(:case_contact2) { create(:case_contact, deleted_at: Time.current) }
+
+      it "shows edit button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).to have_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
+      end
+
+      it "shows follow up button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).to have_button("Follow up")
+      end
+    end
+
+    context "occured_at is after the last day of the month in the quarter that the case contact was created" do
+      let(:case_contact) { create(:case_contact, occurred_at: Time.zone.now - 1.year) }
+
+      it "does not show edit button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).to have_no_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
+      end
+
+      it "does not show follow up button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).to_not have_text("Follow up")
+      end
+    end
   end
 
-  context "occured_at is before the last day of the month in the quarter that the case contact was created" do
+  describe "delete and undelete buttons" do
     let(:case_contact) { create(:case_contact) }
+    let(:case_contact2) { create(:case_contact, deleted_at: Time.current) }
 
-    it "shows edit button" do
-      assign :case_contact, case_contact
-      assign :casa_cases, [case_contact.casa_case]
+    context "when logged in as admin" do
+      before do
+        enable_pundit(view, admin)
+        allow(view).to receive(:current_user).and_return(admin)
+      end
 
-      render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-      expect(rendered).to have_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
+      it "shows delete button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).to have_link("Delete", href: "/case_contacts/#{case_contact.id}")
+      end
+
+      it "shows undelete button" do
+        assign :case_contact, case_contact2
+        assign :casa_cases, [case_contact2.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact2})
+        expect(rendered).to have_link("undelete", href: "/case_contacts/#{case_contact2.id}/restore")
+      end
     end
 
-    it "shows follow up button" do
-      assign :case_contact, case_contact
-      assign :casa_cases, [case_contact.casa_case]
+    context "when logged in as volunteer" do
+      before do
+        enable_pundit(view, volunteer)
+        allow(view).to receive(:current_user).and_return(volunteer)
+      end
 
-      render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-      expect(rendered).to have_button("Follow up")
+      it "should not show delete button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).not_to have_link("Delete", href: "/case_contacts/#{case_contact.id}")
+      end
+
+      it "should not show undelete button" do
+        assign :case_contact, case_contact2
+        assign :casa_cases, [case_contact2.casa_case]
+
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact2})
+        expect(rendered).not_to have_link("undelete", href: "/case_contacts/#{case_contact2.id}/restore")
+      end
     end
-  end
 
-  context "occured_at is after the last day of the month in the quarter that the case contact was created" do
-    let(:case_contact) { create(:case_contact, occurred_at: Time.zone.now - 1.year) }
+    context "when logged in as supervisor" do
+      before do
+        enable_pundit(view, supervisor)
+        allow(view).to receive(:current_user).and_return(supervisor)
+      end
 
-    it "does not show edit button" do
-      assign :case_contact, case_contact
-      assign :casa_cases, [case_contact.casa_case]
+      it "should not show delete button" do
+        assign :case_contact, case_contact
+        assign :casa_cases, [case_contact.casa_case]
 
-      render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-      expect(rendered).to have_no_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
-    end
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
+        expect(rendered).not_to have_link("Delete", href: "/case_contacts/#{case_contact.id}")
+      end
 
-    it "does not show follow up button" do
-      assign :case_contact, case_contact
-      assign :casa_cases, [case_contact.casa_case]
+      it "should not show undelete button" do
+        assign :case_contact, case_contact2
+        assign :casa_cases, [case_contact2.casa_case]
 
-      render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-      expect(rendered).to_not have_text("Follow up")
+        render(partial: "case_contacts/case_contact", locals: {contact: case_contact2})
+        expect(rendered).not_to have_link("undelete", href: "/case_contacts/#{case_contact2.id}/restore")
+      end
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #001

### What changed, and why?
- add test cases for `_case_contact.html.erb` partial: `Delete` and `undelete` buttons

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/YbXtbKoi2ZUOc/giphy.gif)
