### PR TITLE
add display name to sidebar

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -59,6 +59,7 @@
                       class: "list-group-item",
                       target: "_blank" %>
           <li class="list-group-item">
+            <%= current_user.display_name %>
             <%= current_user.email %>
           </li>
         <% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -59,7 +59,7 @@
                       class: "list-group-item",
                       target: "_blank" %>
           <li class="list-group-item">
-            <%= current_user.display_name %>
+            <strong><%= current_user.display_name %></strong>
             <%= current_user.email %>
           </li>
         <% end %>

--- a/spec/system/dashboard/show_spec.rb
+++ b/spec/system/dashboard/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "dashboard/show", :disable_bullet, type: :system do
       create(:case_assignment, volunteer: volunteer, casa_case: casa_case_1)
       create(:case_assignment, volunteer: volunteer, casa_case: casa_case_2)
 
-      visit root_path
+      visit casa_cases_path
       expect(page).to have_text("My Cases")
       expect(page).to have_text(casa_case_1.case_number)
       expect(page).to have_text(casa_case_2.case_number)
@@ -25,16 +25,19 @@ RSpec.describe "dashboard/show", :disable_bullet, type: :system do
       casa_case = create(:casa_case, active: true, casa_org: volunteer.casa_org, case_number: "CINA-1")
       create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
 
-      visit root_path
+      visit casa_cases_path
 
       expect(page).to have_text("Bob Loblaw")
       expect(page).to have_no_link("Bob Loblaw")
+      expect(page).to have_css("td", text: "Bob Loblaw")
+      expect(page).to have_link("Detail View", href: casa_case_path(casa_case.id))
     end
 
     it "displays 'No active cases' when they don't have any assignments", js: true do
-      visit root_path
+      visit casa_cases_path
       expect(page).to have_text("My Cases")
-      expect(page).not_to have_text("Bob Loblaw")
+      expect(page).not_to have_css("td", text: "Bob Loblaw")
+      expect(page).not_to have_text("Detail View")
     end
   end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
     end
+
+    it "renders display name and email" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match user.display_name
+      expect(rendered).to match user.email
+    end
   end
 
   context "when logged in as a volunteer" do
@@ -76,6 +85,15 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
+    end
+
+    it "renders display name and email" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match user.display_name
+      expect(rendered).to match user.email
     end
 
     context "when the volunteer does not have a transitioning case" do
@@ -148,6 +166,15 @@ RSpec.describe "layout/sidebar", :disable_bullet, type: :view do
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
       expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
+    end
+
+    it "renders display name and email" do
+      sign_in user
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match user.display_name
+      expect(rendered).to match user.email
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2186

### What changed, and why?
Added user's display_name to the sidebar above their email to make it feel more personal

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Added test to sidebar view to see if display name and email appear

### Screenshots please :)
![Screen Shot 2021-06-24 at 11 38 31 AM](https://user-images.githubusercontent.com/70556962/123315787-f69a4400-d4e0-11eb-8207-7760ddba5af5.png)
![Screen Shot 2021-06-24 at 11 39 45 AM](https://user-images.githubusercontent.com/70556962/123315799-f8640780-d4e0-11eb-9d69-66631a98e379.png)
![Screen Shot 2021-06-24 at 11 40 07 AM](https://user-images.githubusercontent.com/70556962/123315805-fac66180-d4e0-11eb-9f95-dbf3ba13d5af.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
