### PR TITLE
Add flexbox to .sidebar-wrapper

### DIFF
--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -4,6 +4,8 @@
 
 .sidebar-wrapper {
   background: rgba(0,0,0,0.25);
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   max-height: 100vh;
   position: fixed;
@@ -45,6 +47,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  height: 100vh;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2152 

### What changed, and why?
Added flexbox to `.sidebar-wrapper` and set the `.sidebar-container` to 100vh.  This lets the sidebar stay the full height of the screen, but adjusts the container size based on the image size in `.sidebar-heading`.  This change was necessary because #2251 only fixed the size problem when there were enough sidebar items to fill the whole height of the window.  If there were less, the sidebar container would shrink to fit them if it had no specified height.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
Admin dashboard:
![image](https://user-images.githubusercontent.com/44326005/125123847-0f435600-e0ac-11eb-9dd3-239eb7abe165.png)

All Casa Admins dashboard:
![image](https://user-images.githubusercontent.com/44326005/125123948-34d05f80-e0ac-11eb-9fa0-7e0512c70222.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![CSS hates me](https://media.giphy.com/media/13FrpeVH09Zrb2/giphy.gif)
