### PR TITLE
Add localization support for reports index

### DIFF
--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,5 +1,5 @@
 module ReportHelper
   def boolean_choices
-    [["Both", ""], ["Yes", true], ["No", false]]
+    [[I18n.t(".common.both_text"), ""], [I18n.t(".common.yes_text"), true], [I18n.t(".common.no_text"), false]]
   end
 end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,76 +1,80 @@
-<h1>Export Data</h1>
+<h1><%= t(".page_title") %></h1>
 
 <div class="card card-container">
   <div class="card-body">
-    <h5 class="card-title"><strong>Case Contacts Report</strong></h5>
+    <h5 class="card-title"><strong><%= t(".reports_subhead") %></strong></h5>
     <p class="card-text">
-      This CSV is a listing of all fields for the case contacts of all volunteers. Select the start
-      and end date.
+      <%= t(".reports_description") %>
     </p>
 
     <hr>
 
     <%= form_with url: case_contact_reports_path(format: :csv), scope: 'report', method: :get, local: true do |f| %>
       <div class="field form-group">
-        <label><strong>Starting From:</strong></label>
+        <label><strong><%= t(".start_date_label") %></strong></label>
         <%= f.date_field :start_date, class: "form-control", value: 6.months.ago.to_date %>
       </div>
 
       <div class="field form-group">
-        <label><strong>Ending At:</strong></label>
+        <label><strong><%= t(".end_date_label") %></strong></label>
         <%= f.date_field :end_date, class: "form-control", value: Date.today.to_date %>
       </div>
 
       <% if current_user&.casa_admin? || current_user&.supervisor? %>
         <div class="field form-group">
-          <label><strong>Assigned To:</strong></label>
+          <label><strong><%= t(".assigned_to_label") %></strong></label>
           <%= f.collection_select(
                   :supervisor_ids,
                   Supervisor.where(casa_org: current_user.casa_org),
                   :id, :display_name,
                   {include_hidden: false},
-                  {class: "form-control select2", data: {placeholder: "-Select Supervisors-"}, multiple: true}
+                  {class: "form-control select2",
+                   data: {placeholder: t(".select_supervisors_placeholder")},
+                   multiple: true}
               ) %>
         </div>
 
         <div class="field form-group">
-          <label><strong>Volunteers</strong></label>
+          <label><strong><%= t(".volunteers_label") %></strong></label>
           <%= f.collection_select(
                   :creator_ids,
                   Volunteer.where(casa_org: current_user.casa_org),
                   :id,
                   :display_name,
                   {include_hidden: false},
-                  {class: "form-control select2", data: {placeholder: "-Select Volunteers-"}, multiple: true}
+                  {class: "form-control select2", data: {placeholder: t(".select_volunteers_placeholder")},
+multiple: true}
               ) %>
         </div>
 
         <div class="field form-group">
-          <label><strong>Contact Type:</strong></label>
+          <label><strong><%= t(".contact_type_label") %></strong></label>
           <%= f.collection_select(
                   :contact_type_ids,
                   ContactType.for_organization(current_user.casa_org),
                   :id,
                   :name,
                   {include_hidden: false},
-                  {class: "form-control select2", data: {placeholder: "-Select Contact Types-"}, multiple: true}
+                  {class: "form-control select2", data: {placeholder: t(".select_contact_types_placeholder")},
+multiple: true}
               ) %>
         </div>
 
         <div class="field form-group">
-          <label><strong>Contact Type Group:</strong></label>
+          <label><strong><%= t(".contact_type_group_label") %></strong></label>
           <%= f.collection_select(
                   :contact_type_group_ids,
                   ContactTypeGroup.for_organization(current_user.casa_org),
                   :id,
                   :name,
                   {include_hidden: false},
-                  {class: "form-control select2", data: {placeholder: "-Select Contact Type Groups-"}, multiple: true}
+                  {class: "form-control select2", data: {placeholder: t(".select_contact_type_groups_placeholder")},
+multiple: true}
               ) %>
         </div>
 
         <div class="field form-group">
-          <label><strong>Want Driving Reimbursement:</strong></label>
+          <label><strong><%= t(".driving_reimbursement_label") %></strong></label>
           <%= f.collection_radio_buttons :want_driving_reimbursement, boolean_choices, :last, :first do |b| %>
             <div class="form-check">
               <%= b.radio_button(class: "form-check-input") %>
@@ -80,7 +84,7 @@
         </div>
 
         <div class="field form-group">
-          <label><strong>Contact Made:</strong></label>
+          <label><strong><%= t(".contact_made_label") %></strong></label>
           <%= f.collection_radio_buttons :contact_made, boolean_choices, :last, :first do |b| %>
             <div class="form-check">
               <%= b.radio_button(class: "form-check-input") %>
@@ -90,7 +94,7 @@
         </div>
 
         <div class="field form-group">
-          <label><strong>Transition Aged Youth:</strong></label>
+          <label><strong><%= t(".transition_aged_label") %></strong></label>
           <%= f.collection_radio_buttons :has_transitioned, boolean_choices, :last, :first do |b| %>
             <div class="form-check">
               <%= b.radio_button(class: "form-check-input") %>
@@ -100,7 +104,7 @@
         </div>
       <% end %>
 
