### PR TITLE
Link to CasaOrg logo with Rails path helper

### DIFF
--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -33,7 +33,7 @@ class CasaOrg < ApplicationRecord
 
   def org_logo
     if logo.attached?
-      ActiveStorage::Blob.service.path_for(logo.key)
+      Rails.application.routes.url_helpers.rails_blob_path(logo, only_path: true)
     else
       CASA_DEFAULT_LOGO
     end

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -41,6 +41,7 @@ class DbPopulator
         ["https://example.org/subscribe-to-newsletter/", "Subscribe to newsletter"],
         ["https://www.example.org/give/givefrm.asp?CID=4450", "Donate"]
       ]
+      org.logo.attach(io: File.open(CasaOrg::CASA_DEFAULT_LOGO), filename: CasaOrg::CASA_DEFAULT_LOGO.basename.to_s)
     }
 
     create_users(casa_org, options)

--- a/spec/models/casa_org_spec.rb
+++ b/spec/models/casa_org_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe CasaOrg, type: :model do
       aggregate_failures do
         expect(subject.org_logo).to eq(Pathname.new("#{Rails.root}/public/logo.jpeg"))
         subject.logo.attach(io: File.open("#{Rails.root}/spec/fixtures/company_logo.png"),
-                            filename: "company_logo.png", content_type: "logo/png")
-        expect(subject.logo).to be_attached
-        expect(subject.org_logo).to_not eq(Pathname.new("#{Rails.root}/public/logo.jpeg"))
+                            filename: "company_logo.png", content_type: "image/png")
+        expect(subject.logo).to be_an_instance_of(ActiveStorage::Attached::One)
+        expect(subject.org_logo).to eq("/rails/active_storage/blobs/redirect/#{subject.logo.signed_id}/#{subject.logo.filename}")
       end
     end
   end


### PR DESCRIPTION
### Note

Following the merge of this PR, developers will have to attach valid logos to CasaOrg records in their database. This is now handled in the database seeds, but old records with invalid logos will cause issues. To automate this process, run the following code in the Rails console (it will close the console once it's done):

```ruby
CasaOrg.all.each { |org| org.logo.attach(io: File.open(CasaOrg::CASA_DEFAULT_LOGO), filename: CasaOrg::CASA_DEFAULT_LOGO.basename.to_s) } && exit
```

### What GitHub issue is this PR for, if any?
Fixes #1883

### What changed, and why?
As described in the Rails guide `Active Storage Overview`: https://guides.rubyonrails.org/active_storage_overview.html#linking-to-files

This links correctly to Active Storage blobs for all Active Storage services. The previous approach only worked for
ActiveStorage::Service::DiskService, which broke in production since we're relying on ActiveStorage::Service::AzureStorageService.

The seeds are also now creating an Active Storage blob for the logo of CasaOrg records. It's easier to test org_logo with this change.

### How will this affect user permissions?
It doesn't.
