### PR TITLE
Make past court dates appear in order

### DIFF
--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -13,6 +13,8 @@ class PastCourtDate < ApplicationRecord
 
   accepts_nested_attributes_for :case_court_mandates, reject_if: :all_blank
 
+  scope :ordered_ascending, -> { order("date asc") }
+
   DOCX_TEMPLATE_PATH = Rails.root.join("app", "documents", "templates", "default_past_court_date_template.docx")
 
   def date_must_be_past

--- a/app/views/casa_cases/_past_court_dates.html.erb
+++ b/app/views/casa_cases/_past_court_dates.html.erb
@@ -1,7 +1,7 @@
 <label><%= t(".past_court_dates") %>:</label>
 <% if casa_case.past_court_dates.size > 0 %>
   <ul>
-    <% casa_case.past_court_dates.each do |pcd| %>
+    <% casa_case.past_court_dates.order('date asc').each do |pcd| %>
       <p>
         <%= link_to(pcd.decorate.formatted_date, casa_case_past_court_date_path(casa_case, pcd)) %>
 

--- a/app/views/casa_cases/_past_court_dates.html.erb
+++ b/app/views/casa_cases/_past_court_dates.html.erb
@@ -1,7 +1,7 @@
 <label><%= t(".past_court_dates") %>:</label>
 <% if casa_case.past_court_dates.size > 0 %>
   <ul>
-    <% casa_case.past_court_dates.order('date asc').each do |pcd| %>
+    <% casa_case.past_court_dates.ordered_ascending.each do |pcd| %>
       <p>
         <%= link_to(pcd.decorate.formatted_date, casa_case_past_court_date_path(casa_case, pcd)) %>
 

--- a/spec/models/past_court_date_spec.rb
+++ b/spec/models/past_court_date_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe PastCourtDate, type: :model do
     end
   end
 
+  describe ".ordered_ascending" do
+    subject { described_class.ordered_ascending }
+
+    it "orders the casa cases by updated at date" do
+      very_old_pcd = create(:past_court_date, date: 10.days.ago)
+      old_pcd = create(:past_court_date, date: 5.day.ago)
+      recent_pcd = create(:past_court_date, date: 1.day.ago)
+
+      ordered_pcds = described_class.ordered_ascending
+
+      expect(ordered_pcds.map(&:id)).to eq [very_old_pcd.id, old_pcd.id, recent_pcd.id]
+    end
+  end
+
   describe "reports" do
     let!(:reports) do
       [10, 30, 60].map do |days_ago|

--- a/spec/support/shared_examples/shows_past_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_past_court_dates_links.rb
@@ -19,4 +19,9 @@ shared_examples_for "shows past court dates links" do
     expect(page).to have_text(formatted_date_without_details)
     expect(page).to have_link(formatted_date_without_details)
   end
+
+  it "past court dates are ordered" do
+    expect(page).to have_content((DateTime.current - 10.days).strftime("%B %-d, %Y").to_s)
+    expect(page.body).to match /#{oldest_pcd.date.strftime('%B %-d, %Y')}.*#{newest_pcd.date.strftime('%B %-d, %Y')}/m
+  end
 end

--- a/spec/support/shared_examples/shows_past_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_past_court_dates_links.rb
@@ -1,4 +1,12 @@
 shared_examples_for "shows past court dates links" do
+  let!(:newest_pcd) do
+    create(:past_court_date, date: DateTime.current - 5.days, casa_case: casa_case)
+  end
+
+  let!(:oldest_pcd) do
+    create(:past_court_date, date: DateTime.current - 10.days, casa_case: casa_case)
+  end
+
   let(:past_court_date_with_details) do
     create(:past_court_date, :with_court_details, casa_case: casa_case)
   end
@@ -21,7 +29,9 @@ shared_examples_for "shows past court dates links" do
   end
 
   it "past court dates are ordered" do
-    expect(page).to have_content((DateTime.current - 10.days).strftime("%B %-d, %Y").to_s)
+    visit casa_case_path(casa_case)
+
+    expect(page).to have_text((DateTime.current - 10.days).strftime("%B %-d, %Y").to_s)
     expect(page.body).to match /#{oldest_pcd.date.strftime('%B %-d, %Y')}.*#{newest_pcd.date.strftime('%B %-d, %Y')}/m
   end
 end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "casa_cases/show", type: :system do
   let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: organization, case_number: "CINA-1") }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+  let!(:newest_pcd) { create(:past_court_date, date: DateTime.current - 5.days, casa_case: casa_case) }
+  let!(:oldest_pcd) { create(:past_court_date, date: DateTime.current - 10.days, casa_case: casa_case) }
 
   before do
     sign_in user

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "casa_cases/show", type: :system do
   let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: organization, case_number: "CINA-1") }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
-  let!(:newest_pcd) { create(:past_court_date, date: DateTime.current - 5.days, casa_case: casa_case) }
-  let!(:oldest_pcd) { create(:past_court_date, date: DateTime.current - 10.days, casa_case: casa_case) }
 
   before do
     sign_in user


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2463 

### What changed, and why?
Changed the order of past court dates, now the dates are ordered in ascending style, from oldest to newest.


### How will this affect user permissions?
It will not.

### How is this tested? (please write tests!) 💖💪
Added a test to check the order.


### Screenshots please :)
* Ordered past court dates:
![Screenshot from 2021-08-26 15-19-16](https://user-images.githubusercontent.com/61836657/131016598-b8eb8c94-9eb7-48d8-afe9-2f507ac745c0.png)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![efgalvao](https://media.giphy.com/media/unQ3IJU2RG7DO/giphy.gif?cid=790b76112ad33e65c665bfbe0746afa003cf60e32de25a35&rid=giphy.gif&ct=g)
