### PR TITLE
Final fix of #2049 - Post initial PR Merge.

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -36,10 +36,6 @@
         </div>
       </div>
       <div class="row justify-content-between">
-        <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete,
-                  class: "btn btn-danger") if policy(current_user).destroy? && !contact.deleted? %>
-      </div>
-      <div class="row justify-content-between">
         <% if Pundit.policy(current_user, contact).update? %>
           <% if contact.quarter_editable? %>
             <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
@@ -53,7 +49,12 @@
           <% end %>
         <% end %>
       </div>
-
+      <div class="row pl-3">
+        <div class="col">
+          <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete,
+                class: "btn btn-danger") if policy(current_user).destroy? && !contact.deleted? %>
+        </div>
+      </div>
     </div>
   </div>
   <div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Tweaks to fix #2049 more cleanly.

### What changed, and why?
Delete button was showing as a giant button rather than a clean, evenly sized button.

### How will this affect user permissions?
- Volunteer permissions: No effects on permissions for any, but screenshots are below to show how the buttons will display for each.
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Tests are already implemented

### Screenshots please :)
@compwron , I actually just made it somehow a bit better, as it's not as... idk, awkward?

Volunteer View:
![image](https://user-images.githubusercontent.com/33261934/119364405-db87aa80-bc7c-11eb-9303-e2c368f20c90.png)

Admin View When Followup Selected:
![image](https://user-images.githubusercontent.com/33261934/119365753-408fd000-bc7e-11eb-98f2-87f0d6c5bf60.png)

Admin View When Followup Not Selected and Delete Button Post Fix:
![image](https://user-images.githubusercontent.com/33261934/119365191-b0ea2180-bc7d-11eb-88b5-ed71a04200d3.png)
