### PR TITLE
Volunteer invite and login info expansion

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -6,14 +6,26 @@ class UserDecorator < Draper::Decorator
   end
 
   def formatted_created_at
-    I18n.l(object.created_at, format: :standard, default: nil)
+    I18n.l(object.created_at, format: :full, default: nil)
   end
 
   def formatted_updated_at
-    I18n.l(object.updated_at, format: :standard, default: nil)
+    I18n.l(object.updated_at, format: :full, default: nil)
   end
 
   def formatted_last_sign_in_at
-    I18n.l(object.last_sign_in_at, format: :standard, default: nil)
+    I18n.l(object.last_sign_in_at, format: :full, default: nil)
+  end
+
+  def formatted_invitation_accepted_at
+    I18n.l(object.invitation_accepted_at, format: :full, default: nil)
+  end
+
+  def formatted_reset_password_sent_at
+    I18n.l(object.reset_password_sent_at, format: :full, default: nil)
+  end
+
+  def formatted_invitation_sent_at
+    I18n.l(object.invitation_sent_at, format: :full, default: nil)
   end
 end

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -18,7 +18,8 @@
 
       <div class="field form-group">
         <%= form.label "Last logged in at" %>
-        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: casa_admin.decorate.formatted_last_sign_in_at %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true,
+value: casa_admin.decorate.formatted_last_sign_in_at %>
       </div>
 
       <% if casa_admin.persisted? %>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -10,7 +10,8 @@
                 <%= t('.deleted_text') if policy(contact).restore? && contact.deleted? %>
                 <%= contact.contact_groups_with_types.keys.join(', ') %>
               </strong>
-              <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post, class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
+              <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
+class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">
               <%= contact.decorate.contact_types %>
@@ -35,7 +36,8 @@
         </div>
       </div>
       <div class="align-self-end">
-        <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete, class: "btn btn-danger pull-right") if policy(current_user).destroy? && !contact.deleted? %>
+        <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete,
+class: "btn btn-danger pull-right") if policy(current_user).destroy? && !contact.deleted? %>
       </div>
       <div class="row">
         <% if Pundit.policy(current_user, contact).update? %>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -153,7 +153,8 @@
   </div>
 
   <div class="actions">
-    <%= form.submit t("button.submit"), class: "btn btn-primary", id: "case-contact-submit", "data-target": "#confirm-submit" %>
+    <%= form.submit t("button.submit"), class: "btn btn-primary", id: "case-contact-submit",
+"data-target": "#confirm-submit" %>
     <%= return_to_dashboard_button %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -5,7 +5,6 @@
   </div>
 </div>
 
-
 <% @presenter.case_contacts.each do |casa_case_id, data| %>
   <div class="card card-container">
     <div class="card-body">

--- a/app/views/shared/_invite_login.html.erb
+++ b/app/views/shared/_invite_login.html.erb
@@ -1,0 +1,20 @@
+<div>
+  <span class="font-weight-bold">Added to system </span>
+  <%= resource&.decorate&.formatted_created_at %>
+</div>
+<div>
+  <span class="font-weight-bold">Invitation email sent </span>
+  <%= resource&.decorate&.formatted_invitation_sent_at || "never" %>
+</div>
+<div>
+  <span class="font-weight-bold">Last logged in </span>
+  <%= resource&.decorate&.formatted_last_sign_in_at || "never" %>
+</div>
+<div>
+  <span class="font-weight-bold">Invitation accepted </span>
+  <%= resource&.decorate&.formatted_invitation_accepted_at || "never" %>
+</div>
+<div>
+  <span class="font-weight-bold">Password reset last sent </span>
+  <%= resource&.decorate&.formatted_reset_password_sent_at || "never" %>
+</div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -26,7 +26,8 @@
 
       <div class="field form-group">
         <%= form.label "Last logged in at" %>
-        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: @supervisor.decorate.formatted_last_sign_in_at %>
+        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true,
+value: @supervisor.decorate.formatted_last_sign_in_at %>
       </div>
 
       <div class="actions">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,12 +17,9 @@
 
       <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
 
-      <div class="field form-group">
-        <%= form.label "Last logged in at" %>
-        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: current_user.decorate.formatted_last_sign_in_at %>
-      </div>
+      <%= render "/shared/invite_login", resource: current_user %>
 
-      </br>
+      <br>
       <div class="actions">
         <%= form.submit "Update Profile", class: "btn btn-primary mb-3" %>
         <button class="btn btn-warning accordion mb-3" id="accordionExample" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">

