### PR TITLE
Add warnings to email layouts

### DIFF
--- a/app/views/casa_admin_mailer/account_setup.html.erb
+++ b/app/views/casa_admin_mailer/account_setup.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */<style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/casa_admin_mailer/deactivation.html.erb
+++ b/app/views/casa_admin_mailer/deactivation.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */<style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,6 +1,7 @@
 <meta itemprop="name"
       content="Confirm Email"
       style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */<style>
 <table
   width="100%"
   cellpadding="0"

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,148 +1,152 @@
 <!DOCTYPE html>
 <html style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-<head>
-  <meta name="viewport" content="width=device-width">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Actionable emails e.g. reset password</title>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Actionable emails e.g. reset password</title>
+    <style>/* Email styles need to be inline */<style>
+    <style type="text/css">
+        img {
+            max-width: 100%;
+        }
 
-  <style type="text/css">
-      img {
-          max-width: 100%;
-      }
+        body {
+            -webkit-font-smoothing: antialiased;
+            -webkit-text-size-adjust: none;
+            width: 100% !important;
+            height: 100%;
+            line-height: 1.6em;
+        }
 
-      body {
-          -webkit-font-smoothing: antialiased;
-          -webkit-text-size-adjust: none;
-          width: 100% !important;
-          height: 100%;
-          line-height: 1.6em;
-      }
+        body {
+            background-color: #f6f6f6;
+        }
 
-      body {
-          background-color: #f6f6f6;
-      }
+        @media only screen and (max-width: 640px) {
+            body {
+                padding: 0 !important;
+            }
 
-      @media only screen and (max-width: 640px) {
-          body {
-              padding: 0 !important;
-          }
+            h1 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
 
-          h1 {
-              font-weight: 800 !important;
-              margin: 20px 0 5px !important;
-          }
+            h2 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
 
-          h2 {
-              font-weight: 800 !important;
-              margin: 20px 0 5px !important;
-          }
+            h3 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
 
-          h3 {
-              font-weight: 800 !important;
-              margin: 20px 0 5px !important;
-          }
+            h4 {
+                font-weight: 800 !important;
+                margin: 20px 0 5px !important;
+            }
 
-          h4 {
-              font-weight: 800 !important;
-              margin: 20px 0 5px !important;
-          }
+            h1 {
+                font-size: 22px !important;
+            }
 
-          h1 {
-              font-size: 22px !important;
-          }
+            h2 {
+                font-size: 18px !important;
+            }
 
-          h2 {
-              font-size: 18px !important;
-          }
+            h3 {
+                font-size: 16px !important;
+            }
 
-          h3 {
-              font-size: 16px !important;
-          }
+            .container {
+                padding: 0 !important;
+                width: 100% !important;
+            }
 
-          .container {
-              padding: 0 !important;
-              width: 100% !important;
-          }
+            .content {
+                padding: 0 !important;
+            }
 
-          .content {
-              padding: 0 !important;
-          }
+            .content-wrap {
+                padding: 10px !important;
+            }
 
-          .content-wrap {
-              padding: 10px !important;
-          }
+            .invoice {
+                width: 100% !important;
+            }
+        }
+    </style>
+  </head>
 
-          .invoice {
-              width: 100% !important;
-          }
-      }
-  </style>
-</head>
-
-<body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
-<table class="main-body" style="box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; height: 100%; background-color: rgb(234, 236, 237);" width="100%" height="100%" bgcolor="rgb(234, 236, 237)">
-  <tbody style="box-sizing: border-box;">
-  <tr class="row" style="box-sizing: border-box; vertical-align: top;" valign="top">
-    <td class="main-body-cell" style="box-sizing: border-box;">
-      <table class="container" style="box-sizing: border-box; font-family: Helvetica, serif; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-top: auto; margin-right: auto; margin-bottom: auto; margin-left: auto; height: 0px; width: 90%; max-width: 550px;" width="90%" height="0">
-        <tbody style="box-sizing: border-box;">
-        <tr style="box-sizing: border-box;">
-          <td class="container-cell" style="box-sizing: border-box; vertical-align: top; font-size: medium; padding-bottom: 50px;" valign="top">
-            <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#728089;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+    <table class="main-body" style="box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; height: 100%; background-color: rgb(234, 236, 237);" width="100%" height="100%" bgcolor="rgb(234, 236, 237)">
+      <tbody style="box-sizing: border-box;">
+        <tr class="row" style="box-sizing: border-box; vertical-align: top;" valign="top">
+          <td class="main-body-cell" style="box-sizing: border-box;">
+            <table class="container" style="box-sizing: border-box; font-family: Helvetica, serif; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-top: auto; margin-right: auto; margin-bottom: auto; margin-left: auto; height: 0px; width: 90%; max-width: 550px;" width="90%" height="0">
               <tbody style="box-sizing: border-box;">
