### PR TITLE
[#2142] Make it possible to unset hearing type for a case

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -42,7 +42,7 @@
                   :hearing_type_id,
                   HearingType.active.for_organization(current_organization),
                   :id, :name,
-                  {include_hidden: false, prompt: t(".prompt.select_hearing_type")},
+                  {include_hidden: false, include_blank: t(".prompt.select_hearing_type")},
                   {class: "form-control"}
               ) %>
         </div>

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -409,6 +409,61 @@ of it unless it was included in a previous court report.")
         expect(page).to_not have_text(mandate_text)
       end
     end
+
+    context "with an available hearing type", js: true do
+      let!(:hearing_type) { create(:hearing_type, casa_org: casa_org) }
+
+      it "is able to assign a hearing type when there is none assigned" do
+        casa_case.update(hearing_type: nil)
+
+        visit edit_casa_case_path(casa_case.id)
+
+        expect(page).to have_select("Hearing type",
+          selected: I18n.t('casa_cases.form.prompt.select_hearing_type'))
+        select hearing_type.name, from: "casa_case_hearing_type_id"
+
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
+
+        expect(page).to have_select("Hearing type", selected: hearing_type.name)
+        expect(casa_case.reload.hearing_type).to eq hearing_type
+      end
+
+      it "is able to assign another hearing type to the case" do
+        visit edit_casa_case_path(casa_case.id)
+
+        case_hearing = casa_case.hearing_type
+        expect(page).to have_select("Hearing type", selected: case_hearing.name)
+        select hearing_type.name, from: "casa_case_hearing_type_id"
+
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
+
+        expect(page).to have_select("Hearing type", selected: hearing_type.name)
+        expect(casa_case.reload.hearing_type).to eq hearing_type
+      end
+
+      it "is able to unassign a hearing type from the case" do
+        expect(casa_case.hearing_type).not_to be_nil
+
+        visit edit_casa_case_path(casa_case.id)
+
+        expect(page).to have_select("Hearing type",
+          selected: casa_case.hearing_type.name)
+        select(I18n.t('casa_cases.form.prompt.select_hearing_type'),
+          from: "casa_case_hearing_type_id")
+
+        within ".actions" do
+          click_on "Update CASA Case"
+        end
+
+        expect(page).to have_select("Hearing type",
+          selected: I18n.t('casa_cases.form.prompt.select_hearing_type'))
+        expect(casa_case.reload.hearing_type).to be_nil
+      end
+    end
   end
 
   context "logged in as volunteer" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2142 

### What changed, and why?
* Included empty value in select tag to allow unsetting the current selection.
* Empty value is only selected when hearing type is unset on CASA case.
* When CASA case has a hearing type, selecting the empty value will unset it.

### How will this affect user permissions?
No permissions have been affected internally.

### How is this tested? (please write tests!) 💖💪
 I wrote system specs to check if the supervisors could set/unset the field

### Screenshots please :)
With Hearing Type unset
![Captura de pantalla de 2021-06-23 19-45-44](https://user-images.githubusercontent.com/18152266/123177491-e5b3e900-d474-11eb-9289-e39a058dd0e3.png)

With Hearing type set
![Captura de pantalla de 2021-06-23 19-45-23](https://user-images.githubusercontent.com/18152266/123177499-e9e00680-d474-11eb-940a-0347f8b29337.png)


