### PR TITLE
Fix multitenant bug

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -180,7 +180,8 @@ class CasaCase < ApplicationRecord
   end
 
   def unassigned_volunteers
-    Volunteer.active.where.not(id: assigned_volunteers).order(:display_name)
+    # binding.pry
+    Volunteer.active.where.not(id: assigned_volunteers).order(:display_name).in_organization(casa_org)
   end
 
   private

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to have_many(:case_court_mandates).dependent(:destroy) }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }
 
+  describe ".unassigned_volunteers" do
+    it "only shows volunteers for the current volunteers organization" do
+      casa_case = create(:casa_case)
+      volunteer_same_org = create(:volunteer, casa_org: casa_case.casa_org)
+      volunteer_different_org = create(:volunteer, casa_org: create(:casa_org))
+      expect(casa_case.unassigned_volunteers).to include(volunteer_same_org)
+      expect(casa_case.unassigned_volunteers).not_to include(volunteer_different_org)
+    end
+  end
+
   describe ".ordered" do
     it "orders the casa cases by updated at date" do
       very_old_casa_case = create(:casa_case, updated_at: 5.days.ago)


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
don't show other casa org volunteers in dropdown

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: can no longer see wrong casa org volunteers in assignment dropdown
- Admin permissions:  can no longer see wrong casa org volunteers in assignment dropdown

### How is this tested? (please write tests!) 💖💪
rspec

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
