### PR TITLE
2012 direct to case contact

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,8 +4,8 @@ class DashboardController < ApplicationController
 
   def show
     authorize :dashboard
-    if volunteer_with_only_one_active_case?(current_user)
-      redirect_to casa_case_path(current_user.casa_cases.first)
+    if volunteer_with_only_one_active_case?
+      redirect_to casa_case_path(current_user.casa_cases.active.first)
     elsif current_user.volunteer?
       redirect_to casa_cases_path
     elsif current_user.supervisor?
@@ -17,7 +17,7 @@ class DashboardController < ApplicationController
 
   private
 
-  def volunteer_with_only_one_active_case?(current_user)
+  def volunteer_with_only_one_active_case?
     current_user.volunteer? && current_user.casa_cases.active.count == 1
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,12 +4,20 @@ class DashboardController < ApplicationController
 
   def show
     authorize :dashboard
-    if current_user.volunteer?
+    if volunteer_with_only_one_active_case?(current_user)
+      redirect_to casa_case_path(current_user.casa_cases.first)
+    elsif current_user.volunteer?
       redirect_to casa_cases_path
     elsif current_user.supervisor?
       redirect_to volunteers_path
     elsif current_user.casa_admin?
       redirect_to supervisors_path
     end
+  end
+
+  private
+
+  def volunteer_with_only_one_active_case?(current_user)
+    current_user.volunteer? && current_user.casa_cases.active.count == 1
   end
 end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe DashboardController, type: :controller do
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
+  let(:admin) { create(:casa_admin) }
+  let(:supervisor) { create(:supervisor) }
+  let(:case_id) { volunteer.casa_cases.first.id }
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+  end
+
+  describe "as volunteer" do
+    before do
+      allow(controller).to receive(:current_user).and_return(volunteer)
+    end
+
+    context "with one active case" do
+      it "goes to case" do
+        get :show
+        expect(redirect_to(:casa_case_path)).to be_true
+      end
+    end
+
+    context "with two cases but one is inactive" do
+      it "goes to active case" do
+        get :show
+        # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+      end
+    end
+
+    context "with two active cases" do
+      it "goes to cases page" do
+        get :show
+        # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+      end
+    end
+  end
+
+  describe "as supervisor" do
+    before do
+      allow(controller).to receive(:current_user).and_return(supervisor)
+    end
+
+    it "goes to volunteers overview" do
+      get :show
+      # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+    end
+  end
+
+  describe "as admin" do
+    before do
+      allow(controller).to receive(:current_user).and_return(admin)
+    end
+
+    it "goes to supervisors overview" do
+      get :show
+      # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+    end
+  end
+end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -2,61 +2,71 @@ require "rails_helper"
 
 RSpec.describe DashboardController, type: :controller do
   let(:organization) { create(:casa_org) }
