### PR TITLE
Corrects Date written field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,3 +88,6 @@ en:
     month: Month
     year: Year
     none: None
+  date:
+    formats:
+      full: "%B %-d, %Y"

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe CaseCourtReport, type: :model do
       it "must have Case Contacts as type Array" do
         expect(subject[:case_contacts]).to be_instance_of Array
       end
+
+      it "created_date is not nil" do
+        expect(subject[:created_date]).to_not be(nil)
+      end
     end
 
     describe "when generating report" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1947 Issue

### What changed, and why?
Added the correct command to create the Date. Because with the old command the field was looking in the wrong place for the "full" date format and the field become nil because the default was set to nil.


### How will this affect user permissions?
- Volunteer permissions: Nothing
- Supervisor permissions: Nothing
- Admin permissions: Nothing

### How is this tested? (please write tests!) 💖💪
I have created a simple test to fail if created_date is nil.


### Screenshots please :)
![Screenshot from 2021-04-16 12-43-13](https://user-images.githubusercontent.com/61836657/115049656-59ec7200-9eb1-11eb-9265-f36e812aa110.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
