### PR TITLE
Changes "Volunteer Assignments" fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,10 @@ class User < ApplicationRecord
     casa_cases.active.merge(CaseAssignment.active)
   end
 
+  def active_volunteers
+    volunteers.active.size
+  end
+
   # all contacts this user has with this casa case
   def case_contacts_for(casa_case_id)
     found_casa_case = actively_assigned_and_active_cases.find { |cc| cc.id == casa_case_id }

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -28,10 +28,10 @@
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
-          <% total_volunteers = supervisor.volunteers.size %>
-          <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= total_volunteers %>">
+          <% active_volunteers = supervisor.volunteers.active.size %>
+          <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= active_volunteers %>">
             <span class="mobile-label">Volunteer Assignments</span>
-            <%= total_volunteers %>
+            <%= active_volunteers %>
           </td>
 
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -28,7 +28,7 @@
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
-          <% active_volunteers = supervisor.volunteers.active.size %>
+          <% active_volunteers = supervisor.actives_volunteers %>
           <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= active_volunteers %>">
             <span class="mobile-label">Volunteer Assignments</span>
             <%= active_volunteers %>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -28,7 +28,7 @@
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
-          <% active_volunteers = supervisor.actives_volunteers %>
+          <% active_volunteers = supervisor.active_volunteers %>
           <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= active_volunteers %>">
             <span class="mobile-label">Volunteer Assignments</span>
             <%= active_volunteers %>

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -121,4 +121,23 @@ RSpec.describe "supervisors/index", :disable_bullet, type: :system do
       end
     end
   end
+
+  context "with inactive volunteers assigned" do
+    before do
+      volunteer = create(:volunteer, :with_casa_cases, casa_org: organization)
+      FactoryBot.create(:supervisor_volunteer, supervisor: user, volunteer: volunteer)
+
+      inactive_volunteer = create(:volunteer, :inactive, casa_org: organization)
+      FactoryBot.create(:supervisor_volunteer, supervisor: user, volunteer: inactive_volunteer)
+
+      sign_in user
+      visit supervisors_path
+    end
+
+    it "count only active volunteers" do
+      within "td#volunteer-assignments-#{user.id}" do
+        expect(page).to have_content("1")
+      end
+    end
+  end
 end

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe "supervisors/index", :disable_bullet, type: :system do
         [first_supervisor, last_supervisor]
       )
 
-      allow(first_supervisor).to receive(:active).and_return(9)
+      allow(first_supervisor).to receive(:active_volunteers).and_return(9)
       allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
       allow(first_supervisor).to receive(:no_contact_for_two_weeks).and_return(9)
 
-      allow(last_supervisor).to receive(:active).and_return(11)
+      allow(last_supervisor).to receive(:active_volunteers).and_return(11)
       allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
       allow(last_supervisor).to receive(:no_contact_for_two_weeks).and_return(11)
 

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -48,18 +48,17 @@ RSpec.describe "supervisors/index", :disable_bullet, type: :system do
     let!(:last_supervisor) { create(:supervisor, display_name: "Last Supervisor", casa_org: organization) }
 
     before(:each) do
-      # Stub our `@supervisors` collection so we've got control over column values for sorting.
-      allow_any_instance_of(SupervisorPolicy::Scope).to receive(:resolve).and_return(
-        [first_supervisor, last_supervisor]
-      )
+      9.times do
+        volunteer = FactoryBot.create(:volunteer, :with_casa_cases)
+        volunteer.supervisor = first_supervisor
+        volunteer.save
+      end
 
-      allow(first_supervisor).to receive(:volunteers).and_return(Array.new(9))
-      allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
-      allow(first_supervisor).to receive(:no_contact_for_two_weeks).and_return(9)
-
-      allow(last_supervisor).to receive(:volunteers).and_return(Array.new(11))
-      allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
-      allow(last_supervisor).to receive(:no_contact_for_two_weeks).and_return(11)
+      11.times do
+        volunteer = FactoryBot.create(:volunteer, :with_casa_cases)
+        volunteer.supervisor = last_supervisor
+        volunteer.save
+      end
 
       sign_in user
       visit supervisors_path

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -53,11 +53,11 @@ RSpec.describe "supervisors/index", :disable_bullet, type: :system do
         [first_supervisor, last_supervisor]
       )
 
-      allow(first_supervisor).to receive(:volunteers).and_return(Array.new(9))
+      allow(first_supervisor).to receive(:active).and_return(9)
       allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
       allow(first_supervisor).to receive(:no_contact_for_two_weeks).and_return(9)
 
-      allow(last_supervisor).to receive(:volunteers).and_return(Array.new(11))
+      allow(last_supervisor).to receive(:active).and_return(11)
       allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
       allow(last_supervisor).to receive(:no_contact_for_two_weeks).and_return(11)
 

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -48,17 +48,18 @@ RSpec.describe "supervisors/index", :disable_bullet, type: :system do
     let!(:last_supervisor) { create(:supervisor, display_name: "Last Supervisor", casa_org: organization) }
 
     before(:each) do
-      9.times do
-        volunteer = FactoryBot.create(:volunteer, :with_casa_cases)
-        volunteer.supervisor = first_supervisor
-        volunteer.save
-      end
+      # Stub our `@supervisors` collection so we've got control over column values for sorting.
+      allow_any_instance_of(SupervisorPolicy::Scope).to receive(:resolve).and_return(
+        [first_supervisor, last_supervisor]
+      )
 
-      11.times do
-        volunteer = FactoryBot.create(:volunteer, :with_casa_cases)
-        volunteer.supervisor = last_supervisor
-        volunteer.save
-      end
+      allow(first_supervisor).to receive(:volunteers).and_return(Array.new(9))
+      allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
+      allow(first_supervisor).to receive(:no_contact_for_two_weeks).and_return(9)
+
+      allow(last_supervisor).to receive(:volunteers).and_return(Array.new(11))
+      allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
+      allow(last_supervisor).to receive(:no_contact_for_two_weeks).and_return(11)
 
       sign_in user
       visit supervisors_path


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1680

### What changed, and why?
Changed the way the field "Volunteers Assignments" counts, now it only counts active users who are assigned for that supervisor. The field "No contact" is acting the way as intended. So this is a possible cause for the big difference in the fields values.

### How will this affect user permissions?
It will not affect.

### How is this tested? (please write tests!) 💖💪
Has a test that checks for the correct amount of active assigned volunteers.


### Screenshots please :)
* Supervisor "Pablo Treutel" has 4 Volunteers assigned, 1 has no case so it does no count in the "no contacts", 1 has a recent contact and 2 has no recent contacts:
![Screenshot from 2021-06-29 13-35-26](https://user-images.githubusercontent.com/61836657/123851024-1a022c00-d8f1-11eb-839f-df3a629867af.png)

* Supervisor "Pablo Treutel" has 4 Volunteers assigned, 1 is inactive so it does no count in the "no contacts" and "volunteers assignments", 1 has a recent contact and 2 has no recent contacts:
![Screenshot from 2021-06-29 13-35-51](https://user-images.githubusercontent.com/61836657/123851040-21293a00-d8f1-11eb-9a75-352444a54f4c.png)




### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![Confused](https://media.giphy.com/media/3jN3GziOKUEmI/giphy.gif)
