### PR TITLE
show error on failed case cort report generation when template is not found

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -38,14 +38,15 @@ class CaseCourtReportsController < ApplicationController
 
           render json: {link: case_court_report_path(casa_case.case_number, format: "docx"), status: :ok}
         else
-          flash[:alert] = "Report #{params[:case_number]} is not found."
-          error_messages = render_to_string partial: "layouts/flash_messages", formats: :html, layout: false, locals: flash
-          flash.discard
+          error_messages = generate_error(t(".error.report_not_found", case_number: params[:case_number]))
 
           render json: {link: "", status: :not_found, error_messages: error_messages}, status: :not_found
         end
       end
     end
+  rescue Zip::Error
+    error_messages = generate_error(t(".error.template_not_found"))
+    render json: {status: :not_found, error_messages: error_messages}, status: :not_found
   end
 
   private
@@ -77,5 +78,13 @@ class CaseCourtReportsController < ApplicationController
         io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
       )
     end
+  end
+
+  def generate_error(message)
+    flash[:alert] = message
+    error_messages = render_to_string partial: "layouts/flash_messages", formats: :html, layout: false, locals: flash
+    flash.discard
+
+    error_messages
   end
 end

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -100,7 +100,9 @@
       body: JSON.stringify(formData)
     }
     fetch(url, options)
-      .then(response => response.json())
+      .then(response => {
+        return response.json()
+      })
       .then(data => {
         if (data.status !== 'ok') {
           showAlert(data.error_messages)

--- a/config/locales/controllers.en.yml
+++ b/config/locales/controllers.en.yml
@@ -1,0 +1,6 @@
+en:
+  case_court_reports:
+    generate:
+      error:
+        template_not_found: Template is not found
+        report_not_found: Report %{case_number} is not found.


### PR DESCRIPTION
… found

### What github issue is this PR for, if any?
Resolves #1917 

### What changed, and why?
- show error when the template is not found

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
![image](https://user-images.githubusercontent.com/42526152/114081307-9549d800-98d6-11eb-9b1b-c38c5bbf8e53.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media1.giphy.com/media/26tP4gFBQewkLnMv6/giphy.gif?cid=29caca75rs6wfr7bt5kmt5baqa1nwxisa4e1q3ebb19b6ktg&rid=giphy.gif)
