### PR TITLE
Show activated / deactivated text when activating / deactivating admin

### DIFF
--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -172,6 +172,8 @@ en:
         display_name: Display Name
       prompt:
         mark_inactive_warning: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"
+      active_text: Admin is
+      deactive_text: Admin was deactivated on
     edit:
       title: Edit Casa Admin
     new:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2411

### What changed, and why?
It fetches the correct local for the form when an admin is being edited

### How is this tested? (please write tests!) 💖💪
- no test for that :( 

### Screenshots please :)
![Screenshot 2021-08-18 at 18 54 40](https://user-images.githubusercontent.com/24357305/129939979-040453f9-5ac8-475f-9a54-ec49e3334623.png)