### PR TITLE
replaced icon button with text button

### DIFF
--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -42,7 +42,7 @@ body.casa_cases {
     gap: 10px;
   }
 
-  #add-mandate-button, .remove-mandate-button {
+  #add-mandate-button, {
     color: white;
     border: none;
 
@@ -58,15 +58,6 @@ body.casa_cases {
 
     padding: 0.25em 1.5em;
     border-radius: 10px;
-  }
-
-  .remove-mandate-button {
-    background-color: #{$red};
-
-    border-radius: 100%;
-
-    max-width: 30px;
-    max-height: 30px;
   }
 
   .court-mandate-entry {

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -120,9 +120,7 @@
                       {include_blank: 'Set Implementation Status', selected: ff.object.implementation_status},
                       {class: 'implementation-status'}
                   %>
-                  <button type="button" class="remove-mandate-button">
-                    <i class="fa fa-minus" aria-hidden="true"></i>
-                  </button>
+                <button type="button" class="remove-mandate-button btn btn-danger"><%= t("button.delete") %></button>
                 </div>
               <% end %>
             </div>

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
         expect(page).to have_text("Are you sure you want to remove this court mandate? Doing so will delete all records \
 of it unless it was included in a previous court report.")
 
-        click_on "Delete"
+        find("button.swal2-confirm").click
         expect(page).to have_text("Court mandate has been removed.")
         click_on "OK"
         expect(page).to_not have_text(mandate_text)

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
 
         expect(page).to have_text(mandate_text)
 
-        find("i.fa-minus").click
+        find("button.remove-mandate-button").click
         expect(page).to have_text("Are you sure you want to remove this court mandate? Doing so will delete all records \
 of it unless it was included in a previous court report.")
 


### PR DESCRIPTION
### What changed, and why?
Delete case mandate button is text now
![image](https://user-images.githubusercontent.com/8918762/121793511-634e3e00-cbc5-11eb-9b76-9e112a792195.png)
used to look like
![image](https://user-images.githubusercontent.com/8918762/120879299-fc5ad480-c587-11eb-9aae-3099e0f4c7dc.png)