### PR TITLE
[#2115] Allow unsetting judge on a given CASA case

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -52,7 +52,7 @@
                     :judge_id,
                     Judge.for_organization(current_organization),
                     :id, :name,
-                    {include_hidden: false, prompt: t(".prompt.select_judge")},
+                    {include_hidden: false, include_blank: t(".prompt.select_judge")},
                     {class: "form-control"}
                 ) %>
           </div>

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -162,6 +162,48 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       expect(page).to have_text("8-SEP-#{next_year}")
     end
 
+    context "with an available judge" do
+      let!(:judge) { create(:judge, casa_org: casa_org) }
+
+      it "is able to assign a judge to the case when there is no assigned judge", js: true do
+        casa_case.update(judge: nil)
+
+        visit edit_casa_case_path(casa_case)
+
+        expect(page).to have_select("Judge", selected: "-Select Judge-")
+        select judge.name, from: "casa_case_judge_id"
+
+        click_on "Update CASA Case"
+
+        expect(page).to have_select("Judge", selected: judge.name)
+        expect(casa_case.reload.judge).to eq judge
+      end
+
+      it "is able to assign another judge to the case", js: true do
+        visit edit_casa_case_path(casa_case)
+
+        expect(page).to have_select("Judge", selected: casa_case.judge.name)
+        select judge.name, from: "casa_case_judge_id"
+
+        click_on "Update CASA Case"
+
+        expect(page).to have_select("Judge", selected: judge.name)
+        expect(casa_case.reload.judge).to eq judge
+      end
+
+      it "is able to unassign a judge from the case", js: true do
+        visit edit_casa_case_path(casa_case)
+
+        expect(page).to have_select("Judge", selected: casa_case.judge.name)
+        select "-Select Judge-", from: "casa_case_judge_id"
+
+        click_on "Update CASA Case"
+
+        expect(page).to have_select("Judge", selected: "-Select Judge-")
+        expect(casa_case.reload.judge).to be_nil
+      end
+    end
+
     it "will return error message if date fields are not fully selected" do
       visit casa_case_path(casa_case)
       expect(page).to have_text("Court Report Status: Not submitted")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2115

### What changed, and why?
In the edit page of a given CASA case, supervisors and admins can now select a 'blank' judge from the list.

Before that, they couldn't unassign the judge from the case.

### How will this affect user permissions?
Permissions have not been affected.

### How is this tested? (please write tests!) 💖💪
I added some system specs to check if it was possible to assign, change and unassign a judge from a given case.

Manual testing:
- Go to the edit page of any CASA case
- Check if it is possible to assign a judge and click on Update
- Go to the edit page again
- Check if it the judge dropdown menu now shows a "-Select Judge-" option
- Unassign the judge, and check if the judge is truly unassigned

### Screenshots please :)
The "-Select Judge-" option is now available even after assigning a judge to the case.
![screenshot-judge-01](https://user-images.githubusercontent.com/72531802/121195509-0b6eaa80-c846-11eb-8f40-68b40aa2e630.png)
