### PR TITLE
2466/2467 Send Reminder CC

### DIFF
--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -1,0 +1,23 @@
+class VolunteerDecorator < UserDecorator
+  include Draper::LazyHelpers
+  delegate_all
+
+  def send_reminder_button
+    submit_tag(
+      t(".send_reminder"),
+      class: "btn btn-primary casa-case-button",
+      data_toggle: "tooltip",
+      title: t(".tooltip").to_s
+    )
+  end
+
+  def cc_reminder_text
+    if current_user.supervisor?
+      checkbox_text = "Send CC to Supervisor"
+    elsif current_user.casa_admin?
+      checkbox_text = "Send CC to Supervisor and Admin"
+    end
+
+    checkbox_text
+  end
+end

--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -1,20 +1,10 @@
 class VolunteerDecorator < UserDecorator
   include Draper::LazyHelpers
-  delegate_all
-
-  def send_reminder_button
-    submit_tag(
-      t(".send_reminder"),
-      class: "btn btn-primary casa-case-button",
-      data_toggle: "tooltip",
-      title: t(".tooltip").to_s
-    )
-  end
 
   def cc_reminder_text
-    if current_user.supervisor?
+    if h.current_user.supervisor?
       checkbox_text = "Send CC to Supervisor"
-    elsif current_user.casa_admin?
+    elsif h.current_user.casa_admin?
       checkbox_text = "Send CC to Supervisor and Admin"
     end
 

--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -3,11 +3,9 @@ class VolunteerDecorator < UserDecorator
 
   def cc_reminder_text
     if h.current_user.supervisor?
-      checkbox_text = "Send CC to Supervisor"
+      h.t("volunteers.send_reminder_button.supervisor_checkbox_text")
     elsif h.current_user.casa_admin?
-      checkbox_text = "Send CC to Supervisor and Admin"
+      h.t("volunteers.send_reminder_button.admin_checkbox_text")
     end
-
-    checkbox_text
   end
 end

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -11,8 +11,20 @@ body.casa_cases {
     }
   }
 
+  #cc-check {
+    p {
+      display: flex;
+      align-items: center;
+    }
+
+    #with_cc {
+      margin-right: 5px;
+    }
+  }
+
   #reminder_button {
     margin-left: 30px;