-      <%= f.submit "Download Report", class: "btn btn-primary", data: {disable_with: false} %>
+      <%= f.submit t(".download_report_button"), class: "btn btn-primary", data: {disable_with: false} %>
     <% end %>
 
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
   common:
     yes_text: "Yes"
     no_text: "No"
+    both_text: Both
     active: Active
     inactive: Inactive
     status: Status

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -419,3 +419,22 @@ en:
         actions: Actions
       button:
         new: New Volunteer
+  reports:
+    index:
+      page_title: Export Data
+      reports_subhead: Case Contacts Report
+      reports_description: This CSV is a listing of all fields for the case contacts of all volunteers. Select the start and end date.
+      start_date_label: "Starting From:"
+      end_date_label: "Ending At:"
+      assigned_to_label: "Assigned To:"
+      select_supervisors_placeholder: -Select Supervisors-
+      volunteers_label: Volunteers
+      select_volunteers_placeholder: -Select Volunteers-
+      contact_type_label: "Contact Type:"
+      select_contact_types_placeholder: -Select Contact Types-
+      contact_type_group_label: "Contact Type Group:"
+      select_contact_type_groups_placeholder: -Select Contact Type Groups-
+      driving_reimbursement_label: "Want Driving Reimbursement:"
+      contact_made_label: "Contact Made:"
+      transition_aged_label: "Transition Aged Youth:"
+      download_report_button: Download Report

--- a/spec/helpers/report_helper_spec.rb
+++ b/spec/helpers/report_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe ReportHelper do
+  describe "#boolean_choices" do
+    it "returns array with correct options" do
+      expect(helper.boolean_choices).to eq [[I18n.t(".common.both_text"), ""], [I18n.t(".common.yes_text"), true], [I18n.t(".common.no_text"), false]]
+    end
+  end
+end

--- a/spec/system/reports/case_contact_reports_spec.rb
+++ b/spec/system/reports/case_contact_reports_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "case_contact_reports/index", :disable_bullet, type: :system do
     fill_in "report_start_date", with: 30.days.ago.to_date.strftime("%m/%d/%Y")
     fill_in "report_end_date", with: 10.days.ago.to_date.strftime("%m/%d/%Y")
     select court.name, from: "report_contact_type_ids"
-    click_button "Download Report"
+    click_button I18n.t("reports.index.download_report_button")
     wait_for_download
 
     expect(download_content).to include(contact1.notes)

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -13,18 +13,35 @@ RSpec.describe "reports", :disable_bullet, type: :system do
     let(:user) { create(:volunteer) }
 
     it "redirects to root" do
-      expect(page).to_not have_text "Case Contacts Report"
+      expect(page).to_not have_text I18n.t("reports.index.reports_subhead")
       expect(page).to have_text "not authorized"
     end
   end
 
   shared_examples "can view page" do
-    it "downloads report", js: true do
-      expect(page).to have_text("Case Contacts Report")
+    it "renders form elements", js: true do
+      expect(page).to have_text I18n.t("reports.index.reports_subhead")
       expect(page).to have_field("report_start_date", with: 6.months.ago.to_date)
       expect(page).to have_field("report_end_date", with: Date.today.to_date)
-      click_on "Download Report"
-      expect(page).to have_button "Download Report"
+      expect(page).to have_text I18n.t("reports.index.assigned_to_label")
+      expect(page.find("input[placeholder=\'#{I18n.t("reports.index.select_contact_types_placeholder")}\']")).to be_present
+      expect(page).to have_text I18n.t("reports.index.volunteers_label")
+      expect(page.find("input[placeholder=\'#{I18n.t("reports.index.select_volunteers_placeholder")}\']")).to be_present
+      expect(page).to have_text I18n.t("reports.index.contact_type_label")
+      expect(page.find("input[placeholder=\'#{I18n.t("reports.index.select_contact_types_placeholder")}\']")).to be_present
+      expect(page).to have_text I18n.t("reports.index.contact_type_group_label")
+      expect(page.find("input[placeholder=\'#{I18n.t("reports.index.select_contact_type_groups_placeholder")}\']")).to be_present
+      expect(page).to have_text I18n.t("reports.index.driving_reimbursement_label")
+      expect(page).to have_text I18n.t("reports.index.contact_made_label")
+      expect(page).to have_text I18n.t("reports.index.transition_aged_label")
+      expect(page).to have_field(I18n.t("common.both_text"), count: 3)
+      expect(page).to have_field(I18n.t("common.yes_text"), count: 3)
+      expect(page).to have_field(I18n.t("common.no_text"), count: 3)
+    end
+
+    it "downloads report", js: true do
+      click_on I18n.t("reports.index.download_report_button")
+      expect(page).to have_button I18n.t("reports.index.download_report_button")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2229 

### What changed, and why?
All strings in the reports `index` view have been updated with tokens from `views.yml`. This PR includes the `boolean_choices` from the report helper, which was missing a spec file. I've added basic specs for this and have updated existing tests with tokenized strings too.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Updated existing specs and added new specs for reports_helper

**Note:** there are a few tests failing on main, that fail on this branch too. Wasn't sure what to do about them.

### Screenshots please
![CASA-Volunteer-Tracking](https://user-images.githubusercontent.com/22390758/125173686-56b70880-e1b8-11eb-9210-a05f6f4ccfd8.png)
