### PR TITLE
Add devise_invitable expiration for supervisors and admin

### DIFF
--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -1,4 +1,6 @@
 class CasaAdmin < User
+  devise :invitable, invite_for: 2.weeks
+
   default_scope { order(email: :asc) }
 
   def activate

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -1,4 +1,6 @@
 class Supervisor < User
+  devise :invitable, invite_for: 2.weeks
+
   has_many :supervisor_volunteers, foreign_key: "supervisor_id"
   has_many :active_supervisor_volunteers, -> { where(is_active: true) }, class_name: "SupervisorVolunteer", foreign_key: "supervisor_id"
   has_many :unassigned_supervisor_volunteers, -> { where(is_active: false) }, class_name: "SupervisorVolunteer", foreign_key: "supervisor_id"

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe CasaAdmin, type: :model do
-  describe "#deactivate" do
-    let(:casa_admin) { create(:casa_admin) }
+  let(:casa_admin) { create(:casa_admin) }
 
+  describe "#deactivate" do
     it "deactivates the casa admin" do
       casa_admin.deactivate
 
@@ -25,5 +25,19 @@ RSpec.describe CasaAdmin, type: :model do
     subject(:admin) { create :casa_admin }
 
     it { expect(admin.role).to eq "Casa Admin" }
+  end
+
+  describe "invitation expiration" do
+    let!(:mail) { casa_admin.invite! }
+    let(:expiration_date) { I18n.l(casa_admin.invitation_due_at, format: :full, default: nil) }
+    let(:two_weeks) { I18n.l(2.weeks.from_now, format: :full, default: nil) }
+
+    it { expect(expiration_date).to eq two_weeks }
+    it "expires invitation token after two weeks" do
+      travel_to 2.weeks.from_now
+
+      user = User.accept_invitation!(invitation_token: casa_admin.invitation_token)
+      expect(user.errors.full_messages).to include("Invitation token is invalid")
+    end
   end
 end

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Supervisor, type: :model do
-  describe "#role" do
-    subject(:supervisor) { create :supervisor }
+  subject(:supervisor) { create :supervisor }
 
+  describe "#role" do
     it { expect(supervisor.role).to eq "Supervisor" }
 
     it { is_expected.to have_many(:supervisor_volunteers) }
@@ -11,5 +11,19 @@ RSpec.describe Supervisor, type: :model do
     it { is_expected.to have_many(:unassigned_supervisor_volunteers) }
     it { is_expected.to have_many(:volunteers).through(:active_supervisor_volunteers) }
     it { is_expected.to have_many(:volunteers_ever_assigned).through(:supervisor_volunteers) }
+  end
+
+  describe "invitation expiration" do
+    let!(:mail) { supervisor.invite! }
+    let(:expiration_date) { I18n.l(supervisor.invitation_due_at, format: :full, default: nil) }
+    let(:two_weeks) { I18n.l(2.weeks.from_now, format: :full, default: nil) }
+
+    it { expect(expiration_date).to eq two_weeks }
+    it "expires invitation token after two weeks" do
+      travel_to 2.weeks.from_now
+
+      user = User.accept_invitation!(invitation_token: supervisor.invitation_token)
+      expect(user.errors.full_messages).to include("Invitation token is invalid")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #2278

### What changed, and why?
- Add a 2 week expiration for email invitations to supervisors and admin

### How will this affect user permissions?
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
New model tests for supervisors and casa_admin