### PR TITLE
Change Casa Case Transiton Age Youth Value to be Calculated From Birthday.

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -6,11 +6,11 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def transition_aged_youth
-    object.in_transition_age? ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    (object.in_transition_age? || object.transition_aged_youth) ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
   def transition_aged_youth_icon
-    object.in_transition_age? ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    (object.in_transition_age? || object.transition_aged_youth) ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def court_report_submission

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -6,11 +6,11 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def transition_aged_youth
-    object.transition_aged_youth ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    object.in_transition_age? ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
   def transition_aged_youth_icon
-    object.transition_aged_youth ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    object.in_transition_age? ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def court_report_submission

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -6,11 +6,11 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def transition_aged_youth
-    (object.in_transition_age? || object.transition_aged_youth) ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    object.in_transition_age? || object.transition_aged_youth ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
   def transition_aged_youth_icon
-    (object.in_transition_age? || object.transition_aged_youth) ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    object.in_transition_age? || object.transition_aged_youth ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def court_report_submission

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe CasaCaseDecorator do
   end
 
   describe "#transition_age_youth" do
+    it "returns transition age youth status with icon if transition age youth && birthday is nil" do
+      casa_case = build(:casa_case, transition_aged_youth: true, birth_month_year_youth: nil)
+      expect(casa_case.decorate.transition_aged_youth)
+        .to eq "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}"
+    end
+
+    it "returns transition age youth status with icon if not transition age youth && birthday is nil" do
+      casa_case = build(:casa_case, transition_aged_youth: false, birth_month_year_youth: nil)
+      expect(casa_case.decorate.transition_aged_youth)
+        .to eq "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    end
+
     it "returns transition age youth status with icon if over 14 years old" do
       casa_case = build(:casa_case, birth_month_year_youth: 14.years.ago)
       expect(casa_case.decorate.transition_aged_youth)
@@ -67,6 +79,18 @@ RSpec.describe CasaCaseDecorator do
   end
 
   describe "#transition_age_youth_icon" do
+    it "returns transition age youth status with icon if transition age youth && birthday is nil" do
+      casa_case = build(:casa_case, transition_aged_youth: true, birth_month_year_youth: nil)
+      expect(casa_case.decorate.transition_aged_youth_icon)
+        .to eq CasaCase::TRANSITION_AGE_YOUTH_ICON
+    end
+
+    it "returns transition age youth status with icon if not transition age youth && birthday is nil" do
+      casa_case = build(:casa_case, transition_aged_youth: false, birth_month_year_youth: nil)
+      expect(casa_case.decorate.transition_aged_youth_icon)
+        .to eq CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    end
+
     it "returns transition age youth icon if over 14 years old" do
       casa_case = build(:casa_case, birth_month_year_youth: 14.years.ago)
       expect(casa_case.decorate.transition_aged_youth_icon)

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -53,28 +53,28 @@ RSpec.describe CasaCaseDecorator do
   end
 
   describe "#transition_age_youth" do
-    it "returns transition age youth status with icon if transition age youth" do
-      casa_case = build(:casa_case, transition_aged_youth: true)
+    it "returns transition age youth status with icon if over 14 years old" do
+      casa_case = build(:casa_case, birth_month_year_youth: 14.years.ago)
       expect(casa_case.decorate.transition_aged_youth)
         .to eq "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}"
     end
 
-    it "returns non-transition age youth status with icon if not transition age youth" do
-      casa_case = build(:casa_case, transition_aged_youth: false)
+    it "returns non-transition age youth status with icon if not over 14 years old" do
+      casa_case = build(:casa_case, birth_month_year_youth: 13.years.ago)
       expect(casa_case.decorate.transition_aged_youth)
         .to eq "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
     end
   end
 
   describe "#transition_age_youth_icon" do
-    it "returns transition age youth icon if transition age youth" do
-      casa_case = build(:casa_case, transition_aged_youth: true)
+    it "returns transition age youth icon if over 14 years old" do
+      casa_case = build(:casa_case, birth_month_year_youth: 14.years.ago)
       expect(casa_case.decorate.transition_aged_youth_icon)
         .to eq CasaCase::TRANSITION_AGE_YOUTH_ICON
     end
 
-    it "returns non-transition age youth icon if not transition age youth" do
-      casa_case = build(:casa_case, transition_aged_youth: false)
+    it "returns non-transition age youth icon if not over 14 years old" do
+      casa_case = build(:casa_case, birth_month_year_youth: 13.years.ago)
       expect(casa_case.decorate.transition_aged_youth_icon)
         .to eq CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
     end

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "view all volunteers", :disable_bullet, type: :system do
     context "when no logo_url" do
       it "can see volunteers and navigate to their cases", js: true do
         volunteer = create(:volunteer, :with_assigned_supervisor, display_name: "User 1", email: "casa@example.com", casa_org: organization)
-        volunteer.casa_cases << create(:casa_case, casa_org: organization)
-        volunteer.casa_cases << create(:casa_case, casa_org: organization)
+        volunteer.casa_cases << create(:casa_case, casa_org: organization, birth_month_year_youth: 14.years.ago)
+        volunteer.casa_cases << create(:casa_case, casa_org: organization, birth_month_year_youth: 14.years.ago)
         casa_case = volunteer.casa_cases[0]
 
         sign_in admin
@@ -27,7 +27,7 @@ RSpec.describe "view all volunteers", :disable_bullet, type: :system do
         expect(page).to have_text("Case number: #{casa_case.case_number}")
         expect(page).to have_text("Hearing Type:")
         expect(page).to have_text("Judge:")
-        expect(page).to have_text("Transition Aged Youth: No")
+        expect(page).to have_text("Transition Aged Youth: Yes")
         expect(page).to have_text("Next Court Date:")
         expect(page).to have_text("Court Report Due Date:")
         expect(page).to have_text("Court Report Status: Not submitted")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2344

### What changed, and why?

If you are over 14 years old, the transition icon will be displayed. 
Sometimes the birthday is empty, so we use transition_aged_youth.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
CasaCaseDecorator Spec.

### Screenshots please :)
Over 14 age old.

<img width="1015" alt="スクリーンショット 2021-08-02 12 39 43" src="https://user-images.githubusercontent.com/16137809/127801955-a97a040c-13c0-4c7c-add4-4727eec7e39c.png">

<img width="852" alt="スクリーンショット 2021-08-02 12 48 56" src="https://user-images.githubusercontent.com/16137809/127801967-c53fe870-e882-4ad6-a315-785c2f60ac0f.png">