--- a/app/views/volunteers/_manage_active.html.erb
+++ b/app/views/volunteers/_manage_active.html.erb
@@ -1,0 +1,30 @@
+<div class="field form-group">
+  <% if user.active? %>
+    Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
+    <% if policy(user).deactivate? %>
+      <%= link_to "Deactivate volunteer",
+                  deactivate_volunteer_path(user),
+                  method: :patch,
+                  class: "btn btn-outline-danger",
+                  data: {confirm: t("forms.volunteer.mark_inactive_warning")} %>
+    <% end %>
+  <% else %>
+    <div class="alert alert-danger">
+      Volunteer was deactivated on: <%= user.decorate.formatted_updated_at %>
+    </div>
+    <% if policy(user).activate? %>
+      <%= link_to "Activate volunteer",
+                  activate_volunteer_path(user),
+                  method: :patch,
+                  class: "btn btn-outline-success" %>
+    <% end %>
+  <% end %>
+  <% if (current_user.supervisor? ||
+      current_user.casa_admin?) &&
+      user.invitation_accepted_at == nil %>
+    <%= link_to "Resend Invitation",
+                resend_invitation_volunteer_path(user),
+                method: :patch,
+                class: "btn btn-outline-danger" %>
+  <% end %>
+</div>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -21,63 +21,11 @@
         <%= form.text_field :display_name, class: "form-control" %>
       </div>
 
-      <div class="field form-group">
-        <%= form.label "Start Date" %>
-        <input
-          class="form-control"
-          type="text"
-          placeholder="<%= @volunteer.decorate.formatted_created_at %>"
-          readonly>
-      </div>
+      <%= render "/shared/invite_login", resource: @volunteer %>
 
-      <div class="field form-group">
-        <%= form.label "Last logged in at" %>
-        <%= form.text_field :last_sign_in_at, class: "form-control", disabled: true, value: @volunteer.decorate.formatted_last_sign_in_at %>
-      </div>
-
-      <div class="field form-group">
-        <% if @volunteer.active? %>
-          Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
-          <% if policy(@volunteer).deactivate? %>
-            <%= link_to "Deactivate volunteer",
-                        deactivate_volunteer_path(@volunteer),
-                        method: :patch,
-                        class: "btn btn-outline-danger",
-                        data: {confirm: t("forms.volunteer.mark_inactive_warning")} %>
-          <% end %>
-        <% else %>
-          <div class="alert alert-danger">
-            Volunteer was deactivated on: <%= @volunteer.decorate.formatted_updated_at %>
-          </div>
-          <% if policy(@volunteer).activate? %>
-            <%= link_to "Activate volunteer",
-                        activate_volunteer_path(@volunteer),
-                        method: :patch,
-                        class: "btn btn-outline-success" %>
-          <% end %>
-        <% end %>
-        <% if (current_user.supervisor? ||
-            current_user.casa_admin?) &&
-            @volunteer.invitation_accepted_at == nil %>
-          <%= link_to "Resend Invitation",
-                      resend_invitation_volunteer_path(@volunteer),
-                      method: :patch,
-                      class: "btn btn-outline-danger" %>
-        <% end %>
-      </div>
-
-      <div class="container">
-        <% if @volunteer.invitation_accepted_at == nil %>
-          <%= "#{@volunteer.display_name}, has yet to accept their invitation" %>
-        <% else %>
-          <%= @volunteer.invitation_accepted_at %>
-        <% end %><br>
-
-        <% if @volunteer.reset_password_sent_at == !nil %>
-          <%= @volunteer.reset_password_sent_at %>
-        <% end %>
-      </div>
-      <br>
+      <p>
+        <%= render "manage_active", user: @volunteer %>
+      </p>
 
       <div class="actions">
         <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe "users/edit", type: :system do
     it "is not able to update the email if user is a volunteer" do
       expect(page).to have_field("Email", disabled: true)
     end
-
-    it "is not able to edit last sign in" do
-      expect(page).to have_field("user_last_sign_in_at", disabled: true)
-    end
   end
 
   context "supervisor user" do
@@ -52,10 +48,6 @@ RSpec.describe "users/edit", type: :system do
 
     it "is not able to update the email if user is a supervisor" do
       expect(page).to have_field("Email", disabled: true)
-    end
-
-    it "is not able to edit last sign in" do
-      expect(page).to have_field("user_last_sign_in_at", disabled: true)
     end
   end
 
@@ -78,10 +70,6 @@ RSpec.describe "users/edit", type: :system do
       expect(page).to have_text("Profile was successfully updated.")
       expect(page).to have_text("new_admin@example.com")
       assert_equal "new_admin@example.com", admin.reload.email
-    end
-
-    it "is not able to edit last sign in" do
-      expect(page).to have_field("user_last_sign_in_at", disabled: true)
     end
   end
 end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe "volunteers/edit", type: :system do
   let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
   let(:volunteer) { create(:volunteer, casa_org_id: organization.id) }
 
