### PR TITLE
Add Resend Invite button for Supervisors and Admins

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -66,7 +66,6 @@ class CasaAdminsController < ApplicationController
 
   def resend_invitation
     authorize @casa_admin
-    @casa_admin = CasaAdmin.find(params[:id])
     @casa_admin.invite!
 
     redirect_to edit_casa_admin_path(@casa_admin), notice: "Invitation sent"

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -64,6 +64,14 @@ class CasaAdminsController < ApplicationController
     redirect_to_casa_admin_edition_page(error)
   end
 
+  def resend_invitation
+    authorize @casa_admin
+    @casa_admin = CasaAdmin.find(params[:id])
+    @casa_admin.invite!
+
+    redirect_to edit_casa_admin_path(@casa_admin), notice: "Invitation sent"
+  end
+
   private
 
   def redirect_to_casa_admin_edition_page(error)

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -2,7 +2,7 @@
 
 class SupervisorsController < ApplicationController
   before_action :available_volunteers, only: [:edit, :update, :index]
-  before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate]
+  before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate, :resend_invitation]
   before_action :all_volunteers_ever_assigned, only: [:update]
   before_action :supervisor_has_unassigned_volunteers, only: [:edit]
 

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -71,7 +71,6 @@ class SupervisorsController < ApplicationController
 
   def resend_invitation
     authorize @supervisor
-    @supervisor = Supervisor.find(params[:id])
     @supervisor.invite!
 
     redirect_to edit_supervisor_path(@supervisor), notice: "Invitation sent"

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -69,6 +69,14 @@ class SupervisorsController < ApplicationController
     end
   end
 
+  def resend_invitation
+    authorize @supervisor
+    @supervisor = Supervisor.find(params[:id])
+    @supervisor.invite!
+
+    redirect_to edit_supervisor_path(@supervisor), notice: "Invitation sent"
+  end
+
   private
 
   def set_supervisor

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -73,7 +73,6 @@ class VolunteersController < ApplicationController
 
   def resend_invitation
     authorize @volunteer
-    @volunteer = Volunteer.find(params[:id])
     @volunteer.invite!
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
@@ -81,7 +80,6 @@ class VolunteersController < ApplicationController
 
   def reminder
     authorize @volunteer
-    @volunteer = Volunteer.find(params[:id])
     VolunteerMailer.case_contacts_reminder(@volunteer).deliver
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Reminder sent to volunteer."

--- a/app/policies/casa_admin_policy.rb
+++ b/app/policies/casa_admin_policy.rb
@@ -8,6 +8,7 @@ class CasaAdminPolicy < UserPolicy
   alias_method :edit?, :index?
   alias_method :update?, :index?
   alias_method :activate?, :index?
+  alias_method :resend_invitation?, :index?
   alias_method :restore?, :is_admin?
 
   def deactivate?

--- a/app/policies/supervisor_policy.rb
+++ b/app/policies/supervisor_policy.rb
@@ -20,6 +20,10 @@ class SupervisorPolicy < UserPolicy
     is_admin?
   end
 
+  def resend_invitation?
+    is_admin?
+  end
+
   alias_method :create?, :new?
   alias_method :edit?, :index?
 end

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -39,7 +39,7 @@
             <% end %>
           <% end %>
 
-          <% if (current_user.supervisor? || current_user.casa_admin?) && casa_admin.invitation_accepted_at.nil? %>
+          <% if current_user.casa_admin? && casa_admin.invitation_accepted_at.nil? %>
             <%= link_to "Resend Invitation",
                         resend_invitation_casa_admin_path(casa_admin),
                         method: :patch,

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -38,6 +38,13 @@
                           class: "btn btn-outline-success" %>
             <% end %>
           <% end %>
+
+          <% if (current_user.supervisor? || current_user.casa_admin?) && casa_admin.invitation_accepted_at.nil? %>
+            <%= link_to "Resend Invitation",
+                        resend_invitation_casa_admin_path(casa_admin),
+                        method: :patch,
+                        class: "btn btn-outline-danger" %>
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/supervisors/_manage_active.html.erb
+++ b/app/views/supervisors/_manage_active.html.erb
@@ -19,6 +19,12 @@
                   activate_supervisor_path(user),
                   method: :patch,
                   class: "btn btn-outline-success" %>
+    <% end %>
   <% end %>
-<% end %>
+  <% if (current_user.supervisor? || current_user.casa_admin?) && user.invitation_accepted_at.nil? %>
+    <%= link_to "Resend Invitation",
+                resend_invitation_supervisor_path(user),
+                method: :patch,
+                class: "btn btn-outline-danger" %>
+  <% end %>
 </div>

--- a/app/views/supervisors/_manage_active.html.erb
+++ b/app/views/supervisors/_manage_active.html.erb
@@ -21,7 +21,7 @@
                   class: "btn btn-outline-success" %>
     <% end %>
   <% end %>
