### PR TITLE
Changes the name of the case contact CSV

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -13,12 +13,13 @@ class CasaCasesController < ApplicationController
 
   def show
     authorize @casa_case
+
     respond_to do |format|
       format.html {}
       format.csv do
         case_contacts = @casa_case.decorate.case_contacts_ordered_by_occurred_at
         csv = CaseContactsExportCsvService.new(case_contacts).perform
-        send_data csv, filename: "volunteer-#{current_user.id}-case-contacts-#{Time.zone.now.to_i}.csv"
+        send_data csv, filename: case_contact_csv_name(case_contacts)
       end
     end
   end
@@ -103,5 +104,12 @@ class CasaCasesController < ApplicationController
 
   def set_contact_types
     @contact_types = ContactType.for_organization(current_organization)
+  end
+
+  def case_contact_csv_name(case_contacts)
+    casa_case_number = case_contacts&.first&.casa_case&.case_number
+    current_date = Time.now.strftime("%Y-%m-%d")
+
+    "#{casa_case_number.nil? ? "" : casa_case_number + "-"}case-contacts-#{current_date}.csv"
   end
 end

--- a/spec/controllers/casa_cases_controller_spec.rb
+++ b/spec/controllers/casa_cases_controller_spec.rb
@@ -9,14 +9,26 @@ RSpec.describe CasaCasesController, type: :controller do
       before do
         allow(controller).to receive(:authenticate_user!).and_return(true)
         allow(controller).to receive(:current_user).and_return(volunteer)
-      end
-
-      it "should export csv successfully" do
-        case_id = volunteer.casa_cases.first.id
 
         get :show, params: {id: case_id, format: :csv}
-        expect(response).to have_http_status(:ok)
-        # TODO: add more test cases to cover the amount of data that's exported
+      end
+
+      context "when exporting a csv" do
+        let(:case_id) { volunteer.casa_cases.first.id }
+        let(:current_time) { Time.now.strftime("%Y-%m-%d") }
+        let(:casa_case_number) { volunteer.casa_cases.first.case_number }
+
+        it "generates a csv" do
+          expect(response).to have_http_status(:ok)
+          expect(response.headers["Content-Type"]).to include "text/csv"
+          expect(response.headers["Content-Disposition"]).to include "#{casa_case_number}-case-contacts-#{current_time}"
+        end
+
+        it "adds the correct headers to the csv" do
+          csv_headers = ["Internal Contact Number", "Duration Minutes", "Contact Types", "Contact Made", "Contact Medium", "Occurred At", "Added To System At", "Miles Driven", "Wants Driving Reimbursement", "Casa Case Number", "Creator Email", "Creator Name", "Supervisor Name", "Case Contact Notes"]
+
+          csv_headers.each { |header| expect(response.body).to include header }
+        end
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2382

### What changed, and why?
The name of the case contact CSV has been changed and made more meaningful and prettier 😄 

### How will this affect user permissions?
- Volunteer permissions: -
- Supervisor permissions: -
- Admin permissions: -

### How is this tested? (please write tests!) 💖💪
It is tested inside the casa_cases_controller spec
