### PR TITLE
Create and update past court dates

### DIFF
--- a/app/controllers/past_court_dates_controller.rb
+++ b/app/controllers/past_court_dates_controller.rb
@@ -64,7 +64,7 @@ class PastCourtDatesController < ApplicationController
       :date,
       :hearing_type_id,
       :judge_id,
-      { case_court_mandates_attributes: %i[mandate_text implementation_status id casa_case_id] }
+      {case_court_mandates_attributes: %i[mandate_text implementation_status id casa_case_id]}
     )
   end
 end

--- a/app/controllers/past_court_dates_controller.rb
+++ b/app/controllers/past_court_dates_controller.rb
@@ -1,6 +1,6 @@
 class PastCourtDatesController < ApplicationController
-  before_action :set_casa_case, only: %i[show]
-  before_action :set_past_court_date, only: %i[show generate]
+  before_action :set_casa_case
+  before_action :set_past_court_date, only: %i[edit show generate update]
   before_action :require_organization!
 
   rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }
@@ -20,6 +20,35 @@ class PastCourtDatesController < ApplicationController
     end
   end
 
+  def new
+    @past_court_date = PastCourtDate.new(casa_case: @casa_case)
+    authorize @past_court_date
+  end
+
+  def edit
+    authorize @past_court_date
+  end
+
+  def create
+    @past_court_date = PastCourtDate.new(past_court_dates_params.merge(casa_case: @casa_case))
+    authorize @past_court_date
+
+    if @past_court_date.save
+      redirect_to casa_case_past_court_date_path(@casa_case, @past_court_date), notice: "Past court date was successfully created."
+    else
+      render :new
+    end
+  end
+
+  def update
+    authorize @past_court_date
+    if @past_court_date.update(past_court_dates_params)
+      redirect_to casa_case_past_court_date_path(@casa_case, @past_court_date), notice: "Past court date was successfully updated."
+    else
+      render :edit
+    end
+  end
+
   private
 
   def set_casa_case
@@ -28,5 +57,14 @@ class PastCourtDatesController < ApplicationController
 
   def set_past_court_date
     @past_court_date = @casa_case.past_court_dates.find(params[:id])
+  end
+
+  def past_court_dates_params
+    params.require(:past_court_date).permit(
+      :date,
+      :hearing_type_id,
+      :judge_id,
+      { case_court_mandates_attributes: %i[mandate_text implementation_status id casa_case_id] }
+    )
   end
 end

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -7,8 +7,8 @@ import Swal from 'sweetalert2'
 
 function addCourtMandateInput () {
   const list = '#mandates-list-container'
-  const ref = $(list).data('ref') || 'casa_case';
-  const casaCaseId = $(list).data('casa-case-id');
+  const ref = $(list).data('ref') || 'casa_case'
+  const casaCaseId = $(list).data('casa-case-id')
   const index = $(`${list} textarea`).length
   const html = courtMandateHtml(index, ref, casaCaseId)
 

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -7,14 +7,19 @@ import Swal from 'sweetalert2'
 
 function addCourtMandateInput () {
   const list = '#mandates-list-container'
+  const ref = $(list).data('ref') || 'casa_case';
+  const casaCaseId = $(list).data('casa-case-id');
   const index = $(`${list} textarea`).length
-  const html = courtMandateHtml(index)
+  const html = courtMandateHtml(index, ref, casaCaseId)
 
   $(list).append(html.entry)
   const lastEntry = $(list).children(':last')
 
   $(lastEntry).append(html.textarea)
   $(lastEntry).append(html.select)
+  if (casaCaseId) {
+    $(lastEntry).append(html.hidden)
+  }
   $(lastEntry).children(':first').trigger('focus')
 }
 
@@ -68,7 +73,7 @@ function removeMandateAction (ctx) {
   })
 }
 
