### PR TITLE
Hide Download All button if there are no case contacts

### DIFF
--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -93,9 +93,11 @@
       <% end %>
       <br>
 
-      <div class="text-right mb-2">
-        <%= link_to t(".button.download_all"), casa_case_path(params[:id], format: :csv) , class: "btn btn-success" %>
-      </div>
+      <% if @casa_case.case_contacts.present? %>
+        <div class="text-right mb-2">
+          <%= link_to t(".button.download_all"), casa_case_path(params[:id], format: :csv) , class: "btn btn-success" %>
+        </div>
+      <% end %>
 
       <div>
           <%= render(partial: "case_contacts/case_contact",


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2040 

### What changed, and why?
- Update logic to check whether the casa case has case contacts or not to show the download button

### How will this affect user permissions?
- all

### Screenshots please :)
Has case contacts:
![Screenshot from 2021-05-16 00-21-24](https://user-images.githubusercontent.com/6258714/118372996-96a9a700-b5de-11eb-9444-ab5cb0531c50.png)

Has no case contact:
![Screenshot from 2021-05-16 00-21-08](https://user-images.githubusercontent.com/6258714/118373007-a0330f00-b5de-11eb-91fe-68c8965148da.png)