-  <% if (current_user.supervisor? || current_user.casa_admin?) && user.invitation_accepted_at.nil? %>
+  <% if current_user.casa_admin? && user.invitation_accepted_at.nil? %>
     <%= link_to "Resend Invitation",
                 resend_invitation_supervisor_path(user),
                 method: :patch,

--- a/app/views/volunteers/_manage_active.html.erb
+++ b/app/views/volunteers/_manage_active.html.erb
@@ -21,7 +21,7 @@
   <% end %>
   <% if (current_user.supervisor? ||
       current_user.casa_admin?) &&
-      user.invitation_accepted_at == nil %>
+      user.invitation_accepted_at.nil? %>
     <%= link_to "Resend Invitation",
                 resend_invitation_volunteer_path(user),
                 method: :patch,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     member do
       patch :deactivate
       patch :activate
+      patch :resend_invitation
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
     member do
       patch :activate
       patch :deactivate
+      patch :resend_invitation
     end
   end
   resources :supervisor_volunteers, only: %i[create] do

--- a/spec/policies/casa_admin_policy_spec.rb
+++ b/spec/policies/casa_admin_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CasaAdminPolicy do
   let(:volunteer) { create(:volunteer, casa_org: organization) }
   let(:supervisor) { create(:supervisor, casa_org: organization) }
 
-  permissions :index?, :new?, :create?, :edit?, :update?, :activate? do
+  permissions :index?, :new?, :create?, :edit?, :update?, :activate?, :resend_invitation? do
     it "allows casa_admins" do
       is_expected.to permit(casa_admin)
     end

--- a/spec/policies/supervisor_policy_spec.rb
+++ b/spec/policies/supervisor_policy_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SupervisorPolicy do
     end
   end
 
-  permissions :create?, :new? do
+  permissions :create?, :new?, :resend_invitation?, :activate?, :deactivate? do
     it "allows admins to create supervisors" do
       is_expected.to permit(casa_admin, Supervisor)
     end

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -193,4 +193,21 @@ RSpec.describe "/casa_admins", :disable_bullet, type: :request do
       end
     end
   end
+
+  describe "PATCH /resend_invitation" do
+    let(:casa_admin) { create(:casa_admin, active: true) }
+
+    before { sign_in_as_admin }
+    it "resends an invitation email" do
+      expect(casa_admin.invitation_created_at.present?).to eq(false)
+
+      patch resend_invitation_casa_admin_path(casa_admin)
+      casa_admin.reload
+
+      expect(casa_admin.invitation_created_at.present?).to eq(true)
+      expect(Devise.mailer.deliveries.count).to eq(1)
+      expect(Devise.mailer.deliveries.first.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
+      expect(response).to redirect_to(edit_casa_admin_path(casa_admin))
+    end
+  end
 end

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -157,4 +157,19 @@ RSpec.describe "/supervisors", :disable_bullet, type: :request do
       expect(Devise.mailer.deliveries.first.text_part.body.to_s).to include("This is the first step to accessing your new Supervisor account.")
     end
   end
+
+  describe "PATCH /resend_invitation" do
+    before { sign_in admin }
+    it "resends an invitation email" do
+      expect(supervisor.invitation_created_at.present?).to eq(false)
+
+      patch resend_invitation_supervisor_path(supervisor)
+      supervisor.reload
+
+      expect(supervisor.invitation_created_at.present?).to eq(true)
+      expect(Devise.mailer.deliveries.count).to eq(1)
+      expect(Devise.mailer.deliveries.first.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
+      expect(response).to redirect_to(edit_supervisor_path(supervisor))
+    end
+  end
 end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -196,4 +196,19 @@ RSpec.describe "/volunteers", :disable_bullet, type: :request do
       }.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
+
+  describe "PATCH /resend_invitation" do
+    before { sign_in admin }
+    it "resends an invitation email" do
+      expect(volunteer.invitation_created_at.present?).to eq(false)
+
+      patch resend_invitation_volunteer_path(volunteer)
+      volunteer.reload
+
+      expect(volunteer.invitation_created_at.present?).to eq(true)
+      expect(Devise.mailer.deliveries.count).to eq(1)
+      expect(Devise.mailer.deliveries.first.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
+      expect(response).to redirect_to(edit_volunteer_path(volunteer))
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2275

### What changed, and why?

- Add Resend Invite button for Supervisors and Admins
- Add patch /resend_invitation spec

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: Supervisor can resend to volunteer.
- Admin permissions: Admin can resend to supervisor, admin and volunteer.

### How is this tested? (please write tests!) 💖💪

Add RSpec

### Screenshots please :)

####  Supervisor

<img width="1431" alt="スクリーンショット 2021-07-23 15 50 49" src="https://user-images.githubusercontent.com/16137809/126746896-4413a4f1-cbfb-4231-84cd-63ac7b2aebf6.png">


####  Admin
<img width="1304" alt="スクリーンショット 2021-07-23 13 45 34" src="https://user-images.githubusercontent.com/16137809/126745714-7d992b83-c34c-4a31-b563-9fc3e4c8e964.png">
