### PR TITLE
Fix typos in admin account setup email

### DIFF
--- a/app/views/casa_admin_mailer/account_setup.html.erb
+++ b/app/views/casa_admin_mailer/account_setup.html.erb
@@ -5,12 +5,12 @@
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
       A <%= @casa_organization.display_name %>’s County Admin account has been created for you. Your console account is
       associated with this email. If this is not the correct email to use, please stop here and contact an administrator
-      at PG CASA.
+      at your county's CASA.
     </td>
   </tr>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      If you are ready to get started, please set your password. This is the first step to accessing your new volunteer
+      If you are ready to get started, please set your password. This is the first step to accessing your new admin
       account.
     </td>
   </tr>


### PR DESCRIPTION
### What github issue is this PR for, if any?
No issue, just a quick typo fix

### What changed, and why?
Previously the email said "your volunteer account" even though this is for admin, and it also had "PG CASA" hardcoded into it.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![Spelling Champion](https://media.giphy.com/media/FCCtKHPjWGqic/giphy.gif)
