### PR TITLE
fix account_setup -> case_contacts_reminder

### DIFF
--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -18,7 +18,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
 
   def case_contacts_reminder
     user = User.find_by(id: params[:id]) || User.last
-    VolunteerMailer.account_setup(user)
+    VolunteerMailer.case_contacts_reminder(user)
   end
 end
 # :nocov:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2310

### What changed, and why?
The case_contacts_reminder method was executing account_setup, fix it to execute case_contacts_reminder.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
 
Mailer Preview

### Screenshots please :)

<img width="1120" alt="スクリーンショット 2021-07-26 15 38 22" src="https://user-images.githubusercontent.com/16137809/126944030-050d6de2-ab54-4f69-a78d-1916c9175475.png">
