### PR TITLE
Logo image in mailer should scale

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -102,9 +102,7 @@
       img.c926 {
         box-sizing: border-box;
         color: rgb(158, 83, 129);
-        width: 50%;
         font-size: 50px;
-        height: 265px;
         padding-top: 10px;
         background:#fff;
       }
@@ -304,7 +302,7 @@
               <tbody>
               <tr>
                 <td class="cell c1776 text-center">
-                  <img src="<%= @casa_organization.org_logo %>" alt="Logo" class="c926" height="531">
+                  <img src="<%= @casa_organization.org_logo %>" alt="Logo" class="c926" height="265" width="260">
                 </td>
               </tr>
               </tbody>

--- a/cypress/integration/volunteer/generate_court_report.spec.js
+++ b/cypress/integration/volunteer/generate_court_report.spec.js
@@ -11,7 +11,7 @@ context("Logging into cypress as a volunteer", () => {
 
     // Pick the first non-blank option from the case selection dropdown
     cy.get("#case-selection option")
-      .eq(2)
+      .eq(1)
       .then(element => {
         const option = element.val()
         cy.get('#case-selection').select(option, {force: true});


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1627

### What changed, and why?
- Added height and width to the `img` tag so it could scale properly on smaller screens.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
<img width="256" alt="image" src="https://user-images.githubusercontent.com/4965672/123551509-1e3b1780-d740-11eb-9ff7-0a132f4fb28b.png">


