### PR TITLE
Change Court Report dropdown to searchable dropdown

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -57,7 +57,10 @@ class CasaCaseDecorator < Draper::Decorator
     [
       "#{object.case_number} - #{object.has_transitioned? ? "transition" : "non-transition"}",
       object.case_number,
-      {"data-transitioned": object.has_transitioned?}
+      {
+        "data-transitioned": object.has_transitioned?,
+        "data-lookup": object.assigned_volunteers.map(&:display_name).join(",")
+      }
     ]
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,6 +30,7 @@ require('src/dashboard')
 require('src/sidebar')
 require('src/sessions')
 require('src/readMore')
+require('src/tooltip')
 
 // Uncomment to copy all static images under ../images to the output folder and
 // reference them with the image_pack_tag or asset_pack_path helpers in views.

--- a/app/javascript/src/select.js
+++ b/app/javascript/src/select.js
@@ -1,5 +1,33 @@
 /* global $ */
 
 $('document').ready(() => {
-  $('.select2').select2({ theme: 'classic' })
+  $('.select2').select2({ theme: 'classic', matcher: matchCustom })
 })
+
+function matchCustom(params, data) {
+  // If there are no search terms, return all of the data
+  if ($.trim(params.term) === '') {
+    return data;
+  }
+
+  // Do not display the item if there is no 'text' property
+  if (typeof data.text === 'undefined') {
+    return null;
+  }
+
+  // `params.term` should be the term that is used for searching
+  // `data.text` is the text that is displayed for the data object
+  if (data.text.toUpperCase().indexOf(params.term.toUpperCase()) > -1) {
+    return data;
+  }
+
+  // custom search using lookup data
+  var lookup = $(data.element).data('lookup');
+  if (lookup && lookup.toUpperCase().indexOf(params.term.toUpperCase()) > -1) {
+    return data;
+  }
+
+  // Return `null` if the term should not be displayed
+  return null;
+}
+

--- a/app/javascript/src/select.js
+++ b/app/javascript/src/select.js
@@ -4,30 +4,29 @@ $('document').ready(() => {
   $('.select2').select2({ theme: 'classic', matcher: matchCustom })
 })
 
