### PR TITLE
Make supervisors deactivate-able

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -2,7 +2,7 @@
 
 class SupervisorsController < ApplicationController
   before_action :available_volunteers, only: [:edit, :update]
-  before_action :set_supervisor, only: [:edit, :update]
+  before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate]
   before_action :all_volunteers_ever_assigned, only: [:edit, :update]
   after_action :verify_authorized
 
@@ -36,6 +36,28 @@ class SupervisorsController < ApplicationController
     authorize @supervisor
     if @supervisor.update(update_supervisor_params)
       redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  def activate
+    authorize @supervisor
+    if @supervisor.activate
+      SupervisorMailer.account_setup(@supervisor).deliver
+
+      redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was activated."
+    else
+      render :edit
+    end
+  end
+
+  def deactivate
+    authorize @supervisor
+    if @supervisor.deactivate
+      SupervisorMailer.deactivation(@supervisor).deliver
+
+      redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was deactivated."
     else
       render :edit
     end

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -48,7 +48,7 @@ class SupervisorsController < ApplicationController
 
       redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was activated."
     else
-      render :edit
+      render :edit, notice: "Supervisor could not be activated."
     end
   end
 
@@ -59,7 +59,7 @@ class SupervisorsController < ApplicationController
 
       redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was deactivated."
     else
-      render :edit
+      render :edit, notice: "Supervisor could not be deactivated."
     end
   end
 

--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -1,4 +1,17 @@
 class SupervisorMailer < ApplicationMailer
+  def deactivation(supervisor)
+    @supervisor = supervisor
+    @casa_organization = supervisor.casa_org
+    mail(to: @supervisor.email, subject: "Your account has been deactivated")
+  end
+
+  def account_setup(supervisor)
+    @supervisor = supervisor
+    @casa_organization = supervisor.casa_org
+    @token = @supervisor.generate_password_reset_token
+    mail(to: @supervisor.email, subject: "Create a password & set up your account")
+  end
+
   def weekly_digest(supervisor)
     @supervisor = supervisor
     @casa_organization = supervisor.casa_org

--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -9,7 +9,7 @@ class SupervisorMailer < ApplicationMailer
     @supervisor = supervisor
     @casa_organization = supervisor.casa_org
     @token = @supervisor.generate_password_reset_token
-    mail(to: @supervisor.email, subject: "Create a password & set up your account")
+    mail(to: @supervisor.email, subject: "Create a password and set up your account")
   end
 
   def weekly_digest(supervisor)

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -5,6 +5,23 @@ class Supervisor < User
 
   has_many :volunteers, -> { includes(:supervisor_volunteer).order(:display_name) }, through: :active_supervisor_volunteers
   has_many :volunteers_ever_assigned, -> { includes(:supervisor_volunteer).order(:display_name) }, through: :supervisor_volunteers, source: :volunteer
+
+  # Activates supervisor.
+  def activate
+    update(active: true)
+  end
+
+  # Deactivates supervisor and unassign all volunteers from him.
+  def deactivate
+    transaction do
+      updated = update(active: false)
+      if updated
+        supervisor_volunteers.update_all(is_active: false)
+      end
+
+      updated
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -11,7 +11,7 @@ class Supervisor < User
     update(active: true)
   end
 
-  # Deactivates supervisor and unassign all volunteers from him.
+  # Deactivates supervisor and unassign all volunteers.
   def deactivate
     transaction do
       updated = update(active: false)

--- a/app/policies/supervisor_policy.rb
+++ b/app/policies/supervisor_policy.rb
@@ -12,6 +12,14 @@ class SupervisorPolicy < UserPolicy
       (is_supervisor? && record == user)
   end
 
+  def activate?
+    is_admin?
+  end
+
+  def deactivate?
+    is_admin?
+  end
+
   alias_method :create?, :new?
   alias_method :edit?, :index?
 end

--- a/app/views/supervisor_mailer/account_setup.html.erb
+++ b/app/views/supervisor_mailer/account_setup.html.erb
@@ -1,0 +1,24 @@
+<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      A <%= @supervisor.casa_org.display_name %>’s County supervisor console account has been created for you. This console is
+      for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth,
+      their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated
+      with your CASA case (such as teachers and therapists).
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Your console account is associated with this email. If this is not the correct email to use, please stop here and
+      contact your Administrator to change the email address. If you are ready to get started, please set your
+      password. This is the first step to accessing your new supervisor account.
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      <a href="<%= "#{edit_password_url(@supervisor, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Set
+        Your Password</a>
+    </td>
+  </tr>
+</table>

