### PR TITLE
#2386 volunteer landing page redirect to case for single-case volunteers

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,7 +5,7 @@ class DashboardController < ApplicationController
   def show
     authorize :dashboard
     if volunteer_with_only_one_active_case?
-      redirect_to casa_case_path(current_user.casa_cases.active.first)
+      redirect_to new_case_contact_path
     elsif current_user.volunteer?
       redirect_to casa_cases_path
     elsif current_user.supervisor?

--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), all_casa_admins_casa_org_path(@casa_org) %>
-
 <h1>Edit Admin</h1>
 
 <div class="card card-container">

--- a/app/views/all_casa_admins/casa_admins/new.html.erb
+++ b/app/views/all_casa_admins/casa_admins/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), all_casa_admins_casa_org_path(selected_organization) %>
 <h1>New CASA Admin for <%= selected_organization.name %></h1>
 
 <div class="card card-container">

--- a/app/views/all_casa_admins/casa_orgs/new.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), root_path %>
 <h1>Create a new CASA Organization</h1>
 
 <div class="card card-container">

--- a/app/views/all_casa_admins/casa_orgs/show.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/show.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), root_path %>
 <h1><%= selected_organization.name %></h1>
 
 <div class="card card-container">

--- a/app/views/all_casa_admins/new.html.erb
+++ b/app/views/all_casa_admins/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), authenticated_all_casa_admin_root_path %>
 <h1>New All CASA Admin</h1>
 
 <div class="card card-container">

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), casa_admins_path %>
 <h1><%= title %></h1>
 
 <div class="card card-container">

--- a/app/views/casa_cases/edit.html.erb
+++ b/app/views/casa_cases/edit.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), casa_case_path(@casa_case) %>
 <h1><%= t(".title") %>&nbsp;<%= link_to(@casa_case.case_number, @casa_case) %></h1>
 
 <% if @casa_case.active %>

--- a/app/views/casa_cases/new.html.erb
+++ b/app/views/casa_cases/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), casa_cases_path %>
 <h1><%= t(".title") %></h1>
 
 <%= render 'form', casa_case: @casa_case %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,5 +1,3 @@
-<%= link_to(t("button.back"), casa_cases_path) %>
-
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1><%= @casa_case.decorate.transition_aged_youth_icon %> <%= t(".title") %></h1>

--- a/app/views/case_assignments/index.html.erb
+++ b/app/views/case_assignments/index.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), root_path %>
-
 <h1><%= "#{t(".title")} #{@volunteer.display_name}" %></h1>
 
 <br>

--- a/app/views/case_contacts/edit.html.erb
+++ b/app/views/case_contacts/edit.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), case_contacts_path %>
 <h1><%= t(".title") %></h1>
 
 <div class="card card-container">

--- a/app/views/case_contacts/new.html.erb
+++ b/app/views/case_contacts/new.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), case_contacts_path %>
-
 <h1><%= t(".title") %></h1>
 
 <div class="card card-container">

--- a/app/views/contact_type_groups/_form.html.erb
+++ b/app/views/contact_type_groups/_form.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), :back %>
-
 <h1><%= title %></h1>
 
 <div class="card card-container">

--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), :back %>
-
 <h1><%= title %></h1>
 
 <div class="card card-container">

--- a/app/views/hearing_types/_form.html.erb
+++ b/app/views/hearing_types/_form.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), :back %>
-
 <h1><%= title %></h1>
 
 <div class="card card-container">

--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), :back %>
-
 <h1><%= title %></h1>
 
 <div class="card card-container">

--- a/app/views/past_court_dates/edit.html.erb
+++ b/app/views/past_court_dates/edit.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
 <h1><%= t(".title") %></h1>
 
 <%= render 'form', casa_case: @casa_case, past_court_date: @past_court_date %>

--- a/app/views/past_court_dates/new.html.erb
+++ b/app/views/past_court_dates/new.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
-
 <h1><%= t(".title") %></h1>
 
 <%= render 'form', casa_case: @casa_case, past_court_date: @past_court_date %>

--- a/app/views/past_court_dates/show.html.erb
+++ b/app/views/past_court_dates/show.html.erb
@@ -1,5 +1,3 @@
-<%= link_to t("button.back"), edit_casa_case_path(@casa_case) %>
-
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1><%= t(".title") %></h1>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), supervisors_path %>
 <h1><%= t(".title") %></h1>
 
 <div class="card card-container">

--- a/app/views/supervisors/new.html.erb
+++ b/app/views/supervisors/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), supervisors_path %>
 <h1>Create New Supervisor</h1>
 
 <div class="card card-container">

