### PR TITLE
Changed reference to mandates to orders

### DIFF
--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -24,11 +24,11 @@ function addCourtMandateInput () {
 }
 
 function removeMandateWithConfirmation () {
-  const text = 'Are you sure you want to remove this court mandate? Doing so will ' +
+  const text = 'Are you sure you want to remove this court order? Doing so will ' +
                'delete all records of it unless it was included in a previous court report.'
   Swal.fire({
     icon: 'warning',
-    title: 'Delete court mandate?',
+    title: 'Delete court order?',
     text: text,
     showCloseButton: true,
     showCancelButton: true,
@@ -59,14 +59,14 @@ function removeMandateAction (ctx) {
 
       Swal.fire({
         icon: 'success',
-        text: 'Court mandate has been removed.',
+        text: 'Court order has been removed.',
         showCloseButton: true
       })
     },
     error: () => {
       Swal.fire({
         icon: 'error',
-        text: 'Something went wrong when attempting to delete this court mandate.',
+        text: 'Something went wrong when attempting to delete this court order.',
         showCloseButton: true
       })
     }

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -88,7 +88,7 @@
     <% end %>
 
     <% if @casa_case.case_court_mandates.exists? %>
-      <h6><strong><%= t(".court_mandates") %>:</strong></h6>
+      <h6><strong><%= t(".label.court_mandates") %>:</strong></h6>
       <% @casa_case.case_court_mandates.each do |court_mandate| %>
         <p><%= court_mandate.mandate_text %>, <%= court_mandate.implementation_status&.humanize %></p>
       <% end %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -47,7 +47,7 @@ en:
         court_report_due_date: Court Report Due Date
         court_report_status: Court Report Status
         court_report_submitted_date: Court Report Submitted Date
-        court_mandates: Court Mandates
+        court_mandates: Court Orders
         assigned_volunteers: Assigned Volunteers
         attached_report: Attached Report
       button:
@@ -84,11 +84,11 @@ en:
         select_hearing_type: -Select Hearing Type-
         select_judge: -Select Judge-
       youth_birth_month_year: "Youth's Birth Month & Year"
-      add_court_mandate: Add a court mandate
+      add_court_mandate: Add a court order
       add_past_court_date: Add a past court date
       next_court_date: Next Court Date
       court_report_due_date: Court Report Due Date
-      court_mandates: Court Mandates
+      court_mandates: Court Orders
       court_mandate_privacy_warning: Please check that you didn't enter any youth names
     inactive_case:
       notice: Case was deactivated on
@@ -138,12 +138,12 @@ en:
       title: Editing Past Court Date
     form:
       button:
-        add_court_mandate: Add a court mandate
+        add_court_mandate: Add a court order
         create: Create
         update: Update
       label:
         court_mandates:
-          Court Mandates - Please check that you didn't enter any youth names
+          Court Orders - Please check that you didn't enter any youth names
     new:
       title: New Past Court Date
     show:
@@ -155,10 +155,10 @@ en:
         judge: Judge
         hearing_type: Hearing Type
         none: None
-        case_court_mandates: Court Mandates
-        no_case_court_mandates: There are no court mandates associated with this past court date.
+        case_court_mandates: Court Orders
+        no_case_court_mandates: There are no court orders associated with this past court date.
         casa_case_court_mandate:
-          mandate_text: Court Mandate Text
+          mandate_text: Court Order Text
           implementation_status: Implementation Status
         download_report_docx: Download Report (.docx)
   casa_admins:

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -387,11 +387,11 @@ RSpec.describe "Edit CASA Case", type: :system do
         expect(page).to have_text(mandate_text)
 
         find("button.remove-mandate-button").click
-        expect(page).to have_text("Are you sure you want to remove this court mandate? Doing so will delete all records \
+        expect(page).to have_text("Are you sure you want to remove this court order? Doing so will delete all records \
 of it unless it was included in a previous court report.")
 
         find("button.swal2-confirm").click
-        expect(page).to have_text("Court mandate has been removed.")
+        expect(page).to have_text("Court order has been removed.")
         click_on "OK"
         expect(page).to_not have_text(mandate_text)
 

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     it "can see court mandates" do
-      expect(page).to have_content("Court Mandates")
+      expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     it "can see court mandates" do
-      expect(page).to have_content("Court Mandates")
+      expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)
     end
 
@@ -92,7 +92,7 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     it "can see court mandates" do
-      expect(page).to have_content("Court Mandates")
+      expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_mandates[0].mandate_text)
     end
 

--- a/spec/views/past_court_dates/show.html.erb_spec.rb
+++ b/spec/views/past_court_dates/show.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "past_court_dates/show", type: :view do
       expect(rendered).to include("Hearing Type")
       expect(rendered).to include("None")
 
-      expect(rendered).to include("There are no court mandates associated with this past court date.")
+      expect(rendered).to include("There are no court orders associated with this past court date.")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2474 

### What changed, and why?
Changed all references to court mandates to instead refer to court orders. 

### How will this affect user permissions?
- Volunteer permissions: na
- Supervisor permissions: na
- Admin permissions: na

### How is this tested? (please write tests!) 💖💪
Tests were modified to look for court orders instead of court mandates

### Screenshots please :)
<img width="544" alt="Screen Shot 2021-09-08 at 9 14 41 AM" src="https://user-images.githubusercontent.com/14005075/132548076-b8df40c2-4ed2-45e0-a81e-36979921097e.png">
<img width="568" alt="Screen Shot 2021-09-08 at 9 14 33 AM" src="https://user-images.githubusercontent.com/14005075/132548086-2499204a-69f1-4b42-8a4c-a6cbd469a011.png">
<img width="1019" alt="Screen Shot 2021-09-08 at 8 57 29 AM" src="https://user-images.githubusercontent.com/14005075/132548100-a6ee9864-1436-403f-869e-566ef494457a.png">
<img width="1050" alt="Screen Shot 2021-09-08 at 8 55 49 AM" src="https://user-images.githubusercontent.com/14005075/132548113-668ac4f2-d4d7-4b9b-a6e3-63769721adc6.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