--- a/app/views/supervisor_mailer/deactivation.html.erb
+++ b/app/views/supervisor_mailer/deactivation.html.erb
@@ -1,0 +1,20 @@
+<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Hello <%= @supervisor.display_name %>,
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Your <%= @supervisor.casa_org.display_name %>'s County supervisor console account has been deactivated. Should you resume
+      service as a CASA supervisor in the future, your account will be reactivated. Thank you for your service to CASA!
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      If you have any questions, please contact your most recent <%= @supervisor.casa_org.display_name %> Administrator for
+      assistance.
+    </td>
+  </tr>
+</table>

--- a/app/views/supervisors/_manage_active.html.erb
+++ b/app/views/supervisors/_manage_active.html.erb
@@ -1,0 +1,24 @@
+<div class="field form-group">
+  <% if user.active? %>
+    Supervisor is <span class="badge badge-success text-uppercase display-1">Active</span>
+    <% if current_user.casa_admin? %>
+      <% if policy(user).deactivate? %>
+        <%= link_to "Deactivate supervisor",
+                    deactivate_supervisor_path(user),
+                    method: :patch,
+                    class: "btn btn-outline-danger",
+                    data: {confirm: t("forms.supervisor.mark_inactive_warning")} %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <div class="alert alert-danger">
+      Supervisor was deactivated on: <%= user.decorate.formatted_updated_at %>
+    </div>
+    <% if policy(user).activate? %>
+      <%= link_to "Activate supervisor",
+                  activate_supervisor_path(user),
+                  method: :patch,
+                  class: "btn btn-outline-success" %>
+  <% end %>
+<% end %>
+</div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -28,6 +28,10 @@
         <%= render "/shared/invite_login", resource: @supervisor %>
       </p>
 
+      <p>
+        <%= render "manage_active", user: @supervisor %>
+      </p>
+
       <div class="actions">
         <% if policy(@supervisor).update_supervisor_email? || policy(@supervisor).update_supervisor_name? %>
           <%= form.submit "Submit", class: "btn btn-primary" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,8 @@ en:
       mark_inactive_warning: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"
     case_contact:
       notes_placeholder: "Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth."
+    supervisor:
+      mark_inactive_warning: "WARNING: Marking a supervisor inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?"
     volunteer:
       mark_inactive_warning: "WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?"
   page:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,13 @@ Rails.application.routes.draw do
   resources :emancipation_checklists, only: %i[index]
   resources :judges, only: %i[new create edit update]
   resources :notifications, only: :index
-  resources :supervisors, except: %i[destroy]
+
+  resources :supervisors, except: %i[destroy] do
+    member do
+      patch :activate
+      patch :deactivate
+    end
+  end
   resources :supervisor_volunteers, only: %i[create] do
     member do
       patch :unassign

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -60,6 +60,62 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(page).to have_text "Password reset last sent never"
     end
 
+    it "can go to supervisor edit page and deactivate him", js: true do
+      supervisor = create :supervisor, casa_org: organization
+
+      sign_in user
+      visit edit_supervisor_path(supervisor)
+  
+      dismiss_confirm do
+        click_on "Deactivate supervisor"
+      end
+  
+      accept_confirm do
+        click_on "Deactivate supervisor"
+      end
+      expect(page).to have_text("Supervisor was deactivated on")
+  
+      expect(supervisor.reload).not_to be_active
+    end
+  
+    it "can activate a supervisor" do
+      inactive_supervisor = create(:supervisor, casa_org_id: organization.id)
+      inactive_supervisor.deactivate
+  
+      sign_in user
+  
+      visit edit_supervisor_path(inactive_supervisor)
+  
+      click_on "Activate supervisor"
+  
+      expect(page).not_to have_text("Supervisor was deactivated on")
+  
+      expect(inactive_supervisor.reload).to be_active
+    end
+
+    context "logged in as a supervisor" do
+      let(:supervisor) {create(:supervisor)}
+      it "can't deactivate a supervisor", js: true do
+        supervisor2 = create :supervisor, casa_org: organization
+
+        sign_in supervisor
+        visit edit_supervisor_path(supervisor2)
+    
+        expect(page).to_not have_text("Deactivate supervisor")   
+      end
+    
+      it "can't activate a supervisor" do
+        inactive_supervisor = create(:supervisor, casa_org_id: organization.id)
+        inactive_supervisor.deactivate
+    
+        sign_in supervisor
+    
+        visit edit_supervisor_path(inactive_supervisor)
+    
+        expect(page).not_to have_text("Activate supervisor")
+      end
+    end
+    
     context "when entering valid information" do
       it "updates the e-mail address successfully" do
         sign_in user

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -65,57 +65,57 @@ RSpec.describe "supervisors/edit", type: :system do
 
       sign_in user
       visit edit_supervisor_path(supervisor)
