### PR TITLE
reduced database query count for latest_past_court_date

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -130,7 +130,7 @@ class CasaCase < ApplicationRecord
   end
 
   def latest_past_court_date
-    past_court_dates.any? ? past_court_dates.where(date: past_court_dates.select("MAX(date)"))[0] : nil
+    past_court_dates.order("date").last
   end
 
   def has_contact_type?(contact_type)


### PR DESCRIPTION
### What changed, and why?
`past_court_dates.order("date").last` reduces the amount of database queries needed

```
irb(main):003:0> CasaCase.first.past_court_dates.order("date").last
  CasaCase Load (0.5ms)  SELECT "casa_cases".* FROM "casa_cases" ORDER BY "casa_cases"."id" ASC LIMIT $1  [["LIMIT", 1]]
  PastCourtDate Load (37.6ms)  SELECT "past_court_dates".* FROM "past_court_dates" WHERE "past_court_dates"."casa_case_id" = $1 ORDER BY date DESC LIMIT $2  [["casa_case_id", 21], ["LIMIT", 1]]
=> nil
irb(main):005:0> CasaCase.first.past_court_dates.where(date: CasaCase.first.past_court_dates.select("MAX(date)"))[0]
  CasaCase Load (0.8ms)  SELECT "casa_cases".* FROM "casa_cases" ORDER BY "casa_cases"."id" ASC LIMIT $1  [["LIMIT", 1]]
  CasaCase Load (0.3ms)  SELECT "casa_cases".* FROM "casa_cases" ORDER BY "casa_cases"."id" ASC LIMIT $1  [["LIMIT", 1]]
  PastCourtDate Load (52.5ms)  SELECT "past_court_dates".* FROM "past_court_dates" WHERE "past_court_dates"."casa_case_id" = $1 AND "past_court_dates"."date" IN (SELECT MAX(date) FROM "past_court_dates" WHERE "past_court_dates"."casa_case_id" = $2)  [["casa_case_id", 21], ["casa_case_id", 21]]
=> nil
```