-              <tr style="box-sizing: border-box;">
-                <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;" width="70%" valign="middle">
-                  <div class="c1144" style="box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px; font-size: 17px; font-weight: 500;text-align: center;color: #fff;">Court
-                    Appointed Special Advocate (CASA)
-                    <br style="box-sizing: border-box;">
-                  </div>
-                </td>
-              </tr>
-              </tbody>
-            </table>
-            <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#00447c;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
-              <tbody style="box-sizing: border-box;">
-              <tr style="box-sizing: border-box;">
-                <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
-                  <img src="https://user-images.githubusercontent.com/8918762/120879374-7c813a00-c588-11eb-92d7-efa6fdfdfbf0.png" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); font-size: 50px;padding-top:10px;background:#00447c;">
-                </td>
-              </tr>
-              </tbody>
-            </table>
-            <table class="card" style="background:#fff;box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-bottom: 20px; height: 0px;" height="0">
-              <tbody style="box-sizing: border-box;">
-              <tr style="box-sizing: border-box;">
-                <td class="card-cell" style="box-sizing: border-box; background-color: rgb(255, 255, 255); overflow-x: hidden; overflow-y: hidden; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px; text-align: center;" bgcolor="rgb(255, 255, 255)" align="center">
-                  <table class="table100 c1357" style="box-sizing: border-box; width: 100%; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; height: 0px; margin-top: 0px; margin-right: 0px; margin-bottom: 0px; margin-left: 0px; border-collapse: collapse;" width="100%" height="0">
-                    <tbody style="box-sizing: border-box;">
-                    <tr style="box-sizing: border-box;">
-                      <td class="card-content" style="box-sizing: border-box; font-size: 13px; line-height: 20px; color: rgb(111, 119, 125); padding-top: 10px; padding-right: 20px; padding-bottom: 0px; padding-left: 20px; vertical-align: top;" valign="top">
-                        <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 530px;">
-                          <tr>
-                            <td>
-                              <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                                <tr>
-                                  <td>
-                                    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr style="box-sizing: border-box;">
+                  <td class="container-cell" style="box-sizing: border-box; vertical-align: top; font-size: medium; padding-bottom: 50px;" valign="top">
+                    <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#728089;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;" width="70%" valign="middle">
+                            <div class="c1144" style="box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px; font-size: 17px; font-weight: 500;text-align: center;color: #fff;">Court Appointed Special Advocate (CASA)
+                              <br style="box-sizing: border-box;">
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="c1766" style="box-sizing: border-box; margin-top: 0px; margin-right: auto; background:#00447c;margin-left: 0px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; min-height: 30px;" width="100%">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
+                            <img src="https://user-images.githubusercontent.com/8918762/120879374-7c813a00-c588-11eb-92d7-efa6fdfdfbf0.png" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); font-size: 50px;padding-top:10px;background:#00447c;">
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="card" style="background:#fff;box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; margin-bottom: 20px; height: 0px;" height="0">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="card-cell" style="box-sizing: border-box; background-color: rgb(255, 255, 255); overflow-x: hidden; overflow-y: hidden; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px; text-align: center;" bgcolor="rgb(255, 255, 255)" align="center">
+                            <table class="table100 c1357" style="box-sizing: border-box; width: 100%; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; height: 0px; margin-top: 0px; margin-right: 0px; margin-bottom: 0px; margin-left: 0px; border-collapse: collapse;" width="100%" height="0">
+                              <tbody style="box-sizing: border-box;">
+                                <tr style="box-sizing: border-box;">
+                                  <td class="card-content" style="box-sizing: border-box; font-size: 13px; line-height: 20px; color: rgb(111, 119, 125); padding-top: 10px; padding-right: 20px; padding-bottom: 0px; padding-left: 20px; vertical-align: top;" valign="top">
+                                    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 530px;">
                                       <tr>
