### PR TITLE
Add Past Court Date button should be styled consistently

### DIFF
--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -35,31 +35,6 @@ body.casa_cases {
     }
   }
 
-  .add-court-mandate-container {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 10px;
-  }
-
-  #add-mandate-button {
-    color: white;
-    border: none;
-
-    font-size: 1.25em;
-
-    :hover {
-      cursor: pointer;
-    }
-  }
-
-  #add-mandate-button {
-    background-color: #{$primary};
-
-    padding: 0.25em 1.5em;
-    border-radius: 10px;
-  }
-
   .court-mandate-entry {
     display: flex;
     gap: 8px;
@@ -94,7 +69,7 @@ body.casa_cases {
 }
 
 body.casa_cases-show {
-  .add-past-court-date-container {
+  .past-court-dates.add-container {
     display: none;
   }
 }

--- a/app/javascript/src/stylesheets/pages/past_court_dates.scss
+++ b/app/javascript/src/stylesheets/pages/past_court_dates.scss
@@ -10,31 +10,6 @@ body.past_court_dates {
     }
   }
 
-  .add-court-mandate-container {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    gap: 10px;
-  }
-
-  #add-mandate-button {
-    color: white;
-    border: none;
-
-    font-size: 1.25em;
-
-    :hover {
-      cursor: pointer;
-    }
-  }
-
-  #add-mandate-button {
-    background-color: #{$primary};
-
-    padding: 0.25em 1.5em;
-    border-radius: 10px;
-  }
-
   .court-mandate-entry {
     display: flex;
     gap: 8px;

--- a/app/javascript/src/stylesheets/shared/utilities.scss
+++ b/app/javascript/src/stylesheets/shared/utilities.scss
@@ -10,3 +10,24 @@
   display: flex;
   align-items: center;
 }
+
+.add-container {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 10px;
+
+  .add-button {
+    color: white;
+    border: none;
+    background-color: #{$primary};
+
+    padding: 0.25em 1.5em;
+    border-radius: 10px;
+    font-size: 1.25em;
+
+    :hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -130,8 +130,8 @@
                 </div>
               <% end %>
             </div>
-            <div class="add-court-mandate-container">
-              <button type="button" id="add-mandate-button">
+            <div class="add-container">
+              <button type="button" class="add-button" id="add-mandate-button">
                 <i class="fa fa-plus" aria-hidden="true"></i>
               </button>
               <strong><%= t(".add_court_mandate") %></strong>

--- a/app/views/casa_cases/_past_court_dates.html.erb
+++ b/app/views/casa_cases/_past_court_dates.html.erb
@@ -16,8 +16,8 @@
 <% else %>
   <%= t(".no_past_court_dates") %>
 <% end %>
-<div class="add-past-court-date-container">
-  <a class="btn btn-primary" href="<%= new_casa_case_past_court_date_path(casa_case) %>">
+<div class="add-container past-court-dates">
+  <a class="btn btn-primary add-button" href="<%= new_casa_case_past_court_date_path(casa_case) %>">
     <i class="fa fa-plus" aria-hidden="true"></i>
   </a>
   <strong><%= t(".add_past_court_date") %></strong>

--- a/app/views/past_court_dates/_form.html.erb
+++ b/app/views/past_court_dates/_form.html.erb
@@ -61,8 +61,8 @@
             </div>
           <% end %>
         </div>
-        <div class="add-court-mandate-container">
-          <button type="button" id="add-mandate-button">
+        <div class="add-container">
+          <button type="button" class="add-button" id="add-mandate-button">
             <i class="fa fa-plus" aria-hidden="true"></i>
           </button>
           <strong><%= t(".button.add_court_mandate") %></strong>

--- a/spec/system/past_court_dates/new_spec.rb
+++ b/spec/system/past_court_dates/new_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "past_court_dates/new", :disable_bullet, type: :system do
     click_on "Cases"
     click_on casa_case.case_number
     click_on "Edit Case Details"
-    find(".add-past-court-date-container .btn-primary").click
+    find(".past-court-dates.add-container .btn-primary").click
   end
 
   context "when all fields are filled" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2381

### What changed, and why?
- Refactor `.add-mandate-button` style into utilities.scss so it can be reused
- Style Add Past Court Date button the same way the Add Mandate button is styled

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Fixed existing tests

### Screenshots please :)
<img width="896" alt="image" src="https://user-images.githubusercontent.com/4965672/129065479-7969856f-36de-4bb0-a326-f626845cde6d.png">
