### PR TITLE
Add Params to CasaAdmin Mailer Preview

### DIFF
--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -1,9 +1,11 @@
 class CasaAdminMailerPreview < ActionMailer::Preview
   def account_setup
-    CasaAdminMailer.account_setup(CasaAdmin.last)
+    casa_admin = CasaAdmin.find_by(id: params[:id]) || CasaAdmin.last
+    CasaAdminMailer.account_setup(casa_admin)
   end
 
   def deactivation
-    CasaAdminMailer.deactivation(CasaAdmin.last)
+    casa_admin = CasaAdmin.find_by(id: params[:id]) || CasaAdmin.last
+    CasaAdminMailer.deactivation(casa_admin)
   end
 end

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -31,8 +31,9 @@ class DeviseMailerPreview < ActionMailer::Preview
   end
 
   private
+
   # Unused email types
-  
+
   def update_invitation_sent_at(model)
     # Set :invitation_sent_at to guarantee the preview works
     model.update_attribute(:invitation_sent_at, Date.today)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2313 

### What changed, and why?

- select which admin to show an email preview for via user id
- Fixed a Lint error in this commit.
https://github.com/rubyforgood/casa/commit/ea26bb1f5b8bc6a8ef3be4dbd0486bdde9af8dd5

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

Email Preview

### Screenshots please :)

![スクリーンショット 2021-07-25 20 26 10](https://user-images.githubusercontent.com/16137809/126897394-24f41089-c445-438a-914d-ec8ba7c0aadf.png)
![スクリーンショット 2021-07-25 20 26 18](https://user-images.githubusercontent.com/16137809/126897397-30fd7ee4-cd5b-4626-8f93-0368563780e2.png)

