### PR TITLE
[#2119] Add notes to followups

### DIFF
--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -5,7 +5,7 @@ class CaseContacts::FollowupsController < ApplicationController
     authorize Followup
     case_contact = CaseContact.find(params[:case_contact_id])
 
-    case_contact.followups.create(creator: current_user, status: :requested)
+    case_contact.followups.create(creator: current_user, status: :requested, note: params[:note])
     FollowupNotification
       .with(followup: case_contact.requested_followup, created_by_name: current_user.display_name)
       .deliver(case_contact.creator)

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -120,6 +120,44 @@ window.onload = function () {
     validateDuration()
   }
 }
+
+async function displayFollowupAlert() {
+  const { value: text, isConfirmed } = await fireSwalFollowupAlert();
+
+  if(!isConfirmed) return;
+
+  const params = text ? { note: text } : {}
+  const caseContactId  = this.id.replace('followup-button-', '');
+
+  $.post(
+    `/case_contacts/${caseContactId}/followups`,
+    params,
+    () => location.reload()
+  );
+}
+
+async function fireSwalFollowupAlert() {
+  const inputLabel = 'Optional: Add a note about what followup is needed.'
+
+  return await Swal.fire({
+    input: 'textarea',
+    inputLabel: inputLabel,
+    inputPlaceholder: 'Type your note here...',
+    inputAttributes: { 'aria-label': 'Type your note here' },
+
+    showCancelButton: true,
+    showCloseButton: true,
+
+    confirmButtonText: 'Confirm',
+    confirmButtonColor: '#dc3545',
+
+    customClass: {
+      inputLabel: 'mx-5'
+    }
+  })
+}
+
 $('document').ready(() => {
   $('[data-toggle="tooltip"]').tooltip()
+  $('.followup-button').on('click', displayFollowupAlert)
 })

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -1,3 +1,5 @@
+import Swal from 'sweetalert2'
+
 /* global alert $ */
 window.onload = function () {
   const milesDriven = document.getElementById('case_contact_miles_driven')
@@ -121,22 +123,22 @@ window.onload = function () {
   }
 }
 
-async function displayFollowupAlert() {
-  const { value: text, isConfirmed } = await fireSwalFollowupAlert();
+async function displayFollowupAlert () {
+  const { value: text, isConfirmed } = await fireSwalFollowupAlert()
 
-  if(!isConfirmed) return;
+  if (!isConfirmed) return
 
   const params = text ? { note: text } : {}
-  const caseContactId  = this.id.replace('followup-button-', '');
+  const caseContactId = this.id.replace('followup-button-', '')
 
   $.post(
     `/case_contacts/${caseContactId}/followups`,
     params,
-    () => location.reload()
-  );
+    () => window.location.reload()
+  )
 }
 
