### PR TITLE
Add ability to create new All CASA Admin

### DIFF
--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -2,8 +2,23 @@ class AllCasaAdminsController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :authenticate_all_casa_admin!
 
+  def new
+    @all_casa_admin = AllCasaAdmin.new
+  end
+
   def edit
     @user = current_all_casa_admin
+  end
+
+  def create
+    service = ::CreateAllCasaAdminService.new(params)
+    @all_casa_admin = service.build
+    begin
+      service.create!
+      redirect_to authenticated_all_casa_admin_root_path, notice: "New All CASA admin created successfully"
+    rescue ActiveRecord::RecordInvalid
+      render :new
+    end
   end
 
   def update

--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -4,7 +4,7 @@ class AllCasaAdmin < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :recoverable, :validatable, :timeoutable
+  devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable
 end
 
 # == Schema Information
@@ -14,13 +14,21 @@ end
 #  id                     :bigint           not null, primary key
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invited_by_type        :string
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  invited_by_id          :integer
 #
 # Indexes
 #
 #  index_all_casa_admins_on_email                 (email) UNIQUE
+#  index_all_casa_admins_on_invitation_token      (invitation_token) UNIQUE
 #  index_all_casa_admins_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/app/services/create_all_casa_admin_service.rb
+++ b/app/services/create_all_casa_admin_service.rb
@@ -1,0 +1,16 @@
+class CreateAllCasaAdminService
+  def initialize(params)
+    @params = params
+  end
+
+  def build
+    processed_params = AllCasaAdminParameters.new(@params)
+      .with_password(SecureRandom.hex(10))
+    @all_casa_admin = AllCasaAdmin.new(processed_params)
+  end
+
+  def create!
+    @all_casa_admin.save!
+    @all_casa_admin.invite!
+  end
+end

--- a/app/values/all_casa_admin_parameters.rb
+++ b/app/values/all_casa_admin_parameters.rb
@@ -1,0 +1,19 @@
+class AllCasaAdminParameters < SimpleDelegator
+  def initialize(params)
+    params =
+      params.require(:all_casa_admin).permit(:email, :password)
+
+    super(params)
+  end
+
+  def with_password(password)
+    params[:password] = password
+    self
+  end
+
+  private
+
+  def params
+    __getobj__
+  end
+end

--- a/app/views/all_casa_admins/dashboard/show.html.erb
+++ b/app/views/all_casa_admins/dashboard/show.html.erb
@@ -2,6 +2,7 @@
   <div class="col-sm-12 dashboard-table-header">
     <h1>All CASA Admin</h1>
     <a class="btn btn-primary" href="<%= new_all_casa_admins_casa_org_path %>">New CASA Organization</a>
+    <a class="btn btn-primary" href="<%= new_all_casa_admin_path %>">New All CASA Admin</a>
   </div>
 </div>
 <div class="card card-container">

--- a/app/views/all_casa_admins/new.html.erb
+++ b/app/views/all_casa_admins/new.html.erb
@@ -1,0 +1,19 @@
+<%= link_to t("button.back"), authenticated_all_casa_admin_root_path %>
+<h1>New All CASA Admin</h1>
+
+<div class="card card-container">
+  <div class="card-body">
+    <%= form_for @all_casa_admin, as: :all_casa_admin, url: all_casa_admins_path do |form| %>
+      <%= render "/shared/error_messages", resource: @all_casa_admin %>
+
+      <div class="field form-group">
+        <%= form.label :email %>
+        <%= form.email_field :email, class: "form-control" %>
+      </div>
+
+      <div class="actions">
+        <%= form.submit "Submit", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -6,27 +6,39 @@
   cellpadding="0"
   cellspacing="0"
   style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td
-      class="content-block"
-      style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
-      valign="top">
-      A <%= @resource.casa_org.display_name %>’s County <%= @resource.type %> console account has been created for you.
-      This console is for logging the time you spend and actions you take on your CASA case.
-      You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker,
-      your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
-    </td>
-  </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td
-      class="content-block"
-      style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
-      valign="top">
-      Your console account is associated with this email. If this is not the correct email to use, please stop here
-      and contact your Case Supervisor to change the email address. If you are ready to get started, please set your
-      password. This is the first step to accessing your new <%= @resource.type %> account.
-    </td>
-  </tr>
+  <% if @resource.is_a?(User) %>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+      <td
+        class="content-block"
+        style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
+        valign="top">
+        A <%= @resource.casa_org.display_name %>’s County <%= @resource.type %> console account has been created for you.
+        This console is for logging the time you spend and actions you take on your CASA case.
+        You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker,
+        your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
+      </td>
+    </tr>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+      <td
+        class="content-block"
+        style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
+        valign="top">
+        Your console account is associated with this email. If this is not the correct email to use, please stop here
+        and contact your Case Supervisor to change the email address. If you are ready to get started, please set your
+        password. This is the first step to accessing your new <%= @resource.type %> account.
+      </td>
+    </tr>
+  <% else %>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+      <td
+        class="content-block"
+        style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
+        valign="top">
+        A CASA console admin account has been created for you. Your console account is associated with this email.
+        If you are ready to get started, please set your password. This is the first step to accessing your new account.
+      </td>
+    </tr>
+  <% end %>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td
       class="content-block"

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,4 +1,9 @@
-A <%= @resource.casa_org.display_name %>’s County <%= @resource.type %> console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
+<% if @resource.is_a?(User) %>
+  A <%= @resource.casa_org.display_name %>’s County <%= @resource.type %> console account has been created for you. This console is for logging the time you spend and actions you take on your CASA case. You can log activity with your CASA youth, their family members, their foster family or placement, the DSS worker, your Case Supervisor and others associated with your CASA case (such as teachers and therapists).
 
-Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new <%= @resource.type %> account.
+  Your console account is associated with this email. If this is not the correct email to use, please stop here and contact your Case Supervisor to change the email address. If you are ready to get started, please set your password. This is the first step to accessing your new <%= @resource.type %> account.
+<% else %>
+  A CASA console admin account has been created for you. Your console account is associated with this email.
+  If you are ready to get started, please set your password. This is the first step to accessing your new account.
+<% end %>
 <%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :all_casa_admins, only: [] do
+  resources :all_casa_admins, only: [:new, :create] do
     collection do
       get :edit
       patch :update

--- a/db/migrate/20210502172706_add_devise_invitable_to_all_casa_admins.rb
+++ b/db/migrate/20210502172706_add_devise_invitable_to_all_casa_admins.rb
@@ -1,0 +1,12 @@
+class AddDeviseInvitableToAllCasaAdmins < ActiveRecord::Migration[6.1]
+  def change
+    add_column :all_casa_admins, :invitation_token, :string
+    add_column :all_casa_admins, :invitation_created_at, :datetime
+    add_column :all_casa_admins, :invitation_sent_at, :datetime
+    add_column :all_casa_admins, :invitation_accepted_at, :datetime
+    add_column :all_casa_admins, :invitation_limit, :integer
+    add_column :all_casa_admins, :invited_by_id, :integer
+    add_column :all_casa_admins, :invited_by_type, :string
+    add_index :all_casa_admins, :invitation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_182359) do
+ActiveRecord::Schema.define(version: 2021_05_02_172706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,15 @@ ActiveRecord::Schema.define(version: 2021_04_01_182359) do
     t.datetime "reset_password_sent_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.index ["email"], name: "index_all_casa_admins_on_email", unique: true
+    t.index ["invitation_token"], name: "index_all_casa_admins_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_all_casa_admins_on_reset_password_token", unique: true
   end
 

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -5,12 +5,48 @@ RSpec.describe "/all_casa_admins", type: :request do
 
   before(:each) { sign_in admin }
 
+  describe "GET /new" do
+    context "with a all_casa_admin signed in" do
+      it "renders a successful response" do
+        get new_all_casa_admin_path
+
+        expect(response).to be_successful
+      end
+    end
+  end
+
   describe "GET /edit" do
     context "with a all_casa_admin signed in" do
       it "renders a successful response" do
         get edit_all_casa_admins_path
 
         expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new All CASA admin" do
+        expect {
+          post all_casa_admins_path, params: {
+            all_casa_admin: {
+              email: "admin1@example.com"
+            }
+          }
+        }.to change(AllCasaAdmin, :count).by(1)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders new page" do
+        post all_casa_admins_path, params: {
+          all_casa_admin: {
+            email: ""
+          }
+        }
+        expect(response).to be_successful
+        expect(response).to render_template "all_casa_admins/new"
       end
     end
   end

--- a/spec/system/all_casa_admins/new_spec.rb
+++ b/spec/system/all_casa_admins/new_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "all_casa_admins/new", type: :system do
+  let(:all_casa_admin) { create(:all_casa_admin, email: "theexample@example.com") }
+  let(:path) { authenticated_all_casa_admin_root_path }
+
+  it "validates and creates new all casa admin" do
+    sign_in all_casa_admin
+    visit path
+    expect(page).to have_content "All CASA Admin"
+    click_on "New All CASA Admin"
+    expect(page).to have_content "New All CASA Admin"
+
+    click_button "Submit"
+    expect(page).to have_content "1 error prohibited this All casa admin from being saved:"
+    expect(page).to have_content "Email can't be blank"
+
+    fill_in "Email", with: "invalid email"
+    click_button "Submit"
+    expect(page).to have_content "1 error prohibited this All casa admin from being saved:"
+    expect(page).to have_content "Email is invalid"
+
+    fill_in "Email", with: "valid@example.com"
+    click_button "Submit"
+    expect(page).to have_content "New All CASA admin created successfully"
+
+    click_on "New All CASA Admin"
+    fill_in "Email", with: "valid@example.com"
+    click_button "Submit"
+    expect(page).to have_content "Email has already been taken"
+
+    expect(AllCasaAdmin.find_by(email: "valid@example.com").invitation_created_at).not_to be_nil
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
#1247 

### What changed, and why?
- New button on All CASA Admin dashboard to create "New All CASA Admin"
- New view file for all_casa_admin/new
- New endpoints in all_casa_admins_controller: `new` and `create`
- Changed AllCasaAdmin model to be `invitable`
- Updated invitation instructions so it can invite `User` or `AllCasaAdmin`

### How will this affect user permissions?
It does not affect user permissions

### How is this tested? (please write tests!) 💖💪

- New request tests for `new` and `create` endpoints.
- New system test

### Screenshots please :)

**New button on the All CASA Admin dashboard**
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/4965672/116823488-0a10da80-ab42-11eb-9b0c-99e71006f880.png">

**When you click the new button, you're taken to this page**
<img width="1161" alt="image" src="https://user-images.githubusercontent.com/4965672/116823496-1ac15080-ab42-11eb-9815-a63d07384570.png">

**When you click submit, you're redirected to the dashboard and a flash is shown**
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/4965672/116823517-39bfe280-ab42-11eb-885a-b87f8f576205.png">

**An email is sent to the new account**

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/4965672/116823544-5f4cec00-ab42-11eb-80a2-133ae6b3d800.png">
