### PR TITLE
Refactor inline CSS into a <style> element in deactivation mail

### DIFF
--- a/app/views/casa_admin_mailer/deactivation.html.erb
+++ b/app/views/casa_admin_mailer/deactivation.html.erb
@@ -1,17 +1,45 @@
-<meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-<table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+<style>
+  #table {
+    width: 100%;
+    border-spacing: 0;
+    font-family: Helvetica,Arial,sans-serif;
+    box-sizing: border-box;
+    font-size: 120px;
+    margin: 0;
+  }
+
+    #table tbody tr {
+    font-family: Helvetica,Arial,sans-serif;
+    box-sizing: border-box;
+    font-size: 14px;
+    margin: 0;
+  }
+  
+  .content-block {
+    font-family: Helvetica,Arial,sans-serif;
+    box-sizing: border-box;
+    font-size: 14px;
+    vertical-align: top;
+    margin: 0;
+    padding: 0 0 20px;
+  }
+
+</style>
+
+<meta itemprop="name" content="Confirm Email">
+<table id="table">
+  <tr id="tr">
+    <td class="content-block">
       Hello <%= @user.display_name %>,
     </td>
   </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+  <tr id="tr">
+    <td class="content-block">
       Your <%= @casa_organization.display_name %>’s Admin account has been deactivated.
     </td>
   </tr>
-  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+  <tr id="tr">
+    <td class="content-block">
       If you have any questions, please contact a <%= @casa_organization.display_name %> administrator for assistance.
     </td>
   </tr>

--- a/app/views/casa_admin_mailer/deactivation.html.erb
+++ b/app/views/casa_admin_mailer/deactivation.html.erb
@@ -1,5 +1,5 @@
 <style>
-  #table {
+  td.card-content {
     width: 100%;
     border-spacing: 0;
     font-family: Helvetica,Arial,sans-serif;
@@ -8,7 +8,7 @@
     margin: 0;
   }
 
-    #table tbody tr {
+  td.card-content tbody tr {
     font-family: Helvetica,Arial,sans-serif;
     box-sizing: border-box;
     font-size: 14px;
@@ -27,18 +27,18 @@
 </style>
 
 <meta itemprop="name" content="Confirm Email">
-<table id="table">
-  <tr id="tr">
+<table>
+  <tr>
     <td class="content-block">
       Hello <%= @user.display_name %>,
     </td>
   </tr>
-  <tr id="tr">
+  <tr>
     <td class="content-block">
       Your <%= @casa_organization.display_name %>’s Admin account has been deactivated.
     </td>
   </tr>
-  <tr id="tr">
+  <tr>
     <td class="content-block">
       If you have any questions, please contact a <%= @casa_organization.display_name %> administrator for assistance.
     </td>

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -7,5 +7,3 @@ class CasaAdminMailerPreview < ActionMailer::Preview
     CasaAdminMailer.deactivation(CasaAdmin.last)
   end
 end
-
-

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -2,4 +2,10 @@ class CasaAdminMailerPreview < ActionMailer::Preview
   def account_setup
     CasaAdminMailer.account_setup(CasaAdmin.last)
   end
+
+  def deactivation
+    CasaAdminMailer.deactivation(CasaAdmin.last)
+  end
 end
+
+


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2155 

### What changed, and why?
Refactored the inline CSS into a <style> element in the deactivation mail.


### How will this affect user permissions?
It will not affect.

### How is this tested? (please write tests!) 💖💪
No changes to be tested, the content continues the same.

### Screenshots please :)
* With inline CSS:
![Screenshot from 2021-06-24 13-13-52](https://user-images.githubusercontent.com/61836657/123306579-d7f37780-d4f7-11eb-9c20-805be259e877.png)


* With <style> tag:
![Screenshot from 2021-06-24 14-08-19](https://user-images.githubusercontent.com/61836657/123306653-f35e8280-d4f7-11eb-923b-b957101c621d.png)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