-function courtMandateHtml (index) {
+function courtMandateHtml (index, ref, casaCaseId) {
   const selectOptions = '<option value="">Set Implementation Status</option>' +
                         '<option value="not_implemented">Not implemented</option>' +
                         '<option value="partially_implemented">Partially implemented</option>' +
@@ -76,14 +81,16 @@ function courtMandateHtml (index) {
   return {
     entry: '<div class="court-mandate-entry"></div>',
 
-    textarea: `<textarea name="casa_case[case_court_mandates_attributes][${index}][mandate_text]"\
+    textarea: `<textarea name="${ref}[case_court_mandates_attributes][${index}][mandate_text]"\
                  id="casa_case_case_court_mandates_attributes_${index}_mandate_text"></textarea>`,
 
     select: `<select class="implementation-status"\
-                 name="casa_case[case_court_mandates_attributes][${index}][implementation_status]"\
+                 name="${ref}[case_court_mandates_attributes][${index}][implementation_status]"\
                  id="casa_case_case_court_mandates_attributes_${index}_implementation_status">\
                  ${selectOptions}\
-               </select>`
+               </select>`,
+    hidden: `<textarea class="d-none" name="${ref}[case_court_mandates_attributes][${index}][casa_case_id]"\
+              id="casa_case_case_court_mandates_attributes_${index}_casa_case_id">${casaCaseId}</textarea>`
   }
 }
 

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import "pages/login";
 @import "pages/casa_orgs";
 @import "pages/password";
+@import "pages/past_court_dates";

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -42,7 +42,7 @@ body.casa_cases {
     gap: 10px;
   }
 
-  #add-mandate-button, {
+  #add-mandate-button {
     color: white;
     border: none;
 
@@ -90,5 +90,11 @@ body.casa_cases {
 
       margin: 1em 1em 2em 1em;
     }
+  }
+}
+
+body.casa_cases-show {
+  .add-past-court-date-container {
+    display: none;
   }
 }

--- a/app/javascript/src/stylesheets/pages/past_court_dates.scss
+++ b/app/javascript/src/stylesheets/pages/past_court_dates.scss
@@ -1,0 +1,47 @@
+body.past_court_dates {
+  .court-mandates {
+    textarea {
+      display: block;
+      margin-bottom: 5px;
+    }
+
+    textarea, .add-court-mandate {
+      width: 500px;
+    }
+  }
+
+  .add-court-mandate-container {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 10px;
+  }
+
+  #add-mandate-button {
+    color: white;
+    border: none;
+
+    font-size: 1.25em;
+
+    :hover {
+      cursor: pointer;
+    }
+  }
+
+  #add-mandate-button {
+    background-color: #{$primary};
+
+    padding: 0.25em 1.5em;
+    border-radius: 10px;
+  }
+
+  .court-mandate-entry {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  select {
+    padding: 5px;
+  }
+}

--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -11,6 +11,8 @@ class PastCourtDate < ApplicationRecord
   belongs_to :hearing_type, optional: true
   belongs_to :judge, optional: true
 
+  accepts_nested_attributes_for :case_court_mandates, reject_if: :all_blank
+
   DOCX_TEMPLATE_PATH = Rails.root.join("app", "documents", "templates", "default_past_court_date_template.docx")
 
   # get reports associated with the case this belongs to before this court date but after the court date before this one

--- a/app/policies/past_court_date_policy.rb
+++ b/app/policies/past_court_date_policy.rb
@@ -1,7 +1,13 @@
 class PastCourtDatePolicy < ApplicationPolicy
-  def show?
+  def allowed_to_edit_casa_case?
     casa_case_policy.edit?
   end
+
+  alias_method :show?, :allowed_to_edit_casa_case?
+  alias_method :edit?, :allowed_to_edit_casa_case?
+  alias_method :update?, :allowed_to_edit_casa_case?
+  alias_method :new?, :allowed_to_edit_casa_case?
+  alias_method :create?, :allowed_to_edit_casa_case?
 
   private
 

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -154,7 +154,7 @@
           <% end %>
         </div>
 
-        <div class="field form-group">
+        <div class="field form-group past-court-dates">
           <%= render "past_court_dates", casa_case: @casa_case %>
         </div>
       <% end %>

