### PR TITLE
Email previews for non prod envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Casa
   class Application < Rails::Application
     config.load_defaults 6.0
     config.serve_static_assets = true
-    config.action_mailer.preview_path = "#{Rails.root}/lib/mailers/previews"
+    config.action_mailer.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/lib/mailers/previews" : nil
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,8 @@ module Casa
   class Application < Rails::Application
     config.load_defaults 6.0
     config.serve_static_assets = true
-    config.action_mailer.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/lib/mailers/previews" : nil
+    config.action_mailer.preview_path ||= defined?(Rails.root) ? Rails.root.join("lib", "mailers", "previews") : nil
+    config.action_mailer.show_previews = true
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,6 @@ module Casa
     config.load_defaults 6.0
     config.serve_static_assets = true
     config.action_mailer.preview_path ||= defined?(Rails.root) ? Rails.root.join("lib", "mailers", "previews") : nil
-    config.action_mailer.show_previews = true
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,16 +37,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false
-  config.action_mailer.preview_path ||= defined?(Rails.root) ? Rails.root.join("lib", "mailers", "previews") : nil
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.show_previews = true
-
-  config.autoload_paths += [config.action_mailer.preview_path]
-
-  routes.append do
-    get "/rails/mailers" => "rails/mailers#index"
-    get "/rails/mailers/*path" => "rails/mailers#preview"
-  end
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {host: ENV["DOMAIN"]}
   config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.show_previews = ENV["APP_ENVIRONMENT"] != "production"
   # Do not send emails in staging or qa
   config.action_mailer.perform_deliveries = ENV["APP_ENVIRONMENT"] == "production"
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
### What changed, and why?
reverted changes
check if rails root is nil before calling

Tried to enable previews in `production.rb`