### PR TITLE
Fix flaky Thank You message test

### DIFF
--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -100,16 +100,7 @@ RSpec.describe CaseContactsController, type: :controller do
         it "renders a random thank you message" do
           post :create, params: {case_contact: params}, format: :js
           expect(
-            [
-              "Case contact was successfully created. Thanks for all you do!",
-              "Case contact was successfully created. Thank you for your hard work!",
-              "Case contact was successfully created. Thank you for a job well done!",
-              "Case contact was successfully created. Thank you for volunteering!",
-              "Case contact was successfully created. Thanks for being a great volunteer!",
-              "Case contact was successfully created. One of the greatest gifts you can give is your time!",
-              "Case contact was successfully created. Those who can do, do. Those who can do more, volunteer",
-              "Case contact was successfully created. Volunteers do not necessarily have the time, they just have the heart."
-            ]
+            (1..8).map { |n| "#{I18n.t("create", scope: "case_contact")} #{I18n.t("thank_you_#{n}", scope: "case_contact")}" }
           ).to include(flash[:notice])
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2510

### What changed, and why?
Replaced hard-coded expectation "thank you" messages with their translations. To avoid having to keep them in sync. I could just added the missing dot(".") to the message, but replacing the hard-coded messages seemed a better way

### How will this affect user permissions?
No permission was affected

### How is this tested? (please write tests!) 💖💪
Tests pass