### PR TITLE
Allow admins/supervisors to generate court reports for a case

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -60,10 +60,10 @@ class CaseCourtReportsController < ApplicationController
 
   def assigned_cases
     @assigned_cases = if current_user.volunteer?
-                        CasaCase.actively_assigned_to(current_user)
-                      else
-                        current_user.casa_org.casa_cases.active
-                      end
+      CasaCase.actively_assigned_to(current_user)
+    else
+      current_user.casa_org.casa_cases.active
+    end
   end
 
   def generate_report_to_string(casa_case)

--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -6,8 +6,7 @@ class CaseCourtReportsController < ApplicationController
 
   def index
     authorize CaseCourtReport
-    @assigned_cases = CasaCase.actively_assigned_to(current_user)
-      .select(:id, :case_number, :transition_aged_youth)
+    assigned_cases.select(:id, :case_number, :transition_aged_youth)
   end
 
   def show
@@ -59,12 +58,20 @@ class CaseCourtReportsController < ApplicationController
     @casa_case = CasaCase.find_by(case_number: params[:id])
   end
 
+  def assigned_cases
+    @assigned_cases = if current_user.volunteer?
+                        CasaCase.actively_assigned_to(current_user)
+                      else
+                        current_user.casa_org.casa_cases.active
+                      end
+  end
+
   def generate_report_to_string(casa_case)
     return unless casa_case
 
     casa_case.casa_org.open_org_court_report_template do |template_docx_file|
       court_report = CaseCourtReport.new(
-        volunteer_id: current_user.id, # ??? not a volunteer ? linda
+        volunteer_id: current_user.volunteer? ? current_user.id : casa_case.assigned_volunteers.first.id,
         case_id: casa_case.id,
         path_to_template: template_docx_file.to_path
       )

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -84,7 +84,68 @@ function courtMandateHtml (index) {
   }
 }
 
+function showBtn(el) { el.classList.remove('d-none') }
+function hideBtn(el) { el.classList.add('d-none') }
+function disableBtn(el) {
+  el.disabled = true
+  el.classList.add('disabled')
+  el.setAttribute('aria-disabled', true)
+}
+function enableBtn(el) {
+  el.disabled = false
+  el.classList.remove('disabled')
+  el.removeAttribute('aria-disabled')
+}
+function showAlert(html) {
+  const alertEl = new DOMParser().parseFromString(html, 'text/html').body.firstElementChild
+  document.querySelector('.header-flash').replaceWith(alertEl)
+}
+
+function handleGenerateReport(e) {
+  e.preventDefault()
+
+  const formData = Object.fromEntries(new FormData(e.currentTarget.form))
+
+  if (formData.case_number.length === 0) return
+
+  const generateBtn = e.currentTarget
+  disableBtn(generateBtn)
+
+  const url = e.currentTarget.form.action
+  const options = {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(formData)
+  }
+  hideBtn(generateBtn)
+  showBtn(spinner)
+  fetch(url, options)
+    .then(response => {
+      return response.json()
+    })
+    .then(data => {
+      if (data.status !== 'ok') {
+        showAlert(data.error_messages)
+        enableBtn(generateBtn)
+        showBtn(generateBtn)
+        hideBtn(spinner)
+        return
+      }
+      hideBtn(spinner)
+      window.open(data.link, "_blank")
+    })
+    .catch((error) => {
+      console.error('Debugging info, error:', error)
+    })
+}
+
+
 $('document').ready(() => {
   $('button#add-mandate-button').on('click', addCourtMandateInput)
   $('button.remove-mandate-button').on('click', removeMandateWithConfirmation)
+
+  $("#btnGenerateReport").on("click", handleGenerateReport)
 })

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -1,4 +1,7 @@
 /* eslint-env jquery */
+/* global FormData */
+/* global DOMParser */
+/* global spinner */
 
 import Swal from 'sweetalert2'
 
@@ -84,24 +87,24 @@ function courtMandateHtml (index) {
   }
 }
 
