### PR TITLE
Fix failing system case_contacts test

### DIFF
--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -39,11 +39,9 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
       describe "by date of contact" do
         it "only shows the contacts with the correct date" do
           travel_to Date.new(2021, 1, 2) do
-            case_contacts = [
-                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday - 1),
-                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday),
-                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today)
-            ]
+            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday - 1)
+            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday)
+            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today)
 
             sign_in volunteer
             visit case_contacts_path

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -8,25 +8,27 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
     let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "CINA-1") }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
-    before(:each) do
-      case_contacts
-
-      sign_in volunteer
-      visit case_contacts_path
-    end
-
     context "without filter" do
       let(:case_contacts) { [create(:case_contact, creator: volunteer, casa_case: casa_case)] }
 
       it "can see case creator in card" do
+        case_contacts
+        sign_in volunteer
+        visit case_contacts_path
         expect(page).to have_text("Bob Loblaw")
       end
 
       it "can navigate to edit volunteer page" do
+        case_contacts
+        sign_in volunteer
+        visit case_contacts_path
         expect(page).to have_no_link("Bob Loblaw")
       end
 
       it "displays the contact type groups" do
+        case_contacts
+        sign_in volunteer
+        visit case_contacts_path
         within(".card-title") do
           expect(page).to have_text(case_contacts[0].contact_groups_with_types.keys.first)
         end
@@ -35,25 +37,27 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
 
     describe "filtering case contacts" do
       describe "by date of contact" do
-        let(:case_contacts) do
-          [
-            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday - 1),
-            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday),
-            create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today)
-          ]
-        end
-
         it "only shows the contacts with the correct date" do
-          click_button "Show / Hide"
+          travel_to Date.new(2021, 1, 2) do
+            case_contacts = [
+                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday - 1),
+                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday),
+                create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today)
+            ]
 
-          fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday.to_s
-          fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow.to_s
+            sign_in volunteer
+            visit case_contacts_path
+            click_button "Show / Hide"
 
-          click_button "Filter"
+            fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday.to_s
+            fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow.to_s
 
-          expect(page).not_to have_content I18n.l(case_contacts[0].occurred_at.to_date, format: :long)
-          expect(page).to have_content I18n.l(case_contacts[1].occurred_at.to_date, format: :long)
-          expect(page).to have_content I18n.l(case_contacts[2].occurred_at.to_date, format: :long)
+            click_button "Filter"
+
+            expect(page).not_to have_content "December 31, 2020"
+            expect(page).to have_content "January 1, 2021"
+            expect(page).to have_content "January 2, 2021"
+          end
         end
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
No official issue

### What changed, and why?
In `spec/system/case_contacts/index_spec.rb` the tests were updated to
freeze time to January 2, 2021.
In the previous version of the test, the `expects` were using
`I18n.l(case_contacts[0].occurred_at.to_date, format: :long)` which
caused single digit dates to contain a leading zero and thus fail the
test on the first 9 days of the month.  Freezing time to January 2, 2021
and hard-coding the expected dates ensures that this test won't fail
intermittently in the future.


### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
This is a test update

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![Road Runner](https://media.giphy.com/media/yhRhIgnJIRD0I/giphy.gif)
