### PR TITLE
Show message when notifications are empty

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -23,4 +23,12 @@
       </div>
     </a>
   <% end %>
+
+  <% if @notifications.empty? %>
+    <div class="card card-container my-4 border-warning">
+      <div class="card-body">
+        <%= t(".no_notifications") %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -462,3 +462,6 @@ en:
     filter:
       filter_exported_columns: Filter Exported Columns
       select_columns: "Select columns:"
+  notifications:
+    index:
+      no_notifications: You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "notifications/index", :disable_bullet, type: :system do
 
       expect(page).to have_text(notification_message)
       expect(page).to have_text("Followup resolved")
+      expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
     end
   end
 
@@ -57,6 +58,7 @@ RSpec.describe "notifications/index", :disable_bullet, type: :system do
         expect(page).to have_text(notification_message_heading)
         expect(page).to have_text(note)
         expect(page).to have_text(notification_message_more_info)
+        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
         expect(page).to have_text("New followup")
       end
     end
@@ -75,8 +77,18 @@ RSpec.describe "notifications/index", :disable_bullet, type: :system do
         visit notifications_path
 
         expect(page).to have_text(inline_notification_message)
+        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
         expect(page).to have_text("New followup")
       end
+    end
+  end
+
+  context "when there are no notifications" do
+    it "displays a message to the user" do
+      sign_in volunteer
+      visit notifications_path
+
+      expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2431

### What changed, and why?
- Added a `card-container` to notifications/index to show a message when there are no notifications

### How is this tested? (please write tests!) 💖💪
New system test

### Screenshots please :)
<img width="1391" alt="image" src="https://user-images.githubusercontent.com/4965672/130337171-b542ccac-7812-45d0-8d71-3fbae29b17b4.png">

