### PR TITLE
Fix flaky seed test

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -178,10 +178,10 @@ class DbPopulator
           )
         end
 
-      volunteer = casa_org.volunteers.active.sample(random: rng) ||
-        casa_org.volunteers.active.first ||
+      volunteer = new_casa_case.casa_org.volunteers.active.sample(random: rng) ||
+        new_casa_case.casa_org.volunteers.active.first ||
         Volunteer.create!(
-          casa_org: casa_org,
+          casa_org: new_casa_case.casa_org,
           email: "#{SecureRandom.hex(10)}@example.com",
           password: SEED_PASSWORD,
           display_name: "active volunteer"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2430

### What changed, and why?
- In `create_cases`, if there was already a CasaCase that existed for a generated case_number, that case would be used to generate volunteers. But since that CasaCase was not just created with the script, the casa_org was not correct with what was given as a param to the volunteer. So I fixed this by using `new_casa_case.casa_org` as the param so it's always the correct organization.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
I could reliably get `seed_spec.rb` to fail roughly 1 in 5 times that I ran it locally. I could never get it to fail after this change.
