### PR TITLE
fix emancipations not saving if case is of transitioning age

### DIFF
--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -26,7 +26,7 @@ class EmancipationsController < ApplicationController
       return
     end
 
-    unless current_case.has_transitioned?
+    unless current_case.in_transition_age?
       render json: {error: "The current case is not marked as transitioning"}
       return
     end

--- a/spec/controllers/emancipations_controller_spec.rb
+++ b/spec/controllers/emancipations_controller_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe EmancipationsController, type: :controller do
     let(:params) { {casa_case_id: volunteer.casa_cases.first.id} }
 
     it "errors for unfindable check item" do
+      volunteer.casa_cases.first.update_attribute(:birth_month_year_youth, 8.years.ago)
+
       subject
       expect(response.body).to eq({error: "The current case is not marked as transitioning"}.to_json)
     end

--- a/spec/requests/emancipations_request_spec.rb
+++ b/spec/requests/emancipations_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "/casa_case/:id/emancipation", type: :request do
   let(:organization) { create(:casa_org) }
   let(:organization_different) { create(:casa_org) }
-  let(:casa_case) { create(:casa_case, casa_org: organization, transition_aged_youth: true) }
+  let(:casa_case) { create(:casa_case, casa_org: organization, birth_month_year_youth: 15.years.ago) }
 
   describe "GET /show" do
     before { sign_in user }
@@ -186,7 +186,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
       let(:mutex_option_b) { create(:emancipation_option, emancipation_category_id: mutually_exclusive_category.id, name: "B") }
 
       let(:user) { create(:volunteer, casa_org: organization) }
-      let(:non_transitioning_casa_case) { create(:casa_case, casa_org: organization, transition_aged_youth: false) }
+      let(:non_transitioning_casa_case) { create(:casa_case, casa_org: organization, birth_month_year_youth: 8.years.ago) }
       let!(:case_assignment) { create(:case_assignment, volunteer: user, casa_case: casa_case) }
       let!(:case_assignment_non_transitioning_case) { create(:case_assignment, volunteer: user, casa_case: non_transitioning_casa_case) }
 


### PR DESCRIPTION
### What changed, and why?
Emancipation checklist api calls check for transition age instead of the boolean before saving to the database

### How is this tested? (please write tests!) 💖💪
Updated existing tests