### PR TITLE
[#2286] Display archived contacts differently in order to highlight them

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -3,15 +3,21 @@
     <div class="row d-flex justify-content-between no-gutters">
       <div class="col-8">
         <div class="media">
-          <i class="mt-1 mr-3 text-primary <%= contact.decorate.medium_icon_classes %>"></i>
+          <% header_color_class = contact.quarter_editable? ? "text-primary" : "text-secondary" %>
+
+          <i class="mt-1 mr-3 <%= header_color_class %> <%= contact.decorate.medium_icon_classes %>"></i>
           <div class="media-body">
             <h5 class="mt-0 card-title">
-              <strong class="text-primary">
-                <%= t('.deleted_text') if policy(contact).restore? && contact.deleted? %>
-                <%= contact.contact_groups_with_types.keys.join(', ') %>
+              <strong class="<%= header_color_class %>">
+                <%= t(".deleted_text") if policy(contact).restore? && contact.deleted? %>
+                <%= contact.contact_groups_with_types.keys.join(", ") %>
+                <%= t("case_contacts.archived") unless contact.quarter_editable? %>
               </strong>
               <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
                           class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
+              <% unless contact.quarter_editable? %>
+                <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="<%= t("case_contacts.quarter_not_editable") %>"></i>
+              <% end %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">
               <%= contact.decorate.contact_types %>
@@ -40,12 +46,10 @@
           <% if contact.quarter_editable? %>
             <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
             <div class="col-sm-5">
-              <%= link_to edit_case_contact_path(contact), class: 'btn btn-outline-primary' do %>
+              <%= link_to edit_case_contact_path(contact), class: "btn btn-outline-primary" do %>
                 <strong><%= t("button.edit") %></strong>
               <% end %>
             </div>
-          <% else %>
-            <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="This case contact was created in a previous quarter and is therefore no longer editable."></i>
           <% end %>
         <% end %>
       </div>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -16,7 +16,11 @@
               <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
                           class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
               <% unless contact.quarter_editable? %>
-                <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="<%= t("case_contacts.quarter_not_editable") %>"></i>
+                <i
+                  class="fa fa-question-circle"
+                  aria-hidden="true"
+                  data-toggle="tooltip"
+                  title="<%= t("case_contacts.quarter_not_editable") %>"></i>
               <% end %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -33,6 +33,8 @@ en:
       header: Confirm Note Content
       body: Please double check your notes to ensure they don't contain any identifying details about your youth or anyone else.
       note: Note
+    quarter_not_editable: Archived contacts can't be edited. Case contacts are archived after the end of each quarter.
+    archived: (Archived)
   casa_cases:
     show:
       title: CASA Case Details

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -59,6 +59,49 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
         end
       end
     end
+
+    describe "case contacts text color" do
+      let(:contact_group_text) { case_contact.contact_groups_with_types.keys.first }
+
+      context "with active case contact" do
+        let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday) }
+
+        before do
+          sign_in volunteer
+          visit case_contacts_path
+        end
+
+        it "displays correct color for contact" do
+          within ".card-title" do
+            title = find("strong.text-primary")
+            expect(title).to have_content(contact_group_text)
+          end
+        end
+      end
+
+      context "with archived case contact", js: true do
+        let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 1.year.ago) }
+
+        before do
+          sign_in volunteer
+          visit case_contacts_path
+        end
+
+        it "displays correct color for contact" do
+          within ".card-title" do
+            title = find("strong.text-secondary")
+            expect(title).to have_content("#{contact_group_text} (Archived)")
+          end
+        end
+
+        it "displays an information tooltip about the archived contacts" do
+          tooltip = find('.fa-question-circle')
+          page.driver.browser.action.move_to(tooltip.native).perform
+
+          expect(page).to have_content("Archived contacts can't be edited. Case contacts are archived after the end of each quarter.")
+        end
+      end
+    end
   end
 
   context "without case contacts" do

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
         end
 
         it "displays an information tooltip about the archived contacts" do
-          tooltip = find('.fa-question-circle')
+          tooltip = find(".fa-question-circle")
           page.driver.browser.action.move_to(tooltip.native).perform
 
           expect(page).to have_content("Archived contacts can't be edited. Case contacts are archived after the end of each quarter.")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2286

### What changed, and why?
The pages with case contacts now display archived contacts differently, compared to the active contacts.

Archived contacts now display in grey, with an `(Archived)` text at the end, and with a tooltip beside them with the text: "Archived contacts can't be edited. Case contacts are archived after the end of each quarter.".

### How will this affect user permissions?
No permissions will be affected.

### How is this tested? (please write tests!) 💖💪
I've added system specs to check the CSS of each contact, and whether or not the tooltip is actually displayed.

### Screenshots please :)
#### Desktop view
![01](https://user-images.githubusercontent.com/72531802/126370610-f920a7e7-f541-4b5b-bcaa-986a31a67d79.png)

#### Mobile view
![02](https://user-images.githubusercontent.com/72531802/126370615-0a4713ea-3b67-49b3-bbf8-c5fdf180be92.png)

#### Archived Tooltip
![03](https://user-images.githubusercontent.com/72531802/126370623-272e811e-0ad9-4679-adc9-5635a14e16ca.png)
