### PR TITLE
Sort contact types alphabetically

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -47,6 +47,7 @@ class CaseContactsController < ApplicationController
           .contact_type_groups
           .joins(:contact_types)
           .where(contact_types: {active: true})
+          .alphabetically
           .uniq
       end
   end

--- a/app/models/contact_type.rb
+++ b/app/models/contact_type.rb
@@ -9,6 +9,8 @@ class ContactType < ApplicationRecord
     joins(:contact_type_group)
       .where(contact_type_groups: {casa_org: org})
   }
+
+  scope :alphabetically, -> { order(:name) }
 end
 
 # == Schema Information

--- a/app/models/contact_type_group.rb
+++ b/app/models/contact_type_group.rb
@@ -9,6 +9,8 @@ class ContactTypeGroup < ApplicationRecord
     where(casa_org: org)
       .order(:name)
   }
+
+  scope :alphabetically, -> { order(:name) }
 end
 
 # == Schema Information

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -29,7 +29,7 @@
         <% @current_organization_groups.each do |group| %>
           <td class="align-top d-inline-block pr-5 pb-4">
             <h5> <%= group.name %> </h5>
-            <% group.contact_types.filter do |ct|
+            <% group.contact_types.alphabetically.filter do |ct|
                 @selected_case_contact_types.blank? ||
                     @selected_case_contact_types.include?(ct)
               end.each do |contact_type| %>

--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -42,6 +42,27 @@ RSpec.describe CaseContactsController, type: :controller do
         get :new, params: {case_contact: {casa_case_id: case_id}}
         expect(assigns(:current_organization_groups)).to eq([contact_type_group_one, contact_type_group_two])
       end
+
+      it "calls contact_types_alphabetically" do
+        allow(controller).to receive(:current_organization).and_return(organization)
+        allow(organization).to receive_message_chain(
+          :contact_type_groups,
+          :joins,
+          :where,
+          :alphabetically,
+          :uniq
+        )
+
+        expect(organization).to receive_message_chain(
+          :contact_type_groups,
+          :joins,
+          :where,
+          :alphabetically,
+          :uniq
+        )
+
+        get :new, params: {case_contact: {casa_case_id: case_id}}
+      end
     end
   end
 

--- a/spec/models/contact_type_group_spec.rb
+++ b/spec/models/contact_type_group_spec.rb
@@ -20,4 +20,16 @@ RSpec.describe ContactTypeGroup, type: :model do
       expect(described_class.for_organization(casa_org_2)).to eq([record_2])
     end
   end
+
+  describe ".alphabetically scope" do
+    subject { described_class.alphabetically }
+
+    let!(:contact_type_group1) { create(:contact_type_group, name: "Family") }
+    let!(:contact_type_group2) { create(:contact_type_group, name: "Placement") }
+
+    it "orders alphabetically", :aggregate_failures do
+      expect(subject.first).to eq(contact_type_group1)
+      expect(subject.last).to eq(contact_type_group2)
+    end
+  end
 end

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe ContactType, type: :model do
   describe ".alphabetically scope" do
     subject { described_class.alphabetically }
 
-    let!(:contact_type1) { create(:contact_type, name: "Family") }
-    let!(:contact_type2) { create(:contact_type, name: "Placement") }
+    let!(:contact_type1) { create(:contact_type, name: "Aunt Uncle or Cousin") }
+    let!(:contact_type2) { create(:contact_type, name: "Parent") }
 
     it "orders alphabetically", :aggregate_failures do
       expect(subject.first).to eq(contact_type1)

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -50,4 +50,16 @@ RSpec.describe ContactType, type: :model do
       expect(described_class.for_organization(casa_org_2)).to eq([record_2])
     end
   end
+
+  describe ".alphabetically scope" do
+    subject { described_class.alphabetically }
+
+    let!(:contact_type1) { create(:contact_type, name: "Family") }
+    let!(:contact_type2) { create(:contact_type, name: "Placement") }
+
+    it "orders alphabetically", :aggregate_failures do
+      expect(subject.first).to eq(contact_type1)
+      expect(subject.last).to eq(contact_type2)
+    end
+  end
 end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -150,6 +150,26 @@ RSpec.describe "case_contacts/new", type: :system do
 
       expect { check "Parent" }.not_to raise_error
     end
+
+    it "shows the contact type groups, and their contact type alphabetically", :aggregate_failures do
+      group_1 = create(:contact_type_group, name: "Placement", casa_org: organization)
+      group_2 = create(:contact_type_group, name: "Education", casa_org: organization)
+      create(:contact_type, name: "School", contact_type_group: group_1)
+      create(:contact_type, name: "Sports", contact_type_group: group_1)
+      create(:contact_type, name: "Caregiver Family", contact_type_group: group_2)
+      create(:contact_type, name: "Foster Parent", contact_type_group: group_2)
+
+      visit(new_case_contact_path(casa_case.id))
+
+      expect(index_of("Education")).to be < index_of("Placement")
+      expect(index_of("School")).to be < index_of("Sports")
+      expect(index_of("Caregiver Family")).to be < index_of("Foster Parent")
+      expect(index_of("School")).to be > index_of("Caregiver Family")
+    end
+
+    def index_of(text)
+      page.text.index(text)
+    end
   end
 
   context "volunteer user" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2506

### What changed, and why?

* Add `alphabetically` scopes for `ContactType` and `ContactTypeGroup` models
* Apply scopes in view to sort both, groups and their contact_types.

UX improvements.

### How is this tested? (please write tests!) 💖💪

Unit tests for `scopes`, and capybara test for `view`

### Screenshots please :)
before:
![image](https://user-images.githubusercontent.com/47258878/132396167-8828b460-ff5b-45f6-ad05-1a6cebbe3731.png)

after:
![image](https://user-images.githubusercontent.com/47258878/132396201-a932415e-a9da-47c4-96fe-ea3388412f2d.png)