-  
+
       dismiss_confirm do
         click_on "Deactivate supervisor"
       end
-  
+
       accept_confirm do
         click_on "Deactivate supervisor"
       end
       expect(page).to have_text("Supervisor was deactivated on")
-  
+
       expect(supervisor.reload).not_to be_active
     end
-  
+
     it "can activate a supervisor" do
       inactive_supervisor = create(:supervisor, casa_org_id: organization.id)
       inactive_supervisor.deactivate
-  
+
       sign_in user
-  
+
       visit edit_supervisor_path(inactive_supervisor)
-  
+
       click_on "Activate supervisor"
-  
+
       expect(page).not_to have_text("Supervisor was deactivated on")
-  
+
       expect(inactive_supervisor.reload).to be_active
     end
 
     context "logged in as a supervisor" do
-      let(:supervisor) {create(:supervisor)}
+      let(:supervisor) { create(:supervisor) }
       it "can't deactivate a supervisor", js: true do
         supervisor2 = create :supervisor, casa_org: organization
 
         sign_in supervisor
         visit edit_supervisor_path(supervisor2)
-    
-        expect(page).to_not have_text("Deactivate supervisor")   
+
+        expect(page).to_not have_text("Deactivate supervisor")
       end
-    
+
       it "can't activate a supervisor" do
         inactive_supervisor = create(:supervisor, casa_org_id: organization.id)
         inactive_supervisor.deactivate
-    
+
         sign_in supervisor
-    
+
         visit edit_supervisor_path(inactive_supervisor)
-    
+
         expect(page).not_to have_text("Activate supervisor")
       end
     end
-    
+
     context "when entering valid information" do
       it "updates the e-mail address successfully" do
         sign_in user

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(page).to have_text "Password reset last sent never"
     end
 
-    it "can go to supervisor edit page and deactivate him", js: true do
+    it "can deactivate a supervisor", js: true do
       supervisor = create :supervisor, casa_org: organization
 
       sign_in user


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1906

### What changed, and why?
Now Administrators can deactivate/activate supervisors while in the edit supervisor screen. Created some mailers following the pattern of the activate/deactivate a volunteer.

### How will this affect user permissions?
- Volunteer permissions:
 Nothing change
- Supervisor permissions:
Can't activate/deactivate another supervisor.
- Admin permissions:
Can activate/deactivate a supervisor.

### How is this tested? (please write tests!) 💖💪
I have written tests.
But can be manually tested following this steps:
Admins can deactivate:
- login as an admin
- go to edit a supervisor page
- if the supervisor is active you can deactivate, else you can activate him.

Supervisors can't deactivate:
- login as a supervisor
- go to edit a supervisor page
- you will not see a button for activate/deactivate supervisor


### Screenshots please :)
Logged in as a supervisor editing an active supervisor:

![Screenshot from 2021-04-06 11-37-24](https://user-images.githubusercontent.com/61836657/113753250-43d9f700-96e4-11eb-88f5-e68e3979646d.png)

Logged in as a supervisor editing a deactivated supervisor:

![Screenshot from 2021-04-06 11-37-43](https://user-images.githubusercontent.com/61836657/113753253-450b2400-96e4-11eb-9749-2b5c1cb60674.png)

Logged in as an admin editing an active supervisor:

![Screenshot from 2021-04-06 11-38-25](https://user-images.githubusercontent.com/61836657/113753260-463c5100-96e4-11eb-8761-c10f35b1534e.png)

Logged in as an admin editing a deactivated supervisor:

![Screenshot from 2021-04-06 11-38-12](https://user-images.githubusercontent.com/61836657/113753256-45a3ba80-96e4-11eb-821c-3b7b2df15947.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
