### PR TITLE
Supervisor Importer should generate failure message instead of stacktrace

### DIFF
--- a/app/lib/importers/supervisor_importer.rb
+++ b/app/lib/importers/supervisor_importer.rb
@@ -34,7 +34,7 @@ class SupervisorImporter < FileImporter
         if volunteer.supervisor
           next if volunteer.supervisor == supervisor
 
-          failures << "Volunteer #{volunteer.email} already has a supervisor"
+          raise "Volunteer #{volunteer.email} already has a supervisor"
         else
           supervisor.volunteers << volunteer
         end

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe SupervisorImporter do
         expect(alert[:type]).to eq(:error)
         expect(alert[:message]).to include("Not all rows were imported.")
       end
+
+      context "because the volunteer has already been assigned to a supervisor" do
+        let!(:supervisor_volunteer) { create(:supervisor_volunteer, volunteer: existing_volunteer)}
+
+        it "returns an error message" do
+          alert = SupervisorImporter.new(supervisor_import_data_path, casa_org_id).import_supervisors
+
+          expect(alert[:type]).to eq(:error)
+          expect(alert[:exported_rows]).to include("Volunteer #{existing_volunteer.email} already has a supervisor")
+        end
+      end
     end
   end
 

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SupervisorImporter do
       end
 
       context "because the volunteer has already been assigned to a supervisor" do
-        let!(:supervisor_volunteer) { create(:supervisor_volunteer, volunteer: existing_volunteer)}
+        let!(:supervisor_volunteer) { create(:supervisor_volunteer, volunteer: existing_volunteer) }
 
         it "returns an error message" do
           alert = SupervisorImporter.new(supervisor_import_data_path, casa_org_id).import_supervisors


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2070

### What changed, and why?
- When a volunteer is already assigned to a supervisor, the supervisor importer was generating a file that contained a stack trace instead of a helpful error message. This change fixes that problem, by raising the error so that the parent `FileImporter` can handle the error message appropriately.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
- New test added to `supervisor_importer_spec.rb`

### Screenshots please :)
<img width="804" alt="image" src="https://user-images.githubusercontent.com/4965672/121787547-41849500-cb8c-11eb-97ed-0e2d7318d33d.png">