+  it "shows invite and login info" do
+    sign_in admin
+    visit edit_volunteer_path(volunteer)
+    expect(page).to have_text "Added to system "
+    expect(page).to have_text "Invitation email sent never"
+    expect(page).to have_text "Last logged in"
+    expect(page).to have_text "Invitation accepted never"
+    expect(page).to have_text "Password reset last sent never"
+  end
+
   describe "updating volunteer personal data" do
     before do
       sign_in admin

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -42,60 +42,24 @@ RSpec.describe "volunteers/edit", type: :view do
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
   end
 
-  describe "does not allow" do
-    let(:volunteer) { create :volunteer }
-    let(:supervisor) { build_stubbed :supervisor }
-    let(:admin) { build_stubbed :casa_admin }
+  it "shows invite and login info" do
+    supervisor = build_stubbed :supervisor
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(supervisor)
 
-    it "a supervisor to edit a volunteers last sign in" do
-      enable_pundit(view, supervisor)
-      allow(view).to receive(:current_user).and_return(supervisor)
+    assign :volunteer, volunteer
+    assign :supervisors, []
 
-      assign :volunteer, volunteer
-      assign :supervisors, []
+    render template: "volunteers/edit"
 
-      render template: "volunteers/edit"
-
-      expect(rendered).to have_field("volunteer_last_sign_in_at", disabled: true)
-    end
-
-    it "an admin to edit a volunteers last sign in" do
-      enable_pundit(view, supervisor)
-      allow(view).to receive(:current_user).and_return(admin)
-
-      assign :volunteer, volunteer
-      assign :supervisors, []
-
-      render template: "volunteers/edit"
-
-      expect(rendered).to have_field("volunteer_last_sign_in_at", disabled: true)
-    end
-  end
-
-  context "The user has not accepted their invitation" do
-    it "shows a string stating that the user has not recieved there invation yet" do
-      expect("#{volunteer.display_name},
-        has yet to accept their invitation").to eq("#{volunteer.display_name},
-        has yet to accept their invitation")
-    end
-  end
-
-  context "The user has accepted their invitation" do
-    it "shows the datetime when the user recieved there invation" do
-      expect(volunteer.invitation_accepted_at).to eq(volunteer.invitation_accepted_at)
-    end
-  end
-
-  context " the user has not requested to reset their password" do
-    it "shows no string at all" do
-      expect(volunteer.reset_password_sent_at).to eq(nil)
-    end
+    expect(rendered).to have_text("Added to system ")
+    expect(rendered).to have_text("Invitation email sent \n  never")
+    expect(rendered).to have_text("Last logged in")
+    expect(rendered).to have_text("Invitation accepted \n  never")
+    expect(rendered).to have_text("Password reset last sent \n  never")
   end
 
   context " the user has requested to reset their password" do
-    it "shows the datetime when the user recieved there invation" do
-      expect(volunteer.reset_password_sent_at).to eq(volunteer.reset_password_sent_at)
-    end
     describe "shows resend invitation "
     let(:volunteer) { create :volunteer }
     let(:supervisor) { build_stubbed :supervisor }
@@ -113,7 +77,7 @@ RSpec.describe "volunteers/edit", type: :view do
       expect(rendered).to have_content("Resend Invitation")
     end
 
-    it "allows a supervisor resend invitation to a volunteer" do
+    it "allows a supervisor to resend invitation to a volunteer" do
       enable_pundit(view, supervisor)
       allow(view).to receive(:current_user).and_return(supervisor)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
add move info for supervisors and admins to see about a volunteer invite and login
Also split out some partials not for current reuse but just to make erb files smaller

### How will this affect user permissions?
- Volunteer permissions: volunteer can see more info about their invites and logins
- Supervisor permissions: can see more info about volunteer invites and logins
- Admin permissions:  can see more info about volunteer invites and logins

### How is this tested? (please write tests!) 💖💪
rspec

### Screenshots please :)
![Screen Shot 2021-04-04 at 7 54 54 PM](https://user-images.githubusercontent.com/578159/113532234-b8475580-957f-11eb-9729-86b4ec04ed39.png)
![Screen Shot 2021-04-04 at 7 54 40 PM](https://user-images.githubusercontent.com/578159/113532238-b9788280-957f-11eb-8d16-9320ca8230bd.png)
![Screen Shot 2021-04-04 at 7 49 52 PM](https://user-images.githubusercontent.com/578159/113532239-ba111900-957f-11eb-88b8-88a0628dc681.png)
![Screen Shot 2021-04-04 at 7 49 30 PM](https://user-images.githubusercontent.com/578159/113532241-baa9af80-957f-11eb-8037-eb4c8ea9d017.png)
![Screen Shot 2021-04-04 at 7 49 10 PM](https://user-images.githubusercontent.com/578159/113532242-baa9af80-957f-11eb-9c20-8fb2a3a70759.png)
