### PR TITLE
Fix CodeQL security alert when editing case contacts

### DIFF
--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -94,7 +94,12 @@ window.onload = function () {
     if (noteContent !== '') {
       e.preventDefault()
       $('#confirm-submit').modal('show')
-      document.getElementById('note-content').innerHTML = noteContent
+      const escapedNoteContent = noteContent.replace(/&/g, '&amp;')
+        .replace(/>/g, '&gt;')
+        .replace(/</g, '&lt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;')
+      document.getElementById('note-content').innerHTML = escapedNoteContent
     }
   }
 

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require 'action_view'
+require "action_view"
 
 RSpec.describe "case_contacts/new", :disable_bullet, type: :system do
   include ActionView::Helpers::SanitizeHelper

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
+require 'action_view'
 
 RSpec.describe "case_contacts/new", :disable_bullet, type: :system do
+  include ActionView::Helpers::SanitizeHelper
+
   context "when admin" do
     let(:organization) { create(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
@@ -101,6 +104,26 @@ RSpec.describe "case_contacts/new", :disable_bullet, type: :system do
         expect {
           click_on "Submit"
         }.not_to change(CaseContact, :count)
+      end
+    end
+
+    context "with HTML in notes" do
+      it "renders HTML correctly on the index page", js: true do
+        note_content = "<h1>Hello world</h1>"
+
+        fill_in "case-contact-duration-hours", with: "1"
+        fill_in "case-contact-duration-minutes", with: "45"
+        fill_in "Notes", with: note_content
+        click_on "Submit"
+
+        expect(page).to have_text("Confirm Note Content")
+        expect(page).to have_text(note_content)
+        expect {
+          click_on "Continue Submitting"
+        }.to change(CaseContact, :count).by(1)
+
+        expected_text = strip_tags(note_content)
+        expect(page).to have_css("h1", text: expected_text)
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1602

### What changed, and why?
- Escaped note content string to prevent HTML injection attacks

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
New system test

### Screenshots please :)
1. Type HTML into the notes field of /case_contacts/2/edit

    <img width="1070" alt="image" src="https://user-images.githubusercontent.com/4965672/126353494-e5f98cdb-3c9f-4bde-8185-e93e87f14734.png">

2. Click "Submit" to view the HTML as a string in the popup modal

    <img width="502" alt="image" src="https://user-images.githubusercontent.com/4965672/126353656-cf5da199-37d7-41e2-990a-8a1a27027908.png">

3. Click "Continue Submitting" and view the HTML on the casa_cases page

    <img width="1010" alt="image" src="https://user-images.githubusercontent.com/4965672/126353875-a44774ce-6b35-40ab-b662-1f8ef2a101e3.png">
