### PR TITLE
[#1739] Add court details to past court dates

### DIFF
--- a/app/controllers/past_court_dates_controller.rb
+++ b/app/controllers/past_court_dates_controller.rb
@@ -1,0 +1,23 @@
+class PastCourtDatesController < ApplicationController
+  before_action :set_casa_case, only: %i[show]
+  before_action :set_past_court_date, only: %i[show]
+  before_action :require_organization!
+
+  def show
+    authorize @casa_case
+  end
+
+  private
+
+  def set_casa_case
+    @casa_case = current_organization.casa_cases.find(params[:casa_case_id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def set_past_court_date
+    @past_court_date = @casa_case.past_court_dates.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+end

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -74,8 +74,4 @@ class CasaCaseDecorator < Draper::Decorator
   def formatted_updated_at
     I18n.l(object.updated_at, format: :standard, default: nil)
   end
-
-  def past_court_date_formatted(past_court_date)
-    I18n.l(past_court_date.date, format: :full, default: nil)
-  end
 end

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -74,4 +74,8 @@ class CasaCaseDecorator < Draper::Decorator
   def formatted_updated_at
     I18n.l(object.updated_at, format: :standard, default: nil)
   end
+
+  def past_court_date_formatted(past_court_date)
+    I18n.l(past_court_date.date, format: :full, default: nil)
+  end
 end

--- a/app/decorators/past_court_date_decorator.rb
+++ b/app/decorators/past_court_date_decorator.rb
@@ -1,0 +1,7 @@
+class PastCourtDateDecorator < Draper::Decorator
+  delegate_all
+
+  def formatted_date
+    I18n.l(object.date, format: :full, default: nil)
+  end
+end

--- a/app/models/case_court_mandate.rb
+++ b/app/models/case_court_mandate.rb
@@ -1,8 +1,11 @@
 class CaseCourtMandate < ApplicationRecord
   IMPLEMENTATION_STATUSES = {not_implemented: 1, partially_implemented: 2, implemented: 3}
+
   belongs_to :casa_case
+  belongs_to :past_court_date
 
   validates :mandate_text, presence: true
+
   enum implementation_status: IMPLEMENTATION_STATUSES
 end
 
@@ -16,10 +19,12 @@ end
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  casa_case_id          :bigint           not null
+#  past_court_date_id    :bigint
 #
 # Indexes
 #
-#  index_case_court_mandates_on_casa_case_id  (casa_case_id)
+#  index_case_court_mandates_on_casa_case_id        (casa_case_id)
+#  index_case_court_mandates_on_past_court_date_id  (past_court_date_id)
 #
 # Foreign Keys
 #

--- a/app/models/case_court_mandate.rb
+++ b/app/models/case_court_mandate.rb
@@ -2,7 +2,7 @@ class CaseCourtMandate < ApplicationRecord
   IMPLEMENTATION_STATUSES = {not_implemented: 1, partially_implemented: 2, implemented: 3}
 
   belongs_to :casa_case
-  belongs_to :past_court_date
+  belongs_to :past_court_date, optional: true
 
   validates :mandate_text, presence: true
 

--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -18,6 +18,10 @@ class PastCourtDate < ApplicationRecord
   def latest_associated_report
     associated_reports.order(:created_at).last
   end
+
+  def additional_info?
+    case_court_mandates.any? || hearing_type || judge
+  end
 end
 # == Schema Information
 #

--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -1,6 +1,10 @@
 class PastCourtDate < ApplicationRecord
   belongs_to :casa_case
 
+  has_many :case_court_mandates
+  belongs_to :hearing_type, optional: true
+  belongs_to :judge, optional: true
+
   # get reports associated with the case this belongs to before this court date but after the court date before this one
   def associated_reports
     prev = casa_case.past_court_dates.where("date < ?", date).order(:date).last
@@ -19,15 +23,19 @@ end
 #
 # Table name: past_court_dates
 #
-#  id           :bigint           not null, primary key
-#  date         :datetime         not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  casa_case_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  date            :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  casa_case_id    :bigint           not null
+#  hearing_type_id :bigint
+#  judge_id        :bigint
 #
 # Indexes
 #
-#  index_past_court_dates_on_casa_case_id  (casa_case_id)
+#  index_past_court_dates_on_casa_case_id     (casa_case_id)
+#  index_past_court_dates_on_hearing_type_id  (hearing_type_id)
+#  index_past_court_dates_on_judge_id         (judge_id)
 #
 # Foreign Keys
 #

--- a/app/policies/past_court_date_policy.rb
+++ b/app/policies/past_court_date_policy.rb
@@ -1,0 +1,11 @@
+class PastCourtDatePolicy < ApplicationPolicy
+  def show?
+    casa_case_policy.edit?
+  end
+
+  private
+
+  def casa_case_policy
+    CasaCasePolicy.new(user, record.casa_case)
+  end
+end

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -15,11 +15,13 @@
         <% @casa_case.past_court_dates.each do |pcd| %>
           <p>
             <% if report = pcd.latest_associated_report %>
-              <%= link_to @casa_case.decorate.past_court_date_formatted(pcd),
+              <%= link_to pcd.decorate.formatted_date,
                   rails_blob_path(report, disposition: 'attachment') %>
-            <% else %>
-              <%= link_to @casa_case.decorate.past_court_date_formatted(pcd),
+            <% elsif pcd.additional_info? %>
+              <%= link_to pcd.decorate.formatted_date,
                   casa_case_past_court_date_path(@casa_case, pcd) %>
+            <% else %>
+              <%= pcd.decorate.formatted_date %>
             <% end %>
           </p>
         <% end %>

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -15,10 +15,11 @@
         <% @casa_case.past_court_dates.each do |pcd| %>
           <p>
             <% if report = pcd.latest_associated_report %>
-              <%= link_to I18n.l(pcd.date, format: :full, default: nil),
-rails_blob_path(report, disposition: 'attachment') %>
+              <%= link_to @casa_case.decorate.past_court_date_formatted(pcd),
+                  rails_blob_path(report, disposition: 'attachment') %>
             <% else %>
-              <%= I18n.l(pcd.date, format: :full, default: nil) %>
+              <%= link_to @casa_case.decorate.past_court_date_formatted(pcd),
+                  casa_case_past_court_date_path(@casa_case, pcd) %>
             <% end %>
           </p>
         <% end %>

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -14,14 +14,17 @@
       <ul>
         <% @casa_case.past_court_dates.each do |pcd| %>
           <p>
-            <% if report = pcd.latest_associated_report %>
-              <%= link_to pcd.decorate.formatted_date,
-                  rails_blob_path(report, disposition: 'attachment') %>
-            <% elsif pcd.additional_info? %>
+            <% if pcd.additional_info? %>
               <%= link_to pcd.decorate.formatted_date,
                   casa_case_past_court_date_path(@casa_case, pcd) %>
             <% else %>
               <%= pcd.decorate.formatted_date %>
+            <% end %>
+
+            <% if report = pcd.latest_associated_report %>
+              <%= link_to rails_blob_path(report, disposition: 'attachment') do %>
+                (<%= t(".label.latest_associated_report") %>)
+              <% end %>
             <% end %>
           </p>
         <% end %>

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -23,7 +23,7 @@
 
             <% if report = pcd.latest_associated_report %>
               <%= link_to rails_blob_path(report, disposition: 'attachment') do %>
-                (<%= t(".label.latest_associated_report") %>)
+                (<%= t(".label.attached_report") %>)
               <% end %>
             <% end %>
           </p>

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -24,7 +24,7 @@
     <% if @past_court_date.case_court_mandates.any? %>
       <p>
         <h6>
-          <strong><%= t(".label.court_mandates") %>:</strong>
+          <strong><%= t(".label.case_court_mandates") %>:</strong>
         </h6>
       </p>
 
@@ -47,8 +47,8 @@
     <% else %>
       <p>
         <h6>
-          <strong><%= t(".label.court_mandates") %>:</strong>
-          There are no court mandates associated with this past court date.
+          <strong><%= t(".label.case_court_mandates") %>:</strong>
+          <%= t(".label.no_case_court_mandates") %>
         </h6>
       </p>
     <% end %>

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -1,4 +1,56 @@
 <%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
 
-<h1>PastCourtDates#show</h1>
-<p>Find me in app/views/past_court_dates/show.html.erb</p>
+<h1><%= t(".title") %></h1>
+<h2><%= @past_court_date.decorate.formatted_date %></h2>
+
+<div class="card card-container">
+  <div class="card-body">
+    <p>
+      <h6><strong><%= t(".label.case_number") %>:</strong> <%= @casa_case.case_number %></h6>
+    </p>
+    <p>
+      <h6>
+        <strong><%= t(".label.judge") %>:</strong>
+        <%= @past_court_date.judge&.name || t(".label.none") %>
+      </h6>
+    </p>
+    <p>
+      <h6>
+        <strong><%= t(".label.hearing_type") %>:</strong>
+        <%= @past_court_date.hearing_type&.name || t(".label.none") %>
+      </h6>
+    </p>
+
+    <% if @past_court_date.case_court_mandates.any? %>
+      <p>
+        <h6>
+          <strong><%= t(".label.court_mandates") %>:</strong>
+        </h6>
+      </p>
+
+      <div class="table-responsive">
+        <table class="table table-hover">
+          <thead>
+            <th><%= t(".label.casa_case_court_mandate.mandate_text") %></th>
+            <th class="text-center"><%= t(".label.casa_case_court_mandate.implementation_status") %></th>
+          </thead>
+          <tbody>
+            <% @past_court_date.case_court_mandates.each do |court_mandate| %>
+              <tr>
+                <td><%= court_mandate.mandate_text %></td>
+                <td class="text-center"><%= court_mandate.implementation_status.humanize %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p>
+        <h6>
+          <strong><%= t(".label.court_mandates") %>:</strong>
+          There are no court mandates associated with this past court date.
+        </h6>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -1,0 +1,4 @@
+<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
+
+<h1>PastCourtDates#show</h1>
+<p>Find me in app/views/past_court_dates/show.html.erb</p>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -34,6 +34,7 @@ en:
         court_report_submitted_date: Court Report Submitted Date
         court_mandates: Court Mandates
         assigned_volunteers: Assigned Volunteers
+        attached_report: Attached Report
       button:
         new_contact: New Case Contact
         edit_case: Edit Case Details
@@ -122,8 +123,15 @@ en:
     show:
       title: Past Court Date
       label:
+        case_number: Case Number
+        judge: Judge
+        hearing_type: Hearing Type
+        none: None
+        case_court_mandates: Court Mandates
+        no_case_court_mandates: There are no court mandates associated with this past court date.
         casa_case_court_mandate:
           mandate_text: Court Mandate Text
+          implementation_status: Implementation Status
   casa_admins:
     form:
       button:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -118,6 +118,12 @@ en:
         new: New Case
     new:
       title: New CASA Case
+  past_court_dates:
+    show:
+      title: Past Court Date
+      label:
+        casa_case_court_mandate:
+          mandate_text: Court Mandate Text
   casa_admins:
     form:
       button:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
         post "save"
       end
     end
+
+    resources :past_court_dates, only: %i[show]
+
     member do
       patch :deactivate
       patch :reactivate

--- a/db/migrate/20210521151549_add_casa_case_details_to_past_court_dates.rb
+++ b/db/migrate/20210521151549_add_casa_case_details_to_past_court_dates.rb
@@ -1,0 +1,6 @@
+class AddCasaCaseDetailsToPastCourtDates < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :past_court_dates, :hearing_type, null: true
+    add_reference :past_court_dates, :judge, null: true
+  end
+end

--- a/db/migrate/20210521194321_add_past_court_date_to_case_court_mandates.rb
+++ b/db/migrate/20210521194321_add_past_court_date_to_case_court_mandates.rb
@@ -1,0 +1,5 @@
+class AddPastCourtDateToCaseCourtMandates < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :case_court_mandates, :past_court_date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_02_172706) do
+ActiveRecord::Schema.define(version: 2021_05_21_194321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,7 +161,9 @@ ActiveRecord::Schema.define(version: 2021_05_02_172706) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "implementation_status"
+    t.bigint "past_court_date_id"
     t.index ["casa_case_id"], name: "index_case_court_mandates_on_casa_case_id"
+    t.index ["past_court_date_id"], name: "index_case_court_mandates_on_past_court_date_id"
   end
 
   create_table "contact_type_groups", force: :cascade do |t|
@@ -242,7 +244,11 @@ ActiveRecord::Schema.define(version: 2021_05_02_172706) do
     t.bigint "casa_case_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "hearing_type_id"
+    t.bigint "judge_id"
     t.index ["casa_case_id"], name: "index_past_court_dates_on_casa_case_id"
+    t.index ["hearing_type_id"], name: "index_past_court_dates_on_hearing_type_id"
+    t.index ["judge_id"], name: "index_past_court_dates_on_judge_id"
   end
 
   create_table "supervisor_volunteers", force: :cascade do |t|

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -8,9 +8,17 @@ end
 desc "Clear court dates and report information when date has passed, run by heroku scheduler"
 task clear_passed_dates: :environment do
   puts "Checking case due dates..."
+
   CasaCase.due_date_passed.each do |cc|
-    PastCourtDate.create!(date: cc.court_date, casa_case_id: cc.id)
+    PastCourtDate.create!(date: cc.court_date,
+      casa_case_id: cc.id,
+      case_court_mandates: cc.case_court_mandates,
+      hearing_type_id: cc.hearing_type_id,
+      judge_id: cc.judge_id
+    )
+
     cc.clear_court_dates
   end
+
   puts "done."
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -11,11 +11,10 @@ task clear_passed_dates: :environment do
 
   CasaCase.due_date_passed.each do |cc|
     PastCourtDate.create!(date: cc.court_date,
-      casa_case_id: cc.id,
-      case_court_mandates: cc.case_court_mandates,
-      hearing_type_id: cc.hearing_type_id,
-      judge_id: cc.judge_id
-    )
+                          casa_case_id: cc.id,
+                          case_court_mandates: cc.case_court_mandates,
+                          hearing_type_id: cc.hearing_type_id,
+                          judge_id: cc.judge_id)
 
     cc.clear_court_dates
   end

--- a/spec/factories/past_court_date.rb
+++ b/spec/factories/past_court_date.rb
@@ -2,5 +2,21 @@ FactoryBot.define do
   factory :past_court_date, class: "PastCourtDate" do
     casa_case
     date { Time.now }
+
+    trait :with_court_details do
+      with_judge
+      with_hearing_type
+      with_court_mandate
+    end
+
+    trait(:with_judge) { judge }
+    trait(:with_hearing_type) { hearing_type }
+
+    trait :with_court_mandate do
+      after(:create) do |past_court_date|
+        past_court_date.case_court_mandates << build(:case_court_mandate, casa_case: past_court_date.casa_case)
+        past_court_date.save
+      end
+    end
   end
 end

--- a/spec/policies/past_court_date_policy_spec.rb
+++ b/spec/policies/past_court_date_policy_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe PastCourtDatePolicy do
   let(:different_organization) { create(:casa_org) }
 
   let(:past_court_date) { create(:past_court_date, casa_case: casa_case) }
-  let(:casa_case) { create(:casa_case,  casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
 
   let(:casa_admin) { create(:casa_admin, casa_org: organization) }
-  let(:volunteer)  { create(:volunteer,  casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
 
   permissions :show? do
@@ -21,7 +21,7 @@ RSpec.describe PastCourtDatePolicy do
     end
 
     context "when a supervisor does not belong to the same org as the case" do
-      let(:casa_case)  { create(:casa_case, casa_org: different_organization) }
+      let(:casa_case) { create(:casa_case, casa_org: different_organization) }
 
       it { expect(subject).not_to permit(supervisor, past_court_date) }
     end

--- a/spec/policies/past_court_date_policy_spec.rb
+++ b/spec/policies/past_court_date_policy_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe PastCourtDatePolicy do
+  subject { described_class }
+
+  let(:organization) { create(:casa_org) }
+  let(:different_organization) { create(:casa_org) }
+
+  let(:past_court_date) { create(:past_court_date, casa_case: casa_case) }
+  let(:casa_case) { create(:casa_case,  casa_org: organization) }
+
+  let(:casa_admin) { create(:casa_admin, casa_org: organization) }
+  let(:volunteer)  { create(:volunteer,  casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+  permissions :show? do
+    it { is_expected.to permit(casa_admin, past_court_date) }
+
+    context "when a supervisor belongs to the same org as the case" do
+      it { expect(subject).to permit(supervisor, past_court_date) }
+    end
+
+    context "when a supervisor does not belong to the same org as the case" do
+      let(:casa_case)  { create(:casa_case, casa_org: different_organization) }
+
+      it { expect(subject).not_to permit(supervisor, past_court_date) }
+    end
+
+    context "when volunteer is assigned" do
+      before { volunteer.casa_cases << casa_case }
+
+      it { is_expected.to permit(volunteer, past_court_date) }
+    end
+
+    context "when volunteer is not assigned" do
+      it { is_expected.not_to permit(volunteer, past_court_date) }
+    end
+  end
+end

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -22,5 +22,4 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request 
       it { expect(response).to redirect_to new_user_session_path }
     end
   end
-
 end

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request do
+RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", :disable_bullet, type: :request do
   describe "GET /show" do
     subject(:show) { get casa_case_past_court_date_path(casa_case, past_court_date) }
 

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request do
+  describe "GET /show" do
+    subject(:show) { get casa_case_past_court_date_path(casa_case, past_court_date) }
+
+    let(:casa_case) { past_court_date.casa_case }
+    let(:past_court_date) { create(:past_court_date) }
+
+    context "when the request is authenticated" do
+      before do
+        sign_in_as_admin
+        show
+      end
+
+      it { expect(response).to have_http_status(:success) }
+    end
+
+    context "when the request is unauthenticated" do
+      before { show }
+
+      it { expect(response).to redirect_to new_user_session_path }
+    end
+  end
+
+end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -2,6 +2,30 @@ require "rails_helper"
 require "stringio"
 
 RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
+
+  shared_examples_for "shows past court dates links" do
+    let(:past_court_date_with_details) do
+      create(:past_court_date, :with_court_details, casa_case: casa_case, date: Time.zone.yesterday)
+    end
+
+    let(:past_court_date_without_details) do
+      create(:past_court_date, casa_case: casa_case, date: Time.zone.today)
+    end
+
+    let!(:formatted_date_with_details)    { I18n.l(past_court_date_with_details.date,    format: :full, default: nil) }
+    let!(:formatted_date_without_details) { I18n.l(past_court_date_without_details.date, format: :full, default: nil) }
+
+    it "shows court mandates" do
+      visit edit_casa_case_path(casa_case)
+
+      expect(page).to have_text(formatted_date_with_details)
+      expect(page).to have_link(formatted_date_with_details)
+
+      expect(page).to     have_text(formatted_date_without_details)
+      expect(page).not_to have_link(formatted_date_without_details)
+    end
+  end
+
   context "when admin" do
     let(:organization) { create(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
@@ -12,6 +36,8 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
     let!(:therapist) { create(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
 
     before { sign_in admin }
+
+    it_behaves_like "shows past court dates links"
 
     it "shows court mandates" do
       visit edit_casa_case_path(casa_case)
@@ -91,9 +117,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
     let!(:contact_type_2) { create(:contact_type, name: "Supervisor", contact_type_group: contact_type_group) }
     let!(:next_year) { (Date.today.year + 1).to_s }
 
-    before do
-      sign_in supervisor
-    end
+    before { sign_in supervisor }
+
+    it_behaves_like "shows past court dates links"
 
     it "edits case", js: true do
       visit casa_case_path(casa_case)
@@ -377,13 +403,17 @@ of it unless it was included in a previous court report.")
 
     before { sign_in volunteer }
 
+    it_behaves_like "shows past court dates links"
+
     it "views attached court reports" do
       visit edit_casa_case_path(casa_case)
 
       # test court dates with reports get the correct ones
       [[0, 1], [2, 3], [3, 4]].each do |di, ri|
-        expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil), href: rails_blob_path(reports[ri], disposition: "attachment"))
+        expect(page).to have_link("(Attached Report)", href: rails_blob_path(reports[ri], disposition: "attachment"))
+        expect(page).not_to have_link(I18n.l(court_dates[di].date, format: :full, default: nil))
       end
+
       # and that the one with no report doesn't get one
       expect(page).not_to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))
       expect(page).to have_text(I18n.l(court_dates[1].date, format: :full, default: nil))

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 require "stringio"
 
 RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
-
   shared_examples_for "shows past court dates links" do
     let(:past_court_date_with_details) do
       create(:past_court_date, :with_court_details, casa_case: casa_case, date: Time.zone.yesterday)
@@ -12,7 +11,7 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       create(:past_court_date, casa_case: casa_case, date: Time.zone.today)
     end
 
-    let!(:formatted_date_with_details)    { I18n.l(past_court_date_with_details.date,    format: :full, default: nil) }
+    let!(:formatted_date_with_details) { I18n.l(past_court_date_with_details.date, format: :full, default: nil) }
     let!(:formatted_date_without_details) { I18n.l(past_court_date_without_details.date, format: :full, default: nil) }
 
     it "shows court mandates" do
@@ -21,7 +20,7 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       expect(page).to have_text(formatted_date_with_details)
       expect(page).to have_link(formatted_date_with_details)
 
-      expect(page).to     have_text(formatted_date_without_details)
+      expect(page).to have_text(formatted_date_without_details)
       expect(page).not_to have_link(formatted_date_without_details)
     end
   end

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "past_court_dates/show", type: :view do
   shared_examples_for "a past court date with all court details" do

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -1,5 +1,84 @@
 require 'rails_helper'
 
-RSpec.describe "past_court_dates/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe "past_court_dates/show", type: :view do
+  shared_examples_for "a past court date with all court details" do
+    let(:past_court_date) { create(:past_court_date, :with_court_details) }
+    let(:case_court_mandate) { past_court_date.case_court_mandates.first }
+
+    it "displays all court details" do
+      render template: "past_court_dates/show"
+
+      expect(rendered).to include(past_court_date.judge.name)
+      expect(rendered).to include(past_court_date.hearing_type.name)
+
+      expect(rendered).to include(case_court_mandate.mandate_text)
+      expect(rendered).to include(case_court_mandate.implementation_status.humanize)
+    end
+  end
+  shared_examples_for "a past court date with no court details" do
+    let(:past_court_date) { create(:past_court_date) }
+
+    it "displays all court details" do
+      render template: "past_court_dates/show"
+
+      expect(rendered).to include("Judge:")
+      expect(rendered).to include("Hearing Type")
+      expect(rendered).to include("None")
+
+      expect(rendered).to include("There are no court mandates associated with this past court date.")
+    end
+  end
+
+  let(:organization) { create(:casa_org) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+
+  before do
+    enable_pundit(view, user)
+
+    assign :casa_case, past_court_date.casa_case
+    assign :past_court_date, past_court_date
+
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_organization).and_return(user.casa_org)
+  end
+
+  context "with court details" do
+    context "when accessed by a casa admin" do
+      let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+
+      it_behaves_like "a past court date with all court details"
+    end
+
+    context "when accessed by a supervisor" do
+      let(:user) { build_stubbed(:supervisor, casa_org: organization) }
+
+      it_behaves_like "a past court date with all court details"
+    end
+
+    context "when accessed by a volunteer" do
+      let(:user) { build_stubbed(:volunteer, casa_org: organization) }
+
+      it_behaves_like "a past court date with all court details"
+    end
+  end
+
+  context "without court details" do
+    context "when accessed by an admin" do
+      let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+
+      it_behaves_like "a past court date with no court details"
+    end
+
+    context "when accessed by a supervisor" do
+      let(:user) { build_stubbed(:supervisor, casa_org: organization) }
+
+      it_behaves_like "a past court date with no court details"
+    end
+
+    context "when accessed by a volunteer" do
+      let(:user) { build_stubbed(:volunteer, casa_org: organization) }
+
+      it_behaves_like "a past court date with no court details"
+    end
+  end
 end

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "past_court_dates/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1739 

### What changed, and why?
As requested in #1739, the past court dates now have a page of their own with additional information about the CASA case at the time, such as: judge, hearing type and court mandates.

The link to that page is available at the edit page of a given CASA case.

#### Acceptance Criteria
- [x] Dates are clickable underneath "Past Court Dates" on the Edit CASA Case page.
- [x] Clicking on a date takes you to a page where you can see details associated with that past court date, including:
  - [x] Hearing type
  - [x] Judge
  - [x] Court mandates and implementation status

### How will this affect user permissions?
The permissions to access the past court date page mirror the permissions to edit the associated case.

- Volunteer permissions: Can only see the page if they are associated with the case
- Supervisor permissions: Can only see the page if they are in the same organization as the case
- Admin permissions: Can always see the page

### How is this tested? (please write tests!) 💖💪
#### Automated tests
- Added model and request specs for the past court dates
- Added view specs for the past court date show page
- Modified the system specs for the CASA case edit page to check if the court dates links are actually visible

#### Manual testing
I also had to test if the heroku scheduler task was working, so I modified a CASA case to:
- Have court details
- Have a next court date in the past (so the scheduler task picks it up)

And then I ran the scheduler task.

### Screenshots please :)

#### The CASA case edit page now have links to the past court dates

![01-desktop-edit](https://user-images.githubusercontent.com/72531802/119559626-4fa77880-bd79-11eb-8d3e-644110c2cdaa.png)

#### Past court dates page (desktop)
![02-desktop-show](https://user-images.githubusercontent.com/72531802/119559673-6057ee80-bd79-11eb-9189-58454a3b9ef7.png)

#### Past court dates page (mobile top)
![03-mobile-show](https://user-images.githubusercontent.com/72531802/119559681-61891b80-bd79-11eb-9735-e5c618e42cc2.png)

#### Past court dates page (mobile bottom)
![04-mobile-show](https://user-images.githubusercontent.com/72531802/119559719-6cdc4700-bd79-11eb-85fb-d3fdb5b1d75d.png)

To be honest I'm not a big fan of how the table looks in mobile, but I thought I shouldn't modify the global table style just for this alteration.