### PR TITLE
Fix lint hook

### DIFF
--- a/bin/git_hooks/README.md
+++ b/bin/git_hooks/README.md
@@ -1,4 +1,18 @@
-This folder contains helper scripts for git hooks.
+This folder contains helper scripts for Git hooks.
+
+To create a hook, make a file inside the directory `/.git/hooks` with the name of the hook you want to set up. Do not use a file extension.
+For example, if you want to set up a pre-commit hook, the file should be called `pre-commit`, or if you want a pre-push hook, it should be called `pre-push`.
+
+Once you've created that file, put the appropriate she-bang on the first line:
+```bash
+#!/bin/sh
+```
+followed by the script you want to run and any arguments or flags for that script.
+
+See [Example Hooks](#example-hooks) below for how you might want to set these up.
+You can read more about Git hooks [here](https://git-scm.com/docs/githooks).
+
+## Hook Scripts
 
 ### `update-dependences`  
 Installs dependencies if any are missing  

--- a/bin/git_hooks/lint
+++ b/bin/git_hooks/lint
@@ -57,7 +57,7 @@ if test $rb_changed_count -gt 0; then
     echo "ERROR: Command bundle could not be found"
     exit 1
   else
-    bundle exec standardrb --fix
+    bundle exec standardrb --fix || exit 1
   fi
 fi
 
@@ -70,7 +70,7 @@ if test $erb_changed_count -gt 0; then
     echo "WARNING: Command bundle could not be found"
     exit 1
   else
-    bundle exec erblint --lint-all --autocorrect
+    bundle exec erblint --lint-all --autocorrect || exit 1
   fi
 fi
 

--- a/bin/git_hooks/lint
+++ b/bin/git_hooks/lint
@@ -9,7 +9,13 @@
 #     --all (default)
 #       lints all files in the repo
 
-echo "INFO: Attempting to lint"
+NC="\033[0m" # No Color
+ERROR="\033[0;31mERROR:${NC}" # Red
+WARNING="\033[0;93mWARNING:${NC}" # Bright yellow
+INFO="\033[0;96mINFO:${NC}" # Bright cyan
+OK="\033[0;92mOK${NC}" # Bright Green
+
+echo "${INFO} Attempting to lint"
 
 repo_root="$(git rev-parse --show-toplevel)"
 current_branch="$(git branch --show-current)"
@@ -38,7 +44,7 @@ case $diff_policy in
     ;;
 
   *)
-    echo "ERROR: unknown option $diff_policy"
+    echo "${ERROR} unknown option $diff_policy"
     exit 1
     ;;
 esac
@@ -49,28 +55,36 @@ erb_changed_count=$(echo "$changed_file_list" | grep -c ".erb$")
 lint_time=$(date +%s)
 
 if test $rb_changed_count -gt 0; then
-  echo "INFO: Linting via standardrb"
+  echo "${INFO} Linting via standardrb"
 
   cd $repo_root
 
   if ! [ -x "$(command -v bundle)" ]; then
-    echo "ERROR: Command bundle could not be found"
+    echo "${ERROR} Command bundle could not be found"
     exit 1
   else
-    bundle exec standardrb --fix || exit 1
+    if ! bundle exec standardrb --fix ; then 
+      echo "${ERROR} Standard linting failed, could not fix 1 or more issues"
+      echo "  See above output for more details"
+      exit 1
+    fi
   fi
 fi
 
 if test $erb_changed_count -gt 0; then
-  echo "INFO: Linting via erblint"
+  echo "${INFO} Linting via erblint"
 
   cd $repo_root/app
 
   if ! [ -x "$(command -v bundle)" ]; then
-    echo "WARNING: Command bundle could not be found"
+    echo "${ERROR} Command bundle could not be found"
     exit 1
   else
-    bundle exec erblint --lint-all --autocorrect || exit 1
+    if ! bundle exec erblint --lint-all --autocorrect ; then 
+      echo "${ERROR} ERB Lint linting failed, could not fix 1 or more issues"
+      echo "  See above output for more details"
+      exit 1
+    fi
   fi
 fi
 
@@ -78,10 +92,10 @@ cd $repo_root
 for file in $(git diff --name-only); do
   last_modified_time=$(date -r $file +%s)
   if [ $last_modified_time -ge $lint_time ] ; then
-    echo "INFO: Some files were linted. Please preserve the changes before continuing."
+    echo "${WARNING} Some files were linted. Please preserve the changes before continuing."
     echo "  Run git diff to view linter changes."
     exit 1
   fi
 done
 
-echo "INFO: No files were linted"
+echo "${OK} No files were linted"


### PR DESCRIPTION
### What github issue is this PR for, if any?
No issue

### What changed, and why?
Updates hook so that if the linter cannot
auto-fix the issues, the hook terminates after the linter's error message.

Previously, if there were linting errors that could not be fixed, the
linter would tell you, but the hook would continue and allow the git
action to go forward.
  
### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
🤔 

### Screenshots please :)
Screenshots using `lint` as a pre-commit hook
Before fix:
![image](https://user-images.githubusercontent.com/44326005/124368880-914dfd80-dc1a-11eb-8726-c3d1a3fe0a23.png)


After fix:
![image](https://user-images.githubusercontent.com/44326005/124368857-55b33380-dc1a-11eb-87af-7ae4b0ed6b13.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![hook](https://media.giphy.com/media/9p8hgZoQjj9y8/giphy.gif)
