### PR TITLE
[2003] Add workflow to close issues when moved to the 'Done' column

### DIFF
--- a/.github/workflows/issue-auto-close-done.yml
+++ b/.github/workflows/issue-auto-close-done.yml
@@ -1,0 +1,15 @@
+name: 'Close issue when Done'
+
+on:
+  project_card:
+    types: [created, edited, moved]
+
+jobs:
+  set-state:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/issue-states@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          open-issue-columns: ''
+          closed-issue-columns: 'Done'

--- a/.github/workflows/issue-auto-close-done.yml
+++ b/.github/workflows/issue-auto-close-done.yml
@@ -2,7 +2,7 @@ name: 'Close issue when Done'
 
 on:
   project_card:
-    types: [created, edited, moved]
+    types: [moved]
 
 jobs:
   set-state:


### PR DESCRIPTION
When an issue is created, moved or edited in the 'Done' column this workflow will automatically close it. Based on the examples provided from [Issues States](https://github.com/marketplace/actions/issue-states)

### What github issue is this PR for, if any?
Resolves #2003

### What changed, and why?
Added new workflow

### How will this affect user permissions?
No user permission is affected

### How is this tested? (please write tests!) 💖💪
Tested on personal repo [Workflows Test](https://github.com/r-sierra/workflows-test/)
