### PR TITLE
Removes deactivation email and notification

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -61,8 +61,6 @@ class SupervisorsController < ApplicationController
   def deactivate
     authorize @supervisor
     if @supervisor.deactivate
-      SupervisorMailer.deactivation(@supervisor).deliver
-
       redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was deactivated."
     else
       render :edit, notice: "Supervisor could not be deactivated."

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -63,8 +63,6 @@ class VolunteersController < ApplicationController
   def deactivate
     authorize @volunteer
     if @volunteer.deactivate
-      VolunteerMailer.deactivation(@volunteer).deliver
-
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else
       render :edit

--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -1,10 +1,4 @@
 class SupervisorMailer < UserMailer
-  def deactivation(supervisor)
-    @supervisor = supervisor
-    @casa_organization = supervisor.casa_org
-    mail(to: @supervisor.email, subject: "Your account has been deactivated")
-  end
-
   def account_setup(supervisor)
     @supervisor = supervisor
     @casa_organization = supervisor.casa_org

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -1,10 +1,4 @@
 class VolunteerMailer < UserMailer
-  def deactivation(user)
-    @user = user
-    @casa_organization = user.casa_org
-    mail(to: @user.email, subject: "Your account has been deactivated")
-  end
-
   def account_setup(user)
     @user = user
     @casa_organization = user.casa_org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,9 +44,9 @@ en:
     case_contact:
       notes_placeholder: "Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth."
     supervisor:
-      mark_inactive_warning: "WARNING: Marking a supervisor inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?"
+      mark_inactive_warning: "WARNING: Marking a supervisor inactive will make them unable to login. Are you sure you want to do this?"
     volunteer:
-      mark_inactive_warning: "WARNING: Marking a volunteer inactive will make them unable to login. They will receive an email saying their account has been marked inactive. Are you sure you want to do this?"
+      mark_inactive_warning: "WARNING: Marking a volunteer inactive will make them unable to login. Are you sure you want to do this?"
   page:
     meta:
       title: CASA Volunteer Tracking

--- a/spec/mailers/volunteer_mailer_spec.rb
+++ b/spec/mailers/volunteer_mailer_spec.rb
@@ -4,15 +4,6 @@ RSpec.describe VolunteerMailer, type: :mailer do
   let(:volunteer) { create(:volunteer) }
   let(:volunteer_with_supervisor) { create(:volunteer, :with_assigned_supervisor) }
 
-  describe ".deactivation" do
-    let(:mail) { VolunteerMailer.deactivation(volunteer) }
-
-    it "sends an email saying the account has been deactivated" do
-      expect(mail.body.encoded).to match("Hello #{volunteer.display_name}")
-      expect(mail.body.encoded).to match("has been deactivated")
-    end
-  end
-
   describe ".account_setup" do
     let(:mail) { VolunteerMailer.account_setup(volunteer) }
 

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -158,6 +158,40 @@ RSpec.describe "/supervisors", type: :request do
     end
   end
 
+  describe "PATCH /activate" do
+    let(:inactive_supervisor) { create(:supervisor, :inactive) }
+
+    before { sign_in admin }
+
+    it "activates an inactive supervisor" do
+      patch activate_supervisor_path(inactive_supervisor)
+
+      inactive_supervisor.reload
+      expect(inactive_supervisor.active).to be true
+    end
+
+    it "sends an activation mail" do
+      expect { patch activate_supervisor_path(inactive_supervisor) }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  describe "PATCH /deactivate" do
+    before { sign_in admin }
+
+    it "deactivates an active supervisor" do
+      patch deactivate_supervisor_path(supervisor)
+
+      supervisor.reload
+      expect(supervisor.active).to be false
+    end
+
+    it "doesn't send an deactivation email" do
+      expect {
+        patch deactivate_supervisor_path(supervisor)
+      }.to_not change { ActionMailer::Base.deliveries.count }
+    end
+  end
+
   describe "PATCH /resend_invitation" do
     before { sign_in admin }
     it "resends an invitation email" do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "/volunteers", type: :request do
 
     it "doesn't send an deactivation email" do
       expect {
-        patch deactivate_supervisor_path(volunteer)
+        patch deactivate_volunteer_path(volunteer)
       }.to_not change { ActionMailer::Base.deliveries.count }
     end
   end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -215,12 +215,10 @@ RSpec.describe "/volunteers", type: :request do
       expect(volunteer.active).to eq(false)
     end
 
-    it "sends an activation email" do
-      sign_in admin
-
+    it "doesn't send an deactivation email" do
       expect {
-        patch deactivate_volunteer_path(volunteer)
-      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        patch deactivate_supervisor_path(volunteer)
+      }.to_not change { ActionMailer::Base.deliveries.count }
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2475 

### What changed, and why?
Now, users will not see a notification about email being sent when deactivating. It removes sending an email from their respective Mailer when deactivation.

### How is this tested? (please write tests!) 💖💪
Added tests for that in the volunteer and supervisor's request test.

### Screenshots please :)
<img width="961" alt="Screenshot 2021-08-26 at 13 23 41" src="https://user-images.githubusercontent.com/24357305/130954410-60f43b16-77f6-40a2-a5ff-3326a336cbfa.png">
