### PR TITLE
Fix new session view responsiveness

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,17 @@
-<div class="row">
-  <div class="col-lg-5 col-md-12 vertically-center">
-    <div class="container">
-      <div class="row">
-        <div class="offset-xl-2 col-xl-8 col-lg-12 col-sm-8 col-md-8">
-          <br>
-          <h2>Log in</h2>
-          <br>
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <div class="container d-flex flex-column w-75 h-100 py-5 py-lg-0 px-2 px-xl-5 justify-content-center">
+          <h2 class="mb-4">Log in</h2>
 
           <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
             <div class="field form-group">
-              <%= f.label :email %><br>
+              <%= f.label :email %>
               <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
             </div>
 
             <div class="field form-group">
-              <%= f.label :password %><br>
+              <%= f.label :password %>
               <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
             </div>
 
@@ -23,15 +20,14 @@
             </div>
           <% end %>
 
-          <br>
-          <%= render "devise/shared/links" %>
-          <br>
-        </div>
+          <div class="my-4">
+            <%= render "devise/shared/links" %>
+          </div>
       </div>
     </div>
-  </div>
 
-  <div class="col-lg-7 d-none d-lg-block">
-    <aside class="display-image"></aside>
+    <div class="col col-xl-7 p-0 d-none d-lg-block">
+      <aside class="display-image"></aside>
+    </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
-    <div class="col">
-      <div class="container d-flex flex-column w-75 h-100 py-5 py-lg-0 px-2 px-xl-5 justify-content-center">
+    <div class="col p-0">
+      <div class="container d-flex flex-column w-75 h-100 py-5 py-lg-0 px-0 px-xl-5 justify-content-center">
           <h2 class="mb-4">Log in</h2>
 
           <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
#2397 

### What changed, and why?
All changes have been made on the new session page (login). Removed break lines tags, using [spacing classes](https://getbootstrap.com/docs/5.0/utilities/spacing/) instead helps tweaking more easily; overlapped view within a div with container class since it's [required](https://getbootstrap.com/docs/5.0/layout/containers/) for the grid to work properly; form class has being completed refactored, but it's now able to fit better different resolutions while keeping centralized on user screen.

### How will this affect user permissions?
Not affected.

### How is this tested? (please write tests!) 💖💪
No new tests are required since it's still keeping the same functionalities.

### Screenshots please :)
<details>
<summary>Before</summary>

![casa_before_desktop](https://user-images.githubusercontent.com/25598040/129246501-852d1be1-2677-48bb-b17e-fe6dc2ac8c9c.png)
![casa_before_mobile](https://user-images.githubusercontent.com/25598040/129246514-f39d7c48-96c6-4b07-bc2a-b8cb9c707444.png)
</details>

<details>
<summary>After</summary>

![casa_desktop](https://user-images.githubusercontent.com/25598040/129243613-90034e81-36b7-4041-ab50-ad5f5dd618a7.png)
![casa_mobile](https://user-images.githubusercontent.com/25598040/129246246-403434e7-5b12-4095-83e7-3184ba01b9cf.png)
</details>