### PR TITLE
Fix erblint github action so it will actually fail

### DIFF
--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -30,4 +30,4 @@ jobs:
         bundler-cache: true
 
     - name: ERB lint
-      run: bundle exec erblint --lint-all --autocorrect
+      run: bundle exec erblint --lint-all

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -1,5 +1,5 @@
 <%= link_to t("button.back"), casa_case_path(@casa_case) %>
-<h1><%= t(".title", case_number: link_to(@casa_case.case_number, @casa_case)).html_safe %></h1>
+<h1><%= t(".title") %>&nbsp;<%= link_to(@casa_case.case_number, @casa_case) %></h1>
 
 <% if @casa_case.active %>
   <%= render 'form', casa_case: @casa_case %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -118,8 +118,9 @@
 
   <% @supervisor.pending_volunteers.each do |volunteer| %>
     <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; display: flex; justify-content: flex-start;">
-      <td style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin-right: 30px; padding: 0 0 20px; text-transform: capitalize;" valign="top"
-        <%= volunteer.display_name %>>
+      <td style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin-right: 30px; padding: 0 0 20px; text-transform: capitalize;" valign="top">
+        <%= volunteer.display_name %>
+      </td>
       <td>
         <button> <%= link_to "Re-invite", resend_invitation_volunteer_url(volunteer) %></button>
       </td>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -118,13 +118,11 @@
 
   <% @supervisor.pending_volunteers.each do |volunteer| %>
     <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; display: flex; justify-content: flex-start;">
-      <td style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin-right: 30px; padding: 0 0 20px; text-transform: capitalize;" valign="top"; >
-        <%= volunteer.display_name %>  
-      </td>
-      <td>  
+      <td style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin-right: 30px; padding: 0 0 20px; text-transform: capitalize;" valign="top"
+        <%= volunteer.display_name %>>
+      <td>
         <button> <%= link_to "Re-invite", resend_invitation_volunteer_url(volunteer) %></button>
-      </td>  
+      </td>
   </tr>
   <% end %>
 </table>
-

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -11,7 +11,7 @@
         <% if policy(@supervisor).update_supervisor_email? %>
           <%= form.text_field :email, class: "form-control" %>
         <% else %>
-          <input class="form-control" type="text" placeholder="<%= @supervisor.email %>" readonly>
+          <input class="form-control" type="text" placeholder="<%= @supervisor.email %>" autocomplete="off" readonly>
         <% end %>
       </div>
 
@@ -20,7 +20,7 @@
         <% if policy(@supervisor).update_supervisor_name? %>
           <%= form.text_field :display_name, class: "form-control" %>
         <% else %>
-          <input class="form-control" type="text" placeholder="<%= @supervisor.display_name %>" readonly>
+          <input class="form-control" type="text" placeholder="<%= @supervisor.display_name %>" autocomplete="off" readonly>
         <% end %>
       </div>
 

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -24,7 +24,7 @@
         <% if policy(:volunteer).update_volunteer_email? %>
           <%= form.text_field :email, class: "form-control" %>
         <% else %>
-          <input class="form-control" type="text" placeholder="<%= @volunteer.email %>" readonly>
+          <input class="form-control" type="text" placeholder="<%= @volunteer.email %>" autocomplete="off" readonly>
         <% end %>
       </div>
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -115,7 +115,7 @@ en:
         unassign: Unassign Volunteer
         activate: Activate Volunteer
     edit:
-      title: Editing %{case_number}
+      title: Editing
     index:
       pick_displayed_columns: Pick displayed columns
       own_case: My <%= "Case".pluralize(%{count}) %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
N/A

### What changed, and why?
- I noticed that a r[ecent successful erblint GitHub action](https://github.com/rubyforgood/casa/runs/3193964212) actually had failures. I have changed the GitHub action so it will fail the action when this happens.
- If you look at the first commit of this PR, you can see that the action failed correctly.

<img width="975" alt="image" src="https://user-images.githubusercontent.com/4965672/127715362-d366e29b-49fa-4673-b028-56e9a822ff53.png">


### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A
