### PR TITLE
Change header of Edit Case page to include case number

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -3,14 +3,12 @@
     <%= form_with(model: casa_case, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: casa_case %>
 
-      <div class="field form-group">
-        <% if casa_case.new_record? || policy(casa_case).update_case_number? %>
+      <% if casa_case.new_record? || policy(casa_case).update_case_number? %>
+        <div class="field form-group">
           <%= form.label :case_number %>
           <%= form.text_field :case_number, class: "form-control" %>
-        <% else %>
-          <label for="casa_case_case_number">Case number: <%= link_to(casa_case.case_number, casa_case) %></label>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
 
       <h2><%= form.label :court_details %></h2>
 

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t("button.back"), casa_case_path(@casa_case) %>
-<h1><%= t(".title") %></h1>
+<h1><%= t(".title", case_number: link_to(@casa_case.case_number, @casa_case)).html_safe %></h1>
 
 <% if @casa_case.active %>
   <%= render 'form', casa_case: @casa_case %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -98,7 +98,7 @@ en:
         unassign: Unassign Volunteer
         activate: Activate Volunteer
     edit:
-      title: Editing CASA Case
+      title: Editing %{case_number}
       past_court_dates: Past court dates
       no_past_court_dates: No past court dates
     index:

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -12,9 +12,19 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :view do
 
   context "when accessed by a volunteer" do
     let(:user) { build_stubbed(:volunteer, casa_org: organization) }
+    let(:casa_case) { create(:casa_case, casa_org: organization) }
+
+    it "does not allow editing the case number" do
+      assign :casa_case, casa_case
+
+      render template: "casa_cases/edit"
+
+      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}")
+      expect(rendered).to_not have_selector("input[value='#{casa_case.case_number}']")
+    end
 
     it "does not include volunteer assignment" do
-      assign :casa_case, create(:casa_case, casa_org: organization)
+      assign :casa_case, casa_case
 
       render template: "casa_cases/edit"
 
@@ -25,9 +35,19 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :view do
 
   context "when accessed by an admin" do
     let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+    let(:casa_case) { create(:casa_case, casa_org: organization) }
+
+    it "includes an editable case number" do
+      assign :casa_case, casa_case
+
+      render template: "casa_cases/edit"
+
+      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}")
+      expect(rendered).to have_selector("input[value='#{casa_case.case_number}']")
+    end
 
     it "includes volunteer assignment" do
-      assign :casa_case, create(:casa_case, casa_org: organization)
+      assign :casa_case, casa_case
 
       render template: "casa_cases/edit"
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2117

### What changed, and why?
- Changed the header on the Edit Casa Case page to include the case number
- Removed the `Case Number` label from volunteers and supervisor views of this page

### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
Added two tests in `spec/views/edit.html.erb_spec.rb

### Screenshots please :)
<img width="1368" alt="image" src="https://user-images.githubusercontent.com/4965672/121553249-bca44a80-c9d6-11eb-9839-01d329026edd.png">


