### PR TITLE
Change question icon tooltips to non-hidden small text

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -14,8 +14,7 @@ label {
   font-weight: 900;
 }
 
-.fa-car,
-.fa-question-circle {
+.fa-car {
   color: $primary;
 }
 
@@ -37,6 +36,12 @@ div.row:nth-child(4) {
   margin: 0 0 12px 0;
 }
 
+.card-title {
+  &__hint {
+    font-size: 11px;
+    font-style: italic;
+  }
+}
 
 /* ASSUMPTION: default screen size is desktop view (> 1024px) */
 

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -16,11 +16,10 @@
               <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
                           class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
               <% unless contact.quarter_editable? %>
-                <i
-                  class="fa fa-question-circle"
-                  aria-hidden="true"
-                  data-toggle="tooltip"
-                  title="<%= t("case_contacts.quarter_not_editable") %>"></i>
+                <br>
+                <small aria-hidden="true" class="card-title__hint text-muted">
+                  <%= t("case_contacts.quarter_not_editable") %>
+                </small>
               <% end %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe "case_contacts/edit", :disable_bullet, type: :system do
         expect(page).not_to have_link "Edit", href: edit_case_contact_path(case_contact)
       end
 
-      it "contact has tooltip" do
-        expect(page).to have_css("i.fa-question-circle")
+      it "contact has hint with card information" do
+        expect(page).to have_css("small.card-title__hint")
       end
     end
   end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -94,10 +94,7 @@ RSpec.describe "case_contacts/index", :disable_bullet, js: true, type: :system d
           end
         end
 
-        it "displays an information tooltip about the archived contacts" do
-          tooltip = find(".fa-question-circle")
-          page.driver.browser.action.move_to(tooltip.native).perform
-
+        it "displays an information hint about the archived contacts" do
           expect(page).to have_content("Archived contacts can't be edited. Case contacts are archived after the end of each quarter.")
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2122

### What changed, and why?

Visual change, to improve user experience.

### How is this tested? (please write tests!) 💖💪

With rspec and capybara

### Screenshots please :)

before:
`/casa_case/<id>`
![image](https://user-images.githubusercontent.com/47258878/129427132-38889fcb-8de2-4f8a-a071-4d2dc4c46fdf.png)

after:
`/casa_case/<id>`
![image](https://user-images.githubusercontent.com/47258878/129427094-7a42e0b3-0fe8-48b6-b9a6-7d40c70eae5d.png)