-                                        <td align="left" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" class="padding">
-                                          If you've lost your password or wish to reset it, click the button below. If
-                                          you didn’t request this, you can safely ignore this email.
-                                        </td>
-                                      </tr>
-                                    </table>
-                                  </td>
-                                </tr>
-                                <tr>
-                                  <td align="center">
-                                    <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                                      <tr>
-                                        <td align="center" style="padding-top: 15px;">
-                                          <table border="0" cellspacing="0" cellpadding="0">
+                                        <td>
+                                          <table width="100%" border="0" cellspacing="0" cellpadding="0">
                                             <tr>
-                                              <td align="left">
-                                                <a href="<%= "#{edit_password_url(@resource, reset_password_token: @token)}" %>" target="_blank" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #00447c; margin: 0; border-color: #00447c; border-style: solid; border-width: 10px 20px;">Reset
-                                                  your password</a>
+                                              <td>
+                                                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                                  <tr>
+                                                    <td align="left" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" class="padding">
+                                                      If you've lost your password or wish to reset it, click the button below. If
+                                                      you didn’t request this, you can safely ignore this email.
+                                                    </td>
+                                                  </tr>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td align="center">
+                                                <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                                  <tr>
+                                                    <td align="center" style="padding-top: 15px;">
+                                                      <table border="0" cellspacing="0" cellpadding="0">
+                                                        <tr>
+                                                          <td align="left">
+                                                            <a href="<%= "#{edit_password_url(@resource, reset_password_token: @token)}" %>" target="_blank" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #00447c; margin: 0; border-color: #00447c; border-style: solid; border-width: 10px 20px;">Reset your password</a>
+                                                          </td>
+                                                        </tr>
+                                                      </table>
+                                                    </td>
+                                                  </tr>
+                                                </table>
                                               </td>
                                             </tr>
                                           </table>
@@ -151,38 +155,32 @@
                                     </table>
                                   </td>
                                 </tr>
-                              </table>
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                </td>
-              </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table class="footer" style="box-sizing: border-box; margin-top: 50px; color: rgb(152, 156, 165); text-align: center; font-size: 11px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px;" align="center">
+                      <tbody style="box-sizing: border-box;">
+                        <tr style="box-sizing: border-box;">
+                          <td class="footer-cell" style="box-sizing: border-box;">
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <div class="c2577" style="text-align:center;box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px;">
+                      <p class="footer-info" style="box-sizing: border-box;">Court Appointed Special Advocate (CASA)
+                        <br style="box-sizing: border-box;">
+                      </p>
+                    </div>
+                  </td>
+                </tr>
               </tbody>
             </table>
-            <table class="footer" style="box-sizing: border-box; margin-top: 50px; color: rgb(152, 156, 165); text-align: center; font-size: 11px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px;" align="center">
-              <tbody style="box-sizing: border-box;">
-              <tr style="box-sizing: border-box;">
-                <td class="footer-cell" style="box-sizing: border-box;">
-                </td>
-              </tr>
-              </tbody>
-            </table>
-            <div class="c2577" style="text-align:center;box-sizing: border-box; padding-top: 10px; padding-right: 10px; padding-bottom: 10px; padding-left: 10px;">
-              <p class="footer-info" style="box-sizing: border-box;">Court Appointed Special Advocate (CASA)
-                <br style="box-sizing: border-box;">
-              </p>
-            </div>
           </td>
         </tr>
