### PR TITLE
Resolves #1745: Recently unassigned volunteers in supervisor weekly email

### DIFF
--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -22,6 +22,11 @@ class Supervisor < User
       updated
     end
   end
+
+  def recently_unassigned_volunteers
+    unassigned_supervisor_volunteers.joins(:volunteer).includes(:volunteer)
+      .where(updated_at: 1.week.ago..Time.zone.now).map(&:volunteer)
+  end
 end
 
 # == Schema Information

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -67,6 +67,24 @@
       <% end %>
     <% end %>
   <% end %>
+
+  <% if @supervisor.recently_unassigned_volunteers.any? %>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
+      <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+        <b><%= "The following volunteers have been unassigned from you:" %></b>
+        <br>
+
+        <% @supervisor.recently_unassigned_volunteers.each  do |volunteer| %>
+          - <%= volunteer.display_name %>
+
+          <% unless volunteer.has_supervisor? %>
+            (not assigned to a new supervisor)
+          <% end %>
+          <br>
+        <% end %>
+    </tr>
+  <% end %>
+
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
       <b>Additional Notes:</b>

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -57,5 +57,38 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
     it { expect(rendered).to have_text("No contact attempts were logged for this week.") }
   end
 
+  context "when a volunteer has been unassigned" do
+    before(:each) do
+      supervisor.volunteers << volunteer
+      sign_in supervisor
+      volunteer.supervisor_volunteer.update(is_active: false)
+
+      new_supervisor.volunteers << volunteer
+      volunteer.supervisor_volunteer.update(is_active: true)
+      assign :supervisor, supervisor
+
+      render template: "supervisor_mailer/weekly_digest"
+    end
+
+    let(:new_supervisor) { create(:supervisor) }
+
+    it { expect(rendered).to have_text("The following volunteers have been unassigned from you") }
+    it { expect(rendered).to have_text("- #{volunteer.display_name}") }
+  end
+
+  context "when a volunteer unassigned and has not been assigned to a new supervisor" do
+    before(:each) do
+      supervisor.volunteers << volunteer
+      sign_in supervisor
+      assign :supervisor, supervisor
+      volunteer.supervisor_volunteer.update(is_active: false)
+      render template: "supervisor_mailer/weekly_digest"
+    end
+
+    it { expect(rendered).to have_text("The following volunteers have been unassigned from you") }
+    it { expect(rendered).to have_text("- #{volunteer.display_name}") }
+    it { expect(rendered).to have_text("(not assigned to a new supervisor)") }
+  end
+
   # TODO: Add more cases here
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #1745

### What changed, and why?

1.  Display a list of unassigned volunteers from the supervisor in the weekly email
2.  Display "not assigned to a new supervisor" next to unassigned volunteer if the volunteer has not been assigned to a new supervisor

### How will this affect user permissions?

- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

- Mailer specs

### Screenshots please :)

![image](https://user-images.githubusercontent.com/6352760/116818192-20b23400-ab38-11eb-94cc-1844ed8202f4.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? 

![alt text](https://media.giphy.com/media/Ps89uHS7n72j6/giphy.gif)