--- a/app/views/volunteers/new.html.erb
+++ b/app/views/volunteers/new.html.erb
@@ -1,4 +1,3 @@
-<%= link_to t("button.back"), volunteers_path %>
 <h1>New Volunteer</h1>
 
 <div class="card card-container">

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe DashboardController, type: :controller do
       context "with one active case" do
         let!(:case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: active_case }
 
-        it "goes to case" do
-          is_expected.to redirect_to(casa_case_url(active_case.id))
+        it "goes to new case contact page" do
+          is_expected.to redirect_to(new_case_contact_path)
         end
       end
 
@@ -33,8 +33,8 @@ RSpec.describe DashboardController, type: :controller do
         let!(:inactive_case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: inactive_case }
         let!(:case_assignment) { create :case_assignment, volunteer: volunteer, casa_case: active_case }
 
-        it "goes to active case" do
-          expect(subject).to redirect_to(casa_case_url(active_case.id))
+        it "goes to new case contact page" do
+          expect(subject).to redirect_to(new_case_contact_path)
         end
       end
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe "/dashboard", type: :request do
     end
 
     describe "GET /show" do
-      it "renders a successful response" do
-        get root_url
+      context "with one active case" do
+        it "redirects to the new case contact" do
+          get root_url
 
-        expect(response).to redirect_to(casa_case_path(case_assignment.casa_case.id))
+          expect(response).to redirect_to(new_case_contact_path)
+        end
       end
 
       context "more than one active case" do

--- a/spec/system/all_casa_admins/dashboard/show_spec.rb
+++ b/spec/system/all_casa_admins/dashboard/show_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "all_casa_admin/dashboard/show", type: :system do
 
       expect(page).to have_text "Administrators"
       expect(page).to have_text "New CASA Admin"
-      expect(page).to have_text "Back"
       expect(page).to_not have_text vol.email
       expect(page).to_not have_text sup.email
       expect(page).to have_text ca1.email

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -24,14 +24,6 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text(court_mandate.implementation_status.humanize)
     end
 
-    it "clicks back button after editing case" do
-      visit edit_casa_case_path(casa_case)
-      select "Submitted", from: "casa_case_court_report_status"
-      click_on "Back"
-      visit edit_casa_case_path(casa_case)
-      expect(casa_case).not_to be_court_report_submitted
-    end
-
     it "edits case", js: true do
       visit casa_case_path(casa_case.id)
       click_on "Edit Case Details"
@@ -515,22 +507,6 @@ of it unless it was included in a previous court report.")
 
       expect(page).to have_text(court_mandate.mandate_text)
       expect(page).to have_text(court_mandate.implementation_status.humanize)
-    end
-
-    it "clicks back button after editing case" do
-      visit edit_casa_case_path(casa_case)
-
-      expect(page).to_not have_select("Hearing type")
-      expect(page).to_not have_select("Judge")
-
-      select "Submitted", from: "casa_case_court_report_status"
-      within ".actions" do
-        click_on "Update CASA Case"
-      end
-
-      click_on "Back"
-
-      expect(page).to have_text("My Case")
     end
 
     it "edits case" do

--- a/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "all_casa_admins/casa_orgs/show", type: :view do
     end
 
     it "shows new admin button" do
-      expect(rendered).to have_text("Back")
       expect(rendered).to have_text("New CASA Admin")
     end
 

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "casa_cases/new", type: :view do
       sign_in user
     end
 
-    it { is_expected.to have_selector("a", text: "Back") }
     it { is_expected.to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
   end
 
@@ -30,7 +29,6 @@ RSpec.describe "casa_cases/new", type: :view do
       sign_in user
     end
 
-    it { is_expected.to have_selector("a", text: "Back") }
     it { is_expected.not_to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
     it { is_expected.to have_selector("label", text: "Contact types") }
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2386

### What changed, and why?
Redirect volunteers with only one active case to the new case contact page instead of the active casa_case#show page.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
![CleanShot 2021-08-27 at 02 00 43@2x](https://user-images.githubusercontent.com/54157657/131086137-318b21aa-0a4c-4c38-8899-8f892d948c85.png)
![CleanShot 2021-08-27 at 02 01 47@2x](https://user-images.githubusercontent.com/54157657/131086245-fcc9e876-2b5d-45f4-83e9-250cd64729da.png)


### Screenshots please :)

![CleanShot 2021-08-27 at 02 03 17@2x](https://user-images.githubusercontent.com/54157657/131086445-97a575aa-54d2-4d1f-bddf-e9a3bcd3c984.png)
![CleanShot 2021-08-27 at 02 04 29@2x](https://user-images.githubusercontent.com/54157657/131086615-71853fe4-e977-4413-ae3a-2cf11dba8eb3.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
