### PR TITLE
#2009 - reminder email button for supervisor or admin to remind volunteer

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -82,7 +82,7 @@ class VolunteersController < ApplicationController
   def reminder
     authorize @volunteer
     @volunteer = Volunteer.find(params[:id])
-    VolunteerMailer.reminder(@volunteer).deliver
+    VolunteerMailer.case_contacts_reminder(@volunteer).deliver
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Reminder sent to volunteer."
   end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -79,6 +79,14 @@ class VolunteersController < ApplicationController
     redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
   end
 
+  def reminder
+    authorize @volunteer
+    @volunteer = Volunteer.find(params[:id])
+    VolunteerMailer.reminder(@volunteer).deliver
+
+    redirect_to edit_volunteer_path(@volunteer), notice: "Reminder sent to volunteer."
+  end
+
   private
 
   def set_volunteer

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -11,6 +11,10 @@ body.casa_cases {
     }
   }
 
+  #reminder_button {
+    margin-left: 30px;
+  }
+
   .case-contact-list {
       margin-bottom: 20px;
   }

--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -19,6 +19,12 @@ label {
   color: $primary;
 }
 
+div.row div.col-sm-12.form-header h1 {
+  display: inline-block;
+  margin-right: 15px;
+  vertical-align: middle;
+}
+
 .card.card-container {
   box-shadow: 0 4px 12px 5px rgba(0, 0, 0, 0.08);
 }

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -18,4 +18,9 @@ class VolunteerMailer < ApplicationMailer
     @court_report_due_date = court_report_due_date
     mail(to: @user.email, subject: "Your court report is due on: #{court_report_due_date}")
   end
+
+  def case_contacts_reminder(user)
+    @user = user
+    mail(to: @user.email, subject: "Reminder to input case contacts")
+  end
 end

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -21,6 +21,7 @@ class VolunteerMailer < ApplicationMailer
 
   def case_contacts_reminder(user)
     @user = user
+    @casa_organization = user.casa_org
     mail(to: @user.email, subject: "Reminder to input case contacts")
   end
 end

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -11,4 +11,5 @@ class VolunteerPolicy < UserPolicy
   alias_method :activate?, :index?
   alias_method :deactivate?, :index?
   alias_method :resend_invitation?, :index?
+  alias_method :reminder?, :index?
 end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -98,7 +98,12 @@
         <% if current_user.volunteer? %>
           <p><%= volunteer.display_name %></p>
         <% else %>
-          <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %></p>
+          <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
+                <%= link_to(t(".send_reminder"),
+                            reminder_volunteer_path(volunteer),
+                            method: :patch,
+                            id: "reminder_button",
+                            class: "btn btn-primary casa-case-button") %></p>
         <% end %>
       <% end %>
       <br>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -99,11 +99,13 @@
           <p><%= volunteer.display_name %></p>
         <% else %>
           <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
-                <%= link_to(t(".send_reminder"),
+                <%= link_to t(".send_reminder"),
                             reminder_volunteer_path(volunteer),
                             method: :patch,
                             id: "reminder_button",
-                            class: "btn btn-primary casa-case-button") %></p>
+                            class: "btn btn-primary casa-case-button",
+                            data_toggle: "tooltip",
+                            title: "#{t(".tooltip")}" %></p>
         <% end %>
       <% end %>
       <br>
@@ -122,3 +124,9 @@
     </div>
   </div>
 </div>
+
+<script>
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+</script>

--- a/app/views/volunteer_mailer/case_contacts_reminder.html.erb
+++ b/app/views/volunteer_mailer/case_contacts_reminder.html.erb
@@ -7,7 +7,7 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      You are receiving this email as reminder to input the case contacts which you have made.
+      You are receiving this email as a reminder to input the case contacts which you have made.
     </td>
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/app/views/volunteer_mailer/case_contacts_reminder.html.erb
+++ b/app/views/volunteer_mailer/case_contacts_reminder.html.erb
@@ -1,0 +1,19 @@
+<meta itemprop="name" content="Case Contacts Reminder" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      Hello <%= @user.display_name %>,
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      You are receiving this email as reminder to input the case contacts which you have made.
+    </td>
+  </tr>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      If you have any questions, please contact your most recent <%= @user.casa_org.display_name %> Supervisor for
+      assistance.
+    </td>
+  </tr>
+</table>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -8,7 +8,9 @@
       <%= link_to t(".send_reminder"),
                   reminder_volunteer_path(@volunteer),
                   method: :patch,
-                  class: "btn btn-primary casa-case-button" %>
+                  class: "btn btn-primary casa-case-button",
+                  data_toggle: "tooltip",
+                  title: "#{t(".tooltip")}" %>
     <% end %>
   </div>
 </div>
@@ -47,3 +49,9 @@
 <%= render 'manage_cases' %>
 
 <%= render 'manage_supervisor' %>
+
+<script>
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+</script>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -1,7 +1,17 @@
 <%= link_to 'Back', volunteers_path %>
 
