### PR TITLE
Warn of link expiration in Invitation Email

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -51,10 +51,11 @@
       <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
     </td>
   </tr>
-  <% unless @resource.is_a?(User) %>
+  <% if @resource.is_a?(Supervisor) || @resource.is_a?(CasaAdmin) || @resource.is_a?(AllCasaAdmin) %>
     <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
       <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-        This invitation will expire on <%= I18n.l(@resource.invitation_due_at, format: :full, default: nil) %>(one week).
+        This invitation will expire on <%= I18n.l(@resource.invitation_due_at, format: :full, default: nil) %>
+        <%= @resource.is_a?(AllCasaAdmin) ? '(one week)' : '(two weeks)' %>.
       </td>
     </tr>
   <% end %>

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -6,36 +6,32 @@ class DeviseMailerPreview < ActionMailer::Preview
   end
 
   def invitation_instructions_as_all_casa_admin
-    all_casa_admin_invitation_sent_at = AllCasaAdmin.first.invitation_sent_at
-
-    # Temporarily set :invitation_sent_at to guarantee the preview works
-    AllCasaAdmin.first.update_attribute(:invitation_sent_at, Date.today)
-    preview = Devise::Mailer.invitation_instructions(AllCasaAdmin.first, "faketoken")
-    AllCasaAdmin.first.update_attribute(:invitation_sent_at, all_casa_admin_invitation_sent_at)
-
-    preview
+    all_casa_admin = AllCasaAdmin.first
+    update_invitation_sent_at(all_casa_admin)
+    preview(all_casa_admin)
   end
 
   def invitation_instructions_as_casa_admin
-    casa_admin_invitation_sent_at = CasaAdmin.first.invitation_sent_at
-
-    # Temporarily set :invitation_sent_at to guarantee the preview works
-    CasaAdmin.first.update_attribute(:invitation_sent_at, Date.today)
-    preview = Devise::Mailer.invitation_instructions(CasaAdmin.first, "faketoken")
-    CasaAdmin.first.update_attribute(:invitation_sent_at, casa_admin_invitation_sent_at)
-
-    preview
+    casa_admin = CasaAdmin.first
+    update_invitation_sent_at(casa_admin)
+    preview(casa_admin)
   end
 
   def invitation_instructions_as_supervisor
-    supervisor_invitation_sent_at = Supervisor.first.invitation_sent_at
+    supervisor = Supervisor.first
+    update_invitation_sent_at(supervisor)
+    preview(supervisor)
+  end
 
-    # Temporarily set :invitation_sent_at to guarantee the preview works
-    Supervisor.first.update_attribute(:invitation_sent_at, Date.today)
-    preview = Devise::Mailer.invitation_instructions(Supervisor.first, "faketoken")
-    Supervisor.first.update_attribute(:invitation_sent_at, supervisor_invitation_sent_at)
+  private
 
-    preview
+  def update_invitation_sent_at(model)
+    # Set :invitation_sent_at to guarantee the preview works
+    model.update_attribute(:invitation_sent_at, Date.today)
+  end
+
+  def preview(model)
+    Devise::Mailer.invitation_instructions(model, "faketoken")
   end
 end
 # :nocov:

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -15,5 +15,27 @@ class DeviseMailerPreview < ActionMailer::Preview
 
     preview
   end
+
+  def invitation_instructions_as_casa_admin
+    casa_admin_invitation_sent_at = CasaAdmin.first.invitation_sent_at
+
+    # Temporarily set :invitation_sent_at to guarantee the preview works
+    CasaAdmin.first.update_attribute(:invitation_sent_at, Date.today)
+    preview = Devise::Mailer.invitation_instructions(CasaAdmin.first, "faketoken")
+    CasaAdmin.first.update_attribute(:invitation_sent_at, casa_admin_invitation_sent_at)
+
+    preview
+  end
+
+  def invitation_instructions_as_supervisor
+    supervisor_invitation_sent_at = Supervisor.first.invitation_sent_at
+
+    # Temporarily set :invitation_sent_at to guarantee the preview works
+    Supervisor.first.update_attribute(:invitation_sent_at, Date.today)
+    preview = Devise::Mailer.invitation_instructions(Supervisor.first, "faketoken")
+    Supervisor.first.update_attribute(:invitation_sent_at, supervisor_invitation_sent_at)
+
+    preview
+  end
 end
 # :nocov:

--- a/spec/mailers/casa_admin_mailer_spec.rb
+++ b/spec/mailers/casa_admin_mailer_spec.rb
@@ -27,7 +27,20 @@ RSpec.describe CasaAdminMailer, type: :mailer do
     it "informs the correct expiration date" do
       expiration_date = I18n.l(all_casa_admin.invitation_due_at, format: :full, default: nil)
 
-      expect(mail.body.encoded).to include("This invitation will expire on #{expiration_date}(one week).")
+      email_body = mail.html_part.body.to_s.squish
+      expect(email_body).to include("This invitation will expire on #{expiration_date} (one week).")
+    end
+  end
+
+  describe ".invitation_instructions for a casa admin" do
+    let!(:casa_admin) { create(:casa_admin) }
+    let!(:mail) { casa_admin.invite! }
+
+    it "informs the correct expiration date" do
+      expiration_date = I18n.l(casa_admin.invitation_due_at, format: :full, default: nil)
+
+      email_body = mail.html_part.body.to_s.squish
+      expect(email_body).to include("This invitation will expire on #{expiration_date} (two weeks).")
     end
   end
 end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -62,4 +62,15 @@ RSpec.describe SupervisorMailer, type: :mailer do
       expect(mail.body.encoded).to_not match("Summary for #{volunteer.display_name}")
     end
   end
+
+  describe ".invitation_instructions for a supervisor" do
+    let(:supervisor) { create(:supervisor) }
+    let(:mail) { supervisor.invite! }
+    let(:expiration_date) { I18n.l(supervisor.invitation_due_at, format: :full, default: nil) }
+
+    it "informs the correct expiration date" do
+      email_body = mail.html_part.body.to_s.squish
+      expect(email_body).to include("This invitation will expire on #{expiration_date} (two weeks).")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2278 

### What changed, and why?
- Add a message to the InvitationInstructions email to warn that the link will expire in either 1 week (for AllCasaAdmin) or 2 weeks (for Supervisors and CasaAdmin)

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Mailer tests

### Screenshots please :)
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/4965672/126245975-7511733e-a33e-42dc-a946-da656001156f.png">
