### PR TITLE
Remove unneeded mimemagic dependency from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,9 +211,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.0)
     method_source (1.0.0)
-    mimemagic (0.3.9)
-      nokogiri (~> 1)
-      rake
     mini_magick (4.11.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
The changes were generated after running `bundle install` on the current `main` branch. This is reverting changes from #1938.

Mimemagic isn't needed since it was dropped from Rails' dependencies in Rails 6.1.3.1. Active Storage (and thus Rails) is now relying on Marcel for MIME type data. See upstream: https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/
