### PR TITLE
unbreak qa seed

### DIFF
--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -20,7 +20,7 @@ class CaseAssignment < ApplicationRecord
   private
 
   def assignee_must_be_volunteer
-    errors.add(:volunteer, "Case assignee must be a volunteer") unless volunteer.is_a?(Volunteer) && volunteer.active?
+    errors.add(:volunteer, "Case assignee must be an active volunteer") unless volunteer.is_a?(Volunteer) && volunteer.active?
   end
 
   def casa_case_and_volunteer_must_belong_to_same_casa_org

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -11,7 +11,7 @@
                 <%= contact.contact_groups_with_types.keys.join(', ') %>
               </strong>
               <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
-class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
+                          class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">
               <%= contact.decorate.contact_types %>
@@ -37,7 +37,7 @@ class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
       </div>
       <div class="align-self-end">
         <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete,
-class: "btn btn-danger pull-right") if policy(current_user).destroy? && !contact.deleted? %>
+                    class: "btn btn-danger pull-right") if policy(current_user).destroy? && !contact.deleted? %>
       </div>
       <div class="row">
         <% if Pundit.policy(current_user, contact).update? %>

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -165,7 +165,7 @@ class DbPopulator
           transition_aged_youth: random_true_false
         )
       end
-      volunteer = casa_org.volunteers.sample(random: rng) || casa_org.volunteers.first
+      volunteer = casa_org.volunteers.active.sample(random: rng) || casa_org.volunteers.active.first
       CaseAssignment.find_or_create_by!(casa_case: new_casa_case, volunteer: volunteer)
 
       random_case_contact_count.times do


### PR DESCRIPTION
```
I, [2021-04-24T08:12:26.554329 #33]  INFO -- [Bugsnag]: Notifying https://notify.bugsnag.com of ActiveRecord::RecordInvalid
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Volunteer Case assignee must be a volunteer
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/validations.rb:80:in `raise_validation_error'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/validations.rb:53:in `save!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/transactions.rb:302:in `block in save!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/transactions.rb:302:in `save!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/suppressor.rb:48:in `save!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/persistence.rb:55:in `create!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:805:in `_create!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:114:in `block in create!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:406:in `block in scoping'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:810:in `_scoping'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:406:in `scoping'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:114:in `create!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/relation.rb:175:in `find_or_create_by!'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/querying.rb:22:in `find_or_create_by!'
/app/db/seeds/db_populator.rb:169:in `block in create_cases'
/app/db/seeds/db_populator.rb:159:in `times'
/app/db/seeds/db_populator.rb:159:in `create_cases'
/app/db/seeds/db_populator.rb:46:in `create_org'
/app/db/seeds.rb:31:in `seed'
/app/db/seeds.rb:98:in `<main>'
/app/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
/app/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:59:in `load'
/app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/engine.rb:566:in `block in load_seed'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/execution_wrapper.rb:88:in `wrap'
/app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/engine.rb:640:in `block (2 levels) in <class:Engine>'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `instance_exec'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:126:in `block in run_callbacks'
/app/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.3.1/lib/active_support/callbacks.rb:137:in `run_callbacks'
/app/vendor/bundle/ruby/2.7.0/gems/railties-6.1.3.1/lib/rails/engine.rb:566:in `load_seed'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/tasks/database_tasks.rb:450:in `load_seed'
/app/vendor/bundle/ruby/2.7.0/gems/activerecord-6.1.3.1/lib/active_record/railties/databases.rake:392:in `block (2 levels) in <main>'
/app/vendor/bundle/ruby/2.7.0/gems/bugsnag-6.20.0/lib/bugsnag/integrations/rake.rb:20:in `execute'
Tasks: TOP => db:seed:replant => db:seed
(See full trace by running task with --trace)
D, [2021-04-24T08:12:26.706776 #33] DEBUG -- [Bugsnag]: Request to https://notify.bugsnag.com completed, status: 200
D, [2021-04-24T08:12:26.734972 #33] DEBUG -- [Bugsnag]: Not notifying ActiveRecord::RecordInvalid due to ignore being signified in internal middlewares
```