### PR TITLE
Change supervisor's volunteer list label to match set of volunteers shown Issue 2019

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -34,6 +34,7 @@ class SupervisorsController < ApplicationController
     if params[:include_unassigned] == "true"
       all_volunteers_ever_assigned
     end
+    @unassigned_volunteer_count ||= 0
   end
 
   def update
@@ -74,6 +75,7 @@ class SupervisorsController < ApplicationController
   end
 
   def all_volunteers_ever_assigned
+    @unassigned_volunteer_count = @supervisor.volunteers_ever_assigned.count - @supervisor.volunteers.count
     @all_volunteers_ever_assigned = @supervisor.volunteers_ever_assigned
   end
 

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t("button.back"), supervisors_path %>
-<h1>Editing Supervisor</h1>
+<h1><%= t(".title") %></h1>
 
 <div class="card card-container">
   <div class="card-body">
@@ -41,14 +41,14 @@
   </div>
 </div>
 
-<h1 class="pt-5">Manage Volunteers</h1>
+<h1 class="pt-5"><%= t(".manage_volunteers") %></h1>
 
 <div class="card card-container">
   <div class="card-body">
     <% if (@all_volunteers_ever_assigned || @supervisor.volunteers).any? %>
-      <h3 class="pull-left">Assigned Volunteers</h3>
+      <h3 class="pull-left"><%= t(".volunteer_title", count: @unassigned_volunteer_count) %></h3>
       <% if @supervisor_has_unassigned_volunteers %>
-        <% button_text = @all_volunteers_ever_assigned.nil? ? "Include unassigned" : "Hide unassigned" %>
+        <% button_text = @all_volunteers_ever_assigned.nil? ? t(".include_unassigned") : t(".hide_unassigned") %>
         <%= button_to button_text,
                       edit_supervisor_path(@supervisor),
                       params: { include_unassigned: @all_volunteers_ever_assigned.nil? },
@@ -58,9 +58,9 @@
       <table class='table volunteer-list'>
         <thead>
         <tr>
-          <th>Volunteer Name</th>
-          <th>Volunteer Email</th>
-          <th>Unassign</th>
+          <th><%= t(".volunteer_name") %></th>
+          <th><%= t(".volunteer_email") %></th>
+          <th><%= t(".unassign") %></th>
         </tr>
         </thead>
         <tbody>
@@ -70,14 +70,13 @@
             <td><%= volunteer.email %></td>
             <td>
               <% if volunteer.supervised_by?(@supervisor) %>
-                <%= button_to 'Unassign',
+                <%= button_to t(".unassign"),
                               unassign_supervisor_volunteer_path(volunteer),
                               method: :patch,
                               class: "btn btn-danger" %>
               <% else %>
-                Unassigned
+                <%= t(".unassigned") %>
               <% end %>
-
             </td>
           </tr>
         <% end %>
@@ -85,12 +84,12 @@
       </table>
     <% end %>
 
-    <h3>Assign a Volunteer</h3>
+    <h3><%= t(".assign_a_volunteer") %></h3>
 
     <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
 
       <div class='form-group'>
-        <label for='supervisor_volunteer_volunteer_id'>Select a Volunteer</label>
+        <label for='supervisor_volunteer_volunteer_id'><%= t(".select_a_volunteer") %></label>
         <select name='supervisor_volunteer[volunteer_id]' class='form-control select2'>
           <% @available_volunteers.each do |volunteer| %>
             <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
@@ -98,10 +97,10 @@
         </select>
       </div>
       <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
-      <%= form.submit 'Assign Volunteer', class: 'btn btn-primary' %>
+      <%= form.submit t(".assign_volunteer"), class: 'btn btn-primary' %>
     <% end %>
     <% unless @available_volunteers.any? %>
-      <p class="text-danger">There are no active, unassigned volunteers available.</p>
+      <p class="text-danger"><%= t(".no_volunteers_available") %></p>
     <% end %>
   </div>
 </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -334,3 +334,21 @@ en:
         ruby_for_good: Ruby For Good
         link:
           report_site_issue: Report a site issue
+  supervisors:
+    edit:
+      title: Editing Supervisor
+      assign_a_volunteer: Assign a Volunteer
+      assign_volunteer: Assign Volunteer
+      hide_unassigned: Hide unassigned
+      include_unassigned: Include unassigned
+      manage_volunteers: Manage Volunteers
+      no_volunteers_available: There are no active, unassigned volunteers available.
+      select_a_volunteer: Select a Volunteer
+      unassign: Unassign
+      unassigned: Unassigned
+      volunteer_email: Volunteer Email
+      volunteer_name: Volunteer Name
+      volunteer_title:
+        zero: Assigned Volunteers
+        one: All Volunteers
+        other: All Volunteers

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe "supervisors/edit", type: :system do
             click_on "Include unassigned"
 
             expect(page).to have_button("Hide unassigned")
+            expect(page).to have_text("All Volunteers")
             expect(page).to have_text unassigned_volunteer.email
           end
         end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2019 

### What changed, and why?
When all volunteers are shown, "Assigned Volunteers"  is changed to "All Volunteers"!


### How will this affect user permissions?
Doesn't change permissions just UI.
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
This is tested in the supervisors.edit_spec.rb. 


### Screenshots please :)

![Screen Shot 2021-05-11 at 2 24 45 PM](https://user-images.githubusercontent.com/57972448/117887249-42609900-b265-11eb-8ee1-4feabf765322.png)



### Feelings gif (optional)

![alt text](https://media.giphy.com/media/gX8F8kMRTx44M/giphy.gif)
