### PR TITLE
Court report case search option text format change

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -55,8 +55,9 @@ class CasaCaseDecorator < Draper::Decorator
 
   def court_report_select_option
     volunteer_names = object.assigned_volunteers.map(&:display_name).join(",")
+
     [
-      "#{object.case_number} - #{object.has_transitioned? ? "transition" : "non-transition"} #{volunteer_names}",
+      "#{object.case_number} - #{object.has_transitioned? ? "transition" : "non-transition"}(assigned to #{volunteer_names.length > 0 ? volunteer_names : "no one"})",
       object.case_number,
       {
         "data-transitioned": object.has_transitioned?,

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe "case_court_reports/index", :disable_bullet, type: :system do
 
   describe "'Case Number' dropdown list", js: true do
     let(:transitioned_case_number) { casa_cases.find(&:has_transitioned?).case_number.to_s }
-    let(:transitioned_option_text) { "#{transitioned_case_number} - transition Name Last" }
+    let(:transitioned_option_text) { "#{transitioned_case_number} - transition(assigned to Name Last)" }
     let(:non_transitioned_case_number) { casa_cases.reject(&:has_transitioned?).first.case_number.to_s }
-    let(:non_transitioned_option_text) { "#{non_transitioned_case_number} - non-transition Name Last" }
+    let(:non_transitioned_option_text) { "#{non_transitioned_case_number} - non-transition(assigned to Name Last)" }
 
     it "has transition case option selected" do
       page.select transitioned_option_text, from: "case-selection"


### PR DESCRIPTION
### What changed, and why?
The text in the dropdown for cases on the generate court reports page specifies the name is the assigned volunteers or lack thereof

#### Previous
![image](https://user-images.githubusercontent.com/8918762/122631712-24235f80-d093-11eb-8fa7-3c79de2ef835.png)
#### New
![image](https://user-images.githubusercontent.com/8918762/122631678-e58da500-d092-11eb-9eb3-8d88890b7968.png)