### PR TITLE
Refactor and add admin court report download test

### DIFF
--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -89,20 +89,56 @@ RSpec.describe "/case_court_reports", :disable_bullet, type: :request do
 
   # case_court_reports#generate
   describe "POST /case_court_reports" do
-    context "when no custom template is set" do
+    context "when an INVALID / non-existing case is sent" do
+      let(:casa_case) { build_stubbed(:casa_case) }
+
       before do
         request_generate_court_report
       end
 
-      context "when a valid / existing case is sent" do
+      it "sends response as a JSON string" do
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(JSON.parse(response.body)).to be_instance_of Hash
+      end
+
+      it "has keys ['link','status','error_messages'] in JSON string" do
+        body_hash = JSON.parse(response.body)
+
+        expect(body_hash).to have_key "link"
+        expect(body_hash).to have_key "status"
+        expect(body_hash).to have_key "error_messages"
+      end
+
+      it "sends response with status :not_found" do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "contains a empty link" do
+        body_hash = JSON.parse(response.body)
+
+        expect(body_hash["link"].length).to be 0
+      end
+
+      it "contains error messages with words 'not found'" do
+        body_hash = JSON.parse(response.body)
+
+        expect(body_hash["error_messages"].length).to be > 0
+        expect(body_hash["error_messages"]).to match(/not found/)
+      end
+    end
+
+    context "when a valid / existing case is sent" do
+      context "when no custom template is set" do
         let(:casa_case) { volunteer.casa_cases.first }
 
         it "sends response as a JSON string" do
+          request_generate_court_report
           expect(response.content_type).to eq("application/json; charset=utf-8")
           expect(JSON.parse(response.body)).to be_instance_of Hash
         end
 
         it "has keys ['link', 'status'] in JSON string" do
+          request_generate_court_report
           body_hash = JSON.parse(response.body)
 
           expect(body_hash).to have_key "link"
@@ -110,81 +146,39 @@ RSpec.describe "/case_court_reports", :disable_bullet, type: :request do
         end
 
         it "sends response with status :ok" do
+          request_generate_court_report
           expect(response).to have_http_status(:ok)
         end
 
         it "contains a link ending with .DOCX extension" do
+          request_generate_court_report
           body_hash = JSON.parse(response.body)
 
-          expect(body_hash["link"]).to end_with("#{casa_case.case_number}.docx")
+          expect(body_hash["link"]).to end_with(".docx")
         end
 
         it "uses the default template" do
+          request_generate_court_report
           get JSON.parse(response.body)["link"]
 
           expect(get_docx_subfile_contents(response.body, "word/header3.xml")).to include("YOUR CASA ORG’S NUMBER")
         end
-
-        # TODO admin and supervisor tests instruction in wrong order
-        # context "as a supervisor" do
-        #  let(:supervisor) { volunteer.supervisor }
-        #
-        #  it "generates the report" do
-        #    sign_in supervisor
-
-        #    expect(JSON.parse(response.body)["link"]).to end_with("#{casa_case.case_number}.docx")
-        #  end
-        # end
       end
 
-      context "when an INVALID / non-existing case is sent" do
-        let(:casa_case) { build_stubbed(:casa_case) }
+      context "when a custom template is set" do
+        let(:casa_case) { volunteer.casa_cases.first }
 
-        it "sends response as a JSON string" do
-          expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(JSON.parse(response.body)).to be_instance_of Hash
+        before do
+          volunteer.casa_org.court_report_template.attach(io: File.new(Rails.root.join("app", "documents", "templates", "montgomery_report_template.docx")), filename: "montgomery_report_template.docx")
+
+          request_generate_court_report
         end
 
-        it "has keys ['link','status','error_messages'] in JSON string" do
-          body_hash = JSON.parse(response.body)
+        it "uses the custom template" do
+          get JSON.parse(response.body)["link"]
 
-          expect(body_hash).to have_key "link"
-          expect(body_hash).to have_key "status"
-          expect(body_hash).to have_key "error_messages"
+          expect(get_docx_subfile_contents(response.body, "word/document.xml")).to include("Did you forget to enter your court orders?")
         end
-
-        it "sends response with status :not_found" do
-          expect(response).to have_http_status(:not_found)
-        end
-
-        it "contains a empty link" do
-          body_hash = JSON.parse(response.body)
-
-          expect(body_hash["link"].length).to be 0
-        end
-
-        it "contains error messages with words 'not found'" do
-          body_hash = JSON.parse(response.body)
-
-          expect(body_hash["error_messages"].length).to be > 0
-          expect(body_hash["error_messages"]).to match(/not found/)
-        end
-      end
-    end
-
-    context "when a custom template is set" do
-      let(:casa_case) { volunteer.casa_cases.first }
-
-      before do
-        volunteer.casa_org.court_report_template.attach(io: File.new(Rails.root.join("app", "documents", "templates", "montgomery_report_template.docx")), filename: "montgomery_report_template.docx")
-
-        request_generate_court_report
-      end
-
-      it "uses the custom template" do
-        get JSON.parse(response.body)["link"]
-
-        expect(get_docx_subfile_contents(response.body, "word/document.xml")).to include("Did you forget to enter your court orders?")
       end
     end
   end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -163,6 +163,28 @@ RSpec.describe "/case_court_reports", :disable_bullet, type: :request do
 
           expect(get_docx_subfile_contents(response.body, "word/header3.xml")).to include("YOUR CASA ORG’S NUMBER")
         end
+
+        context "as a supervisor" do
+          let(:supervisor) { volunteer.supervisor }
+
+          it "generates the report" do
+            sign_in supervisor
+            request_generate_court_report
+
+            expect(JSON.parse(response.body)["link"]).to end_with(".docx")
+          end
+        end
+
+        context "as an admin" do
+          let(:admin) { volunteer.casa_org.casa_admins.first || create(:casa_admin, casa_org: volunteer.casa_org) }
+
+          it "generates the report" do
+            sign_in admin
+            request_generate_court_report
+
+            expect(JSON.parse(response.body)["link"]).to end_with(".docx")
+          end
+        end
       end
 
       context "when a custom template is set" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2378

### What changed, and why?
 - Rearranged test contexts
   -  set invalid casa case and valid casa case as the main contexts for grouping tests
   -  moved most tests under the valid casa case context
 - restored supervisor being able to generate a court report test
 - created admin being able to generate a court report test