### PR TITLE
Handle error when generating court report fails

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -46,6 +46,9 @@ class CaseCourtReportsController < ApplicationController
   rescue Zip::Error
     error_messages = generate_error(t(".error.template_not_found"))
     render json: {status: :not_found, error_messages: error_messages}, status: :not_found
+  rescue StandardError => e
+    error_messages = generate_error(e.to_s)
+    render json: {status: :unprocessable_entity, error_messages: error_messages}, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -46,7 +46,7 @@ class CaseCourtReportsController < ApplicationController
   rescue Zip::Error
     error_messages = generate_error(t(".error.template_not_found"))
     render json: {status: :not_found, error_messages: error_messages}, status: :not_found
-  rescue StandardError => e
+  rescue => e
     error_messages = generate_error(e.to_s)
     render json: {status: :unprocessable_entity, error_messages: error_messages}, status: :unprocessable_entity
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2038 

### What changed, and why?
- Rescue StandardError beside Zip::Error to handle error log when generating court report fails.

### How will this affect user permissions?
- Volunteer permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

