### PR TITLE
Volunteer activation flash msg

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -51,9 +51,9 @@ class VolunteersController < ApplicationController
       VolunteerMailer.account_setup(@volunteer).deliver
 
       if (params[:redirect_to_path] == "casa_case") && (casa_case = CasaCase.find(params[:casa_case_id]))
-        redirect_to edit_casa_case_path(casa_case), notice: "Volunteer was activated."
+        redirect_to edit_casa_case_path(casa_case), notice: "Volunteer was activated. They have been sent an email."
       else
-        redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated."
+        redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated. They have been sent an email."
       end
     else
       render :edit


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2468 

### What changed, and why?
Updated the flash message that is displayed upon a volunteer being activated.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
![CleanShot 2021-08-25 at 23 53 14](https://user-images.githubusercontent.com/54157657/130902957-210cdd85-d738-4377-8a9f-a8836978fccc.png)


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/tJdQOstqgosI01y393/giphy.gif)`

