### PR TITLE
[#2150] Restrict case court report searching to admins and supervisors

### DIFF
--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -13,12 +13,18 @@
       <div class="field form-group">
         <%= label_tag :case_number, t(".label.case_number") %>
         <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
+
+        <% show_search = !current_user.volunteer? %>
+
+        <% select_case_prompt = show_search ? t(".prompt.search_case_number") : t(".prompt.select_case_number") %>
+        <% select2_class = show_search ? "select2" : "" %>
+
         <%= select_tag :case_number,
                        options_for_select(select_options),
-                       prompt: t(".prompt.select_case_number"),
+                       prompt: select_case_prompt,
                        include_blank: false,
                        id: "case-selection",
-                       class: "custom-select select2" %>
+                       class: "custom-select #{select2_class}" %>
 
       </div>
       <div class="form-group">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -179,7 +179,8 @@ en:
       label:
         case_number: "Case Number:"
       prompt:
-        select_case_number: Search by volunteer name or case number
+        select_case_number: Select case number
+        search_case_number: Search by volunteer name or case number
       button:
         generate: Generate Report
         download: Download Court Report

--- a/cypress/integration/volunteer/generate_court_report.spec.js
+++ b/cypress/integration/volunteer/generate_court_report.spec.js
@@ -8,10 +8,12 @@ context("Logging into cypress as a volunteer", () => {
   it("should generate a court report", () => {
     cy.get("#toggle-sidebar-js").click();
     cy.contains("Generate Court Reports").click();
-    // Pick the first option from the case selection dropdown
-    cy.get('#case-selection')
-      .find('option').then(elements => {
-        const option = elements[1].getAttribute('value');
+
+    // Pick the first non-blank option from the case selection dropdown
+    cy.get("#case-selection option")
+      .eq(2)
+      .then(element => {
+        const option = element.val()
         cy.get('#case-selection').select(option, {force: true});
 
         cy.contains("Generate Report").click();


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2150

### What changed, and why?
In the "Generate Court Reports" page, volunteers now can't search for a specific case, only select from a dropdown menu.

### How will this affect user permissions?
No permissions have been affected internally.

### How is this tested? (please write tests!) 💖💪
I wrote system specs to check if the volunteers/supervisors could see the search menu and interact with it.

### Screenshots please :)
Supervisor view:
![image](https://user-images.githubusercontent.com/72531802/122790210-78defa00-d28e-11eb-9f62-bbb8f585b18e.png)

Volunteer view:
![image](https://user-images.githubusercontent.com/72531802/122790335-9a3fe600-d28e-11eb-91ba-0259894cfc5e.png)

