### PR TITLE
New test for editing case contact across organizations

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -113,7 +113,11 @@ class CaseContactsController < ApplicationController
   private
 
   def set_case_contact
-    @case_contact = authorize(current_organization.case_contacts.find(params[:id]))
+    if current_organization.case_contacts.exists?(params[:id])
+      @case_contact = authorize(current_organization.case_contacts.find(params[:id]))
+    else
+      redirect_to authenticated_user_root_path
+    end
   end
 
   def set_contact_types

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe "case_contacts/edit", type: :system do
   let!(:case_contact) { create(:case_contact, duration_minutes: 105, casa_case: casa_case) }
 
   context "when admin" do
+    let(:admin) { create(:casa_admin, casa_org: organization) }
+
     it "admin successfully edits case contact", js: true do
-      admin = create(:casa_admin, casa_org: organization)
       sign_in admin
 
       visit edit_case_contact_path(case_contact)
@@ -24,12 +25,16 @@ RSpec.describe "case_contacts/edit", type: :system do
       expect(case_contact.contact_made).to eq true
     end
 
-    it "fails across organizations" do
-      admin = create(:casa_admin, casa_org: create(:casa_org))
-      sign_in admin
+    context "is part of a different organization" do
+      let(:other_organization) { create(:casa_org) }
+      let(:admin) { create(:casa_admin, casa_org: other_organization) }
 
-      visit edit_case_contact_path(case_contact)
-      expect(current_path).to eq supervisors_path
+      it "fails across organizations" do
+        sign_in admin
+
+        visit edit_case_contact_path(case_contact)
+        expect(current_path).to eq supervisors_path
+      end
     end
   end
 

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe "case_contacts/edit", type: :system do
       expect(case_contact.medium_type).to eq "letter"
       expect(case_contact.contact_made).to eq true
     end
+
+    it "fails across organizations" do
+      admin = create(:casa_admin, casa_org: create(:casa_org))
+      sign_in admin
+
+      visit edit_case_contact_path(case_contact)
+      expect(current_path).to eq supervisors_path
+    end
   end
 
   context "volunteer user" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #988

### What changed, and why?
I added a new test to verify that admins cannot edit a case contact outside of their organization. Also, I edited the controller so it would redirect instead of just failing.

FYI, the ticket asked for fleshing out the functionality of `spec/system/admin_edits_a_case_contact_spec.rb`, but this file was deleted in https://github.com/rubyforgood/casa/pull/1410 and moved to `spec/system/case_contacts/edit_spec.rb` so that's the one I edited here.

### How will this affect user permissions?
No user permissions are affected.

### How is this tested? (please write tests!) 💖💪
system test

### Screenshots please :)
N/A

