### PR TITLE
Change warning text phrasing for all casa admins

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -39,11 +39,6 @@
         If you are ready to get started, please set your password. This is the first step to accessing your new account.
       </td>
     </tr>
-    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-      <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-        <%= t 'devise.mailer.invitation_instructions.accept_until',due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format') %>
-      </td>
-    </tr>
   <% end %>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
     <td
@@ -56,4 +51,11 @@
       <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
     </td>
   </tr>
+  <% unless @resource.is_a?(User) %>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+      <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+        This invitation will expire on <%= I18n.l(@resource.invitation_due_at, format: :full, default: nil) %>(one week).
+      </td>
+    </tr>
+  <% end %>
 </table>

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -5,8 +5,15 @@ class DeviseMailerPreview < ActionMailer::Preview
     Devise::Mailer.reset_password_instructions(User.first, "faketoken")
   end
 
-  def invitation_instructions
-    Devise::Mailer.invitation_instructions(AllCasaAdmin.first, "faketoken")
+  def all_casa_admin_invitation_instructions
+    all_casa_admin_invitation_sent_at = AllCasaAdmin.first.invitation_sent_at
+
+    # Temporarily set :invitation_sent_at to guarantee the preview works
+    AllCasaAdmin.first.update_attribute(:invitation_sent_at, Date.today)
+    preview = Devise::Mailer.invitation_instructions(AllCasaAdmin.first, "faketoken")
+    AllCasaAdmin.first.update_attribute(:invitation_sent_at, all_casa_admin_invitation_sent_at)
+
+    preview
   end
 end
 # :nocov:

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -5,7 +5,7 @@ class DeviseMailerPreview < ActionMailer::Preview
     Devise::Mailer.reset_password_instructions(User.first, "faketoken")
   end
 
-  def all_casa_admin_invitation_instructions
+  def invitation_instructions_as_all_casa_admin
     all_casa_admin_invitation_sent_at = AllCasaAdmin.first.invitation_sent_at
 
     # Temporarily set :invitation_sent_at to guarantee the preview works

--- a/spec/mailers/casa_admin_mailer_spec.rb
+++ b/spec/mailers/casa_admin_mailer_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe CasaAdminMailer, type: :mailer do
     let!(:mail) { all_casa_admin.invite! }
 
     it "informs the correct expiration date" do
-      expiration_date = all_casa_admin.invitation_due_at.strftime("%B %d, %Y %I:%M %p")
+      expiration_date = I18n.l(all_casa_admin.invitation_due_at, format: :full, default: nil)
 
-      expect(mail.body.encoded).to match("This invitation will be due in #{expiration_date}")
+      expect(mail.body.encoded).to include("This invitation will expire on #{expiration_date}(one week).")
     end
   end
 end


### PR DESCRIPTION
### What changed, and why?
Changed all casa admin warning from "This invitation will be due in `#{expiration_date}`" to "This invitation will expire on `#{expiration_date}`(one week)."

Guaranteed the invitation preview for all casa admins will display

### How will this affect user permissions?
all casa admin:
 - invitations expire after a week for account setup

### How is this tested?
updated a test

### Screenshots
![image](https://user-images.githubusercontent.com/8918762/126058931-b0064d64-498b-46d1-a7ca-573d24689f68.png)

