### PR TITLE
Pending volunteers should include assigned and pending

### DIFF
--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -26,7 +26,9 @@ class Supervisor < User
   end
 
   def pending_volunteers
-    Volunteer.where(invited_by_id: id, invitation_accepted_at: nil).where.not(invitation_created_at: nil)
+    Volunteer.where(invited_by_id: id).or(
+      Volunteer.where(id: volunteers.pluck(:id))
+    ).where(invitation_accepted_at: nil).where.not(invitation_created_at: nil)
   end
 
   def recently_unassigned_volunteers

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe Supervisor, type: :model do
       expect(user.errors.full_messages).to include("Invitation token is invalid")
     end
   end
+
+  describe "pending volunteers" do
+    let(:volunteer) { create(:volunteer) }
+    let(:assign_volunteer) { create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer) }
+
+    it "returns volunteers invited by the supervisor" do
+      volunteer.invite!(supervisor)
+      expect(supervisor.pending_volunteers).to eq([volunteer])
+    end
+
+    it "returns volunteers invited by others but assigned to supervisor" do
+      volunteer.invite!
+      assign_volunteer
+      expect(supervisor.pending_volunteers).to eq([volunteer])
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2340

### What changed, and why?
- Updated the `pending_volunteers` method on the Supervisor model so it would return volunteers that have been invited by the supervisor but also volunteers that have been assigned to the supervisor.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
New tests in `supervisor_spec.rb`

### Screenshots please :)
<img width="416" alt="image" src="https://user-images.githubusercontent.com/4965672/127893048-065a8f5f-01b3-405d-b1d0-8e7aeb83d828.png">
