### PR TITLE
Add VolunteerPolicy::Scope class allowing volunteers to see other from same CasaCase

### DIFF
--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -1,4 +1,22 @@
 class VolunteerPolicy < UserPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      case user
+      when CasaAdmin, Supervisor, Volunteer
+        scope.by_organization(@user.casa_org)
+      else
+        raise "unrecognized role #{@user.type}"
+      end
+    end
+  end
+
   def index?
     admin_or_supervisor?
   end

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -46,4 +46,37 @@ RSpec.describe VolunteerPolicy do
       end
     end
   end
+
+  describe "VolunteerPolicy::Scope" do
+    describe "#resolve" do
+      subject { described_class::Scope.new(user, Volunteer.all).resolve }
+
+      let!(:volunteer1) { create(:volunteer, casa_org: casa_org) }
+      let!(:another_org_volunteer) { create(:volunteer, casa_org: another_casa_org) }
+
+      let(:casa_org) { create(:casa_org) }
+      let(:another_casa_org) { create(:casa_org) }
+
+      context "when admin" do
+        let(:user) { build_stubbed(:casa_admin, casa_org: casa_org) }
+
+        it { is_expected.to include(volunteer1) }
+        it { is_expected.not_to include(another_org_volunteer) }
+      end
+
+      context "when supervisor" do
+        let(:user) { build_stubbed(:supervisor, casa_org: casa_org) }
+
+        it { is_expected.to include(volunteer1) }
+        it { is_expected.not_to include(another_org_volunteer) }
+      end
+
+      context "when volunteer" do
+        let(:user) { build_stubbed(:volunteer, casa_org: casa_org) }
+
+        it { is_expected.to include(volunteer1) }
+        it { is_expected.not_to include(another_org_volunteer) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2465

### What changed, and why?

Adding `VolunteerPolicy::Scope` class, overwriting `UserPolicy::Scope`, to allow any volunteer see other volunteers from same CasaCase, in CasaCase show page.

### How will this affect user permissions?
- Volunteer permissions: will be able to see other volunteers from same CasaCase.

### How is this tested? (please write tests!) 💖💪

With rspec, ensuring `policy_scope` method returns the right volunteers.

### Screenshots please :)

before:
![image](https://user-images.githubusercontent.com/47258878/132018816-c5f7b928-7818-4f59-ae66-859837884355.png)

after:
![image](https://user-images.githubusercontent.com/47258878/132018864-0a18cacd-4592-4c50-9638-f5e16e62992d.png)