-async function fireSwalFollowupAlert() {
+async function fireSwalFollowupAlert () {
   const inputLabel = 'Optional: Add a note about what followup is needed.'
 
   return await Swal.fire({

--- a/app/javascript/src/stylesheets/pages/case_contacts.scss
+++ b/app/javascript/src/stylesheets/pages/case_contacts.scss
@@ -30,3 +30,7 @@ legend {
 .dataTables_scrollHeadInner {
   width: 100% !important;
 }
+
+.followup-button {
+  min-width: max-content;
+}

--- a/app/models/followup.rb
+++ b/app/models/followup.rb
@@ -25,6 +25,7 @@ end
 # Table name: followups
 #
 #  id              :bigint           not null, primary key
+#  note            :text
 #  status          :integer          default("requested")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -22,10 +22,30 @@ class FollowupNotification < Noticed::Base
   end
 
   def message
-    t(".message", created_by_name: params[:created_by_name])
+    note = params[:followup][:note]
+
+    note.present? ? message_with_note(note) : message_without_note
   end
 
   def url
     edit_case_contact_path(params[:followup][:case_contact_id], notification_id: record.id)
+  end
+
+  private
+
+  def message_with_note(note)
+    [
+      message_heading,
+      t(".note", note: note),
+      t(".more_info")
+    ].join("\n")
+  end
+
+  def message_without_note
+    [message_heading, t(".more_info")].join(" ")
+  end
+
+  def message_heading
+    t(".message", created_by_name: params[:created_by_name])
   end
 end

--- a/app/views/case_contacts/_followup.html.erb
+++ b/app/views/case_contacts/_followup.html.erb
@@ -9,6 +9,11 @@
   </div>
 <% else %>
   <div class="col-sm-4">
-    <%= button_to t("button.follow_up"), case_contact_followups_path(contact), method: "post", class: "btn btn-danger" %>
+    <button type="button"
+            class="btn btn-danger followup-button"
+            id="followup-button-<%= contact.id %>">
+
+      <%= t("button.follow_up") %>
+    </button>
   </div>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -16,7 +16,9 @@
             <h5 class="mb-1"><%= notification.to_notification.title %></h5>
             <small><%= time_ago_in_words(notification.updated_at) %> ago</small>
           </div>
-          <p class="mb-1"><%= notification.to_notification.message %></p>
+          <div class="my-1">
+            <%= simple_format notification.to_notification.message %>
+          </div>
         </div>
       </div>
     </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,9 @@ en:
       message: "%{created_by_name} resolved a follow up. Click to see more."
     followup_notification:
       title: "New followup"
-      message: "%{created_by_name} has flagged a Case Contact that needs follow up. Click to see more."
+      message: "%{created_by_name} has flagged a Case Contact that needs follow up."
+      note: "Note: \"%{note}\""
+      more_info: "Click to see more."
   button:
     delete: Delete
     undelete: undelete

--- a/db/migrate/20210624125750_add_note_to_followups.rb
+++ b/db/migrate/20210624125750_add_note_to_followups.rb
@@ -1,0 +1,5 @@
+class AddNoteToFollowups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :followups, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_21_194321) do
+ActiveRecord::Schema.define(version: 2021_06_24_125750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(version: 2021_05_21_194321) do
     t.integer "status", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "note"
     t.index ["case_contact_id"], name: "index_followups_on_case_contact_id"
     t.index ["creator_id"], name: "index_followups_on_creator_id"
   end

--- a/spec/requests/followups_spec.rb
+++ b/spec/requests/followups_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "/followups", :disable_bullet, type: :request do
 
       context "no followup exists yet" do
         context "when a note is provided" do
-          let(:params) { { note: "Hello, world!" } }
+          let(:params) { {note: "Hello, world!"} }
 
           it "creates a followup" do
             expect { create_request }.to change(Followup, :count).by(1)
@@ -77,7 +77,7 @@ RSpec.describe "/followups", :disable_bullet, type: :request do
         end
 
         context "when a note is not provided" do
-          let(:params) { { note: nil } }
+          let(:params) { {note: nil} }
 
           it "creates a followup" do
             expect { create_request }.to change(Followup, :count).by(1)

--- a/spec/requests/followups_spec.rb
+++ b/spec/requests/followups_spec.rb
@@ -55,25 +55,62 @@ RSpec.describe "/followups", :disable_bullet, type: :request do
 
   describe "POST /create" do
     context "with valid parameters" do
-      context "no followup exists yet" do
-        it "creates a followup" do
-          sign_in admin
+      subject(:create_request) do
+        post case_contact_followups_path(contact), params: params
+      end
 
-          expect {
-            post case_contact_followups_path(contact)
-          }.to change(Followup, :count).by(1)
+      before { sign_in admin }
+
+      context "no followup exists yet" do
+        context "when a note is provided" do
+          let(:params) { { note: "Hello, world!" } }
+
+          it "creates a followup" do
+            expect { create_request }.to change(Followup, :count).by(1)
+          end
+
+          it "contains a note" do
+            create_request
+
+            expect(Followup.last.note).to eq "Hello, world!"
+          end
+        end
+
+        context "when a note is not provided" do
+          let(:params) { { note: nil } }
+
+          it "creates a followup" do
+            expect { create_request }.to change(Followup, :count).by(1)
+          end
+
+          it "does not contain a note" do
+            create_request
+
+            expect(Followup.last.note).to be_nil
+          end
+        end
+
+        context "when no params are provided" do
+          let(:params) { {} }
+
+          it "creates a followup" do
+            expect { create_request }.to change(Followup, :count).by(1)
+          end
+
+          it "does not contain a note" do
+            create_request
+
+            expect(Followup.last.note).to be_nil
+          end
         end
       end
 
       context "followup exists and is in :requested status" do
         let!(:followup) { create(:followup, case_contact: contact) }
+        let(:params) { {} }
 
         it "should not create another followup" do
-          sign_in admin
-
-          expect {
-            post case_contact_followups_path(contact)
-          }.not_to change(Followup, :count)
+          expect { create_request }.not_to change(Followup, :count)
         end
       end
     end

--- a/spec/system/case_contacts/followups/create_spec.rb
+++ b/spec/system/case_contacts/followups/create_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "followups/create", :disable_bullet, type: :system, js: true do
+  let(:admin) { create(:casa_admin) }
+  let(:case_contact) { create(:case_contact) }
+  let(:note) { "Lorem ipsum dolor sit amet." }
+
+  describe "Creating a followup" do
+    before do
+      sign_in admin
+      visit casa_case_path(case_contact.casa_case)
+
+      click_button "Follow up"
+    end
+
+    it "displays correct prompt" do
+      expect(page).to have_content("Optional: Add a note about what followup is needed.")
+    end
+
+    context "when confirming the Swal alert" do
+      it "creates a followup with a note when the note textarea is filled" do
+        find(".swal2-textarea").set(note)
+
+        click_button "Confirm"
+
+        expect(page).to have_button("Resolve")
+
+        case_contact.followups.reload
+
+        expect(case_contact.followups.count).to eq(1)
+        expect(case_contact.followups.last.note).to eq(note)
+      end
+
+      it "creates a followup without a note when the note textarea is empty" do
+        click_button "Confirm"
+
+        expect(page).to have_button("Resolve")
+
+        case_contact.followups.reload
+
+        expect(case_contact.followups.count).to eq(1)
+        expect(case_contact.followups.last.note).to be_nil
+      end
+    end
+
+    context "when cancelling the Swal alert" do
+      it "does nothing when there is text in the note textarea" do
+        find(".swal2-textarea").set(note)
+
+        click_button "Cancel"
+
+        expect(case_contact.followups.reload.count).to be_zero
+      end
+
+      it "does nothing when there is no text in the note textarea" do
+        click_button "Cancel"
+
+        expect(case_contact.followups.reload.count).to be_zero
+      end
+    end
+
+    context "when closing the Swal alert" do
+      it "does nothing when there is text in the note textarea" do
+        find(".swal2-textarea").set(note)
+
+        find(".swal2-close").click
+
+        expect(case_contact.followups.reload.count).to be_zero
+      end
+
+      it "does nothing when there is no text in the note textarea" do
+        find(".swal2-close").click
+
+        expect(case_contact.followups.reload.count).to be_zero
+      end
+    end
+  end
+end

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -4,39 +4,79 @@ RSpec.describe "notifications/index", :disable_bullet, type: :system do
   let(:admin) { create(:casa_admin) }
   let(:volunteer) { create(:volunteer) }
   let(:case_contact) { create(:case_contact, creator: volunteer) }
+  let(:casa_case) { case_contact.casa_case }
+
+  before { casa_case.assigned_volunteers << volunteer}
 
   context "FollowupResolvedNotification" do
+    let(:notification_message) { "#{volunteer.display_name} resolved a follow up. Click to see more." }
     let!(:followup) { create(:followup, creator: admin, case_contact: case_contact) }
-    it "lists my notifcations" do
-      casa_case = case_contact.casa_case
-      casa_case.assigned_volunteers << volunteer
+
+    it "lists my notifications" do
       sign_in volunteer
+
       visit case_contacts_path
       click_button "Resolve"
 
       sign_in admin
       visit notifications_path
 
-      notification_message = "#{volunteer.display_name} resolved a follow up. Click to see more."
       expect(page).to have_text(notification_message)
       expect(page).to have_text("Followup resolved")
     end
   end
 
-  context "FollowupNotification" do
-    it "lists my notifcations" do
-      casa_case = case_contact.casa_case
-      casa_case.assigned_volunteers << volunteer
+  context "FollowupNotification", js: true do
+    let(:note) { "Lorem ipsum dolor sit amet." }
+
+    let(:notification_message_heading) { "#{admin.display_name} has flagged a Case Contact that needs follow up." }
+    let(:notification_message_more_info) { "Click to see more." }
+
+    let(:inline_notification_message) { "#{notification_message_heading} #{notification_message_more_info}" }
+
+    before do
       sign_in admin
       visit casa_case_path(casa_case)
-      click_button "Follow up"
+    end
 
-      sign_in volunteer
-      visit notifications_path
+    context "when followup has a note" do
+      before do
+        click_button "Follow up"
+        find(".swal2-textarea").set(note)
 
-      notification_message = "#{admin.display_name} has flagged a Case Contact that needs follow up. Click to see more."
-      expect(page).to have_text(notification_message)
-      expect(page).to have_text("New followup")
+        click_button "Confirm"
+      end
+
+      it "lists followup notifications, showing their note" do
+        # Wait until page reloads
+        expect(page).to have_content "Resolve"
+
+        sign_in volunteer
+        visit notifications_path
+
+        expect(page).to have_text(notification_message_heading)
+        expect(page).to have_text(note)
+        expect(page).to have_text(notification_message_more_info)
+        expect(page).to have_text("New followup")
+      end
+    end
+
+    context "when followup doesn't have a note" do
+      before do
+        click_button "Follow up"
+        click_button "Confirm"
+      end
+
+      it "lists followup notifications, showing the information in a single line when there are no notes" do
+        # Wait until page reloads
+        expect(page).to have_content "Resolve"
+
+        sign_in volunteer
+        visit notifications_path
+
+        expect(page).to have_text(inline_notification_message)
+        expect(page).to have_text("New followup")
+      end
     end
   end
 end

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "notifications/index", :disable_bullet, type: :system do
   let(:case_contact) { create(:case_contact, creator: volunteer) }
   let(:casa_case) { case_contact.casa_case }
 
-  before { casa_case.assigned_volunteers << volunteer}
+  before { casa_case.assigned_volunteers << volunteer }
 
   context "FollowupResolvedNotification" do
     let(:notification_message) { "#{volunteer.display_name} resolved a follow up. Click to see more." }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2119

### What changed, and why?
Followups now have a `note` attribute associated with them. Admins, supervisors and volunteers can write an optional note when creating a followup for a given case contact by interacting with a `Swal` alert.

### How will this affect user permissions?
No permissions will be affected. All users that can create followups can add notes to them.

### How is this tested? (please write tests!) 💖💪
#### Manual testing:
- Go a case page or the case contacts page
- Click on the "Followup" button of a given contact
- Check if the close and cancel button are working properly
- Check if adding a followup with and without a note work properly
- Go (as another user) to the notifications page
- Check if the notifications with and without notes display properly

#### Automated testing:
I've added the following specs:
- Request specs to see if the followups are being created properly and accepts the correct parameters
- System specs for the followups, to see if the Swal works properly (confirm, cancel and close button behave as expected)
- System specs for the notifications, to see if followups with and without notes are being displayed properly

### Screenshots please :)
When an user clicks on the "Follow up" button the `Swal` displays the following prompt:
![03-prompt](https://user-images.githubusercontent.com/72531802/123631455-269d5c00-d7ed-11eb-9dfb-24435df192ef.png)

The notifications page now displays followups with and without notes:
![01-notifications](https://user-images.githubusercontent.com/72531802/123631562-43d22a80-d7ed-11eb-9f9b-441efac51314.png)

Mobile view of notifications page:
![02-notifications-mobile](https://user-images.githubusercontent.com/72531802/123631597-4f255600-d7ed-11eb-9ef4-7300abeaee89.png)
