### PR TITLE
add docker build+tests to CI so we stop breaking it unknowingly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - 'bin/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - 'bin/**'
+
+jobs:
+  rspec:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Run docker build to make sure it works
+        run: |
+          docker-compose build web
+
+      - name: Run tests in docker to make sure they work
+        run: |
+          docker-compose exec web rspec spec


### PR DESCRIPTION
see r4g slack
https://rubyforgood.slack.com/archives/CVB0QJGVD/p1625501851139400
follow-up to https://github.com/rubyforgood/casa/pull/2238 so we will notice faster when we break docker, since so many people use it. Eventually we should remove the rspec build and just do the docker build, but let's have both at once for long enough to make sure that they reliably break at the same time. 