### PR TITLE
update volunteer name and case number to be links

### DIFF
--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -22,7 +22,10 @@
         <% casa_case = case_assignment.casa_case %>
         <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
           <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-            <b><%= "Summary for #{volunteer.display_name} Case #{casa_case.case_number}" %></b>
+            <b>
+              Summary for <%= link_to volunteer.display_name, edit_volunteer_url(volunteer) %>
+              Case <%= link_to casa_case.case_number, casa_case_url(casa_case) %>
+            </b>
             <br>
             <% successful_contacts = recently_unassigned ?
                 casa_case.decorate.successful_contacts_this_week_before(case_assignment.updated_at) :

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
       let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
 
       it "shows a summary for a volunteer assigned to the supervisor" do
-        expect(mail.body.encoded).to match("Summary for #{volunteer.display_name}")
+        expect(mail.body.encoded).to match("Summary for <a href=\"#{edit_volunteer_url(volunteer)}\">#{volunteer.display_name}</a>")
       end
 
       it "does not show a case contact that did not occurr in the week" do
@@ -33,7 +33,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
       let!(:case_assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false, updated_at: Date.today - 2.days) }
 
       it "shows a summary for a volunteer recently unassigned from the supervisor" do
-        expect(mail.body.encoded).to match("Summary for #{volunteer.display_name}")
+        expect(mail.body.encoded).to match("Summary for <a href=\"#{edit_volunteer_url(volunteer)}\">#{volunteer.display_name}</a>")
       end
 
       it "shows a disclaimer for a volunteer recently unassigned from the supervisor" do

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe "supervisor_mailer/weekly_digest", :disable_bullet, type: :view d
     end
 
     it { expect(rendered).to have_text("Here's a summary of what happened with your volunteers this last week.") }
-    it { expect(rendered).to have_text(volunteer.display_name) }
+    it { expect(rendered).to have_link(volunteer.display_name) }
+    it { expect(rendered).to have_link(casa_case.case_number) }
     it { expect(rendered).not_to have_text(inactive_volunteer.display_name) }
     it { expect(rendered).to have_text("Number of unsuccessful case contacts made this week: 2") }
     it { expect(rendered).to have_text("Number of successful case contacts made this week: 1") }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2225 

### What changed, and why?
Volunteer names and case numbers in title are clickable and lead to Edit volunteer and Edit case pages.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Updated existing specs to check for presence of a link rather than text.

### Screenshots please
https://user-images.githubusercontent.com/22390758/125179079-bb875880-e1e2-11eb-843d-3b0d7b089e37.mov