--- a/app/views/casa_cases/_past_court_dates.html.erb
+++ b/app/views/casa_cases/_past_court_dates.html.erb
@@ -3,11 +3,7 @@
   <ul>
     <% casa_case.past_court_dates.each do |pcd| %>
       <p>
-        <% if pcd.additional_info? %>
-          <%= link_to(pcd.decorate.formatted_date, casa_case_past_court_date_path(casa_case, pcd)) %>
-        <% else %>
-          <%= pcd.decorate.formatted_date %>
-        <% end %>
+        <%= link_to(pcd.decorate.formatted_date, casa_case_past_court_date_path(casa_case, pcd)) %>
 
         <% if report = pcd.latest_associated_report %>
           <%= link_to(rails_blob_path(report, disposition: 'attachment')) do %>
@@ -20,3 +16,9 @@
 <% else %>
   <%= t(".no_past_court_dates") %>
 <% end %>
+<div class="add-past-court-date-container">
+  <a class="btn btn-primary" href="<%= new_casa_case_past_court_date_path(casa_case) %>">
+    <i class="fa fa-plus" aria-hidden="true"></i>
+  </a>
+  <strong><%= t(".add_past_court_date") %></strong>
+</div>

--- a/app/views/past_court_dates/_form.html.erb
+++ b/app/views/past_court_dates/_form.html.erb
@@ -1,0 +1,73 @@
+<div class="card card-container">
+  <div class="card-body">
+    <%= form_with(model: past_court_date, url: [casa_case, past_court_date], local: true) do |form| %>
+      <%= render "/shared/error_messages", resource: past_court_date %>
+
+      <div class="top-page-actions pull-right">
+        <%= form.submit past_court_date.persisted? ? t(".button.update") : t(".button.create"), class: "btn btn-primary" %>
+      </div>
+
+      <p>
+        <h6><strong><%= t(".label.case_number") %>:</strong> <%= casa_case.case_number %></h6>
+      </p>
+
+      <div class="field form-group">
+        <%= form.label :date, "Add Court Date (past)" %>
+        <br>
+        <span class="datetime-year-month">
+          <%= form.date_select :date,
+                                {
+                                    order: [:day, :month, :year],
+                                    start_year: Date.current.year,
+                                    end_year: 2000,
+                                    prompt: {day: t("common.day"), month: t("common.month"), year: t("common.year")}
+                                },
+                                class: "select2 date-input" %>
+        </span>
+      </div>
+      <div class="field form-group">
+        <%= form.label :judge_id %>
+        <%= form.collection_select(
+                :judge_id,
+                Judge.for_organization(current_organization),
+                :id, :name,
+                {include_hidden: false, include_blank: t(".prompt.select_judge")},
+                {class: "form-control"}
+            ) %>
+      </div>
+      <div class="field form-group">
+        <%= form.label :hearing_type_id %>
+        <%= form.collection_select(
+                :hearing_type_id,
+                HearingType.active.for_organization(current_organization),
+                :id, :name,
+                {include_hidden: false, include_blank: t(".prompt.select_hearing_type")},
+                {class: "form-control"}
+            ) %>
+      </div>
+      <div class="field form-group court-mandates">
+        <%= form.label :case_court_mandates, "#{t(".label.court_mandates")}" %>
+        <div id="mandates-list-container" data-ref="past_court_date" data-casa-case-id="<%= casa_case.id %>">
+          <%= form.fields_for :case_court_mandates do |ff| %>
+            <div class="court-mandate-entry">
+              <%= ff.text_area :mandate_text %>
+              <%=
+                ff.select :implementation_status,
+                          casa_case.decorate.court_mandate_select_options,
+                          {include_blank: 'Set Implementation Status'},
+                          {class: 'implementation-status'}
+              %>
+              <button type="button" class="remove-mandate-button btn btn-danger"><%= t("button.delete") %></button>
+            </div>
+          <% end %>
+        </div>
+        <div class="add-court-mandate-container">
+          <button type="button" id="add-mandate-button">
+            <i class="fa fa-plus" aria-hidden="true"></i>
+          </button>
+          <strong><%= t(".button.add_court_mandate") %></strong>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/past_court_dates/edit.html.erb
+++ b/app/views/past_court_dates/edit.html.erb
@@ -1,0 +1,4 @@
+<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
+<h1><%= t(".title") %></h1>
+
+<%= render 'form', casa_case: @casa_case, past_court_date: @past_court_date %>

