### PR TITLE
Move "Past Court Dates" section and make Create/Update button more obvious

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -3,10 +3,16 @@
     <%= form_with(model: casa_case, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: casa_case %>
 
+      <% if casa_case.active %>
+        <div class="top-page-actions pull-right">
+          <%= form.submit casa_case.persisted? ? t(".button.update") : t(".button.create"), class: "btn btn-primary" %>
+        </div>
+      <% end %>
+
       <% if casa_case.new_record? || policy(casa_case).update_case_number? %>
         <div class="field form-group">
           <%= form.label :case_number %>
-          <%= form.text_field :case_number, class: "form-control" %>
+          <%= form.text_field :case_number, class: "form-control w-25" %>
         </div>
       <% end %>
 
@@ -146,6 +152,10 @@
               <% end %>
             </div>
           <% end %>
+        </div>
+
+        <div class="field form-group">
+          <%= render "past_court_dates", casa_case: @casa_case %>
         </div>
       <% end %>
 

--- a/app/views/casa_cases/_past_court_dates.html.erb
+++ b/app/views/casa_cases/_past_court_dates.html.erb
@@ -1,0 +1,23 @@
+<label><%= t(".past_court_dates") %>:</label>
+<% if casa_case.past_court_dates.size > 0 %>
+  <ul>
+    <% casa_case.past_court_dates.each do |pcd| %>
+      <p>
+        <% if pcd.additional_info? %>
+          <%= link_to pcd.decorate.formatted_date,
+              casa_case_past_court_date_path(casa_case, pcd) %>
+        <% else %>
+          <%= pcd.decorate.formatted_date %>
+        <% end %>
+
+        <% if report = pcd.latest_associated_report %>
+          <%= link_to rails_blob_path(report, disposition: 'attachment') do %>
+            (<%= t(".label.attached_report") %>)
+          <% end %>
+        <% end %>
+      </p>
+    <% end %>
+  </ul>
+<% else %>
+  <%= t(".no_past_court_dates") %>
+<% end %>

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -7,34 +7,6 @@
   <%= render 'inactive_case', casa_case: @casa_case %>
 <% end %>
 
-<div class="card card-container">
-  <div class="card-body">
-    <h6><strong><%= t(".past_court_dates") %>:</strong></h6>
-    <% if @casa_case.past_court_dates.size > 0 %>
-      <ul>
-        <% @casa_case.past_court_dates.each do |pcd| %>
-          <p>
-            <% if pcd.additional_info? %>
-              <%= link_to pcd.decorate.formatted_date,
-                  casa_case_past_court_date_path(@casa_case, pcd) %>
-            <% else %>
-              <%= pcd.decorate.formatted_date %>
-            <% end %>
-
-            <% if report = pcd.latest_associated_report %>
-              <%= link_to rails_blob_path(report, disposition: 'attachment') do %>
-                (<%= t(".label.attached_report") %>)
-              <% end %>
-            <% end %>
-          </p>
-        <% end %>
-      </ul>
-    <% else %>
-      <%= t(".no_past_court_dates") %>
-    <% end %>
-  </div>
-</div>
-
 <% if Pundit.policy(current_user, @casa_case).assign_volunteers? %>
   <%= render "volunteer_assignment" %>
 <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -92,6 +92,8 @@
       <% end %>
     <% end %>
 
+    <%= render "past_court_dates", casa_case: @casa_case %>
+
     <div>
       <h6><strong><%= t(".assigned_volunteers") %>:</strong></h6>
       <% policy_scope(@casa_case.assigned_volunteers).each_with_index do |volunteer, index| %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -78,6 +78,8 @@ en:
       court_mandate_privacy_warning: Please check that you didn't enter any youth names
     inactive_case:
       notice: Case was deactivated on
+    no_past_court_dates: No past court dates
+    past_court_dates: Past court dates
     volunteer_assignment:
       title: Manage Volunteers
       assigned_volunteers: Assigned Volunteers
@@ -99,8 +101,6 @@ en:
         activate: Activate Volunteer
     edit:
       title: Editing %{case_number}
-      past_court_dates: Past court dates
-      no_past_court_dates: No past court dates
     index:
       pick_displayed_columns: Pick displayed columns
       own_case: My <%= "Case".pluralize(%{count}) %>

--- a/spec/support/shared_examples/shows_past_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_past_court_dates_links.rb
@@ -1,0 +1,22 @@
+shared_examples_for "shows past court dates links" do
+  let(:past_court_date_with_details) do
+    create(:past_court_date, :with_court_details, casa_case: casa_case, date: Time.zone.yesterday)
+  end
+
+  let(:past_court_date_without_details) do
+    create(:past_court_date, casa_case: casa_case, date: Time.zone.today)
+  end
+
+  let!(:formatted_date_with_details) { I18n.l(past_court_date_with_details.date, format: :full, default: nil) }
+  let!(:formatted_date_without_details) { I18n.l(past_court_date_without_details.date, format: :full, default: nil) }
+
+  it "shows court mandates" do
+    visit edit_casa_case_path(casa_case)
+
+    expect(page).to have_text(formatted_date_with_details)
+    expect(page).to have_link(formatted_date_with_details)
+
+    expect(page).to have_text(formatted_date_without_details)
+    expect(page).not_to have_link(formatted_date_without_details)
+  end
+end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -2,29 +2,6 @@ require "rails_helper"
 require "stringio"
 
 RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
-  shared_examples_for "shows past court dates links" do
-    let(:past_court_date_with_details) do
-      create(:past_court_date, :with_court_details, casa_case: casa_case, date: Time.zone.yesterday)
-    end
-
-    let(:past_court_date_without_details) do
-      create(:past_court_date, casa_case: casa_case, date: Time.zone.today)
-    end
-
-    let!(:formatted_date_with_details) { I18n.l(past_court_date_with_details.date, format: :full, default: nil) }
-    let!(:formatted_date_without_details) { I18n.l(past_court_date_without_details.date, format: :full, default: nil) }
-
-    it "shows court mandates" do
-      visit edit_casa_case_path(casa_case)
-
-      expect(page).to have_text(formatted_date_with_details)
-      expect(page).to have_link(formatted_date_with_details)
-
-      expect(page).to have_text(formatted_date_without_details)
-      expect(page).not_to have_link(formatted_date_without_details)
-    end
-  end
-
   context "when admin" do
     let(:organization) { create(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
@@ -65,7 +42,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       page.find("#add-mandate-button").click
       find("#mandates-list-container").first("textarea").send_keys("Court Mandate Text One")
 
-      click_on "Update CASA Case"
+      within ".top-page-actions" do
+        click_on "Update CASA Case"
+      end
       expect(page).to have_text("Submitted")
       expect(page).to have_text("Court Date")
       expect(page).to have_text("Court Report Due Date")
@@ -141,7 +120,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
 
       expect(page).to have_text("Set Implementation Status")
 
-      click_on "Update CASA Case"
+      within ".actions" do
+        click_on "Update CASA Case"
+      end
       has_checked_field? "Youth"
       has_no_checked_field? "Supervisor"
 
@@ -173,7 +154,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
         expect(page).to have_select("Judge", selected: "-Select Judge-")
         select judge.name, from: "casa_case_judge_id"
 
-        click_on "Update CASA Case"
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
 
         expect(page).to have_select("Judge", selected: judge.name)
         expect(casa_case.reload.judge).to eq judge
@@ -185,7 +168,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
         expect(page).to have_select("Judge", selected: casa_case.judge.name)
         select judge.name, from: "casa_case_judge_id"
 
-        click_on "Update CASA Case"
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
 
         expect(page).to have_select("Judge", selected: judge.name)
         expect(casa_case.reload.judge).to eq judge
@@ -197,7 +182,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
         expect(page).to have_select("Judge", selected: casa_case.judge.name)
         select "-Select Judge-", from: "casa_case_judge_id"
 
-        click_on "Update CASA Case"
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
 
         expect(page).to have_select("Judge", selected: "-Select Judge-")
         expect(casa_case.reload.judge).to be_nil
@@ -212,7 +199,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       select "November", from: "casa_case_court_date_2i"
       select "April", from: "casa_case_court_report_due_date_2i"
 
-      click_on "Update CASA Case"
+      within ".actions" do
+        click_on "Update CASA Case"
+      end
 
       expect(page).to have_text("Court date was not a valid date.")
       expect(page).to have_text("Court report due date was not a valid date.")
@@ -231,7 +220,9 @@ RSpec.describe "casa_cases/edit", :disable_bullet, type: :system do
       select "April", from: "casa_case_court_report_due_date_2i"
       select next_year, from: "casa_case_court_report_due_date_1i"
 
-      click_on "Update CASA Case"
+      within ".actions" do
+        click_on "Update CASA Case"
+      end
 
       expect(page).to have_text("Court date was not a valid date.")
       expect(page).to have_text("Court report due date was not a valid date.")
@@ -412,7 +403,9 @@ of it unless it was included in a previous court report.")
         click_on "OK"
         expect(page).to_not have_text(mandate_text)
 
-        click_on "Update CASA Case"
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
         expect(page).to_not have_text(mandate_text)
       end
     end
@@ -476,7 +469,9 @@ of it unless it was included in a previous court report.")
       expect(page).to_not have_select("Judge")
 
       select "Submitted", from: "casa_case_court_report_status"
-      click_on "Update CASA Case"
+      within ".actions" do
+        click_on "Update CASA Case"
+      end
 
       click_on "Back"
 
@@ -488,7 +483,9 @@ of it unless it was included in a previous court report.")
       expect(page).to have_text("Court Report Status: Not submitted")
       visit edit_casa_case_path(casa_case)
       select "Submitted", from: "casa_case_court_report_status"
-      click_on "Update CASA Case"
+      within ".actions" do
+        click_on "Update CASA Case"
+      end
 
       expect(page).not_to have_text("Day")
       expect(page).not_to have_text("Month")

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe "casa_cases/new", :disable_bullet, type: :system do
 
         select "Submitted", from: "casa_case_court_report_status"
 
-        click_on "Create CASA Case"
+        within ".top-page-actions" do
+          click_on "Create CASA Case"
+        end
 
         expect(page.body).to have_content(case_number)
         expect(page).to have_content("CASA case was successfully created.")
@@ -46,7 +48,9 @@ RSpec.describe "casa_cases/new", :disable_bullet, type: :system do
   context "when non-mandatory fields are not filled" do
     it "is successful" do
       fill_in "Case number", with: case_number
-      click_on "Create CASA Case"
+      within ".actions" do
+        click_on "Create CASA Case"
+      end
 
       expect(page.body).to have_content(case_number)
       expect(page).to have_content("CASA case was successfully created.")
@@ -58,7 +62,9 @@ RSpec.describe "casa_cases/new", :disable_bullet, type: :system do
 
   context "when the case number field is not filled" do
     it "does not create a new case" do
-      click_on "Create CASA Case"
+      within ".actions" do
+        click_on "Create CASA Case"
+      end
 
       expect(page).to have_current_path(casa_cases_path, ignore_query: true)
       expect(page).to have_content("Case number can't be blank")
@@ -70,7 +76,9 @@ RSpec.describe "casa_cases/new", :disable_bullet, type: :system do
 
     it "does not create a new case" do
       fill_in "Case number", with: case_number
-      click_on "Create CASA Case"
+      within ".actions" do
+        click_on "Create CASA Case"
+      end
 
       expect(page).to have_current_path(casa_cases_path, ignore_query: true)
       expect(page).to have_content("Case number has already been taken")

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
   context "when admin" do
     let(:user) { admin }
 
+    it_behaves_like "shows past court dates links"
+
     it "can see case creator in table" do
       expect(page).to have_text("Bob Loblaw")
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2116 

### What changed, and why?
- On the casa_cases/edit page, moved the Past Court Dates section into the Court Details section
- On the casa_cases/edit page, added an Update/Create button to the top of the page (did not remove this button from the bottom of the page)
- On the casa_cases/show page, added a Past Court Dates section

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
- Updated existing tests
- Added a test for the past court dates section on the casa_cases/show page

### Screenshots please :)
**Show page**
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/4965672/122122330-49457300-cdf2-11eb-9252-c03ce909db72.png">

**Edit page**
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/4965672/122122420-64b07e00-cdf2-11eb-997c-acfd803b075e.png">

