### PR TITLE
Refactor inline styles out of application layout

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "shared/sidebar";
 @import "shared/typography";
 @import "shared/utilities";
+@import "shared/noscript";
 
 @import "pages/casa_cases";
 @import "pages/case_contacts";

--- a/app/javascript/src/stylesheets/shared/noscript.css
+++ b/app/javascript/src/stylesheets/shared/noscript.css
@@ -1,0 +1,9 @@
+noscript div {
+  color: #b71c1c;
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #eee;
+  padding: 0 1em;
+  z-index: 99;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 </head>
 <body class="<%= body_class %>">
   <noscript>
-    <div style="color: #b71c1c; position:fixed; left: 50%; transform: translateX(-50%); background: #eee; padding: 0 1em;">
+    <div>
       <h2>
         <%= t(".javascript_instrucion.enable") %>
       </h2>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2106

### What changed, and why?
In order to move the inline styles from the application layout to a stylesheet, I needed webpacker to extract css files into the `public` folder since all of these files were not accessible within the `noscript` tag (i.e. without Javascript).

Now that the styles are available without Javascript, the site looks a lot better if a user navigates to the site with Javascript disabled, but they will still see a warning message on every page that Javascript is required (see screenshots below).

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Existing tests

### Screenshots please :)
**Before**
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/4965672/122247135-c45b6780-ce8c-11eb-91f1-8fbe34f69ba8.png">

**After**
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/4965672/122246975-9d9d3100-ce8c-11eb-86eb-0da148afb00b.png">