+    margin-bottom: 0;
   }
 
   .case-contact-list {

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -101,10 +101,9 @@
         <% else %>
           <%= form_tag reminder_volunteer_path(volunteer),
                   method: :patch, id: "cc-check" do %>
-            <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
-              <%= volunteer.decorate.send_reminder_button %>
-              <%= check_box_tag 'with_cc', 1 %>
-              <%= volunteer.decorate.cc_reminder_text %>
+            <p>
+              <%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
+              <%= render "volunteers/send_reminder_button", volunteer: volunteer %>
             </p>
           <% end %>
         <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -95,18 +95,18 @@
 
     <div>
       <h6><strong><%= t(".assigned_volunteers") %>:</strong></h6>
-      <% policy_scope(@casa_case.assigned_volunteers).each_with_index do |volunteer, index| %>
+      <% policy_scope(@casa_case.assigned_volunteers).each do |volunteer| %>
         <% if current_user.volunteer? %>
           <p><%= volunteer.display_name %></p>
         <% else %>
-          <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
-            <%= link_to t(".send_reminder"),
-                        reminder_volunteer_path(volunteer),
-                        method: :patch,
-                        id: "reminder_button",
-                        class: "btn btn-primary casa-case-button",
-                        data_toggle: "tooltip",
-                        title: "#{t(".tooltip")}" %></p>
+          <%= form_tag reminder_volunteer_path(volunteer),
+                  method: :patch, id: "cc-check" do %>
+            <p><%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
+              <%= volunteer.decorate.send_reminder_button %>
+              <%= check_box_tag 'with_cc', 1 %>
+              <%= volunteer.decorate.cc_reminder_text %>
+            </p>
+          <% end %>
         <% end %>
       <% end %>
       <br>

--- a/app/views/volunteers/_send_reminder_button.html.erb
+++ b/app/views/volunteers/_send_reminder_button.html.erb
@@ -1,0 +1,6 @@
+<%= submit_tag t(".send_reminder"),
+  class: "btn btn-primary casa-case-button",
+  data_toggle: "tooltip",
+  title: "#{t(".tooltip")}".to_s %>
+<%= check_box_tag 'with_cc', 1 %>
+<%= volunteer.decorate.cc_reminder_text %>

--- a/app/views/volunteers/_send_reminder_button.html.erb
+++ b/app/views/volunteers/_send_reminder_button.html.erb
@@ -1,5 +1,6 @@
 <%= submit_tag t(".send_reminder"),
   class: "btn btn-primary casa-case-button",
+  id: "reminder_button",
   data_toggle: "tooltip",
   title: "#{t(".tooltip")}".to_s %>
 <%= check_box_tag 'with_cc', 1 %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -3,16 +3,11 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1>Editing Volunteer</h1>
-    <% if current_user.supervisor? ||
-        current_user.casa_admin? %>
-      <%= form_tag reminder_volunteer_path(@volunteer),
-                   method: :patch, id: "cc-check" do %>
-        <%= submit_tag t(".send_reminder"),
-                       class: "btn btn-primary casa-case-button",
-                       data_toggle: "tooltip",
-                       title: "#{t(".tooltip")}" %>
-        <%= check_box_tag 'with_cc', 1 %> Send CC to Supervisor
-      <% end %>
+    <%= form_tag reminder_volunteer_path(@volunteer),
+                  method: :patch, id: "cc-check" do %>
+      <%= @volunteer.decorate.send_reminder_button %>
+      <%= check_box_tag 'with_cc', 1 %>
+      <%= @volunteer.decorate.cc_reminder_text %>
     <% end %>
   </div>
 </div>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -3,11 +3,8 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1>Editing Volunteer</h1>
-    <%= form_tag reminder_volunteer_path(@volunteer),
-                  method: :patch, id: "cc-check" do %>
-      <%= @volunteer.decorate.send_reminder_button %>
-      <%= check_box_tag 'with_cc', 1 %>
-      <%= @volunteer.decorate.cc_reminder_text %>
+    <%= form_tag reminder_volunteer_path(@volunteer), method: :patch, id: "cc-check" do %>
+      <%= render "send_reminder_button", volunteer: @volunteer %>
     <% end %>
   </div>
 </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -57,8 +57,6 @@ en:
         click_to_download: Click to download
         download_all: Download All
         generate_court_report: Generate Report
-      send_reminder: Send Reminder
-      tooltip: Sends to volunteer a reminder email to input case contacts
     shared:
       filter_by: Filter by
       assigned_single: Assigned to Volunteer
@@ -410,9 +408,6 @@ en:
         one: All Volunteers
         other: All Volunteers
   volunteers:
-    edit:
-      send_reminder: Send reminder
-      tooltip: Sends to volunteer a reminder email to input case contacts
     index:
       volunteers: Volunteers
       filter: Filter by
@@ -438,6 +433,9 @@ en:
         actions: Actions
       button:
         new: New Volunteer
+    send_reminder_button:
+      send_reminder: Send Reminder
+      tooltip: Sends to volunteer a reminder email to input case contacts
   reports:
     index:
       export_page_title: Export Data

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -436,6 +436,8 @@ en:
     send_reminder_button:
       send_reminder: Send Reminder
       tooltip: Sends to volunteer a reminder email to input case contacts
+      admin_checkbox_text: "Send CC to Supervisor and Admin"
+      supervisor_checkbox_text: "Send CC to Supervisor"
   reports:
     index:
       export_page_title: Export Data

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -435,9 +435,9 @@ en:
         new: New Volunteer
     send_reminder_button:
       send_reminder: Send Reminder
-      tooltip: Sends to volunteer a reminder email to input case contacts
-      admin_checkbox_text: "Send CC to Supervisor and Admin"
-      supervisor_checkbox_text: "Send CC to Supervisor"
+      tooltip: Remind volunteer to input case contacts
+      admin_checkbox_text: Send CC to Supervisor and Admin
+      supervisor_checkbox_text: Send CC to Supervisor
   reports:
     index:
       export_page_title: Export Data

--- a/spec/decorators/volunteer_decorator_spec.rb
+++ b/spec/decorators/volunteer_decorator_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe VolunteerDecorator do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+
+  describe "CC reminder text" do
+    context "when user is admin" do
+      it "includes both supervisor and admin in prompt" do
+        sign_in admin
+
+        expect(volunteer.decorate.cc_reminder_text).to include "Supervisor"
+        expect(volunteer.decorate.cc_reminder_text).to include "Admin"
+      end
+    end
+
+    context "when user is supervisor" do
+      it "includes only supervisor in prompt" do
+        sign_in supervisor
+
+        expect(volunteer.decorate.cc_reminder_text).to include "Supervisor"
+        expect(volunteer.decorate.cc_reminder_text).not_to include "Admin"
+      end
+    end
+  end
+end

--- a/spec/system/casa_cases/show_more_spec.rb
+++ b/spec/system/casa_cases/show_more_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe "casa_cases/show", type: :system do
       sign_in admin
       visit casa_case_path(casa_case.id)
 
-      expect(page).to have_link("Send Reminder")
+      expect(page).to have_button("Send Reminder")
+      expect(page).to have_text("Send CC to Supervisor and Admin")
 
       click_on "Send Reminder"
 
       expect(page).to have_text("Reminder sent to volunteer")
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
   end
 
@@ -40,11 +42,13 @@ RSpec.describe "casa_cases/show", type: :system do
       sign_in supervisor
       visit casa_case_path(casa_case.id)
 
-      expect(page).to have_link("Send Reminder")
+      expect(page).to have_button("Send Reminder")
+      expect(page).to have_text(/^Send CC to Supervisor$/)
 
       click_on "Send Reminder"
 
       expect(page).to have_text("Reminder sent to volunteer")
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
   end
 

--- a/spec/system/casa_cases/show_more_spec.rb
+++ b/spec/system/casa_cases/show_more_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "casa_cases/show", type: :system do
+RSpec.describe "casa_cases/show", js: true, type: :system do
   let(:user) { build_stubbed :casa_admin }
 
   let(:organization) { create(:casa_org) }
@@ -43,7 +43,7 @@ RSpec.describe "casa_cases/show", type: :system do
       visit casa_case_path(casa_case.id)
 
       expect(page).to have_button("Send Reminder")
-      expect(page).to have_text(/^Send CC to Supervisor$/)
+      expect(page).to have_text(/Send CC to Supervisor$/)
 
       click_on "Send Reminder"
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -230,10 +230,10 @@ RSpec.describe "volunteers/edit", type: :system do
 
       visit edit_volunteer_path(volunteer)
 
-      expect(page).to have_button("Send reminder")
+      expect(page).to have_button("Send Reminder")
       expect(page).to have_text(/Send CC to Supervisor$/)
 
-      click_on "Send reminder"
+      click_on "Send Reminder"
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
@@ -244,10 +244,10 @@ RSpec.describe "volunteers/edit", type: :system do
 
     visit edit_volunteer_path(volunteer)
 
-    expect(page).to have_button("Send reminder")
+    expect(page).to have_button("Send Reminder")
     expect(page).to have_text("Send CC to Supervisor and Admin")
 
-    click_on "Send reminder"
+    click_on "Send Reminder"
 
     expect(ActionMailer::Base.deliveries.count).to eq(1)
   end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe "volunteers/edit", type: :system do
       visit edit_volunteer_path(volunteer)
 
       expect(page).to have_button("Send reminder")
+      expect(page).to have_text(/^Send CC to Supervisor$/)
 
       click_on "Send reminder"
 
@@ -244,6 +245,7 @@ RSpec.describe "volunteers/edit", type: :system do
     visit edit_volunteer_path(volunteer)
 
     expect(page).to have_button("Send reminder")
+    expect(page).to have_text("Send CC to Supervisor and Admin")
 
     click_on "Send reminder"
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "volunteers/edit", type: :system do
       visit edit_volunteer_path(volunteer)
 
       expect(page).to have_button("Send reminder")
-      expect(page).to have_text(/^Send CC to Supervisor$/)
+      expect(page).to have_text(/Send CC to Supervisor$/)
 
       click_on "Send reminder"
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2466, Resolves #2467 

### What changed, and why?
- Create and use `VolunteerDecorator` and `send_reminder_button` partial to avoid duplicate logic in volunteers/edit and casa_cases/show views.
- Remove unnecessary logic in views.
- Improve existing system tests for these two views.
- Add test for decorator logic just in case
- Clean up views.en.yml so that Send Reminder button text/tooltip is only in one place.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Added/edited tests. See above ☝️ 

### Screenshots please :)
When logged in as admin:
![image](https://user-images.githubusercontent.com/44326005/131782504-6d5eea13-e602-41c3-b183-730171aeb3b5.png)
![image](https://user-images.githubusercontent.com/44326005/131782544-fdeae43e-40fb-4041-9a82-a03a41f4ee62.png)

When logged in as supervisor:
![image](https://user-images.githubusercontent.com/44326005/131782617-4b474718-c6c6-4840-8044-f7b8e23757fb.png)
![image](https://user-images.githubusercontent.com/44326005/131782654-e1e72d70-3f7d-4018-ae6f-55707f6b43d0.png)


### Feelings gif (optional)
![Too easy](https://media.giphy.com/media/bn0zlGb4LOyo8/giphy.gif?cid=ecf05e47dednaw4wqi7n2x1vd3m4bjk8a0m48qf3oilp34zx&rid=giphy.gif&ct=g)
