### PR TITLE
Fix tests

### DIFF
--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -148,7 +148,7 @@ async function fireSwalFollowupAlert () {
 
   return await Swal.fire({
     input: 'textarea',
-    inputLabel: inputLabel,
+    title: inputLabel,
     inputPlaceholder: 'Type your note here...',
     inputAttributes: { 'aria-label': 'Type your note here' },
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -429,7 +429,7 @@ en:
         assigned_transition_aged_youth: Assigned To Transition Aged Youth
         case_number: Case Number(s)
         last_contact_made: Last Contact Made
-        contacts: Contacts Made in Past 60 Days</th>
+        contacts: Contacts Made in Past 60 Days
         actions: Actions
       button:
         new: New Volunteer

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe "case_contacts/new", type: :system do
         fill_in "case-contact-duration-minutes", with: "45"
         fill_in "Notes", with: note_content
         click_on "Submit"
-        
+
         expect(page).to have_text("Confirm Note Content")
         expect {
           click_on "Continue Submitting"
         }.to change(CaseContact, :count).by(1)
-        
+
         hello_line = page.body.split("\n").select { |x| x.include?("Hello") }
         expect(hello_line.first.include?(note_content)).to be true
         expected_text = strip_tags(note_content)

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -116,13 +116,14 @@ RSpec.describe "case_contacts/new", type: :system do
         fill_in "case-contact-duration-minutes", with: "45"
         fill_in "Notes", with: note_content
         click_on "Submit"
-
+        
         expect(page).to have_text("Confirm Note Content")
-        hello_line = page.body.split("\n").select { |x| x.include?("Hello") }
-        expect(hello_line).to eq(["        <div id=\"note-content\"><h1>Hello world</h1></div>"])
         expect {
           click_on "Continue Submitting"
         }.to change(CaseContact, :count).by(1)
+        
+        hello_line = page.body.split("\n").select { |x| x.include?("Hello") }
+        expect(hello_line.first.include?(note_content)).to be true
         expected_text = strip_tags(note_content)
         expect(page).to have_css("h1", text: expected_text)
       end

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "view all volunteers", type: :system do
     end
 
     it "can show/hide columns on volunteers table", js: true do
-      travel_to Dave.new(2021, 1, 1)
+      travel_to Date.new(2021, 1, 1)
       sign_in supervisor
 
       visit volunteers_path
@@ -243,8 +243,10 @@ RSpec.describe "view all volunteers", type: :system do
 
       expect(page).to have_text("Name")
       expect(page).to have_text("Status")
-      expect(page).not_to have_text("Contact Made In Past 60 Days")
-      expect(page).not_to have_text("Last Contact Made")
+      within("#volunteers") do
+        expect(page).to have_no_text("Contact Made In Past 60 Days")
+        expect(page).to have_no_text("Last Contact Made")
+      end
     end
 
     context "with volunteers" do

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "view all volunteers", type: :system do
     end
 
     it "can show/hide columns on volunteers table", js: true do
-      travel_to Date.new(2021, 1, 1)
+      travel_to Dave.new(2021, 1, 1)
       sign_in supervisor
 
       visit volunteers_path

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe "view all volunteers", type: :system do
 
       expect(page).to have_text("Name")
       expect(page).to have_text("Status")
-      expect(page).not_to have_text("Contact Made In Past 60 Days")
-      expect(page).not_to have_text("Last Contact Made")
+      within("#volunteers") do
+        expect(page).to have_no_text("Contact Made In Past 60 Days")
+        expect(page).to have_no_text("Last Contact Made")
+      end
     end
 
     it "can filter volunteers", js: true do


### PR DESCRIPTION
Fixing some tests that are failing on `main` branch.  

-  The label on the case contact wasn't showing up on the modal, so I changed Swal to use a title instead which shows up.
-  Moved the expectation of the case contact to be after clicking the "continue submitting" button to test that the HTML is showing up on the case contact page. 
- Modal for editing columns on volunteers index page is still showing in the html even when it's not visible so it was making the test fail.  I changed the expectation to look at the table and make sure that the header isn't showing when it's been deselected.

I think this along with PR #2527 get `main` back to green.