### PR TITLE
Set production log level to INFO

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #1834

### What changed, and why?
- Change the logging level in production from `:debug` to `:info` to reduce the size of logs in Heroku

### How will this affect user permissions?
N/A
