### PR TITLE
Fix CodeQL alert by escaping HTML message

### DIFF
--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -18,11 +18,17 @@ function notify (message, level) {
     throw new TypeError('Param message must be a string')
   }
 
+  const escapedMessage = message.replace(/&/g, '&amp;')
+    .replace(/>/g, '&gt;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+
   switch (level) {
     case 'error':
       emancipationPage.notifications.append(`
         <div class="async-failure-indicator">
-          Error: ${message}
+          Error: ${escapedMessage}
           <button class="btn btn-danger btn-sm">×</button>
         </div>`)
         .find('.async-failure-indicator button').click(function () {
@@ -32,7 +38,7 @@ function notify (message, level) {
     case 'info':
       emancipationPage.notifications.append(`
         <div class="async-success-indicator">
-          ${message}
+          ${escapedMessage}
           <button class="btn btn-success btn-sm">×</button>
         </div>`)
         .find('.async-success-indicator button').click(function () {
@@ -172,9 +178,7 @@ $('document').ready(() => {
             const checkbox = $(this).find('input')
 
             checkbox.prop('checked', false)
-
-            const checkboxText = checkbox.next().prop('textContent')
-            notify('Unchecked ' + checkboxText, 'info')
+            notify('Unchecked ' + checkbox.next().text(), 'info')
           })
         }
         saveAction = 'delete_category'


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #1602

### What changed, and why?
- Undo previous change from #2269
- Escape message string to prevent HTML injection attacks
- This _actually_ fixes [two of the alerts](https://github.com/rubyforgood/casa/pull/2290/checks?check_run_id=3105970606) 🎉 

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Test introduced in #2269

