### PR TITLE
Prune unused casa case scope

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -101,20 +101,6 @@ class CasaCase < ApplicationRecord
     end
   end
 
-  def self.available_for_volunteer(volunteer)
-    ids = connection.select_values(%{
-      SELECT casa_cases.id
-      FROM casa_cases
-      WHERE id NOT IN (SELECT ca.casa_case_id
-                      FROM case_assignments ca
-                      WHERE ca.volunteer_id = #{volunteer.id}
-                      GROUP BY ca.casa_case_id)
-      GROUP BY casa_cases.id;
-    })
-    where(id: ids, casa_org: volunteer.casa_org)
-      .order(:case_number)
-  end
-
   def clear_court_dates
     if court_date && court_date < Time.current
       update(

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -87,32 +87,6 @@ RSpec.describe CasaCase, type: :model do
     end
   end
 
-  describe ".available_for_volunteer" do
-    let(:casa_org) { create(:casa_org) }
-    let!(:casa_case1) { create(:casa_case, :with_case_assignments, case_number: "foo", casa_org: casa_org) }
-    let!(:casa_case2) { create(:casa_case, :with_case_assignments, case_number: "bar", casa_org: casa_org) }
-    let!(:casa_case3) { create(:casa_case, case_number: "baz", casa_org: casa_org) }
-    let!(:casa_case4) { create(:casa_case, casa_org: create(:casa_org)) }
-    let(:volunteer) { create(:volunteer, casa_org: casa_org) }
-
-    context "when volunteer has no case assignments" do
-      it "returns all cases in volunteer's organization" do
-        expect(described_class.available_for_volunteer(volunteer)).to eq [casa_case2, casa_case3, casa_case1]
-      end
-    end
-
-    context "when volunteer has case assignments" do
-      let(:volunteer2) { create(:volunteer, casa_org: casa_org) }
-      let(:casa_case) { create(:casa_case, casa_org: casa_org) }
-
-      it "returns cases to which volunteer is not assigned in same org" do
-        casa_case.volunteers << volunteer
-        casa_case.volunteers << volunteer2
-        expect(described_class.available_for_volunteer(volunteer)).to eq [casa_case2, casa_case3, casa_case1]
-      end
-    end
-  end
-
   describe ".should_transition" do
     it "returns only youth who should have transitioned but have not" do
       not_transitioned_13_yo = create(:casa_case,


### PR DESCRIPTION
### What changed, and why?
removed `available_for_volunteer` in `app/models/casa_case.rb` because it was not called anywhere.  
Also in the place it was expected to be called, 2 other scopes were used instead. See https://github.com/rubyforgood/casa/blob/main/app/helpers/ui_helper.rb