### PR TITLE
Makes the case number a link

### DIFF
--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -13,7 +13,8 @@
 <div class="card card-container">
   <div class="card-body">
     <p>
-      <h6><strong><%= t(".label.case_number") %>:</strong> <%= @casa_case.case_number %></h6>
+      <h6><strong><%= t(".label.case_number") %>:</strong> <%= link_to "#{@casa_case.case_number}",
+casa_case_path(@casa_case) %></h6>
     </p>
     <p>
       <h6>

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "past_court_dates/show", type: :view do
     before { render template: "past_court_dates/show" }
 
     it "displays all court details" do
+      expect(rendered).to include("/casa_cases/#{past_court_date.casa_case.id}")
       expect(rendered).to include(ERB::Util.html_escape(past_court_date.judge.name))
       expect(rendered).to include(past_court_date.hearing_type.name)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2418

### What changed, and why?
Now the case number is a link that goes to the case show page

### How is this tested? (please write tests!) 💖💪
Added a test in the show spec where it checks if the path to the case is present

### Screenshots please :)
![Screenshot 2021-08-18 at 17 47 32](https://user-images.githubusercontent.com/24357305/129929777-ebb45278-b959-4284-ace8-2406799be1cb.png)