### PR TITLE
2244 - Updates to test view for HTML escaped characters

### DIFF
--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe "past_court_dates/show", type: :view do
       expect(rendered).to include(case_court_mandate.implementation_status.humanize)
     end
 
+    context "when judge's name has escaped characters" do
+      let(:past_court_date) { create(:past_court_date, :with_court_details, judge: create(:judge, name: "/-'<>#&")) }
+
+      it "correctly displays judge's name" do
+        expect(rendered).to include(ERB::Util.html_escape(past_court_date.judge.name))
+      end
+    end
+
     it "displays the download button for .docx" do
       expect(rendered).to include "Download Report (.docx)"
       expect(rendered).to include "/casa_cases/#{past_court_date.casa_case.id}/past_court_dates/#{past_court_date.id}.docx"

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "past_court_dates/show", type: :view do
     before { render template: "past_court_dates/show" }
 
     it "displays all court details" do
-      expect(rendered).to include(past_court_date.judge.name)
+      expect(rendered).to include(ERB::Util.html_escape(past_court_date.judge.name))
       expect(rendered).to include(past_court_date.hearing_type.name)
 
       expect(rendered).to include(case_court_mandate.mandate_text)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2244 

### What changed, and why?
Test spec failed when judge's name included an apostrophe. Updated spec to resolve this issue and added additional test to boost confidence in approach.


### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor permissions: no change
- Admin permissions: no change

### How is this tested? (please write tests!) 💖💪
The whole change is to the specs 😄 
I added an additional test to check the accuracy of the test I fixed.


### Screenshots please :)
👇👇
![image](https://user-images.githubusercontent.com/41805567/125010482-994fd800-e034-11eb-9abe-7e2cff608db8.png)

### Feelings gif (optional)

![ya heard](https://media.giphy.com/media/x6RunS9u1L3AA/giphy.gif)