-function showBtn(el) { el.classList.remove('d-none') }
-function hideBtn(el) { el.classList.add('d-none') }
-function disableBtn(el) {
+function showBtn (el) { el.classList.remove('d-none') }
+function hideBtn (el) { el.classList.add('d-none') }
+function disableBtn (el) {
   el.disabled = true
   el.classList.add('disabled')
   el.setAttribute('aria-disabled', true)
 }
-function enableBtn(el) {
+function enableBtn (el) {
   el.disabled = false
   el.classList.remove('disabled')
   el.removeAttribute('aria-disabled')
 }
-function showAlert(html) {
+function showAlert (html) {
   const alertEl = new DOMParser().parseFromString(html, 'text/html').body.firstElementChild
   document.querySelector('.header-flash').replaceWith(alertEl)
 }
 
-function handleGenerateReport(e) {
+function handleGenerateReport (e) {
   e.preventDefault()
 
   const formData = Object.fromEntries(new FormData(e.currentTarget.form))
@@ -115,14 +118,14 @@ function handleGenerateReport(e) {
   const options = {
     method: 'POST',
     headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(formData)
   }
   hideBtn(generateBtn)
   showBtn(spinner)
-  fetch(url, options)
+  window.fetch(url, options)
     .then(response => {
       return response.json()
     })
@@ -135,17 +138,16 @@ function handleGenerateReport(e) {
         return
       }
       hideBtn(spinner)
-      window.open(data.link, "_blank")
+      window.open(data.link, '_blank')
     })
     .catch((error) => {
       console.error('Debugging info, error:', error)
     })
 }
 
-
 $('document').ready(() => {
   $('button#add-mandate-button').on('click', addCourtMandateInput)
   $('button.remove-mandate-button').on('click', removeMandateWithConfirmation)
 
-  $("#btnGenerateReport").on("click", handleGenerateReport)
+  $('#btnGenerateReport').on('click', handleGenerateReport)
 })

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -63,7 +63,7 @@ class ApplicationPolicy
   end
 
   def see_court_reports_page?
-    is_volunteer?
+    is_volunteer? || is_supervisor? || is_admin?
   end
 
   alias_method :modify_organization?, :is_admin?

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -16,6 +16,16 @@
         casa_case_emancipation_path(@casa_case),
         class: "btn btn-primary casa-case-button") %>
     <% end %>
+    <% if current_user.supervisor? || current_user.casa_admin? %>
+      <%= form_with url: generate_case_court_reports_path, local: false, class: "d-inline" do |form| %>
+        <%= form.hidden_field :case_number, value: @casa_case.case_number %>
+        <%= button_tag t(".button.generate_report"), type: :submit,
+            data: { button_name: t(".button.generate_report") },
+            id: "btnGenerateReport",
+            class: "btn btn-success pull-right" %>
+        <i id="spinner" class='fas fa-spin d-none pull-right'>⏳</i>
+      <% end %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -9,7 +9,7 @@
 
     <hr>
 
-    <%= form_with url: "#", local: false do |form| %>
+    <%= form_with url: generate_case_court_reports_path, local: false do |form| %>
       <div class="field form-group">
         <%= label_tag :case_number, t(".label.case_number") %>
         <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
@@ -38,75 +38,18 @@
 <script>
   const ELEMENTS = {
     'caseSelect': '#case-selection',
-    'downloadBtn': '#btnDownloadReport',
     'generateBtn': '#btnGenerateReport',
-    'spinner': '#spinner'
   }
   const showBtn = el => el.classList.remove('d-none')
-  const hideBtn = el => el.classList.add('d-none')
-  const disableBtn = (el) => {
-    el.disabled = true
-    el.classList.add('disabled')
-    el.setAttribute('aria-disabled', true)
-  }
   const enableBtn = (el) => {
     el.disabled = false
     el.classList.remove('disabled')
     el.removeAttribute('aria-disabled')
   }
-  const showAlert = (html) => {
-    const alertEl = new DOMParser().parseFromString(html, 'text/html').body.firstElementChild
-    document.querySelector('.header-flash').replaceWith(alertEl)
-  }
-
-  const handleGenerateReport = (e) => {
-    e.preventDefault()
-
-    const formData = Object.fromEntries(new FormData(e.target.form))
-
-    if (formData.case_number.length === 0) return
-
-    const generateBtn = e.target
-    disableBtn(generateBtn)
-
-    <%# This will show "/case_court_reports/generate"  %>
-    const url = "<%= generate_case_court_reports_path %>"
-    const options = {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(formData)
-    }
-    hideBtn(generateBtn)
-    showBtn(spinner)
-    fetch(url, options)
-      .then(response => {
-        return response.json()
-      })
-      .then(data => {
-        if (data.status !== 'ok') {
-          showAlert(data.error_messages)
-          enableBtn(generateBtn)
-          showBtn(generateBtn)
-          hideBtn(spinner)
-          return
-        }
-        // when receiving a link to report, show 'Download Court Report' btn and show the link in the button
-        const downloadBtn = generateBtn.form.querySelector(ELEMENTS.downloadBtn)
-        hideBtn(spinner)
-        window.open(data.link, "_blank")
-      })
-      .catch((error) => {
-        console.error('Debugging info, error:', error)
-      })
-  }
 
   const handleSelect = (e) => {
     const selectEl = e.target
     const generateBtn = selectEl.form.querySelector(ELEMENTS.generateBtn)
-    const downloadBtn = selectEl.form.querySelector(ELEMENTS.downloadBtn)
 
     // when selecting a case, reset buttons to initial state
     enableBtn(generateBtn)
@@ -115,12 +58,9 @@
 
   const bindElements = () => {
     const caseSelectEl = document.querySelector(ELEMENTS.caseSelect)
-    const generateReportEl = document.querySelector(ELEMENTS.generateBtn)
 
     if (caseSelectEl)
       caseSelectEl.addEventListener('change', handleSelect)
-    if (generateReportEl)
-      generateReportEl.addEventListener('click', handleGenerateReport)
   }
 
   window.onload = function () {

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -40,6 +40,7 @@ en:
         emancipation: Emancipation
         click_to_download: Click to download
         download_all: Download All
+        generate_court_report: Generate Report
     shared:
       filter_by: Filter by
       assigned_single: Assigned to Volunteer

--- a/cypress/integration/volunteer/generate_court_report.spec.js
+++ b/cypress/integration/volunteer/generate_court_report.spec.js
@@ -8,10 +8,16 @@ context("Logging into cypress as a volunteer", () => {
   it("should generate a court report", () => {
     cy.get("#toggle-sidebar-js").click();
     cy.contains("Generate Court Reports").click();
-    cy.get("#case-selection").select("CINA-18-1003 - non-transition");
-    cy.contains("Generate Report").click();
+    // Pick the first option from the case selection dropdown
+    cy.get('#case-selection')
+      .find('option').then(elements => {
+        const option = elements[1].getAttribute('value');
+        cy.get('#case-selection').select(option);
 
-    const downloadsFolder = Cypress.config("downloadsFolder");
-    cy.readFile(path.join(downloadsFolder, "CINA-18-1003.docx")).should("exist");
+        cy.contains("Generate Report").click();
+
+        const downloadsFolder = Cypress.config("downloadsFolder");
+        cy.readFile(path.join(downloadsFolder, `${option}.docx`)).should("exist");
+      });
   });
 });

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe ApplicationPolicy do
       expect(subject).to permit(create(:volunteer))
     end
 
-    it "does not allow casa_admins" do
-      expect(subject).not_to permit(create(:casa_admin))
+    it "allows casa_admins" do
+      expect(subject).to permit(create(:casa_admin))
     end
 
-    it "does not allow supervisors" do
-      expect(subject).not_to permit(create(:supervisor))
+    it "allows supervisors" do
+      expect(subject).to permit(create(:supervisor))
     end
   end
 

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -13,6 +13,31 @@ RSpec.describe "/case_court_reports", :disable_bullet, type: :request do
       it "can view 'Generate Court Report' page" do
         get case_court_reports_path
         expect(response).to be_successful
+        expect(assigns(:assigned_cases)).to_not be_empty
+      end
+    end
+
+    context "as a supervisor" do
+      let(:supervisor) { volunteer.supervisor }
+
+      before do
+        sign_in supervisor
+      end
+
+      it "can view the 'Generate Court Report' page" do
+        get case_court_reports_path
+        expect(response).to be_successful
+        expect(assigns(:assigned_cases)).to_not be_empty
+      end
+
+      context "with no cases in the organization" do
+        let(:supervisor) { create(:supervisor, casa_org: create(:casa_org)) }
+
+        it "can view 'Generate Court Report page" do
+          get case_court_reports_path
+          expect(response).to be_successful
+          expect(assigns(:assigned_cases)).to be_empty
+        end
       end
     end
   end
@@ -150,6 +175,17 @@ RSpec.describe "/case_court_reports", :disable_bullet, type: :request do
         get JSON.parse(response.body)["link"]
 
         expect(get_docx_subfile_contents(response.body, "word/header2.xml")).to include("Voices for Children Montgomery")
+      end
+
+      context "as a supervisor" do
+        let(:supervisor) { volunteer.supervisor }
+
+        it "generates the report" do
+          sign_in supervisor
+
+          get JSON.parse(response.body)["link"]
+          expect(get_docx_subfile_contents(response.body, "word/header2.xml")).to include("Voices for Children Montgomery")
+        end
       end
     end
   end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -46,6 +46,28 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
       expect(page).to have_content("Court Mandates")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)
     end
+
+    context "when generating a report, supervisor sees waiting page", js: true do
+      before do
+        click_button "Generate Report"
+      end
+
+      describe "'Generate Report' button" do
+        it "has been hidden and disabled" do
+          options = {visible: :hidden}
+
+          expect(page).to have_selector "#btnGenerateReport[disabled]", **options
+        end
+      end
+
+      describe "Spinner" do
+        it "becomes visible" do
+          options = {visible: :visible}
+
+          expect(page).to have_selector "#spinner", **options
+        end
+      end
+    end
   end
 
   context "volunteer user" do
@@ -58,6 +80,10 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
     it "can see court mandates" do
       expect(page).to have_content("Court Mandates")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)
+    end
+
+    it "cannot see Generate Report button" do
+      expect(page).to_not have_button("Generate Report")
     end
   end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to_not have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
-      expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
   end
@@ -143,7 +143,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Supervisors", href: "/supervisors")
       expect(rendered).to have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
-      expect(rendered).to_not have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1969

### What changed, and why?
- Added the "Generate Court Reports" link in the sidebar for admin and supervisors
- Added a "Generate Report" button to the casa_cases#show page

### How will this affect user permissions?
Supervisors and Admin can now access the Generate Court Reports page and can generate reports for CasaCases within their organization

### How is this tested? (please write tests!) 💖💪

- Request tests for case_court_reports controller
- System tests for casa_cases#show page

### Screenshots please :)

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/4965672/118323676-36234880-b4be-11eb-8ac2-471825a18e3e.png">