--- a/app/views/past_court_dates/new.html.erb
+++ b/app/views/past_court_dates/new.html.erb
@@ -1,0 +1,5 @@
+<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
+
+<h1><%= t(".title") %></h1>
+
+<%= render 'form', casa_case: @casa_case, past_court_date: @past_court_date %>

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -1,7 +1,12 @@
 <%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
 
-<h1><%= t(".title") %></h1>
-<h2><%= @past_court_date.decorate.formatted_date %></h2>
+<div class="row">
+  <div class="col-sm-12 form-header">
+    <h1><%= t(".title") %></h1>
+    <%= link_to t(".button.edit_past_court_date"), edit_casa_case_past_court_date_path(@casa_case, @past_court_date), class: "btn btn-primary casa-case-button pull-right" %>
+  </div>
+</div>
+<h2 class="d-inline-block"><%= @past_court_date.decorate.formatted_date %></h2>
 
 <div class="card card-container">
   <div class="card-body">

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -3,7 +3,9 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1><%= t(".title") %></h1>
-    <%= link_to t(".button.edit_past_court_date"), edit_casa_case_past_court_date_path(@casa_case, @past_court_date), class: "btn btn-primary casa-case-button pull-right" %>
+    <%= link_to t(".button.edit_past_court_date"),
+        edit_casa_case_past_court_date_path(@casa_case, @past_court_date),
+        class: "btn btn-primary casa-case-button pull-right" %>
   </div>
 </div>
 <h2 class="d-inline-block"><%= @past_court_date.decorate.formatted_date %></h2>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -87,6 +87,7 @@ en:
         select_judge: -Select Judge-
       youth_birth_month_year: "Youth's Birth Month & Year"
       add_court_mandate: Add a court mandate
+      add_past_court_date: Add a past court date
       next_court_date: Next Court Date
       court_report_due_date: Court Report Due Date
       court_mandates: Court Mandates
@@ -135,7 +136,21 @@ en:
     new:
       title: New CASA Case
   past_court_dates:
+    edit:
+      title: Editing Past Court Date
+    form:
+      button:
+        add_court_mandate: Add a court mandate
+        create: Create
+        update: Update
+      label:
+        court_mandates:
+          Court Mandates - Please check that you didn't enter any youth names
+    new:
+      title: New Past Court Date
     show:
+      button:
+        edit_past_court_date: Edit
       title: Past Court Date
       label:
         case_number: Case Number

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :past_court_dates, only: %i[show]
+    resources :past_court_dates, only: %i[create edit new show update]
 
     member do
       patch :deactivate

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", :disable_bullet
     let(:past_court_date) { PastCourtDate.last }
 
     context "with valid parameters" do
-
       it "creates a new PastCourtDate" do
         expect do
           post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_attributes}

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -1,25 +1,53 @@
 require "rails_helper"
 
 RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", :disable_bullet, type: :request do
+  let(:admin) { create(:casa_admin) }
+  let(:casa_case) { past_court_date.casa_case }
+  let(:past_court_date) { create(:past_court_date) }
+  let(:hearing_type) { create(:hearing_type) }
+  let(:judge) { create(:judge) }
+  let(:valid_attributes) do
+    {
+      date: Date.yesterday,
+      hearing_type_id: hearing_type.id,
+      judge_id: judge.id
+    }
+  end
+  let(:mandate_texts) { ["1-New Mandate Text One", "0-New Mandate Text Two"] }
+  let(:implementation_statuses) { ["not_implemented", nil] }
+  let(:mandates_attributes) do
+    {
+      "0" => {mandate_text: mandate_texts[0], implementation_status: implementation_statuses[0], casa_case_id: casa_case.id},
+      "1" => {mandate_text: mandate_texts[1], implementation_status: implementation_statuses[1], casa_case_id: casa_case.id}
+    }
+  end
+  let(:invalid_attributes) do
+    {
+      date: nil,
+      hearing_type_id: hearing_type.id,
+      judge_id: judge.id
+    }
+  end
+
+  before do
+    sign_in admin
+  end
+
   describe "GET /show" do
     subject(:show) { get casa_case_past_court_date_path(casa_case, past_court_date) }
 
