### PR TITLE
Refactor inline styles for casa_admin_mailer/account_setup

### DIFF
--- a/app/views/casa_admin_mailer/account_setup.html.erb
+++ b/app/views/casa_admin_mailer/account_setup.html.erb
@@ -1,22 +1,49 @@
-<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+<style>
+  meta, .account-setup body, .account-setup tr, .account-setup td, .account-setup a {
+    font-family: Helvetica,Arial,sans-serif;
+    box-sizing: border-box;
+    font-size: 14px;
+    margin: 0;
+  }
+  .account-setup td {
+    padding: 0 0 20px;
+  }
+  .account-setup a {
+    color: #FFF;
+    text-decoration: none;
+    line-height: 2em;
+    font-weight: bold;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    border-radius: 5px;
+    text-transform: capitalize;
+    background-color: #348eda;
+    border-color: #348eda;
+    border-style: solid;
+    border-width: 10px 20px;
+  }
+</style>
+<meta itemprop="name" content="Confirm Email">
+<table class="account-setup" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td class="content-block" valign="top">
       A <%= @casa_organization.display_name %>’s County Admin account has been created for you. Your console account is
       associated with this email. If this is not the correct email to use, please stop here and contact an administrator
       at PG CASA.
     </td>
   </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+  <tr>
+    <td class="content-block" valign="top">
       If you are ready to get started, please set your password. This is the first step to accessing your new volunteer
       account.
     </td>
   </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      <a href="<%= "#{edit_password_url(@user, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Set
-        Your Password</a>
+  <tr>
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" valign="top">
+      <a href="<%= "#{edit_password_url(@user, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url">
+        Set Your Password
+      </a>
     </td>
   </tr>
 </table>

--- a/app/views/casa_admin_mailer/account_setup.html.erb
+++ b/app/views/casa_admin_mailer/account_setup.html.erb
@@ -5,8 +5,14 @@
     font-size: 14px;
     margin: 0;
   }
+  .account-setup table {
+    width: 100%;
+  }
   .account-setup td {
     padding: 0 0 20px;
+    border-spacing: 0;
+    border-collapse: separate;
+    vertical-align: top;
   }
   .account-setup a {
     color: #FFF;
@@ -25,22 +31,22 @@
   }
 </style>
 <meta itemprop="name" content="Confirm Email">
-<table class="account-setup" width="100%" cellpadding="0" cellspacing="0">
+<table class="account-setup">
   <tr>
-    <td class="content-block" valign="top">
+    <td class="content-block">
       A <%= @casa_organization.display_name %>’s County Admin account has been created for you. Your console account is
       associated with this email. If this is not the correct email to use, please stop here and contact an administrator
       at PG CASA.
     </td>
   </tr>
   <tr>
-    <td class="content-block" valign="top">
+    <td class="content-block">
       If you are ready to get started, please set your password. This is the first step to accessing your new volunteer
       account.
     </td>
   </tr>
   <tr>
-    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" valign="top">
+    <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler">
       <a href="<%= "#{edit_password_url(@user, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url">
         Set Your Password
       </a>

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -1,0 +1,5 @@
+class CasaAdminMailerPreview < ActionMailer::Preview
+  def account_setup
+    CasaAdminMailer.account_setup(CasaAdmin.last)
+  end
+end

--- a/spec/mailers/casa_admin_mailer_spec.rb
+++ b/spec/mailers/casa_admin_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe CasaAdminMailer, type: :mailer do
+  let(:casa_admin) { create(:casa_admin) }
+
+  describe ".account_setup" do
+    let(:mail) { CasaAdminMailer.account_setup(casa_admin) }
+
+    it "sends an email saying the account has been created" do
+      expect(mail.body.encoded).to match("A #{casa_admin.casa_org.display_name}’s County Admin account")
+      expect(mail.body.encoded).to match("has been created for you")
+    end
+
+    it "generates a password reset token and sends email" do
+      expect(casa_admin.reset_password_token).to be_nil
+      expect(casa_admin.reset_password_sent_at).to be_nil
+      expect(mail.body.encoded.squish).to match("Set Your Password")
+      expect(casa_admin.reset_password_token).to_not be_nil
+      expect(casa_admin.reset_password_sent_at).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2154

### What changed, and why?
- Refactored inline styles into one `<style>` tag
- Add mailer preview for `CasaAdminMailer`
- Add mailer test for `CasaAdminMailer`

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
`spec/mailers/casa_admin_mailer_spec.rb`

### Screenshots please :)
<img width="433" alt="image" src="https://user-images.githubusercontent.com/4965672/122598679-c52dfe00-d032-11eb-9934-f8434c18ea27.png">
