### PR TITLE
Renames "Generate Report" menu entry

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -46,7 +46,7 @@
             <%= link_to t(".link.generate_court_reports"), case_court_reports_path, class: "list-group-item" %>
           <% end %>
           <% if policy(:application).see_reports_page? %>
-            <%= link_to t(".link.generate_reports"), reports_path, class: "list-group-item" %>
+            <%= link_to t(".link.export_data"), reports_path, class: "list-group-item" %>
           <% end %>
           <% if policy(:application).see_import_page? %>
             <%= link_to t(".link.system_imports"), imports_path, class: "list-group-item" %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -333,7 +333,7 @@ en:
       link:
         edit_profile: Edit Profile
         generate_court_reports: Generate Court Reports
-        generate_reports: Generate Reports
+        export_data: Export Data
         system_imports: System Imports
         edit_organization: Edit Organization
         report_site_issue: Report a site issue

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
   end
@@ -71,6 +72,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
       expect(rendered).to have_link("Generate Court Report", href: "/case_court_reports")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
+      expect(rendered).to_not have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
@@ -144,6 +146,7 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Admins", href: "/casa_admins")
       expect(rendered).to have_link("Report a site issue", href: "https://rubyforgood.typeform.com/to/iXY4BubB")
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
+      expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2125 

### What changed, and why?
Changed translation for menu entry "Generates Report" to "Export Data".

### How will this affect user permissions?
Dos not affect

### How is this tested? (please write tests!) 💖💪
Added some tests to expect the exact menu entry.


### Screenshots please :)
* Supervisor:

![Screenshot from 2021-06-18 16-00-19](https://user-images.githubusercontent.com/61836657/122608213-329d5700-d052-11eb-88d7-46bf498060a9.png)

* Admin:

![Screenshot from 2021-06-18 16-00-59](https://user-images.githubusercontent.com/61836657/122608253-40eb7300-d052-11eb-91fb-c807a3ae5727.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
