### PR TITLE
Adds "re-invite" button in weekly digest email

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -23,7 +23,7 @@ class SupervisorsController < ApplicationController
     @supervisor = Supervisor.new(supervisor_params.merge(supervisor_values))
 
     if @supervisor.save
-      @supervisor.invite!
+      @supervisor.invite!(current_user)
       redirect_to edit_supervisor_path(@supervisor)
     else
       render new_supervisor_path

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -74,9 +74,13 @@ class VolunteersController < ApplicationController
   def resend_invitation
     authorize @volunteer
     @volunteer = Volunteer.find(params[:id])
-    @volunteer.invite!(current_user)
+    if @volunteer.invitation_accepted_at == nil
+      @volunteer.invite!(current_user)
 
-    redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
+      redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
+    else
+      redirect_to edit_volunteer_path(@volunteer), notice: "User already accepted invitation"
+    end
   end
 
   def reminder

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -24,7 +24,7 @@ class VolunteersController < ApplicationController
     @volunteer = Volunteer.new(create_volunteer_params)
 
     if @volunteer.save
-      @volunteer.invite!
+      @volunteer.invite!(current_user)
       redirect_to edit_volunteer_path(@volunteer)
     else
       render :new
@@ -74,7 +74,7 @@ class VolunteersController < ApplicationController
   def resend_invitation
     authorize @volunteer
     @volunteer = Volunteer.find(params[:id])
-    @volunteer.invite!
+    @volunteer.invite!(current_user)
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"
   end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -74,7 +74,7 @@ class VolunteersController < ApplicationController
   def resend_invitation
     authorize @volunteer
     @volunteer = Volunteer.find(params[:id])
-    if @volunteer.invitation_accepted_at == nil
+    if @volunteer.invitation_accepted_at.nil?
       @volunteer.invite!(current_user)
 
       redirect_to edit_volunteer_path(@volunteer), notice: "Invitation sent"

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -26,8 +26,7 @@ class Supervisor < User
   end
 
   def pending_volunteers
-    Volunteer.where(invited_by_id: id, invitation_accepted_at: nil)
-             .where.not(invitation_created_at: nil)
+    Volunteer.where(invited_by_id: id, invitation_accepted_at: nil).where.not(invitation_created_at: nil)
   end
 
   def recently_unassigned_volunteers

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -25,6 +25,11 @@ class Supervisor < User
     end
   end
 
+  def pending_volunteers
+    Volunteer.where(invited_by_id: id, invitation_accepted_at: nil)
+             .where.not(invitation_created_at: nil)
+  end
+
   def recently_unassigned_volunteers
     unassigned_supervisor_volunteers.joins(:volunteer).includes(:volunteer)
       .where(updated_at: 1.week.ago..Time.zone.now).map(&:volunteer)

--- a/app/services/create_all_casa_admin_service.rb
+++ b/app/services/create_all_casa_admin_service.rb
@@ -11,6 +11,6 @@ class CreateAllCasaAdminService
 
   def create!
     @all_casa_admin.save!
-    @all_casa_admin.invite!
+    @all_casa_admin.invite!(current_user)
   end
 end

--- a/app/services/create_casa_admin_service.rb
+++ b/app/services/create_casa_admin_service.rb
@@ -14,7 +14,7 @@ class CreateCasaAdminService
 
   def create!
     @casa_admin.save!
-    @casa_admin.invite!
+    @casa_admin.invite!(current_user)
     @casa_admin
   end
 end

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -95,16 +95,36 @@
       <br>
     </td>
   </tr>
+
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
       <% @supervisor.volunteers.each do |volunteer| %>
         <% inactive_cases = CaseAssignment.inactive_this_week(volunteer.id) %>
