### PR TITLE
Fix DOM text reinterpreted as HTML

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,22 +9,25 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ main ]
-      paths-ignore:
-        - 'doc/**'
-        - '**.md'
-        - 'bin/**'
+    branches:
+      - main
+      - lr-1602-codeql
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - 'bin/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-      paths-ignore:
-        - 'doc/**'
-        - '**.md'
-        - 'bin/**'
+    branches:
+      - main
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - 'bin/**'
   schedule:
     - cron: '36 22 * * 3'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,6 @@ on:
   push:
     branches:
       - main
-      - lr-1602-codeql
     paths-ignore:
       - 'doc/**'
       - '**.md'

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -172,7 +172,9 @@ $('document').ready(() => {
             const checkbox = $(this).find('input')
 
             checkbox.prop('checked', false)
-            notify('Unchecked ' + checkbox.next().text(), 'info')
+
+            const checkboxText = checkbox.next().prop('textContent')
+            notify('Unchecked ' + checkboxText, 'info')
           })
         }
         saveAction = 'delete_category'

--- a/spec/system/casa_cases/emancipation/show_spec.rb
+++ b/spec/system/casa_cases/emancipation/show_spec.rb
@@ -6,17 +6,29 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
   let(:casa_case) { create(:casa_case, casa_org: organization, transition_aged_youth: true) }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:emancipation_category) { create(:emancipation_category, mutually_exclusive: true) }
+  let!(:emancipation_option) { create(:emancipation_option, emancipation_category: emancipation_category) }
 
   before do
     sign_in user
     visit casa_case_emancipation_path(casa_case.id)
   end
 
-  context "volunteer user" do
+  context "volunteer user", js: true do
     let(:user) { volunteer }
 
     it "sees title" do
       expect(page).to have_content("Emancipation Checklist")
+
+      expect(page).to have_content(emancipation_category.name)
+      expect(page).to_not have_content(emancipation_option.name)
+
+      find(".emancipation-category").click  # Open list of options for this category
+      expect(page).to have_content(emancipation_option.name) # Make sure list of options is showing
+      find(".check-item").click             # Select the first option
+      find(".emancipation-category").click  # Close the list of options for this category
+
+      expect(page).to have_css(".async-success-indicator", text: "Unchecked #{emancipation_option.name}")
+
       # TODO more asserts here - checking and unchecking items
     end
   end

--- a/spec/system/casa_cases/emancipation/show_spec.rb
+++ b/spec/system/casa_cases/emancipation/show_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
       expect(page).to have_content(emancipation_category.name)
       expect(page).to_not have_content(emancipation_option.name)
 
-      find(".emancipation-category").click  # Open list of options for this category
+      find(".emancipation-category").click # Open list of options for this category
       expect(page).to have_content(emancipation_option.name) # Make sure list of options is showing
-      find(".check-item").click             # Select the first option
-      find(".emancipation-category").click  # Close the list of options for this category
+      find(".check-item").click # Select the first option
+      find(".emancipation-category").click # Close the list of options for this category
 
       expect(page).to have_css(".async-success-indicator", text: "Unchecked #{emancipation_option.name}")
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #1602

### What changed, and why?
- Fix CodeQL workflow
- Fix CodeQL security warning of "DOM text reinterpreted as HTML" by using `textContent` property (which is text only) instead of `text()`
See explanation of this CodeQL error [here](https://codeql.github.com/codeql-query-help/javascript/js-xss-through-dom/)

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
New system test
