### PR TITLE
Resolves #1729 - Reassigned volunteers should only show in new super's weekly email

### DIFF
--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     </td>
   </tr>
-  <% @supervisor.volunteers_ever_assigned.active.each do |volunteer| %>
+  <% @supervisor.volunteers_ever_assigned.where("supervisor_volunteers.is_active = ?", true).active.each do |volunteer| %>
     <% volunteer.case_assignments_with_cases.each do |case_assignment| %>
       <% recently_unassigned = case_assignment.decorate.unassigned_in_past_week? %>
       <% if case_assignment.active || recently_unassigned %>

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -57,5 +57,25 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
     it { expect(rendered).to have_text("No contact attempts were logged for this week.") }
   end
 
+  context "when a volunteer has been reassigned to a new supervisor" do
+    before(:each) do
+      supervisor.volunteers << volunteer
+      volunteer.casa_cases << casa_case
+
+      # reassign volunteer
+      volunteer.supervisor_volunteer.update(is_active: false)
+      other_supervisor.volunteers << volunteer
+      volunteer.supervisor_volunteer.update(is_active: true)
+
+      sign_in supervisor
+      assign :supervisor, supervisor
+      render template: "supervisor_mailer/weekly_digest"
+    end
+
+    let(:other_supervisor) { create(:supervisor) }
+
+    it { expect(rendered).not_to have_text(volunteer.display_name) }
+  end
+
   # TODO: Add more cases here
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #1729

### What changed, and why?

- Limited "active volunteers ever assigned" in mailer further to where supervisor_volunteers.is_active = true
- This is because when a volunteer is reassigned, supervisor_volunteers row for that supervisor/volunteer is marked as inactive

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

- Mailer test (reassign volunteer and expect volunteer display name not to show up)
- Wrote the failing test first (you can verify by reverting line of code in mailer and running new spec)

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? 

![alt text](https://media.giphy.com/media/Ps89uHS7n72j6/giphy.gif)
