### PR TITLE
Hide/Show unassigned volunteers on Supervisor Edit page

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -3,7 +3,8 @@
 class SupervisorsController < ApplicationController
   before_action :available_volunteers, only: [:edit, :update]
   before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate]
-  before_action :all_volunteers_ever_assigned, only: [:edit, :update]
+  before_action :all_volunteers_ever_assigned, only: [:update]
+  before_action :supervisor_has_unassigned_volunteers, only: [:edit]
   after_action :verify_authorized
 
   def index
@@ -30,6 +31,9 @@ class SupervisorsController < ApplicationController
 
   def edit
     authorize @supervisor
+    if params[:include_unassigned] == "true"
+      all_volunteers_ever_assigned
+    end
   end
 
   def update
@@ -71,6 +75,10 @@ class SupervisorsController < ApplicationController
 
   def all_volunteers_ever_assigned
     @all_volunteers_ever_assigned = @supervisor.volunteers_ever_assigned
+  end
+
+  def supervisor_has_unassigned_volunteers
+    @supervisor_has_unassigned_volunteers = @supervisor.volunteers_ever_assigned.count > @supervisor.volunteers.count
   end
 
   def available_volunteers

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -45,8 +45,16 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <% if @all_volunteers_ever_assigned.any? %>
-      <h3>Assigned Volunteers</h3>
+    <% if (@all_volunteers_ever_assigned || @supervisor.volunteers).any? %>
+      <h3 class="pull-left">Assigned Volunteers</h3>
+      <% if @supervisor_has_unassigned_volunteers %>
+        <% button_text = @all_volunteers_ever_assigned.nil? ? "Include unassigned" : "Hide unassigned" %>
+        <%= button_to button_text,
+                      edit_supervisor_path(@supervisor),
+                      params: { include_unassigned: @all_volunteers_ever_assigned.nil? },
+                      method: :get,
+                      class: "btn btn-outline-primary pull-right" %>
+      <% end %>
       <table class='table volunteer-list'>
         <thead>
         <tr>
@@ -56,7 +64,7 @@
         </tr>
         </thead>
         <tbody>
-        <% @all_volunteers_ever_assigned.each do |volunteer| %>
+        <% (@all_volunteers_ever_assigned || @supervisor.volunteers).each do |volunteer| %>
           <tr>
             <td><%= link_to volunteer.display_name, edit_volunteer_path(volunteer) %></td>
             <td><%= volunteer.email %></td>

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -52,6 +52,24 @@ RSpec.describe "/supervisors", type: :request do
 
       expect(response).to be_successful
     end
+
+    it "returns volunteers ever assigned if include_unassigned param is present" do
+      sign_in admin
+
+      get edit_supervisor_url(supervisor), params: { include_unassigned: true }
+
+      expect(response).to be_successful
+      expect(assigns(:all_volunteers_ever_assigned)).to_not be_nil
+    end
+
+    it "returns no volunteers ever assigned if include_unassigned param is false" do
+      sign_in admin
+
+      get edit_supervisor_url(supervisor), params: { include_unassigned: false }
+
+      expect(response).to be_successful
+      expect(assigns(:all_volunteers_ever_assigned)).to be_nil
+    end
   end
 
   describe "PATCH /update" do

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "/supervisors", type: :request do
     it "returns volunteers ever assigned if include_unassigned param is present" do
       sign_in admin
 
-      get edit_supervisor_url(supervisor), params: { include_unassigned: true }
+      get edit_supervisor_url(supervisor), params: {include_unassigned: true}
 
       expect(response).to be_successful
       expect(assigns(:all_volunteers_ever_assigned)).to_not be_nil
@@ -65,7 +65,7 @@ RSpec.describe "/supervisors", type: :request do
     it "returns no volunteers ever assigned if include_unassigned param is false" do
       sign_in admin
 
-      get edit_supervisor_url(supervisor), params: { include_unassigned: false }
+      get edit_supervisor_url(supervisor), params: {include_unassigned: false}
 
       expect(response).to be_successful
       expect(assigns(:all_volunteers_ever_assigned)).to be_nil

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -197,6 +197,36 @@ RSpec.describe "supervisors/edit", type: :system do
           expect(page).to have_text("There are no active, unassigned volunteers available.")
         end
       end
+
+      context "when there are assigned volunteers" do
+        let(:supervisor) { create(:supervisor, :with_volunteers, casa_org: organization) }
+
+        it "shows assigned volunteers" do
+          visit edit_supervisor_path(supervisor)
+
+          expect(page).to have_text "Assigned Volunteers"
+          expect(page).to_not have_button("Include unassigned")
+          supervisor.volunteers.each do |volunteer|
+            expect(page).to have_text volunteer.email
+          end
+        end
+
+        context "when there are previously unassigned volunteers" do
+          let!(:unassigned_volunteer) { create(:supervisor_volunteer, :inactive, supervisor: supervisor).volunteer }
+
+          it "does not show them by default" do
+            visit edit_supervisor_path(supervisor)
+
+            expect(page).to_not have_text unassigned_volunteer.email
+            expect(page).to have_button("Include unassigned")
+
+            click_on "Include unassigned"
+
+            expect(page).to have_button("Hide unassigned")
+            expect(page).to have_text unassigned_volunteer.email
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1369 

### What changed, and why?

- Hide previously unassigned volunteers from supervisor edit page by default
- Added a new button to the supervisor edit page to show/hide previously unassigned volunteers

### How will this affect user permissions?
It will not affect user permissions.

### How is this tested? (please write tests!) 💖💪
Added controller tests and system tests

### Screenshots please :)

**New button to "Include unassigned" only if there are previously unassigned volunteers that are currently hiding**
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/4965672/116926101-3fd3c300-ac17-11eb-8751-e85e497c075e.png">

**Button text changes when you click it**
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/4965672/116926165-4f530c00-ac17-11eb-9db8-346a73cd2866.png">

**No button is shown if there are no previously unassigned volunteers for this supervisor**
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/4965672/116926291-701b6180-ac17-11eb-93e6-d178dd44f6ca.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