-        </tbody>
-      </table>
-    </td>
-  </tr>
-  </tbody>
-</table>
-</body>
+      </tbody>
+    </table>
+  </body>
 </html>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Actionable emails e.g. reset password</title>
-
+  <style>/* Email styles need to be inline */<style>
   <style type="text/css">
       img {
           max-width: 100%;

--- a/app/views/supervisor_mailer/account_setup.html.erb
+++ b/app/views/supervisor_mailer/account_setup.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/supervisor_mailer/deactivation.html.erb
+++ b/app/views/supervisor_mailer/deactivation.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Weekly Volunteer Activity Summary Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/views/volunteer_mailer/account_setup.html.erb
+++ b/app/views/volunteer_mailer/account_setup.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
@@ -17,8 +18,7 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" itemprop="handler" itemscope itemtype="http://schema.org/HttpActionHandler" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      <a href="<%= "#{edit_password_url(@user, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Set
-        Your Password</a>
+      <a href="<%= "#{edit_password_url(@user, reset_password_token: @token)}" %>" target="_blank" class="btn-primary" itemprop="url" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">Set Your Password</a>
     </td>
   </tr>
 </table>

--- a/app/views/volunteer_mailer/case_contacts_reminder.html.erb
+++ b/app/views/volunteer_mailer/case_contacts_reminder.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Case Contacts Reminder" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
@@ -12,8 +13,7 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      If you have any questions, please contact your most recent <%= @user.casa_org.display_name %> Supervisor for
-      assistance.
+      If you have any questions, please contact your most recent CASA supervisor for assistance.
     </td>
   </tr>
 </table>

--- a/app/views/volunteer_mailer/court_report_reminder.html.erb
+++ b/app/views/volunteer_mailer/court_report_reminder.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Court Report Due Reminder Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
@@ -7,14 +8,14 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      This is a reminder that your next court report is due on <%= @court_report_due_date %>. Please submit your court
-      report to your supervisor no later than this date.
+      This is a reminder that your next court report is due on <%= @court_report_due_date %>.
+      Please submit your court report to your supervisor no later than this date.
     </td>
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      You can generate a court report by clicking on "Generate Court Reports" in your volunteer portal. Log in here to
-      get started: https://www.casavolunteertracking.org
+      You can generate a court report by clicking on "Generate Court Reports" in your volunteer portal.
+      Log in at https://www.casavolunteertracking.org to get started.
     </td>
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">

--- a/app/views/volunteer_mailer/deactivation.html.erb
+++ b/app/views/volunteer_mailer/deactivation.html.erb
@@ -1,4 +1,5 @@
 <meta itemprop="name" content="Confirm Email" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<style>/* Email styles need to be inline */</style>
 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
@@ -7,14 +8,14 @@
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      Your <%= @user.casa_org.display_name %>'s County volunteer console account has been deactivated. Should you resume
-      service as a CASA volunteer in the future, your account will be reactivated. Thank you for your service to CASA!
+      Your <%= @user.casa_org.display_name %>'s County volunteer console account has been deactivated.
+      Should you resume service as a CASA volunteer in the future, your account will be reactivated.
+      Thank you for your service to CASA!
     </td>
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      If you have any questions, please contact your most recent <%= @user.casa_org.display_name %> Supervisor for
-      assistance.
+      If you have any questions, please contact your most recent CASA supervisor for assistance.
     </td>
   </tr>
 </table>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2224

### What changed, and why?
Added css warnings as comments for email layouts with inline css because inline css is the only css supported on some email platforms.

Corrected HTML indentation for `app/views/devise/mailer/reset_password_instructions.html.erb `

Removed CASA org name to describe supervisors in  
`app/views/volunteer_mailer/case_contacts_reminder.html.erb`  
`app/views/volunteer_mailer/deactivation.html.erb `