### PR TITLE
Renames "Generate Reports" menu entry

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -46,7 +46,7 @@
             <%= link_to t(".link.generate_court_reports"), case_court_reports_path, class: "list-group-item" %>
           <% end %>
           <% if policy(:application).see_reports_page? %>
-            <%= link_to t(".link.generate_reports"), reports_path, class: "list-group-item" %>
+            <%= link_to t(".link.export_data"), reports_path, class: "list-group-item" %>
           <% end %>
           <% if policy(:application).see_import_page? %>
             <%= link_to t(".link.system_imports"), imports_path, class: "list-group-item" %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -333,7 +333,7 @@ en:
       link:
         edit_profile: Edit Profile
         generate_court_reports: Generate Court Reports
-        generate_reports: Generate Reports
+        export_data: Export Data
         system_imports: System Imports
         edit_organization: Edit Organization
         report_site_issue: Report a site issue

--- a/public/404.html
+++ b/public/404.html
@@ -20,7 +20,6 @@
       height: 80px;
       justify-content: flex-start;
       padding: 16px;
-      width: 100vw;
       display: flex;
       flex-direction: row;
       font-size: 48px;

--- a/public/404.html
+++ b/public/404.html
@@ -4,64 +4,88 @@
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+    .rails-default-error-page {
+      background-color: #EFEFEF;
+      color: #2E2F30;
+      text-align: center;
+      font-family: arial, sans-serif;
+      margin: 0;
+    }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+    .rails-default-error-page .header {
+      color: #fff;
+      background: #00447c;
+      background-color: rgb(0, 68, 124);
+      box-shadow: 0 0 4px 4px rgb(0 0 0 / 28%);
+      height: 80px;
+      justify-content: flex-start;
+      padding: 16px;
+      width: 100vw;
+      display: flex;
+      flex-direction: row;
+      font-size: 48px;
+      align-items: center;
+      font-weight: bolder;
+    }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+    .rails-default-error-page div.dialog {
+      width: 95%;
+      max-width: 33em;
+      margin: 15em auto;
+    }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+    .rails-default-error-page div.dialog > div {
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-left-color: #999;
+      border-bottom-color: #BBB;
+      border-top: #103862 solid 4px;
+      border-radius: 9px;
+      background-color: white;
+      padding: 7px 12% 0;
+      box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      height: 150px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+    .rails-default-error-page h1 {
+      font-size: 100%;
+      color: #103862;
+      line-height: 1.5em;
+    }
+
+    .rails-default-error-page .footer {
+      color: #fff;
+      padding: 2rem 0;
+      text-align: center;
+      background-color: #00447c;
+      bottom: 0;
+      position: fixed;
+      width: 100vw;
+    }
   </style>
 </head>
 
 <body class="rails-default-error-page">
   <!-- This file lives in public/404.html -->
+  <div class="header">
+    CASA/Volunteer Tracking
+  </div>
+
   <div class="dialog">
     <div>
       <h1>The page you were looking for doesn't exist.</h1>
       <p>You may have mistyped the address or the page may have moved.</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+
+  <div class="footer">
+    <p class="copyright">
+      &#169 CASA / Volunteer Tracking
+      </class>
   </div>
 </body>
+
 </html>

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
   end
@@ -71,6 +72,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Generate Court Report", href: "/case_court_reports")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
+      expect(rendered).to_not have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
@@ -144,6 +146,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2125

### What changed, and why?
Changed translation for menu entry "Generates Report" to "Export Data".


### How will this affect user permissions?
Does not affect.

### How is this tested? (please write tests!) 💖💪
Added some tests expecting to find the correct menu entry.

### Screenshots please :)
* Supervisor:

![Screenshot from 2021-06-18 16-00-19](https://user-images.githubusercontent.com/61836657/122607166-8b6bf000-d050-11eb-85ed-25a80c1419b0.png)

* Admin:

![Screenshot from 2021-06-18 16-00-59](https://user-images.githubusercontent.com/61836657/122607191-96268500-d050-11eb-92d3-bcacb2ad7a22.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
