### PR TITLE
fix(): fix duplicate case numbers in assign a new case dropdown

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -9,12 +9,14 @@ module UiHelper
         "Not Assigned",
         CasaCase
           .not_assigned(@volunteer.casa_org).active
+          .uniq { |casa_case| casa_case.case_number }
           .map { |casa_case| [casa_case.case_number, casa_case.id] }
       ],
       [
         "Assigned",
         CasaCase
           .actively_assigned_excluding_volunteer(@volunteer)
+          .uniq { |casa_case| casa_case.case_number }
           .map { |casa_case| [casa_case.case_number, casa_case.id] }
       ]
     ]

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe UiHelper do
+  describe "#grouped_options_for_assigning_case" do
+    before(:each) do
+      @casa_cases = create_list(:casa_case, 4)
+      @volunteer = create(:volunteer, casa_org: @casa_cases[0].casa_org)
+    end
+
+    it "does not render duplicate casa_case" do
+      options = helper.grouped_options_for_assigning_case(@volunteer)
+
+      expect(options[0]).to eq(options[0].uniq { |option| option[0] })
+      expect(options[1]).to eq(options[1].uniq { |option| option[0] })
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2345

### What changed, and why?
The `uniq` method was add to `grouped_options_for_assigning_case` to prevent duplicates on the dropdown

### How is this tested? (please write tests!) 💖💪
A unit test was created to test this scenario.

