### PR TITLE
Do not hide Generate Report button

### DIFF
--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -123,7 +123,6 @@ function handleGenerateReport (e) {
     },
     body: JSON.stringify(formData)
   }
-  hideBtn(generateBtn)
   showBtn(spinner)
   window.fetch(url, options)
     .then(response => {
@@ -133,11 +132,11 @@ function handleGenerateReport (e) {
       if (data.status !== 'ok') {
         showAlert(data.error_messages)
         enableBtn(generateBtn)
-        showBtn(generateBtn)
         hideBtn(spinner)
         return
       }
       hideBtn(spinner)
+      enableBtn(generateBtn)
       window.open(data.link, '_blank')
     })
     .catch((error) => {

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
       end
 
       describe "'Generate Report' button" do
-        it "has been hidden and disabled" do
-          options = {visible: :hidden}
+        it "has been disabled" do
+          options = {visible: :visible}
 
           expect(page).to have_selector "#btnGenerateReport[disabled]", **options
         end

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe "case_court_reports/index", :disable_bullet, type: :system do
     end
 
     describe "'Generate Report' button" do
-      it "has been hidden and disabled" do
-        options = {visible: :hidden}
+      it "has been disabled" do
+        options = {visible: :visible}
 
         expect(page).to have_selector "#btnGenerateReport[disabled]", **options
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2084

### What changed, and why?
- When you click the 'Generate Report' button on the `/case_court_reports` or `/casa_cases/{id}` pages, it no longer disappears.

### How will this affect user permissions?
It will not affect user permissions.

### How is this tested? (please write tests!) 💖💪
I tweaked two existing system tests

### Screenshots please :)
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/4965672/120873670-1210cf80-c571-11eb-8736-4d44855719f6.png">
