### PR TITLE
[#1734] Add Implementation Status to Court Mandates

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -61,6 +61,12 @@ class CasaCaseDecorator < Draper::Decorator
     ]
   end
 
+  def court_mandate_select_options
+    CaseCourtMandate.implementation_statuses.map do |status|
+      [status[0].humanize, status[0]]
+    end
+  end
+
   def inactive_class
     !object.active ? "table-secondary" : ""
   end

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -2,23 +2,22 @@ function add_court_mandate_input () {
   const list = '#mandates-list-container'
   const index = $(`${list} textarea`).length
 
-  const entry_class = 'court-mandate-entry'
-  const entry_html = `<div class="${entry_class}"></div>`
+  const entry_html = `<div class="court-mandate-entry"></div>`
 
   const textarea_html = `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
-id="casa_case_case_court_mandates_attributes_${index}_mandate_text">\
-</textarea>`
+                         id="casa_case_case_court_mandates_attributes_${index}_mandate_text">\
+                         </textarea>`
 
   const select_options = `<option value="">Set Implementation Status</option>\
-<option value="not_implemented">Not implemented</option>\
-<option value="partially_implemented">Partially implemented</option>\
-<option value="implemented">Implemented</option>`
+                          <option value="not_implemented">Not implemented</option>\
+                          <option value="partially_implemented">Partially implemented</option>\
+                          <option value="implemented">Implemented</option>`
 
   const select_html = `<select class="select-implementation-status"\
-name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
-id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
-${select_options}\
-</select>`
+                       name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
+                       id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
+                       ${select_options}\
+                       </select>`
 
   $(list).append(entry_html)
   let last_entry = $(list).children(':last')

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -2,12 +2,30 @@ function add_court_mandate_input () {
   const list = '#mandates-list-container'
   const index = $(`${list} textarea`).length
 
+  const entry_class = 'court-mandate-entry'
+  const entry_html = `<div class="${entry_class}"></div>`
+
   const textarea_html = `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
-id="casa_case_case_court_mandates_attributes_1_mandate_text">\
+id="casa_case_case_court_mandates_attributes_${index}_mandate_text">\
 </textarea>`
 
-  $(list).append(textarea_html)
-  $(list).children(':last').trigger('focus')
+  const select_options = `<option value="">Set Implementation Status</option>\
+<option value="not_implemented">Not implemented</option>\
+<option value="partially_implemented">Partially implemented</option>\
+<option value="implemented">Implemented</option>`
+
+  const select_html = `<select class="select-implementation-status"\
+name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
+id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
+${select_options}\
+</select>`
+
+  $(list).append(entry_html)
+  let last_entry = $(list).children(':last')
+
+  $(last_entry).append(textarea_html)
+  $(last_entry).append(select_html)
+  $(last_entry).children(':first').trigger('focus')
 }
 
 function remove_mandate_with_confirmation () {

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -72,7 +72,7 @@ function court_mandate_html(index) {
     textarea: `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
                  id="casa_case_case_court_mandates_attributes_${index}_mandate_text"></textarea>`,
 
-    select:   `<select class="select-implementation-status"\
+    select:   `<select class="implementation-status"\
                  name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
                  id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
                  ${select_options}\

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -1,29 +1,13 @@
 function add_court_mandate_input () {
   const list = '#mandates-list-container'
   const index = $(`${list} textarea`).length
+  const html = court_mandate_html(index)
 
-  const entry_html = `<div class="court-mandate-entry"></div>`
-
-  const textarea_html = `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
-                         id="casa_case_case_court_mandates_attributes_${index}_mandate_text">\
-                         </textarea>`
-
-  const select_options = `<option value="">Set Implementation Status</option>\
-                          <option value="not_implemented">Not implemented</option>\
-                          <option value="partially_implemented">Partially implemented</option>\
-                          <option value="implemented">Implemented</option>`
-
-  const select_html = `<select class="select-implementation-status"\
-                       name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
-                       id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
-                       ${select_options}\
-                       </select>`
-
-  $(list).append(entry_html)
+  $(list).append(html.entry)
   let last_entry = $(list).children(':last')
 
-  $(last_entry).append(textarea_html)
-  $(last_entry).append(select_html)
+  $(last_entry).append(html.textarea)
+  $(last_entry).append(html.select)
   $(last_entry).children(':first').trigger('focus')
 }
 
@@ -75,6 +59,25 @@ function remove_mandate_action (ctx) {
       })
     }
   })
+}
+
+function court_mandate_html(index) {
+  const select_options = `<option value="">Set Implementation Status</option>\
+                          <option value="not_implemented">Not implemented</option>\
+                          <option value="partially_implemented">Partially implemented</option>\
+                          <option value="implemented">Implemented</option>`
+  return {
+    entry:    `<div class="court-mandate-entry"></div>`,
+
+    textarea: `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
+                 id="casa_case_case_court_mandates_attributes_${index}_mandate_text"></textarea>`,
+
+    select:   `<select class="select-implementation-status"\
+                 name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
+                 id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
+                 ${select_options}\
+               </select>`
+  }
 }
 
 $('document').ready(() => {

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -49,30 +49,30 @@ body.casa_cases {
     }
   }
 
-  .court-mandate-entry {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-
-    .remove-mandate-button {
-      background-color: #{$red};
-
-      border-radius: 100%;
-
-      max-width: 30px;
-      max-height: 30px;
-    }
-  }
-
-  .select-implementation-status {
-    padding: 5px;
-  }
-
   #add-mandate-button {
     background-color: #{$primary};
 
     padding: 0.25em 1.5em;
     border-radius: 10px;
+  }
+
+  .remove-mandate-button {
+    background-color: #{$red};
+
+    border-radius: 100%;
+
+    max-width: 30px;
+    max-height: 30px;
+  }
+
+  .court-mandate-entry {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  select {
+    padding: 5px;
   }
 }
 
@@ -82,6 +82,17 @@ body.casa_cases {
       textarea, .add-court-mandate {
         width: 100%;
       }
+    }
+
+    .court-mandate-entry {
+      display: grid;
+      grid-template-columns: minmax(100px, 100%) 1fr;
+
+      .implementation-status {
+        grid-row: 2;
+      }
+
+      margin: 0 1em 64px 1em;
     }
   }
 }

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -87,12 +87,13 @@ body.casa_cases {
     .court-mandate-entry {
       display: grid;
       grid-template-columns: minmax(100px, 100%) 1fr;
+      gap: 2px;
 
       .implementation-status {
         grid-row: 2;
       }
 
-      margin: 0 1em 64px 1em;
+      margin: 1em 1em 2em 1em;
     }
   }
 }

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -64,6 +64,10 @@ body.casa_cases {
     }
   }
 
+  .select-implementation-status {
+    padding: 5px;
+  }
+
   #add-mandate-button {
     background-color: #{$primary};
 

--- a/app/models/case_court_mandate.rb
+++ b/app/models/case_court_mandate.rb
@@ -1,18 +1,21 @@
 class CaseCourtMandate < ApplicationRecord
   belongs_to :casa_case
 
-  validates :mandate_text, presence: true
+  validates :mandate_text, :implementation_status, presence: true
+
+  enum implementation_status: { not_implemented: 1, partially_implemented: 2, implemented: 3 }
 end
 
 # == Schema Information
 #
 # Table name: case_court_mandates
 #
-#  id           :bigint           not null, primary key
-#  mandate_text :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  casa_case_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  implementation_status :integer
+#  mandate_text          :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  casa_case_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/case_court_mandate.rb
+++ b/app/models/case_court_mandate.rb
@@ -1,7 +1,7 @@
 class CaseCourtMandate < ApplicationRecord
   belongs_to :casa_case
 
-  validates :mandate_text, :implementation_status, presence: true
+  validates :mandate_text, presence: true
 
   enum implementation_status: { not_implemented: 1, partially_implemented: 2, implemented: 3 }
 end

--- a/app/models/case_court_mandate.rb
+++ b/app/models/case_court_mandate.rb
@@ -3,7 +3,7 @@ class CaseCourtMandate < ApplicationRecord
 
   validates :mandate_text, presence: true
 
-  enum implementation_status: { not_implemented: 1, partially_implemented: 2, implemented: 3 }
+  enum implementation_status: {not_implemented: 1, partially_implemented: 2, implemented: 3}
 end
 
 # == Schema Information

--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -59,10 +59,10 @@ class CasaCasePolicy < ApplicationPolicy
     case @user
       when CasaAdmin
         common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
-        common_attrs << {case_court_mandates_attributes: %i[mandate_text id]}
+        common_attrs << case_court_mandates_attributes
       when Supervisor
         common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
-        common_attrs << {case_court_mandates_attributes: %i[mandate_text id]}
+        common_attrs << case_court_mandates_attributes
       else
         common_attrs
     end
@@ -99,5 +99,9 @@ class CasaCasePolicy < ApplicationPolicy
 
   def is_volunteer_actively_assigned_to_case?
     record.case_assignments.exists?(volunteer_id: user.id, active: true)
+  end
+
+  def case_court_mandates_attributes
+    {case_court_mandates_attributes: %i[mandate_text implementation_status id]}
   end
 end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -125,6 +125,12 @@
               <%= form.fields_for :case_court_mandates do |ff| %>
                 <div class="court-mandate-entry">
                   <%= ff.text_area :mandate_text %>
+                  <%=
+                    ff.select :implementation_status,
+                      @casa_case.decorate.court_mandate_select_options,
+                      {include_blank: 'Set Implementation Status', selected: ff.object.implementation_status},
+                      {class: 'select-implementation-status'}
+                  %>
                   <button type="button" class="remove-mandate-button">
                     <i class="fa fa-minus" aria-hidden="true"></i>
                   </button>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -148,10 +148,13 @@
               <% @casa_case.case_court_mandates.each do |mandate| %>
                 <div class="court-mandate-entry">
                   <textarea disabled><%= mandate.mandate_text %></textarea>
-                  <p class="implementation-status">
-                    <strong>Status:</strong>
-                    <%= mandate.implementation_status.humanize %>
-                  </p>
+
+                  <% if mandate.implementation_status %>
+                    <p class="implementation-status">
+                      <strong>Status:</strong>
+                      <%= mandate.implementation_status.humanize %>
+                    </p>
+                  <% end %>
                 </div>
               <% end %>
             </div>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -146,7 +146,10 @@
           <% else %>
             <div id="mandate-list-container">
               <% @casa_case.case_court_mandates.each do |mandate| %>
-                <textarea disabled><%= mandate.mandate_text %></textarea>
+                <div class="court-mandate-entry">
+                  <textarea disabled><%= mandate.mandate_text %></textarea>
+                  <p><strong><%= mandate.implementation_status.humanize %></strong></p>
+                </div>
               <% end %>
             </div>
           <% end %>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -129,7 +129,7 @@
                     ff.select :implementation_status,
                       @casa_case.decorate.court_mandate_select_options,
                       {include_blank: 'Set Implementation Status', selected: ff.object.implementation_status},
-                      {class: 'select-implementation-status'}
+                      {class: 'implementation-status'}
                   %>
                   <button type="button" class="remove-mandate-button">
                     <i class="fa fa-minus" aria-hidden="true"></i>
@@ -148,7 +148,10 @@
               <% @casa_case.case_court_mandates.each do |mandate| %>
                 <div class="court-mandate-entry">
                   <textarea disabled><%= mandate.mandate_text %></textarea>
-                  <p><strong><%= mandate.implementation_status.humanize %></strong></p>
+                  <p class="implementation-status">
+                    <strong>Status:</strong>
+                    <%= mandate.implementation_status.humanize %>
+                  </p>
                 </div>
               <% end %>
             </div>

--- a/db/migrate/20210401182359_add_implementation_status_to_edit_case_court_mandates.rb
+++ b/db/migrate/20210401182359_add_implementation_status_to_edit_case_court_mandates.rb
@@ -1,0 +1,5 @@
+class AddImplementationStatusToEditCaseCourtMandates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :case_court_mandates, :implementation_status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_161710) do
+ActiveRecord::Schema.define(version: 2021_04_01_182359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_161710) do
     t.bigint "casa_case_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "implementation_status"
     t.index ["casa_case_id"], name: "index_case_court_mandates_on_casa_case_id"
   end
 

--- a/spec/factories/case_court_mandates.rb
+++ b/spec/factories/case_court_mandates.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :case_court_mandate do
     casa_case
     mandate_text { Faker::Lorem.paragraph(sentence_count: 5, supplemental: true, random_sentences_to_add: 20) }
+    implementation_status { [:not_implemented, :partially_implemented, :implemented].sample }
   end
 end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe "/casa_cases", type: :request do
   let(:invalid_attributes) { {case_number: nil} }
   let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "111") }
   let(:mandate_texts) { ["1-New Mandate Text One", "0-New Mandate Text Two"] }
-  let(:mandates_attributes) { {"0" => {mandate_text: mandate_texts[0]}, "1" => {mandate_text: mandate_texts[1]}} }
+  let(:implementation_statuses) { ["not_implemented", nil] }
+  let(:mandates_attributes) do
+    {
+      "0" => {mandate_text: mandate_texts[0], implementation_status: implementation_statuses[0]},
+      "1" => {mandate_text: mandate_texts[1], implementation_status: implementation_statuses[1]}
+    }
+  end
 
   before { sign_in user }
 
@@ -182,7 +188,9 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.hearing_type).to eq hearing_type
           expect(casa_case.judge).to eq judge
           expect(casa_case.case_court_mandates[0].mandate_text).to eq mandate_texts[0]
+          expect(casa_case.case_court_mandates[0].implementation_status).to eq implementation_statuses[0]
           expect(casa_case.case_court_mandates[1].mandate_text).to eq mandate_texts[1]
+          expect(casa_case.case_court_mandates[1].implementation_status).to eq implementation_statuses[1]
         end
 
         it "redirects to the casa_case" do
@@ -205,7 +213,8 @@ RSpec.describe "/casa_cases", type: :request do
             {
               case_court_mandates_attributes: {
                 "0" => {
-                  mandate_text: "New Mandate Text One Updated"
+                  mandate_text: "New Mandate Text One Updated",
+                  implementation_status: :not_implemented
                 },
                 "1" => {
                   mandate_text: ""
@@ -474,7 +483,10 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.court_report_completed?).to be true
 
           expect(casa_case.case_court_mandates[0].mandate_text).to eq mandate_texts[0]
+          expect(casa_case.case_court_mandates[0].implementation_status).to eq implementation_statuses[0]
+
           expect(casa_case.case_court_mandates[1].mandate_text).to eq mandate_texts[1]
+          expect(casa_case.case_court_mandates[1].implementation_status).to eq implementation_statuses[1]
         end
 
         it "redirects to the casa_case" do

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -5,13 +5,22 @@ RSpec.describe "casa_cases/edit", type: :system do
   context "when admin" do
     let(:organization) { create(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
-    let(:casa_case) { create(:casa_case, casa_org: organization) }
+    let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: organization) }
     let!(:judge) { create(:judge, casa_org: organization) }
     let(:contact_type_group) { create(:contact_type_group, casa_org: organization) }
     let!(:school) { create(:contact_type, name: "School", contact_type_group: contact_type_group) }
     let!(:therapist) { create(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
 
     before { sign_in admin }
+
+    it "shows court mandates" do
+      visit edit_casa_case_path(casa_case)
+
+      court_mandate = casa_case.case_court_mandates.first
+
+      expect(page).to have_text(court_mandate.mandate_text)
+      expect(page).to have_text(court_mandate.implementation_status.humanize)
+    end
 
     it "clicks back button after editing case" do
       visit edit_casa_case_path(casa_case)
@@ -76,7 +85,7 @@ RSpec.describe "casa_cases/edit", type: :system do
   context "supervisor user" do
     let(:casa_org) { create(:casa_org) }
     let(:supervisor) { create(:supervisor, casa_org: casa_org) }
-    let(:casa_case) { create(:casa_case, casa_org: casa_org) }
+    let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: casa_org) }
     let!(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
     let!(:contact_type_1) { create(:contact_type, name: "Youth", contact_type_group: contact_type_group) }
     let!(:contact_type_2) { create(:contact_type, name: "Supervisor", contact_type_group: contact_type_group) }
@@ -173,6 +182,15 @@ RSpec.describe "casa_cases/edit", type: :system do
       expect(page).not_to have_text("Year")
       expect(page).not_to have_text("Reactivate Case")
       expect(page).not_to have_text("Update Casa Case")
+    end
+
+    it "shows court mandates" do
+      visit edit_casa_case_path(casa_case)
+
+      court_mandate = casa_case.case_court_mandates.first
+
+      expect(page).to have_text(court_mandate.mandate_text)
+      expect(page).to have_text(court_mandate.implementation_status.humanize)
     end
 
     context "When a Casa instance has no judge names added" do
@@ -335,7 +353,7 @@ of it unless it was included in a previous court report.")
 
   context "volunteer user" do
     let(:volunteer) { create(:volunteer) }
-    let(:casa_case) { create(:casa_case, casa_org: volunteer.casa_org) }
+    let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: volunteer.casa_org) }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
     let!(:court_dates) do
@@ -369,6 +387,15 @@ of it unless it was included in a previous court report.")
       # and that the one with no report doesn't get one
       expect(page).not_to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))
       expect(page).to have_text(I18n.l(court_dates[1].date, format: :full, default: nil))
+    end
+
+    it "shows court mandates" do
+      visit edit_casa_case_path(casa_case)
+
+      court_mandate = casa_case.case_court_mandates.first
+
+      expect(page).to have_text(court_mandate.mandate_text)
+      expect(page).to have_text(court_mandate.implementation_status.humanize)
     end
 
     it "clicks back button after editing case" do

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe "casa_cases/edit", type: :system do
       page.find("#add-mandate-button").click
       find("#mandates-list-container").first("textarea").send_keys("Court Mandate Text One")
 
+      select "Partially implemented", from: "casa_case[case_court_mandates_attributes][0][implementation_status]"
+
+      expect(page).to have_text("Set Implementation Status")
+
       click_on "Update CASA Case"
       has_checked_field? "Youth"
       has_no_checked_field? "Supervisor"
@@ -115,6 +119,7 @@ RSpec.describe "casa_cases/edit", type: :system do
       expect(page).to have_text("November")
       expect(page).to have_text("September")
       expect(page).to have_text("Court Mandate Text One")
+      expect(page).to have_text("Partially implemented")
 
       visit casa_case_path(casa_case)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1734

### What changed, and why?
Court mandates now have an "implementation status" field. Only admins and supervisors can add or edit this field from a given court mandate, but volunteers can still see this field.

Acceptance criteria:
 - [x] Only supervisors can edit implementation status.
 - [x] Implementation status should display as a dropdown menu,   with the following items in it:
    - [x] not implemented
    - [x] partially implemented
    - [x] implemented
 - [x] When nothing is selected in the dropdown menu, the default (first item) should be: set implementation status
 - [x] On desktop web, implementation status should appear to the right of each court mandate.
 - [x] On mobile web, implementation status should appear underneath each court mandate.

### How will this affect user permissions?
- Volunteer permissions: Can now see (but not add/edit) case mandates implementation status.
- Supervisor permissions: Can now add and edit implementation status of case mandates
- Admin permissions: Can now add and edit implementation status of case mandates

### How is this tested? (please write tests!) 💖💪
#### Automated specs:
I basically expanded on the specs I've created in #1802.
I tested whether or not admins, supervisors and volunteers could see, add, or edit the implementation status of court mandates.

#### Manual testing
##### Admin/Supervisor:
1. Login as admin/supervisor
2. Go to the cases page, choose a case and click Edit
3. Click "Add a court mandate"
    * Check if the text area and select box show up
    * Check if the select area has the correct fields
    * Check if the select area is displayed beside the text area in desktop
    * Check if it is displayed below the text area in mobile, with enough space between the court mandates to avoid confusion
    * Add more court mandates to check the same conditions but with other court mandates
4. Click "Update CASA Case"
    * Check if the saved court mandate fields show up with the same info as before
    * Check if it looks the same as before, but now with a delete button alongside the fields
##### Volunteer:
1. Login as volunteer
2. Go to the cases page, choose a case that has court mandates and click Edit
    * Check if the disabled text area shows up
    * Check if a text with "Status: [status name]" shows up for each court mandate
    * Check if the implementation status text displays correctly in both desktop and mobile

### Screenshots please :)
#### Admin/Supervisor view
Adding a new court mandate
![01-edit-desktop](https://user-images.githubusercontent.com/72531802/113597328-ed03ed00-9611-11eb-8d11-a25682942ad9.png)

Saving it and adding a new one
![02-more-desktop](https://user-images.githubusercontent.com/72531802/113597336-effedd80-9611-11eb-9abc-c35b90875cc6.png)

Select options
![03-select-desktop](https://user-images.githubusercontent.com/72531802/113597366-fd1bcc80-9611-11eb-9dc2-571367ea30a2.png)

Mobile view
![04-mobile](https://user-images.githubusercontent.com/72531802/113597388-03aa4400-9612-11eb-9dc3-b2a4ed07461f.png)

#### Volunteer view
Desktop view
![05-volunteer-desktop](https://user-images.githubusercontent.com/72531802/113597422-10c73300-9612-11eb-96e5-2224666b59c5.png)

Mobile view
![06-volunteer-mobile](https://user-images.githubusercontent.com/72531802/113597428-13c22380-9612-11eb-8436-be607804f198.png)

