### PR TITLE
2274 add invite email tests

### DIFF
--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe "casa_admins/edit", :disable_bullet, type: :system do
     expect(another.reload.active).to be_falsey
   end
 
+  it "can resend invitation to a another admin", js: true do
+    another = create(:casa_admin)
+    visit edit_casa_admin_path(another)
+
+    click_on "Resend Invitation"
+
+    expect(page).to have_content("Invitation sent")
+
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.count).to eq(1)
+    expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
+  end
+
   it "is not able to edit last sign in" do
     visit edit_casa_admin_path(admin)
 

--- a/spec/system/casa_admins/new_spec.rb
+++ b/spec/system/casa_admins/new_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe "casa_admins/new", :disable_bullet, type: :system do
     expect(page).to have_content "New admin created successfully"
     expect(page).to have_content "valid@example.com"
 
+    last_email = ActionMailer::Base.deliveries.last
+    expect(last_email.to).to eq ["valid@example.com"]
+    expect(last_email.subject).to have_text "CASA Console invitation instructions"
+    expect(last_email.html_part.body.encoded).to have_text "your new CasaAdmin account."
+
     click_on "New Admin"
     fill_in "Email", with: "valid@example.com"
     fill_in "Display Name", with: "Freddy Valid"

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe "supervisors/edit", :disable_bullet, type: :system do
       expect(inactive_supervisor.reload).to be_active
     end
 
+    it "can resend invitation to a supervisor", js: true do
+      supervisor = create :supervisor, casa_org: organization
+
+      sign_in user
+
+      visit edit_supervisor_path(supervisor)
+
+      click_on "Resend Invitation"
+
+      expect(page).to have_content("Invitation sent")
+
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.count).to eq(1)
+      expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
+    end
+
     context "logged in as a supervisor" do
       let(:supervisor) { create(:supervisor) }
       it "can't deactivate a supervisor", js: true do

--- a/spec/system/supervisors/new_spec.rb
+++ b/spec/system/supervisors/new_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe "supervisors/new", :disable_bullet, type: :system do
         click_on "Create Supervisor"
       }.to change(User, :count).by(1)
     end
+
+    it "sends invitation email to the new supervisor" do
+      sign_in admin
+      visit new_supervisor_path
+
+      fill_in "Email", with: "new_supervisor_email2@example.com"
+      fill_in "Display Name", with: "New Supervisor Display Name 2"
+
+      click_on "Create Supervisor"
+
+      last_email = ActionMailer::Base.deliveries.last
+      expect(last_email.to).to eq ["new_supervisor_email2@example.com"]
+      expect(last_email.subject).to have_text "CASA Console invitation instructions"
+      expect(last_email.html_part.body.encoded).to have_text "your new Supervisor account."
+    end
   end
 
   context "volunteer user" do

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -193,33 +193,39 @@ RSpec.describe "volunteers/edit", :disable_bullet, type: :system do
   describe "resend invite" do
     let(:supervisor) { create(:supervisor, casa_org: organization) }
 
-    it "allows a supervisor resend invitation to a volunteer" do
+    it "allows a supervisor resend invitation to a volunteer", js: true do
       sign_in supervisor
 
       visit edit_volunteer_path(volunteer)
 
       click_on "Resend Invitation"
 
-      expect(page).to have_content("Resend Invitation")
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(page).to have_content("Invitation sent")
+
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.count).to eq(1)
+      expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
     end
   end
 
-  it "allows an administrator resend invitation to a volunteer" do
+  it "allows an administrator resend invitation to a volunteer", js: true do
     sign_in admin
 
     visit edit_volunteer_path(volunteer)
 
     click_on "Resend Invitation"
 
-    expect(page).to have_content("Resend Invitation")
-    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(page).to have_content("Invitation sent")
+
+    deliveries = ActionMailer::Base.deliveries
+    expect(deliveries.count).to eq(1)
+    expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
   end
 
   describe "send reminder as a supervisor" do
     let(:supervisor) { create(:supervisor, casa_org: organization) }
 
-    it "allows a supervisor resend invitation to a volunteer" do
+    it "allows a supervisor to send case contact reminder to a volunteer" do
       sign_in supervisor
 
       visit edit_volunteer_path(volunteer)

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "volunteers/new", :disable_bullet, type: :system do
+  context "when admin" do
+    let(:admin) { create(:casa_admin) }
+
+    it "creates a new volunteer and sends invitation" do
+      sign_in admin
+      visit new_volunteer_path
+
+      fill_in "Email", with: "new_volunteer@example.com"
+      fill_in "Display name", with: "New Volunteer Display Name"
+
+      click_on "Create User"
+
+      last_email = ActionMailer::Base.deliveries.last
+      expect(last_email.to).to eq ["new_volunteer@example.com"]
+      expect(last_email.subject).to have_text "CASA Console invitation instructions"
+      expect(last_email.html_part.body.encoded).to have_text "your new Volunteer account."
+      expect(Volunteer.find_by(email: "new_volunteer@example.com").invitation_created_at).not_to be_nil
+    end
+  end
+
+  context "when supervisor" do
+    let(:supervisor) { create(:supervisor) }
+
+    it "lets Supervisor create new volunteer" do
+      sign_in supervisor
+      visit new_volunteer_path
+
+      fill_in "Email", with: "new_volunteer2@example.com"
+      fill_in "Display name", with: "New Volunteer Display Name 2"
+
+      expect {
+        click_on "Create User"
+      }.to change(User, :count).by(1)
+    end
+  end
+
+  context "volunteer user" do
+    let(:volunteer) { create(:volunteer) }
+
+    before { sign_in volunteer }
+
+    it "redirects the user with an error message" do
+      visit new_volunteer_path
+
+      expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2274 

### What changed, and why?
Adds a bunch of test to make sure invitation email is being sent when Admins, Supervisors and Volunteers are invited or the "Resend Invitation" button is pressed.

### How will this affect user permissions? 
N/A

### How is this tested? (please write tests!) 💖💪
Pure test PR here

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

![Super Good Test](https://media.giphy.com/media/7MZ0v9KynmiSA/giphy.gif)
