### PR TITLE
Move erb_lint to development and test groups in Gemfile

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,7 @@
 ---
 EnableDefaultLinters: true
+exclude:
+  - '**/vendor/**/*'
 linters:
   ErbSafety:
     enabled: true

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -26,9 +26,8 @@ jobs:
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-
-    - name: install gem erb_lint
-      run: gem install erb_lint
+      with:
+        bundler-cache: true
 
     - name: ERB lint
-      run: erblint --lint-all --autocorrect
+      run: bundle exec erblint --lint-all --autocorrect

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "request_store"
 group :development, :test do
   gem "bullet" # Detect and fix N+1 queries
   gem "byebug", platforms: %i[mri mingw x64_mingw] # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem "erb_lint", require: false
   gem "factory_bot_rails"
   gem "pry"
   gem "pry-byebug"
@@ -45,7 +46,6 @@ end
 
 group :development do
   gem "annotate" # for adding db field listings to models as comments
-  gem "erb_lint", require: false
   gem "letter_opener" # Opens emails in new tab for easier testing
   gem "listen", ">= 3.0.5", "< 3.6"
   gem "spring" # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring


### PR DESCRIPTION
Installing erb_lint is now unneeded in the erb_lint GitHub workflow since it's now part of the bundler cache, like all gems in the test group.

### How is this tested? (please write tests!) 💖💪
The erb_lint GitHub workflow should still pass.