### PR TITLE
Show deactivated label in admin list

### DIFF
--- a/app/views/casa_admins/index.html.erb
+++ b/app/views/casa_admins/index.html.erb
@@ -20,6 +20,11 @@
         <tr id="admin-<%= admin.id %>">
           <th scope="row">
             <%= admin.email %>
+            <% unless admin.active? %>
+              <span class="badge badge-danger display-1 text-uppercase">
+                <%= t(".deactivated") %>
+              </span>
+            <% end %>
           </th>
           <td>
             <%= link_to t(".button.edit"), edit_casa_admin_path(admin) %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -132,6 +132,7 @@ en:
       title: Admins
       active: Active
       active_text: Admin is
+      deactivated: Deactivated
       deactive_text: Admin was deactivated on
       button:
         new: New Admin
@@ -274,7 +275,7 @@ en:
         do_not: Do not
         change_values: change any of the values in the first line of the example csv file.
         import: Then click the "Import Volunteers CSV" button to import your volunteers.
-        note: This will email the new volunteers asking them to log in! 
+        note: This will email the new volunteers asking them to log in!
       disable_with: Importing File
     index:
       title: Import Categories

--- a/spec/system/casa_admins/index_spec.rb
+++ b/spec/system/casa_admins/index_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe "casa_admins/index", type: :system do
       expect(page).to have_no_content(volunteer.email)
     end
   end
+
+  it "displays a deactivated tag for inactive admins" do
+    inactive_admin = create(:casa_admin, :inactive, casa_org: organization)
+
+    sign_in admin
+    visit casa_admins_path
+
+    within "#admins" do
+      expect(page).to have_content(inactive_admin.email)
+      expect(page).to have_content("Deactivated")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2018

### What changed, and why?
Added a badge on the admin list to show if an admin has been deactivated

### How will this affect user permissions?
Doesn't affect user permissions

### How is this tested? (please write tests!) 💖💪
System test

### Screenshots please :)
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/4965672/117520829-89017b00-af67-11eb-899b-680899ac05dd.png">

