### PR TITLE
Make sidebar height 100vh regardless of image size

### DIFF
--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -5,6 +5,7 @@
 .sidebar-wrapper {
   background: rgba(0,0,0,0.25);
   min-height: 100vh;
+  max-height: 100vh;
   position: fixed;
   width: 320px;
   overflow: auto;
@@ -44,7 +45,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: calc(100vh - 144px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2152 

### What changed, and why?
Change `.sidebar-wrapper` height to have a max-height of 100% of the
viewport and get rid of the calculated height on `.sidebar-container`.
This should ensure that the sidebar is always the size of the viewport,
no matter the image size and any extra height will scroll.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
I don't think we need a test for this.  If we do, let me know how and I'll write it up.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/44326005/125040125-1fc3e400-e04c-11eb-9502-6afaeb862ba3.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![CSS hates me](https://media.giphy.com/media/13FrpeVH09Zrb2/giphy.gif)
