### PR TITLE
A supervisor with no active volunteers should be able to view previously assigned volunteers

### DIFF
--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -45,7 +45,7 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <% if (@all_volunteers_ever_assigned || @supervisor.volunteers).any? %>
+    <% if @supervisor_has_unassigned_volunteers || @supervisor.volunteers.any? %>
       <h3 class="pull-left">Assigned Volunteers</h3>
       <% if @supervisor_has_unassigned_volunteers %>
         <% button_text = @all_volunteers_ever_assigned.nil? ? "Include unassigned" : "Hide unassigned" %>

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -227,6 +227,27 @@ RSpec.describe "supervisors/edit", type: :system do
           end
         end
       end
+
+      context "when there are no currently assigned volunteers" do
+        let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+        context "and there are previously unassigned volunteers" do
+          let!(:unassigned_volunteer) { create(:supervisor_volunteer, :inactive, supervisor: supervisor).volunteer }
+
+          it "does not show them by default" do
+            visit edit_supervisor_path(supervisor)
+
+            expect(page).to have_text "Assigned Volunteers"
+            expect(page).to_not have_text unassigned_volunteer.email
+            expect(page).to have_button("Include unassigned")
+
+            click_on "Include unassigned"
+
+            expect(page).to have_button("Hide unassigned")
+            expect(page).to have_text unassigned_volunteer.email
+          end
+        end
+      end
     end
   end
 end

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "supervisors/edit", type: :view do
     create :supervisor_volunteer, :inactive, supervisor: supervisor, volunteer: volunteer
 
     assign :supervisor, supervisor
+    assign :supervisor_has_unassigned_volunteers, true
     assign :all_volunteers_ever_assigned, [volunteer]
     assign :available_volunteers, []
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2035

### What changed, and why?
If a supervisor/admin views the edit page for a supervisor with no currently assigned volunteers, the Hide/Show unassigned volunteers button was hidden. I fixed this so it will show in this case.

### How will this affect user permissions?
It doesn't affect permissions.

### How is this tested? (please write tests!) 💖💪
I added a system test.

### Screenshots please :)

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/4965672/118021145-2538d280-b318-11eb-8738-5ecc55b9f3a7.png">