-<h1>Editing Volunteer</h1>
-
+<div class="row">
+  <div class="col-sm-12 form-header">
+    <h1>Editing Volunteer</h1>
+    <% if current_user.supervisor? ||
+        current_user.casa_admin? %>
+      <%= link_to t(".send_reminder"),
+                  reminder_volunteer_path(@volunteer),
+                  method: :patch,
+                  class: "btn btn-primary casa-case-button" %>
+    <% end %>
+  </div>
+</div>
 <div class="card card-container">
   <div class="card-body">
     <%= form_for @volunteer, url: volunteer_path(@volunteer) do |form| %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -41,7 +41,8 @@ en:
         click_to_download: Click to download
         download_all: Download All
         generate_court_report: Generate Report
-        send_reminder: Send Reminder
+      send_reminder: Send Reminder
+      tooltip: Sends to volunteer a reminder email to input case contacts
     shared:
       filter_by: Filter by
       assigned_single: Assigned to Volunteer
@@ -356,3 +357,4 @@ en:
   volunteers:
     edit:
       send_reminder: Send reminder
+      tooltip: Sends to volunteer a reminder email to input case contacts

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -41,6 +41,7 @@ en:
         click_to_download: Click to download
         download_all: Download All
         generate_court_report: Generate Report
+        send_reminder: Send Reminder
     shared:
       filter_by: Filter by
       assigned_single: Assigned to Volunteer
@@ -352,3 +353,6 @@ en:
         zero: Assigned Volunteers
         one: All Volunteers
         other: All Volunteers
+  volunteers:
+    edit:
+      send_reminder: Send reminder

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
       patch :activate
       patch :deactivate
       patch :resend_invitation
+      patch :reminder
     end
   end
   resources :case_assignments, only: %i[create destroy] do

--- a/spec/mailers/volunteer_mailer_spec.rb
+++ b/spec/mailers/volunteer_mailer_spec.rb
@@ -32,4 +32,13 @@ RSpec.describe VolunteerMailer, type: :mailer do
       expect(mail.body.encoded).to match("next court report is due on #{report_due_date}")
     end
   end
+
+  describe ".case_contacts_reminder" do
+    let(:mail) { VolunteerMailer.case_contacts_reminder(volunteer) }
+
+    it "sends an email reminding volunteer" do
+      expect(mail.body.encoded).to match("Hello #{volunteer.display_name}")
+      expect(mail.body.encoded).to match("as a reminder")
+    end
+  end
 end

--- a/spec/system/casa_cases/show_more_spec.rb
+++ b/spec/system/casa_cases/show_more_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
 
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
   let(:volunteer) { create :volunteer, display_name: "Andy Dwyer", casa_org: organization }
   let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
   let(:casa_case) { create(:casa_case, casa_org: organization) }
@@ -20,6 +21,30 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
       click_on "Andy Dwyer"
 
       expect(page).to have_text("Editing Volunteer")
+    end
+
+    it "sends reminder to volunteer" do
+      sign_in admin
+      visit casa_case_path(casa_case.id)
+
+      expect(page).to have_link("Send Reminder")
+
+      click_on "Send Reminder"
+
+      expect(page).to have_text("Reminder sent to volunteer")
+    end
+  end
+
+  context "user is a supervisor" do
+    it "sends reminder to volunteer" do
+      sign_in supervisor
+      visit casa_case_path(casa_case.id)
+
+      expect(page).to have_link("Send Reminder")
+
+      click_on "Send Reminder"
+
+      expect(page).to have_text("Reminder sent to volunteer")
     end
   end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -215,4 +215,32 @@ RSpec.describe "volunteers/edit", :disable_bullet, type: :system do
     expect(page).to have_content("Resend Invitation")
     expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
+
+  describe "send reminder as a supervisor" do
+    let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+    it "allows a supervisor resend invitation to a volunteer" do
+      sign_in supervisor
+
+      visit edit_volunteer_path(volunteer)
+
+      expect(page).to have_link("Send reminder")
+
+      click_on "Send reminder"
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+  end
+
+  it "send reminder as an admin" do
+    sign_in admin
+
+    visit edit_volunteer_path(volunteer)
+
+    expect(page).to have_link("Send reminder")
+
+    click_on "Send reminder"
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2009

### What changed, and why?
Created button which allows supervisors and admins to send an email reminding the volunteer to input case contacts.


### How will this affect user permissions?
- Volunteer permissions:
Nothing changes to volunteers.

Supervisor and Admins:
Now has a button in the volunteers edit page and casa case details page to send a reminder to volunteer input case contacts.

### How is this tested? (please write tests!) 💖💪
Created some tests sending the reminder.

### Screenshots please :)
![Screenshot from 2021-05-21 15-15-43](https://user-images.githubusercontent.com/61836657/119181840-8b280700-ba48-11eb-9459-de07e48973da.png)
![Screenshot from 2021-05-21 15-15-27](https://user-images.githubusercontent.com/61836657/119181855-8ebb8e00-ba48-11eb-9275-ecc99a92c691.png)

* Tooltip

![tooltip](https://user-images.githubusercontent.com/61836657/119185750-83b72c80-ba4d-11eb-8b7c-e9bc0c172cb7.jpg)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