-    let(:casa_case) { past_court_date.casa_case }
-    let(:past_court_date) { create(:past_court_date) }
+    before { show }
 
     context "when the request is authenticated" do
-      before do
-        sign_in_as_admin
-        show
-      end
-
       it { expect(response).to have_http_status(:success) }
     end
 
     context "when the request is unauthenticated" do
-      before { show }
-
-      it { expect(response).to redirect_to new_user_session_path }
+      it "redirects to login page" do
+        sign_out admin
+        get casa_case_past_court_date_path(casa_case, past_court_date)
+        expect(response).to redirect_to new_user_session_path
+      end
     end
 
     context "when request format is word document" do
@@ -27,12 +55,190 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", :disable_bullet
 
       let(:headers) { {accept: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"} }
 
-      before do
-        sign_in_as_admin
-        show
+      it { expect(response).to be_successful }
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_casa_case_past_court_date_path(casa_case)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      get edit_casa_case_past_court_date_path(casa_case, past_court_date)
+      expect(response).to be_successful
+    end
+
+    it "fails across organizations" do
+      other_org = create(:casa_org)
+      other_case = create(:casa_case, casa_org: other_org)
+
+      get edit_casa_case_past_court_date_path(other_case, past_court_date)
+      expect(response).to be_not_found
+    end
+  end
+
+  describe "POST /create" do
+    let(:casa_case) { create(:casa_case) }
+    let(:past_court_date) { PastCourtDate.last }
+
+    context "with valid parameters" do
+
+      it "creates a new PastCourtDate" do
+        expect do
+          post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_attributes}
+        end.to change(PastCourtDate, :count).by(1)
       end
 
-      it { expect(response).to be_successful }
+      it "redirects to the casa_case" do
+        post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_attributes}
+        expect(response).to redirect_to(casa_case_past_court_date_path(casa_case, past_court_date))
+      end
+
+      it "sets fields correctly" do
+        post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_attributes}
+
+        expect(past_court_date.casa_case).to eq casa_case
+        expect(past_court_date.date).to eq Date.yesterday
+        expect(past_court_date.hearing_type).to eq hearing_type
+        expect(past_court_date.judge).to eq judge
+      end
+
+      context "with case_court_mandates_attributes being passed as a parameter" do
+        let(:valid_params) do
+          attributes = valid_attributes
+          attributes[:case_court_mandates_attributes] = mandates_attributes
+          attributes
+        end
+
+        it "Creates a new CaseCourtMandate" do
+          expect do
+            post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_params}
+          end.to change(CaseCourtMandate, :count).by(2)
+        end
+
+        it "sets fields correctly" do
+          post casa_case_past_court_dates_path(casa_case), params: {past_court_date: valid_params}
+
+          expect(past_court_date.case_court_mandates.count).to eq 2
+          expect(past_court_date.case_court_mandates[0].mandate_text).to eq mandate_texts[0]
+          expect(past_court_date.case_court_mandates[0].implementation_status).to eq implementation_statuses[0]
+          expect(past_court_date.case_court_mandates[1].mandate_text).to eq mandate_texts[1]
+          expect(past_court_date.case_court_mandates[1].implementation_status).to eq implementation_statuses[1]
+        end
+      end
+    end
+
+    describe "invalid request" do
+      context "with invalid parameters" do
+        it "does not create a new PastCourtDate" do
+          expect do
+            post casa_case_past_court_dates_path(casa_case), params: {past_court_date: invalid_attributes}
+          end.to change(PastCourtDate, :count).by(0)
+        end
+
+        it "renders a successful response (i.e. to display the 'new' template)" do
+          post casa_case_past_court_dates_path(casa_case), params: {past_court_date: invalid_attributes}
+          expect(response).to be_successful
+          expect(assigns[:past_court_date].errors.full_messages).to eq ["Date can't be blank"]
+        end
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    let(:new_attributes) {
+      {
+        date: 1.week.ago.to_date,
+        hearing_type_id: hearing_type.id,
+        judge_id: judge.id,
+        case_court_mandates_attributes: mandates_attributes
+      }
+    }
+
+    context "with valid parameters" do
+      it "updates the requested past_court_date" do
+        patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: new_attributes}
+        past_court_date.reload
+        expect(past_court_date.date).to eq 1.week.ago.to_date
+        expect(past_court_date.hearing_type).to eq hearing_type
+        expect(past_court_date.judge).to eq judge
+        expect(past_court_date.case_court_mandates[0].mandate_text).to eq mandate_texts[0]
+        expect(past_court_date.case_court_mandates[0].implementation_status).to eq implementation_statuses[0]
+        expect(past_court_date.case_court_mandates[1].mandate_text).to eq mandate_texts[1]
+        expect(past_court_date.case_court_mandates[1].implementation_status).to eq implementation_statuses[1]
+      end
+
+      it "redirects to the past_court_date" do
+        patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: new_attributes}
+
+        expect(response).to redirect_to casa_case_past_court_date_path(casa_case, past_court_date)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders a successful response displaying the edit template" do
+        patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: invalid_attributes}
+
+        expect(response).to be_successful
+        expect(assigns[:past_court_date].errors.full_messages).to eq ["Date can't be blank"]
+      end
+    end
+
+    describe "court mandates" do
+      context "when the user tries to make an existing mandate empty" do
+        let(:mandates_updated) do
+          {
+            case_court_mandates_attributes: {
+              "0" => {
+                mandate_text: "New Mandate Text One Updated",
+                implementation_status: :not_implemented
+              },
+              "1" => {
+                mandate_text: ""
+              }
+            }
+          }
+        end
+
+        before do
+          patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: new_attributes}
+          past_court_date.reload
+
+          mandates_updated[:case_court_mandates_attributes]["0"][:id] = past_court_date.case_court_mandates[0].id
+          mandates_updated[:case_court_mandates_attributes]["1"][:id] = past_court_date.case_court_mandates[1].id
+        end
+
+        it "does not update the first mandate" do
+          expect do
+            patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: mandates_updated}
+          end.not_to(
+            change { past_court_date.reload.case_court_mandates[0].mandate_text }
+          )
+        end
+
+        it "does not update the second mandate" do
+          expect do
+            patch casa_case_past_court_date_path(casa_case, past_court_date), params: {past_court_date: mandates_updated}
+          end.not_to(
+            change { past_court_date.reload.case_court_mandates[1].mandate_text }
+          )
+        end
+      end
+    end
+
+    it "does not update across organizations" do
+      other_org = create(:casa_org)
+      other_casa_case = create(:casa_case, case_number: "abc", casa_org: other_org)
+
+      expect do
+        patch casa_case_past_court_date_path(other_casa_case, past_court_date), params: {past_court_date: new_attributes}
+      end.not_to(
+        change { past_court_date.reload.date }
+      )
     end
   end
 end