-function matchCustom(params, data) {
+function matchCustom (params, data) {
   // If there are no search terms, return all of the data
   if ($.trim(params.term) === '') {
-    return data;
+    return data
   }
 
   // Do not display the item if there is no 'text' property
   if (typeof data.text === 'undefined') {
-    return null;
+    return null
   }
 
   // `params.term` should be the term that is used for searching
   // `data.text` is the text that is displayed for the data object
   if (data.text.toUpperCase().indexOf(params.term.toUpperCase()) > -1) {
-    return data;
+    return data
   }
 
   // custom search using lookup data
-  var lookup = $(data.element).data('lookup');
+  const lookup = $(data.element).data('lookup')
   if (lookup && lookup.toUpperCase().indexOf(params.term.toUpperCase()) > -1) {
-    return data;
+    return data
   }
 
   // Return `null` if the term should not be displayed
-  return null;
+  return null
 }
-

--- a/app/javascript/src/tooltip.js
+++ b/app/javascript/src/tooltip.js
@@ -1,0 +1,5 @@
+/* global $ */
+
+$('document').ready(() => {
+  $('[data-toggle="tooltip"]').tooltip()
+})

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -124,9 +124,3 @@
     </div>
   </div>
 </div>
-
-<script>
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
-</script>

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -14,11 +14,11 @@
         <%= label_tag :case_number, t(".label.case_number") %>
         <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
         <%= select_tag :case_number,
-                        options_for_select(select_options),
-                        prompt: t(".prompt.select_case_number"),
-                        include_blank: false,
-                        id: "case-selection",
-                        class: "custom-select select2" %>
+                       options_for_select(select_options),
+                       prompt: t(".prompt.select_case_number"),
+                       include_blank: false,
+                       id: "case-selection",
+                       class: "custom-select select2" %>
 
       </div>
       <div class="form-group">

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -12,15 +12,13 @@
     <%= form_with url: generate_case_court_reports_path, local: false do |form| %>
       <div class="field form-group">
         <%= label_tag :case_number, t(".label.case_number") %>
-        <select id="case-selection" name="case_number" class="custom-select select2">
-          <option value="" selected><%= t(".prompt.select_case_number") %></option>
-          <% @assigned_cases.each do |casa_case| %>
-            <% option = casa_case.decorate.court_report_select_option %>
-            <option value="<%= option[1] %>" data-lookup="<%= casa_case.assigned_volunteers.map(&:display_name).join(",") %>">
-              <%= option[0] %>
-            </option>
-          <% end %>
-        </select>
+        <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
+        <%= select_tag :case_number,
+                        options_for_select(select_options),
+                        prompt: t(".prompt.select_case_number"),
+                        include_blank: false,
+                        id: "case-selection",
+                        class: "custom-select select2" %>
 
       </div>
       <div class="form-group">

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -12,13 +12,15 @@
     <%= form_with url: generate_case_court_reports_path, local: false do |form| %>
       <div class="field form-group">
         <%= label_tag :case_number, t(".label.case_number") %>
-        <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
-        <%= select_tag :case_number,
-                       options_for_select(select_options),
-                       prompt: t(".prompt.select_case_number"),
-                       include_blank: false,
-                       id: "case-selection",
-                       class: "custom-select" %>
+        <select id="case-selection" name="case_number" class="custom-select select2">
+          <option value="" selected><%= t(".prompt.select_case_number") %></option>
+          <% @assigned_cases.each do |casa_case| %>
+            <% option = casa_case.decorate.court_report_select_option %>
+            <option value="<%= option[1] %>" data-lookup="<%= casa_case.assigned_volunteers.map(&:display_name).join(",") %>">
+              <%= option[0] %>
+            </option>
+          <% end %>
+        </select>
 
       </div>
       <div class="form-group">

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -49,4 +49,3 @@
 <%= render 'manage_cases' %>
 
 <%= render 'manage_supervisor' %>
-

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -50,8 +50,3 @@
 
 <%= render 'manage_supervisor' %>
 
-<script>
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
-</script>

--- a/cypress/integration/volunteer/generate_court_report.spec.js
+++ b/cypress/integration/volunteer/generate_court_report.spec.js
@@ -12,7 +12,7 @@ context("Logging into cypress as a volunteer", () => {
     cy.get('#case-selection')
       .find('option').then(elements => {
         const option = elements[1].getAttribute('value');
-        cy.get('#case-selection').select(option);
+        cy.get('#case-selection').select(option, {force: true});
 
         cy.contains("Generate Report").click();
 

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe "case_court_reports/index", :disable_bullet, type: :system do
 
       expect(page).to have_selector "#case-selection option", text: expected_text
     end
+
+    it "adds data-lookup attribute for searching by volunteer name" do
+      casa_cases.each do |casa_case|
+        lookup = casa_case.assigned_volunteers.map(&:display_name).join(",")
+        expect(page).to have_selector "#case-selection option[data-lookup='#{lookup}']"
+      end
+    end
   end
 
   context "when choosing the prompt option (value is empty) and click on 'Generate Report' button, nothing should happen", js: true do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2067

### What changed, and why?

- Adds `select2` class to the Court Report dropdown
- Adds a custom matcher function to `select.js` file, and add `data-lookup` attributes to court report dropdown options so a user can search by court report name or volunteer names

### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
Fixed the cypress tests that test this functionality 🤞 

### Screenshots please :)
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/4965672/120679678-734c7c00-c467-11eb-831e-70fc7f0a0e01.png">

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/4965672/120679714-7d6e7a80-c467-11eb-8d1a-201ca997c565.png">

