### PR TITLE
Enable annotate_rendered_view_with_filenames in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
     Bullet.rails_logger = true
     Bullet.bullet_logger = true
   end
+
+  # Annotate rendered view with file names.
+  config.action_view.annotate_rendered_view_with_filenames = true
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2457

### What changed, and why?
Added new configuration option in development environment. This options adds HTML comments to the rendered output indicating where each template begins and ends.

### How will this affect user permissions?
None affected

### How is this tested? (please write tests!) 💖💪
Manually

### Screenshots please :)
![Captura de pantalla de 2021-08-31 10-49-27](https://user-images.githubusercontent.com/18152266/131514474-2e3fc1ac-4824-45ce-8d32-469fd9fcb797.png)