--- a/spec/support/shared_examples/shows_past_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_past_court_dates_links.rb
@@ -17,6 +17,6 @@ shared_examples_for "shows past court dates links" do
     expect(page).to have_link(formatted_date_with_details)
 
     expect(page).to have_text(formatted_date_without_details)
-    expect(page).not_to have_link(formatted_date_without_details)
+    expect(page).to have_link(formatted_date_without_details)
   end
 end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -500,11 +500,11 @@ of it unless it was included in a previous court report.")
       # test court dates with reports get the correct ones
       [[0, 1], [2, 3], [3, 4]].each do |di, ri|
         expect(page).to have_link("(Attached Report)", href: rails_blob_path(reports[ri], disposition: "attachment"))
-        expect(page).not_to have_link(I18n.l(court_dates[di].date, format: :full, default: nil))
+        expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil))
       end
 
-      # and that the one with no report doesn't get one
-      expect(page).not_to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))
+      # and that the one with no report still gets one
+      expect(page).to have_link(I18n.l(court_dates[1].date, format: :full, default: nil))
       expect(page).to have_text(I18n.l(court_dates[1].date, format: :full, default: nil))
     end
 

--- a/spec/system/past_court_dates/edit_spec.rb
+++ b/spec/system/past_court_dates/edit_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "past_court_dates/edit", :disable_bullet, type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let!(:casa_case) { create(:casa_case, casa_org: organization) }
+  let!(:past_court_date) { create(:past_court_date, :with_court_details, casa_case: casa_case) }
+
+  before do
+    sign_in admin
+    visit root_path
+    click_on "Cases"
+    click_on casa_case.case_number
+    click_on "Edit Case Details"
+    click_on past_court_date.date.strftime("%B %-d, %Y")
+    click_on "Edit"
+  end
+
+  it "shows court mandates" do
+    court_mandate = past_court_date.case_court_mandates.first
+
+    expect(page).to have_text(court_mandate.mandate_text)
+    expect(page).to have_text(court_mandate.implementation_status.humanize)
+  end
+
+  it "edits past court date", js: true do
+    expect(page).to have_select("Hearing type")
+    expect(page).to have_select("Judge")
+
+    page.find("#add-mandate-button").click
+    find("#mandates-list-container").first("textarea").send_keys("Court Mandate Text One")
+
+    within ".top-page-actions" do
+      click_on "Update"
+    end
+    expect(page).to have_text("Court Mandate Text One")
+  end
+end

