### PR TITLE
Ability to exclude columns from CaseContactReport

### DIFF
--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -27,7 +27,8 @@ class CaseContactReportsController < ApplicationController
       contact_type_ids: [],
       contact_type_group_ids: [],
       creator_ids: [],
-      supervisor_ids: []
+      supervisor_ids: [],
+      filtered_csv_cols: {}
     ).merge(casa_org_id: current_organization.id)
     convert_radio_options_to_boolean(parameters)
     parameters

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -29,8 +29,6 @@ class CaseContactReport
   def filtered_columns(args)
     if args[:filtered_csv_cols].present?
       args[:filtered_csv_cols].select { |_key, value| value == "true" }.keys.map(&:to_sym)
-    else
-      CaseContactsExportCsvService.DATA_COLUMNS.keys
     end
   end
 end

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -1,13 +1,14 @@
 class CaseContactReport
-  attr_reader :case_contacts
+  attr_reader :case_contacts, :columns
 
   def initialize(args = {})
+    @columns = filtered_columns(args)
     @case_contacts = filtered_case_contacts(args)
   end
 
   def to_csv
     case_contacts_for_csv = @case_contacts
-    CaseContactsExportCsvService.new(case_contacts_for_csv).perform
+    CaseContactsExportCsvService.new(case_contacts_for_csv, columns).perform
   end
 
   private
@@ -23,5 +24,13 @@ class CaseContactReport
       .want_driving_reimbursement(args[:want_driving_reimbursement])
       .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
+  end
+
+  def filtered_columns(args)
+    if args[:filtered_csv_cols].present?
+      args[:filtered_csv_cols].select { |_key, value| value == "true" }.keys.map(&:to_sym)
+    else
+      CaseContactsExportCsvService.DATA_COLUMNS.keys
+    end
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -1,26 +1,26 @@
 require "csv"
 
 class CaseContactsExportCsvService
-  attr_reader :case_contacts
+  attr_reader :case_contacts, :filtered_columns
 
-  def initialize(case_contacts)
+  def initialize(case_contacts, filtered_columns)
+    @filtered_columns = filtered_columns
+
     @case_contacts = case_contacts.preload({creator: :supervisor}, :contact_types, :casa_case)
   end
 
   def perform
     CSV.generate(headers: true) do |csv|
-      csv << full_data.keys.map(&:to_s).map(&:titleize)
+      csv << filtered_columns.map(&:to_s).map(&:titleize)
       if case_contacts.present?
         case_contacts.decorate.each do |case_contact|
-          csv << full_data(case_contact).values
+          csv << CaseContactsExportCsvService.DATA_COLUMNS(case_contact).slice(*filtered_columns).values
         end
       end
     end
   end
 
-  private
-
-  def full_data(case_contact = nil)
+  def self.DATA_COLUMNS(case_contact = nil)
     # Note: these header labels are for stakeholders and do not match the
     # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
     {

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -3,8 +3,8 @@ require "csv"
 class CaseContactsExportCsvService
   attr_reader :case_contacts, :filtered_columns
 
-  def initialize(case_contacts, filtered_columns)
-    @filtered_columns = filtered_columns
+  def initialize(case_contacts, filtered_columns = nil)
+    @filtered_columns = filtered_columns || CaseContactsExportCsvService.DATA_COLUMNS.keys
 
     @case_contacts = case_contacts.preload({creator: :supervisor}, :contact_types, :casa_case)
   end

--- a/app/views/reports/_filter.html.erb
+++ b/app/views/reports/_filter.html.erb
@@ -1,0 +1,34 @@
+<div class="modal fade" id="filterColumns" tabindex="-1" role="dialog" aria-labelledby="filterColumnsLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="filterColumnsLabel">
+          <%= t(".filter_exported_columns") %>
+        </h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div>
+          <%= t(".select_columns") %>
+          <%= form.fields_for :filtered_csv_cols do |ff| %>
+            <% CaseContactsExportCsvService.DATA_COLUMNS.keys.each_with_index do |column, index| %>
+              <div class="row mt-0">
+                <div class="col-sm-12">
+                  <div class="form-check">
+                    <%= ff.check_box column, { class: "form-check-input", checked: true }, true, false %>
+                    <%= ff.label column, column.to_s.titleize, class: "form-check-label" %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal"><%= t("button.close") %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -113,6 +113,11 @@ multiple: true}
         </div>
       <% end %>
 
+      <%= render 'filter', form: f %>
+      <button type="button" class="btn btn-outline-primary" data-toggle="modal" data-target="#filterColumns">
+        <%= t(".filter_cols") %>
+      </button>
+
       <%= f.submit t(".download_report_button"), class: "btn btn-primary", data: {disable_with: false} %>
     <% end %>
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -456,3 +456,7 @@ en:
       transition_aged_label: "Transition Aged Youth:"
       download_report_button: Download Report
       download_mileage_report_button: Mileage Report
+      filter_cols: Filter Columns
+    filter:
+      filter_exported_columns: Filter Exported Columns
+      select_columns: "Select columns:"

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -334,5 +334,29 @@ RSpec.describe CaseContactReport, type: :model do
         end
       end
     end
+
+    context "when columns are filtered" do
+      let(:args) do
+        {
+          filtered_csv_cols: {
+            internal_contact_number: "true",
+            duration_minutes: "true",
+            contact_types: "false"
+          }
+        }
+      end
+
+      it "returns a report with only the selected columns" do
+        create(:case_contact)
+        csv = described_class.new(args).to_csv
+        parsed_csv = CSV.parse(csv)
+
+        expect(parsed_csv.length).to eq(2)
+        expect(parsed_csv[0]).to eq([
+          "Internal Contact Number",
+          "Duration Minutes"
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2227

### What changed, and why?
- Added a new button and modal to the "Export data" page that will let a user choose which columns to include/exclude from the report

### How will this affect user permissions?
All users have the permission to filter columns on the reports generated on this page

### How is this tested? (please write tests!) 💖💪
New test

### Screenshots please :)
**New button to open a modal**
<img width="648" alt="image" src="https://user-images.githubusercontent.com/4965672/129985047-50e496d2-f7e6-41c5-8752-366c4ac2bfd3.png">

**New modal to exclude columns**
<img width="652" alt="image" src="https://user-images.githubusercontent.com/4965672/129985070-d989fa5a-b934-4e79-8751-2798a83e1d71.png">

**Generated report with columns excluded**
<img width="835" alt="image" src="https://user-images.githubusercontent.com/4965672/129985161-af624dd5-6ade-4b59-a107-dd9c4c6fbdba.png">