-        <% inactive_cases.each do |case_assignment| %>
-          <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-          <% inactive_case_number = case_assignment.casa_case.case_number %>
-          <%= "#{volunteer.display_name} Case #{inactive_case_number} marked inactive this week." %>
-          <br>
+          <% inactive_cases.each do |case_assignment| %>
+            <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+            <% inactive_case_number = case_assignment.casa_case.case_number %>
+            <%= "#{volunteer.display_name} Case #{inactive_case_number} marked inactive this week." %>
+            <br>
     </td>
   </tr>
+<% end %>
+<% end %>
+
+  <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 18px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+      <b>Pending Volunteers:</b>
+      <br>
+    </td>
+  </tr>
+
+  <% @supervisor.pending_volunteers.each do |volunteer| %>
+    <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; display: flex; justify-content: flex-start;">
+      <td style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin-right: 30px; padding: 0 0 20px; text-transform: capitalize;" valign="top"; >
+        <%= volunteer.display_name %>  
+      </td>
+      <td>  
+        <button> <%= link_to "Re-invite", resend_invitation_volunteer_url(volunteer) %></button>
+      </td>  
+  </tr>
+  <% end %>
 </table>
-<% end %>
-<% end %>
+

--- a/app/views/volunteers/_manage_active.html.erb
+++ b/app/views/volunteers/_manage_active.html.erb
@@ -24,7 +24,6 @@
       user.invitation_accepted_at == nil %>
     <%= link_to "Resend Invitation",
                 resend_invitation_volunteer_path(user),
-                method: :patch,
                 class: "btn btn-outline-danger" %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,7 @@ Rails.application.routes.draw do
     member do
       patch :activate
       patch :deactivate
-      patch :resend_invitation
+      get :resend_invitation
       patch :reminder
     end
   end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe SupervisorMailer, type: :mailer do
       create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false, updated_at: Date.today - 8.days)
       expect(mail.body.encoded).to_not match("Summary for #{volunteer.display_name}")
     end
+
+    context "when a supervisor has pending volunteer to accepts invitation" do
+      let!(:volunteer2) { create(:volunteer) }
+      let!(:invite) { volunteer2.invite!(supervisor) }
+
+      it "shows a summary of pending volunteers" do
+        expect(mail.body.encoded).to match(volunteer2.display_name.to_s)
+      end
+
+      it "has a button to re-invite volunteer" do
+        expect(mail.body.encoded).to match("<a href=\"#{resend_invitation_volunteer_url(volunteer2)}\">")
+      end
+    end
   end
 
   describe ".invitation_instructions for a supervisor" do

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -63,8 +63,10 @@ RSpec.describe SupervisorMailer, type: :mailer do
     end
 
     context "when a supervisor has pending volunteer to accepts invitation" do
-      let!(:volunteer2) { create(:volunteer) }
-      let!(:invite) { volunteer2.invite!(supervisor) }
+      let(:volunteer2) { create(:volunteer) }
+      before do
+        volunteer2.invite!(supervisor)
+      end
 
       it "shows a summary of pending volunteers" do
         expect(mail.body.encoded).to match(volunteer2.display_name.to_s)

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe SupervisorMailer, type: :mailer do
       it "has a button to re-invite volunteer" do
         expect(mail.body.encoded).to match("<a href=\"#{resend_invitation_volunteer_url(volunteer2)}\">")
       end
+
+      it "do not shows a summary of pending volunteers if the volunteer already accepted" do
+        volunteer2.invitation_accepted_at = DateTime.current
+        volunteer2.save
+
+        expect(mail.body.encoded).to_not match(volunteer2.display_name.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2210

### What changed, and why?
Added a list to weekly digest if the supervisor has invited a volunteer and he not accepted it yet,  changed the resend invitation method so it could be called from the button in e-mail, also created a method to list all pending invitations for a specific supevisor.


### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
There are some tests that checks for the volunteer in the email if he not accepted and another one when the volunteer has accepted.


### Screenshots please :)
![Screenshot from 2021-07-25 19-52-33](https://user-images.githubusercontent.com/61836657/126916319-79e61cb2-969b-4009-9d58-3393a00c64ed.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![efgalvao](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