--- a/spec/system/past_court_dates/new_spec.rb
+++ b/spec/system/past_court_dates/new_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "past_court_dates/new", :disable_bullet, type: :system do
+  let(:casa_org) { create(:casa_org) }
+  let!(:casa_case) { create(:casa_case, casa_org: casa_org) }
+  let!(:judge) { create(:judge) }
+  let!(:hearing_type) { create(:hearing_type) }
+  let(:admin) { create(:casa_admin, casa_org: casa_org) }
+  let(:mandate_text) { Faker::Lorem.paragraph(sentence_count: 2) }
+
+  before do
+    sign_in admin
+    visit root_path
+    click_on "Cases"
+    click_on casa_case.case_number
+    click_on "Edit Case Details"
+    find(".add-past-court-date-container .btn-primary").click
+  end
+
+  context "when all fields are filled" do
+    it "is successful", js: true do
+      expect(page.body).to have_content(casa_case.case_number)
+
+      select "3", from: "past_court_date_date_3i"
+      select "March", from: "past_court_date_date_2i"
+      select "2020", from: "past_court_date_date_1i"
+
+      select judge.name, from: "Judge"
+      select hearing_type.name, from: "Hearing type"
+
+      find("#add-mandate-button").click
+
+      fill_in "casa_case_case_court_mandates_attributes_0_mandate_text", with: mandate_text
+      select "Partially implemented", from: "casa_case_case_court_mandates_attributes_0_implementation_status"
+
+      within ".top-page-actions" do
+        click_on "Create"
+      end
+
+      expect(page.body).to have_content(casa_case.case_number)
+      expect(page).to have_content("Past court date was successfully created.")
+      expect(page).to have_content(judge.name)
+      expect(page).to have_content(hearing_type.name)
+      expect(page).to have_content(mandate_text)
+      expect(page).to have_content("Partially implemented")
+    end
+  end
+
+  context "when non-mandatory fields are not filled" do
+    it "does not create a new past_court_date" do
+      within ".top-page-actions" do
+        click_on "Create"
+      end
+
+      expect(page).to have_current_path(casa_case_past_court_dates_path(casa_case), ignore_query: true)
+      expect(page).to have_content("Date can't be blank")
+    end
+  end
+
+  context "when the case number field is not filled" do
+    it "does not create a new case" do
+      within ".actions" do
+        click_on "Create CASA Case"
+      end
+
+      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
+      expect(page).to have_content("Case number can't be blank")
+    end
+  end
+end

