### PR TITLE
File download tests in docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,4 +31,4 @@ jobs:
       - name: db:reset
         run: docker-compose exec -T web rails db:reset
       - name: Test
-        run: docker-compose exec -T web bundle exec rspec spec/system/reports/export_data_spec.rb
+        run: docker-compose exec -T web bundle exec rspec spec

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
+      - name: Create downloads folder
+        run: |
+          mkdir -p tmp/downloads
+          chmod 777 tmp tmp/downloads
       - name: docker UP
         run: docker-compose up -d
       - name: db:reset
         run: docker-compose exec -T web rails db:reset
       - name: Test
-        run: docker-compose exec -T web bundle exec rspec spec
+        run: docker-compose exec -T web bundle exec rspec spec/system/reports/export_data_spec.rb


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2246
Resolves #2333

### What changed, and why?
- The download tests were failing in docker bc the runner did not have a `tmp/downloads/` folder so the docker volume was not mounted to anything on the runner. I changed the GitHub action to create the folders with write permissions before spinning docker up.

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
all tests pass now in CI!
