### PR TITLE
Fix admin change password bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,7 @@ class UsersController < ApplicationController
       flash[:success] = "Password was successfully updated."
       redirect_to edit_users_path
     else
+      @active_casa_admins = CasaAdmin.in_organization(current_organization).active
       render "edit"
     end
   end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "users/edit", :disable_bullet, type: :system do
       expect(page).to have_text("Password is too short (minimum is 6 characters)")
     end
 
-    it "display sucesscfull message when admin update password" do
+    it "display success message when admin update password" do
       click_on "Change Password"
 
       fill_in "Password", with: "1234567"

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -71,5 +71,28 @@ RSpec.describe "users/edit", :disable_bullet, type: :system do
       expect(page).to have_text("new_admin@example.com")
       assert_equal "new_admin@example.com", admin.reload.email
     end
+
+    it "displays password errors messages when admin is unable to set a password" do
+      click_on "Change Password"
+
+      fill_in "Password", with: "123"
+      fill_in "Password Confirmation", with: "1234"
+
+      click_on "Update Password"
+
+      expect(page).to have_text("Password confirmation doesn't match Password")
+      expect(page).to have_text("Password is too short (minimum is 6 characters)")
+    end
+
+    it "display sucesscfull message when admin update password" do
+      click_on "Change Password"
+
+      fill_in "Password", with: "1234567"
+      fill_in "Password Confirmation", with: "1234567"
+
+      click_on "Update Password"
+
+      expect(page).to have_text("Password was successfully updated.")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2352 

### What changed, and why?
Added to the controller the active_casa_admin so the view can render normally.


### How will this affect user permissions?
It will not

### How is this tested? (please write tests!) 💖💪
Now there are 2 tests to check if an admin can change passwod


### Screenshots please :)
* Showing errors for admin:

![Screenshot from 2021-08-06 16-02-53](https://user-images.githubusercontent.com/61836657/128560068-9d9caccf-7765-44fa-828c-1760d16cfe46.png)

* Showing  success message:

![Screenshot from 2021-08-06 16-03-26](https://user-images.githubusercontent.com/61836657/128560117-27835764-8094-4710-8c8e-6b0493d2217f.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![efgalvao](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif)