--- a/spec/system/past_court_dates/new_spec.rb
+++ b/spec/system/past_court_dates/new_spec.rb
@@ -56,15 +56,4 @@ RSpec.describe "past_court_dates/new", :disable_bullet, type: :system do
       expect(page).to have_content("Date can't be blank")
     end
   end
-
-  context "when the case number field is not filled" do
-    it "does not create a new case" do
-      within ".actions" do
-        click_on "Create CASA Case"
-      end
-
-      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
-      expect(page).to have_content("Case number can't be blank")
-    end
-  end
 end

--- a/spec/views/past_court_dates/edit.html.erb_spec.rb
+++ b/spec/views/past_court_dates/edit.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "past_court_dates/edit", :disable_bullet, type: :view do
+  subject { render template: "past_court_dates/edit" }
+
+  let(:organization) { create(:casa_org) }
+  let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let(:past_court_date) { create(:past_court_date, :with_court_details, casa_case: casa_case) }
+  let(:court_mandate) { past_court_date.case_court_mandates.first }
+  let(:implementation_status_name) do
+    "past_court_date_case_court_mandates_attributes_0_implementation_status"
+  end
+  let(:implementation_status) do
+    court_mandate.implementation_status.humanize
+  end
+
+  before do
+    assign :casa_case, casa_case
+    assign :past_court_date, past_court_date
+
+    enable_pundit(view, user)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_organization).and_return(user.casa_org)
+  end
+
+  it { is_expected.to have_select("past_court_date_judge_id", selected: past_court_date.judge.name) }
+  it { is_expected.to have_select("past_court_date_hearing_type_id", selected: past_court_date.hearing_type.name) }
+  it { is_expected.to have_selector("textarea", text: court_mandate.mandate_text) }
+  it { is_expected.to have_select(implementation_status_name, selected: implementation_status) }
+  it { is_expected.to have_selector(".btn-primary") }
+end

--- a/spec/views/past_court_dates/new.html.erb_spec.rb
+++ b/spec/views/past_court_dates/new.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "past_court_dates/new", :disable_bullet, type: :view do
+  subject { render template: "past_court_dates/new" }
+
+  before do
+    assign :casa_case, casa_case
+    assign :past_court_date, PastCourtDate.new
+
+    allow(view).to receive(:current_organization).and_return(user.casa_org)
+  end
+
+  let(:user) { build_stubbed(:casa_admin) }
+  let(:casa_case) { create(:casa_case) }
+
+  it { is_expected.to have_selector("h1", text: "New Past Court Date") }
+  it { is_expected.to have_selector("h6", text: casa_case.case_number) }
+  it { is_expected.to have_selector(".btn-primary") }
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2312

### What changed, and why?
- Added a new page to create past court dates
- Added a new page to edit past court dates
- Added a link from the casa_cases/edit page to add past court dates
- Added a link from the past_court_dates/show page to edit

### How will this affect user permissions?
Creating and editing past court dates uses the same permissions as casa cases

### How is this tested? (please write tests!) 💖💪
LOTS of tests

### Screenshots please :)
**From casa_cases/edit**

<img width="672" alt="image" src="https://user-images.githubusercontent.com/4965672/128568462-634cd3d8-9740-457b-a85d-c94239ce65f3.png">

**From past_court_dates/show**

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/4965672/128568618-fdb730ae-efcc-4751-aa9d-4988fe81faed.png">

**New past court date**

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/4965672/128568486-7749f5f1-04c0-4904-8b2d-e09c7e30c2f0.png">

**Update past court date**

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/4965672/128568551-c00309a0-79d5-4090-ade2-fd2166991716.png">