-  let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
   let(:admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
   let(:case_id) { volunteer.casa_cases.first.id }
+  let(:inactive_case) { create :casa_case, :inactive }
+  let(:active_case) { create :casa_case, :active }
 
   before do
     allow(controller).to receive(:authenticate_user!).and_return(true)
   end
 
-  describe "as volunteer" do
-    before do
-      allow(controller).to receive(:current_user).and_return(volunteer)
-    end
+  describe "get show" do
+    subject { get :show }
 
-    context "with one active case" do
-      it "goes to case" do
-        get :show
-        expect(redirect_to(:casa_case_path)).to be_true
+    describe "as volunteer" do
+      before do
+        allow(controller).to receive(:current_user).and_return(volunteer)
+      end
+
+      context "with one active case" do
+        let!(:case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: active_case }
+
+        it "goes to case" do
+          is_expected.to redirect_to(casa_case_url(active_case.id))
+        end
+      end
+
+      context "with two cases but one is inactive" do
+        let!(:inactive_case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: inactive_case }
+        let!(:case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: active_case }
+
+        it "goes to active case" do
+          expect(subject).to redirect_to(casa_case_url(active_case.id))
+        end
+      end
+
+      context "with two active cases" do
+        let(:active_case2) { create :casa_case, :active }
+        let!(:case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: active_case }
+        let!(:case_assignment2) { create :case_assignment, volunteer: volunteer, casa_case: active_case2 }
+
+        it "goes to cases page" do
+          is_expected.to redirect_to(casa_cases_url)
+        end
       end
     end
 
-    context "with two cases but one is inactive" do
-      it "goes to active case" do
-        get :show
-        # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+    describe "as supervisor" do
+      before do
+        allow(controller).to receive(:current_user).and_return(supervisor)
+      end
+
+      it "goes to volunteers overview" do
+        is_expected.to redirect_to(volunteers_url)
       end
     end
 
-    context "with two active cases" do
-      it "goes to cases page" do
-        get :show
-        # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+    describe "as admin" do
+      before do
+        allow(controller).to receive(:current_user).and_return(admin)
       end
-    end
-  end
 
-  describe "as supervisor" do
-    before do
-      allow(controller).to receive(:current_user).and_return(supervisor)
-    end
-
-    it "goes to volunteers overview" do
-      get :show
-      # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
-    end
-  end
-
-  describe "as admin" do
-    before do
-      allow(controller).to receive(:current_user).and_return(admin)
-    end
-
-    it "goes to supervisors overview" do
-      get :show
-      # expect(assigns(:current_organization_groups)).to eq([contact_type_group_one])
+      it "goes to supervisors overview" do
+        is_expected.to redirect_to(supervisors_url)
+      end
     end
   end
 end

--- a/spec/controllers/emancipations_controller_spec.rb
+++ b/spec/controllers/emancipations_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe EmancipationsController, type: :controller do
-  # TODO improve these
   let(:organization) { create(:casa_org) }
   let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
   let(:test_case_category) { create(:casa_case_emancipation_category) }

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "/dashboard", :disable_bullet, type: :request do
 
   context "as a volunteer" do
     let(:volunteer) { create(:volunteer, casa_org: organization) }
+    let!(:case_assignment) { create(:case_assignment, volunteer: volunteer) }
     before do
-      create(:case_assignment, volunteer: volunteer)
       sign_in volunteer
     end
 
@@ -14,36 +14,49 @@ RSpec.describe "/dashboard", :disable_bullet, type: :request do
       it "renders a successful response" do
         get root_url
 
-        expect(response).to redirect_to(casa_cases_path)
+        expect(response).to redirect_to(casa_case_path(case_assignment.casa_case.id))
       end
 
-      it "shows my cases" do
-        get root_url
-        follow_redirect!
+      context "more than one active case" do
+        let!(:active_case_assignment) { create :case_assignment, volunteer: volunteer }
 
-        expect(response.body).to include(volunteer.casa_cases.first.case_number)
-      end
+        it "renders a successful response" do
+          get root_url
 
-      it "doesn't show other volunteers' cases" do
-        not_logged_in_volunteer = create(:volunteer)
-        create(:case_assignment, volunteer: not_logged_in_volunteer)
+          expect(response).to redirect_to(casa_cases_path)
+        end
 
-        get root_url
-        follow_redirect!
+        it "shows my cases" do
+          get root_url
+          follow_redirect!
 
-        expect(response.body).to include(volunteer.casa_cases.first.case_number)
-        expect(response.body).not_to include(not_logged_in_volunteer.casa_cases.first.case_number)
-      end
+          expect(response.body).to include(active_case_assignment.casa_case.case_number)
+          expect(response.body).to include(case_assignment.casa_case.case_number)
+        end
 
-      it "doesn't show other organizations' cases" do
-        different_org = create(:casa_org)
-        not_my_case_assignment = create(:case_assignment, casa_org: different_org)
+        it "doesn't show other volunteers' cases" do
+          not_logged_in_volunteer = create(:volunteer)
+          create(:case_assignment, volunteer: not_logged_in_volunteer)
 
-        get root_url
-        follow_redirect!
+          get root_url
+          follow_redirect!
 
-        expect(response.body).to include(volunteer.casa_cases.first.case_number)
-        expect(response.body).not_to include(not_my_case_assignment.casa_case.case_number)
+          expect(response.body).to include(active_case_assignment.casa_case.case_number)
+          expect(response.body).to include(case_assignment.casa_case.case_number)
+          expect(response.body).not_to include(not_logged_in_volunteer.casa_cases.first.case_number)
+        end
+
+        it "doesn't show other organizations' cases" do
+          different_org = create(:casa_org)
+          not_my_case_assignment = create(:case_assignment, casa_org: different_org)
+
+          get root_url
+          follow_redirect!
+
+          expect(response.body).to include(active_case_assignment.casa_case.case_number)
+          expect(response.body).to include(case_assignment.casa_case.case_number)
+          expect(response.body).not_to include(not_my_case_assignment.casa_case.case_number)
+        end
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2059 

### What changed, and why?
Now when there is only one case we direct to that one case instead of all cases. This creates fewer clicks for the user.


### How will this affect user permissions?
Doesn't affect permissions.

### How is this tested? (please write tests!) 💖💪
dashboard_controller_spec

### Screenshots!
Three cases for volunteer.
![Screen Shot 2021-05-18 at 2 42 28 PM](https://user-images.githubusercontent.com/57972448/118729744-4a7f8200-b7eb-11eb-96ca-d3ac78ceae19.png)
Changed 2 cases to `active: false` and refreshed page. Now, the page redirects to Case Details.
![Screen Shot 2021-05-18 at 2 43 31 PM](https://user-images.githubusercontent.com/57972448/118729811-68e57d80-b7eb-11eb-91f9-37c8aab88844.png)




### Feelings gif (optional)
![](https://media.giphy.com/media/VgeGEVTdwzZao/giphy.gif)


Co-authored-by: Rachael Wright-Munn <ChaelCodes@users.noreply.github.com>