### PR TITLE
Fix file download tests in docker (locally)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,10 +26,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Build
         run: docker-compose build
-      - name: bundle install
-        run: docker-compose run web bundle install
-      - name: db:reset
-        run: docker-compose run web rails db:reset
       - name: docker UP
         run: docker-compose up -d
       - name: Test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Build
         run: docker-compose build
       - name: bundle install

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Build
         run: docker-compose build
+      - name: db:reset
+        run: docker-compose run web rails db:reset
       - name: docker UP
         run: docker-compose up -d
       - name: Test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,17 +22,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
-      - name: Build
-        run: docker-compose build
-      - name: bundle install
-        run: docker-compose run web bundle install
-      - name: db:reset
-        run: docker-compose run web rails db:reset
       - name: docker UP
         run: docker-compose up -d
-      - name: docker PS
-        run: docker ps
-      - name: docker inspect
-        run: docker inspect casa_selenium_chrome_1
       - name: Test
         run: docker-compose exec -T web bundle exec rspec spec

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    container:
+      image: selenium/standalone-chrome-debug
+      volumes:
+        - ${{ github.workspace }}/tmp/downloads:/home/seluser/Downloads
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,10 +19,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    container:
-      image: selenium/standalone-chrome-debug
-      volumes:
-        - ${{ github.workspace }}/tmp/downloads:/home/seluser/Downloads
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
@@ -34,5 +30,9 @@ jobs:
         run: docker-compose run web rails db:reset
       - name: docker UP
         run: docker-compose up -d
+      - name: docker PS
+        run: docker ps
+      - name: docker inspect
+        run: docker inspect casa_selenium_chrome_1
       - name: Test
         run: docker-compose exec -T web bundle exec rspec spec

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,5 +24,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: docker UP
         run: docker-compose up -d
+      - name: db:reset
+        run: docker-compose exec -T web rails db:reset
       - name: Test
         run: docker-compose exec -T web bundle exec rspec spec

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Build
         run: docker-compose build
+      - name: bundle install
+        run: docker-compose run web bundle install
       - name: db:reset
         run: docker-compose run web rails db:reset
       - name: docker UP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       driver: none
     ports:
       - "5900:5900"
+    volumes:
+      - ./tmp/downloads:/home/seluser/Downloads
 
 volumes:
   db_data:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -22,7 +22,7 @@ Capybara.register_driver :selenium_chrome_headless_in_container do |app|
         "prefs" => {
           "download.prompt_for_download" => false,
           "download.default_directory" => "/home/seluser/Downloads",
-          "browser.set_download_behavior" => { "behavior" => "allow" }
+          "browser.set_download_behavior" => {"behavior" => "allow"}
         }
       }
     )]
@@ -51,7 +51,7 @@ RSpec.configure do |config|
     config.include DownloadHelpers
     clear_downloads
     if ENV["DOCKER"]
-      driven_by :selenium_chrome_headless_in_container
+      driven_by :selenium_chrome_in_container
       Capybara.server_host = "0.0.0.0"
       Capybara.server_port = 4000
       Capybara.app_host = "http://web:4000"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -51,7 +51,7 @@ RSpec.configure do |config|
     config.include DownloadHelpers
     clear_downloads
     if ENV["DOCKER"]
-      driven_by :selenium_chrome_in_container
+      driven_by :selenium_chrome_headless_in_container
       Capybara.server_host = "0.0.0.0"
       Capybara.server_port = 4000
       Capybara.app_host = "http://web:4000"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -7,18 +7,26 @@ require "selenium/webdriver"
 Capybara.register_driver :selenium_chrome_in_container do |app|
   Capybara::Selenium::Driver.new app,
     browser: :remote,
-    url: "http://selenium_chrome:4444",
+    url: "http://selenium_chrome:4444/wd/hub",
     capabilities: [:chrome]
 end
 
 # used in docker
 Capybara.register_driver :selenium_chrome_headless_in_container do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << "--headless"
+    opts.args << "--disable-gpu"
+    opts.args << "--disable-site-isolation-trials"
+    opts.args << "--window-size=1280,900"
+  end
+  browser_options.add_preference(:download, prompt_for_download: false, default_directory: DownloadHelpers::PATH.to_s)
+
+  browser_options.add_preference(:browser, set_download_behavior: {behavior: "allow"})
+
   Capybara::Selenium::Driver.new app,
     browser: :remote,
     url: "http://selenium_chrome:4444/wd/hub",
-    capabilities: [Selenium::WebDriver::Remote::Capabilities.chrome(
-      "goog:chromeOptions" => {"args" => %w[headless disable-gpu window-size=1280,900]}
-    )]
+    options: browser_options
 end
 
 # used without docker
@@ -44,7 +52,7 @@ RSpec.configure do |config|
     config.include DownloadHelpers
     clear_downloads
     if ENV["DOCKER"]
-      driven_by :selenium_chrome_headless_in_container
+      driven_by :selenium_chrome_in_container
       Capybara.server_host = "0.0.0.0"
       Capybara.server_port = 4000
       Capybara.app_host = "http://web:4000"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #2246

### What changed, and why?
- This is only the **first** step to fixing these errors. Now, these tests pass locally. The last step must be related to GitHub actions, but I'm having trouble figuring out the last piece here.
- By using `:selenium_chrome_in_container` and `vnc://localhost:5900`, I was able to spy on the test as it was running in docker. I could see that the download was working correctly. It was downloading to `/home/seluser/Downloads` so I created a shared volume from the host (/tmp/downloads/) to the container

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
The existing tests pass locally!

### Feelings gif (optional)
![Alt Text](https://media.giphy.com/media/l0amJzVHIAfl7jMDos/giphy.gif)
