### PR TITLE
after_party task to fix transition_aged_youth when DOB is nil

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -162,7 +162,7 @@ class DbPopulator
         new_casa_case = CasaCase.find_or_create_by!(
           casa_org_id: casa_org.id,
           case_number: case_number,
-          transition_aged_youth: random_true_false
+          transition_aged_youth: false
         )
       end
       volunteer = casa_org.volunteers.active.sample(random: rng) || casa_org.volunteers.active.first

--- a/lib/tasks/deployment/20210507200644_fix_transition_aged_youth_for_nil_birth_month_year_youth.rake
+++ b/lib/tasks/deployment/20210507200644_fix_transition_aged_youth_for_nil_birth_month_year_youth.rake
@@ -1,13 +1,14 @@
 namespace :after_party do
   desc "Deployment task: fix_transition_aged_youth_for_nil_birth_month_year_youth"
   task fix_transition_aged_youth_for_nil_birth_month_year_youth: :environment do
-    puts "Running deploy task 'fix_transition_aged_youth_for_nil_birth_month_year_youth'"
+    unless Rails.env.production?
+      puts "Running deploy task 'fix_transition_aged_youth_for_nil_birth_month_year_youth'"
 
-    CasaCase
-      .where(transition_aged_youth: true)
-      .where(birth_month_year_youth: nil)
-      .update(transition_aged_youth: false)
-
+      CasaCase
+        .where(transition_aged_youth: true)
+        .where(birth_month_year_youth: nil)
+        .update(transition_aged_youth: false)
+    end
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).
     AfterParty::TaskRecord

--- a/lib/tasks/deployment/20210507200644_fix_transition_aged_youth_for_nil_birth_month_year_youth.rake
+++ b/lib/tasks/deployment/20210507200644_fix_transition_aged_youth_for_nil_birth_month_year_youth.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc "Deployment task: fix_transition_aged_youth_for_nil_birth_month_year_youth"
+  task fix_transition_aged_youth_for_nil_birth_month_year_youth: :environment do
+    puts "Running deploy task 'fix_transition_aged_youth_for_nil_birth_month_year_youth'"
+
+    CasaCase
+      .where(transition_aged_youth: true)
+      .where(birth_month_year_youth: nil)
+      .update(transition_aged_youth: false)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1996

### What changed, and why?

- Add an after_party task to fix an invalid scenario in staging data
- Fix seeder so this scenario doesn't happen again

### How will this affect user permissions?
It does not affect user permissions
