### PR TITLE
[#2121] Fix reset password mail hardcoded image

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -93,18 +93,18 @@
               <tr style="box-sizing: border-box;">
                 <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;" width="70%" valign="middle">
                   <div class="c1144" style="box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px; font-size: 17px; font-weight: 500;text-align: center;color: #fff;">Court
-                    Appointed Special Advocate (CASA) / Prince George's County
+                    Appointed Special Advocate (CASA)
                     <br style="box-sizing: border-box;">
                   </div>
                 </td>
               </tr>
               </tbody>
             </table>
-            <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#fff;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+            <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#00447c;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
               <tbody style="box-sizing: border-box;">
               <tr style="box-sizing: border-box;">
                 <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
-                  <img src="https://user-images.githubusercontent.com/62810851/81514853-1e7f1600-92e6-11ea-8122-2b9faad228b3.jpg" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); width: 50%; font-size: 50px; height: 265px;padding-top:10px;background:#fff;" height="531">
+                  <img src="https://user-images.githubusercontent.com/8918762/120879374-7c813a00-c588-11eb-92d7-efa6fdfdfbf0.png" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); font-size: 50px;padding-top:10px;background:#00447c;">
                 </td>
               </tr>
               </tbody>
@@ -141,7 +141,7 @@
                                           <table border="0" cellspacing="0" cellpadding="0">
                                             <tr>
                                               <td align="left">
-                                                <a href="<%= "#{edit_password_url(@resource, reset_password_token: @token)}" %>" target="_blank" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Reset
+                                                <a href="<%= "#{edit_password_url(@resource, reset_password_token: @token)}" %>" target="_blank" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #00447c; margin: 0; border-color: #00447c; border-style: solid; border-width: 10px 20px;">Reset
                                                   your password</a>
                                               </td>
                                             </tr>
@@ -172,10 +172,8 @@
               </tbody>
             </table>
             <div class="c2577" style="text-align:center;box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px;">
-              <p class="footer-info" style="box-sizing: border-box;">Court Appointed Special Advocate (CASA) / Prince
-                George's County
+              <p class="footer-info" style="box-sizing: border-box;">Court Appointed Special Advocate (CASA)
                 <br style="box-sizing: border-box;">
-                <br style="box-sizing: border-box;">6811 Kenilworth Ave. Suite 402, Riverdale, MD, 20737
               </p>
               <table id="iwvod" style="box-sizing: border-box; height: 150px; margin: 0 auto 10px auto; padding: 5px 5px 5px 5px; width: 100%;" width="100%" height="150">
                 <tbody style="box-sizing: border-box;">

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -1,0 +1,8 @@
+# Preview all emails at http://localhost:3000/rails/mailers/devise_mailer
+# :nocov:
+class DeviseMailerPreview < ActionMailer::Preview
+  def reset_password_instructions
+    Devise::Mailer.reset_password_instructions(User.first, "faketoken")
+  end
+end
+# :nocov:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2121

### What changed, and why?
The "Reset password instructions" email used a hardcoded logo (and text) of Prince George CASA.
It now shows a generic CASA logo and information.
I also added a preview for the reset password mail.

### How will this affect user permissions?
No permissions will be affected.

### How is this tested? (please write tests!) 💖💪
Since this is only a style change, automated tests have not been written.

Manual testing:
- Request password reset
- Receive/preview e-mail, check if the style and displayed information is correct

### Screenshots please :)
How the email looked before the change:
![01-email-before](https://user-images.githubusercontent.com/72531802/121068690-f8ef6500-c7a2-11eb-9b04-0e6c741e4e10.png)

After the change:
![02-email-after](https://user-images.githubusercontent.com/72531802/121068714-fdb41900-c7a2-11eb-9b1f-1bd412816667.png)

