### PR TITLE
Email Invitations to volunteers should expire in 1 year

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,6 +1,8 @@
 # not a database model -- used for display in tables
 # volunteer is a user role and is controlled by User model
 class Volunteer < User
+  devise :invitable, invite_for: 1.year
+
   NAME_COLUMN = "name"
   EMAIL_COLUMN = "email"
   SUPERVISOR_COLUMN = "supervisor"

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -51,12 +51,16 @@
       <p><%= link_to "Set your password", accept_invitation_url(@resource, invitation_token: @token) %></p>
     </td>
   </tr>
-  <% if @resource.is_a?(Supervisor) || @resource.is_a?(CasaAdmin) || @resource.is_a?(AllCasaAdmin) %>
-    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-      <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-        This invitation will expire on <%= I18n.l(@resource.invitation_due_at, format: :full, default: nil) %>
-        <%= @resource.is_a?(AllCasaAdmin) ? '(one week)' : '(two weeks)' %>.
-      </td>
-    </tr>
-  <% end %>
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      This invitation will expire on <%= I18n.l(@resource.invitation_due_at, format: :full, default: nil) %>
+      <% if @resource.is_a?(AllCasaAdmin) %>
+        (one week).
+      <% elsif @resource.is_a?(Supervisor) || @resource.is_a?(CasaAdmin) %>
+        (two weeks).
+      <% elsif @resource.is_a?(Volunteer) %>
+        (one year).
+      <% end %>
+    </td>
+  </tr>
 </table>

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -24,6 +24,12 @@ class DeviseMailerPreview < ActionMailer::Preview
     preview(supervisor)
   end
 
+  def invitation_instructions_as_volunteer
+    volunteer = Volunteer.first
+    update_invitation_sent_at(volunteer)
+    preview(volunteer)
+  end
+
   private
 
   def update_invitation_sent_at(model)

--- a/spec/mailers/volunteer_mailer_spec.rb
+++ b/spec/mailers/volunteer_mailer_spec.rb
@@ -41,4 +41,14 @@ RSpec.describe VolunteerMailer, type: :mailer do
       expect(mail.body.encoded).to match("as a reminder")
     end
   end
+
+  describe ".invitation_instructions for a volunteer" do
+    let(:mail) { volunteer.invite! }
+    let(:expiration_date) { I18n.l(volunteer.invitation_due_at, format: :full, default: nil) }
+
+    it "informs the correct expiration date" do
+      email_body = mail.html_part.body.to_s.squish
+      expect(email_body).to include("This invitation will expire on #{expiration_date} (one year).")
+    end
+  end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -260,4 +260,19 @@ RSpec.describe Volunteer, type: :model do
       expect(volunteer.casa_cases).to eq([ca1.casa_case])
     end
   end
+
+  describe "invitation expiration" do
+    let(:volunteer) { create :volunteer }
+    let!(:mail) { volunteer.invite! }
+    let(:expiration_date) { I18n.l(volunteer.invitation_due_at, format: :full, default: nil) }
+    let(:one_year) { I18n.l(1.year.from_now, format: :full, default: nil) }
+
+    it { expect(expiration_date).to eq one_year }
+    it "expires invitation token after one year" do
+      travel_to 1.year.from_now
+
+      user = User.accept_invitation!(invitation_token: volunteer.invitation_token)
+      expect(user.errors.full_messages).to include("Invitation token is invalid")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2277

### What changed, and why?
- Changed the email invitation expiration for volunteers to be 1 year.
- Changed the invitation_instructions email to show the expiration in the email body
- Added an email preview for volunteers

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Model test and email test

### Screenshots please :)
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/4965672/126676869-4af72842-313a-4161-b04e-cc07373518eb.png">
