### PR TITLE
fixed bad link between admin to supervisor link on case contact

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -72,7 +72,7 @@
           <%= contact.creator&.display_name %>
         <% else %>
           <% if contact.creator&.supervisor? %>
-            <%= link_to contact.creator&.display_name, edit_supervisor_path(current_user) %>
+            <%= link_to contact.creator&.display_name, edit_supervisor_path(contact.creator) %>
           <% elsif contact.creator&.casa_admin? %>
             <%= link_to contact.creator&.display_name, edit_users_path %>
           <% else %>

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe "casa_cases/show", :disable_bullet, type: :system do
       expect(page).to have_link(href: "/supervisors/#{user.id}/edit")
     end
 
+    context "case contact by another supervisor" do
+      let(:other_supervisor) { create(:supervisor, casa_org: organization) }
+      let!(:case_contact) { create(:case_contact, creator: other_supervisor, casa_case: casa_case) }
+      it "sees link to other supervisor" do
+        expect(page).to have_link(href: "/supervisors/#{other_supervisor.id}/edit")
+      end
+    end
+
     it "can see court mandates" do
       expect(page).to have_content("Court Mandates")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2414

### What changed, and why?
The link between admin to edit supervisor page had a reference to the current user and not the supervisor. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
spec/system/casa_cases/show_spec.rb:51

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
![first pr](https://media.giphy.com/media/vCN9rQbyw2fhKFelgM/giphy.gif?cid=ecf05e47xlsc0ksuh5qm2jfub5fwfnsabanymkd0euevmf64&rid=giphy.gif&ct=g)