### PR TITLE
Removes CSS out of style tag

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Actionable emails e.g. reset password</title>
-  <style>/* Email styles need to be inline */</style>
+  <style>/* Email styles need to be inline, except @media queries */</style>
   <style type="text/css">
       @media only screen and (max-width: 640px) {
           body {

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -6,22 +6,6 @@
   <title>Actionable emails e.g. reset password</title>
   <style>/* Email styles need to be inline */</style>
   <style type="text/css">
-      img {
-          max-width: 100%;
-      }
-
-      body {
-          -webkit-font-smoothing: antialiased;
-          -webkit-text-size-adjust: none;
-          width: 100% !important;
-          height: 100%;
-          line-height: 1.6em;
-      }
-
-      body {
-          background-color: #f6f6f6;
-      }
-
       @media only screen and (max-width: 640px) {
           body {
               padding: 0 !important;
@@ -104,7 +88,7 @@
               <tbody style="box-sizing: border-box;">
               <tr style="box-sizing: border-box;">
                 <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
-                  <img src="<%= @casa_organization.org_logo %>" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); width: 50%; font-size: 50px; height: 265px;padding-top:10px;background:#fff;" height="265" width="260">
+                  <img src="<%= @casa_organization.org_logo %>" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); width: 50%; font-size: 50px; height: 265px;padding-top:10px;background:#fff; max-width: 100%;" height="265" width="260">
                 </td>
               </tr>
               </tbody>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2223

### What changed, and why?
Refactored some CSS from style tag to inline. But "@media" queries can't go in inline form, so they need to stay in style tag.


### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
No changes to test.


### Screenshots please :)
* After moving CSS o inline:
![Screenshot from 2021-07-15 09-00-09](https://user-images.githubusercontent.com/61836657/125784764-1a4b5f1a-4d44-4cec-8e73-ac9c2ff279b5.png)

