### PR TITLE
Adds warn in email about expiration date

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -39,6 +39,11 @@
         If you are ready to get started, please set your password. This is the first step to accessing your new account.
       </td>
     </tr>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+      <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+        <%= t 'devise.mailer.invitation_instructions.accept_until',due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format') %>
+      </td>
+    </tr>
   <% end %>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -5,5 +5,6 @@
 <% else %>
   A CASA console admin account has been created for you. Your console account is associated with this email.
   If you are ready to get started, please set your password. This is the first step to accessing your new account.
+  <%= t 'devise.mailer.invitation_instructions.accept_until',due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format') %>
 <% end %>
 <%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -5,6 +5,6 @@
 <% else %>
   A CASA console admin account has been created for you. Your console account is associated with this email.
   If you are ready to get started, please set your password. This is the first step to accessing your new account.
-  <%= t 'devise.mailer.invitation_instructions.accept_until',due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format') %>
+  <%= t 'devise.mailer.invitation_instructions.accept_until', due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format') %>
 <% end %>
 <%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %>

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -4,5 +4,9 @@ class DeviseMailerPreview < ActionMailer::Preview
   def reset_password_instructions
     Devise::Mailer.reset_password_instructions(User.first, "faketoken")
   end
+
+  def invitation_instructions
+    Devise::Mailer.invitation_instructions(AllCasaAdmin.first, "faketoken")
+  end
 end
 # :nocov:

--- a/spec/mailers/casa_admin_mailer_spec.rb
+++ b/spec/mailers/casa_admin_mailer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CasaAdminMailer, type: :mailer do
   let(:casa_admin) { create(:casa_admin) }
 
-  describe ".account_setup" do
+  describe ".account_setup for an admin " do
     let(:mail) { CasaAdminMailer.account_setup(casa_admin) }
 
     it "sends an email saying the account has been created" do
@@ -17,6 +17,17 @@ RSpec.describe CasaAdminMailer, type: :mailer do
       expect(mail.body.encoded.squish).to match("Set Your Password")
       expect(casa_admin.reset_password_token).to_not be_nil
       expect(casa_admin.reset_password_sent_at).to_not be_nil
+    end
+  end
+
+  describe ".accunt_setup for an all casa admin" do
+    let!(:all_casa_admin) { create(:all_casa_admin) }
+    let!(:mail) { all_casa_admin.invite! }
+
+    it "informs the correct expiration date" do
+      expiration_date = all_casa_admin.invitation_due_at.strftime("%B %d, %Y %I:%M %p")
+
+      expect(mail.body.encoded).to match("This invitation will be due in #{expiration_date}")
     end
   end
 end

--- a/spec/mailers/casa_admin_mailer_spec.rb
+++ b/spec/mailers/casa_admin_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CasaAdminMailer, type: :mailer do
     end
   end
 
-  describe ".accunt_setup for an all casa admin" do
+  describe ".invitation_instructions for an all casa admin" do
     let!(:all_casa_admin) { create(:all_casa_admin) }
     let!(:mail) { all_casa_admin.invite! }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2279

### What changed, and why?
Added warn in e-mail("invitation instructions") about the expiration date of the invitation.


### How will this affect user permissions?
It will not affect.

### How is this tested? (please write tests!) 💖💪
I have created a test to check if the date in the e-mail is the correct date of expiration.

### Screenshots please :)
![Screenshot from 2021-07-16 15-44-18](https://user-images.githubusercontent.com/61836657/125996844-41b2fbb9-33ea-46ca-96a8-0a9716dfeb5d.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![efgalvao](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
