### PR TITLE
Top Aligns Case Details Buttons

### DIFF
--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -33,7 +33,7 @@ div.row:nth-child(4) {
 }
 
 .casa-case-button {
-  margin: 0 0 12px 0;
+  margin: 0 10px 10px 0;
 }
 
 .card-title {

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -25,7 +25,7 @@
         <%= button_tag t(".button.generate_report"), type: :submit,
                        data: {button_name: t(".button.generate_report")},
                        id: "btnGenerateReport",
-                       class: "btn btn-success pull-right casa-case-generate-button" %>
+                       class: "btn btn-success pull-right mb-2" %>
         <i id="spinner" class='fas fa-spin d-none pull-right'>⏳</i>
       <% end %>
     <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,17 +1,17 @@
 <div class="row">
   <div class="col-sm-12 form-header">
-    <h1><%= @casa_case.decorate.transition_aged_youth_icon %> <%= t(".title") %></h1>
+    <h1 class="pull-left"><%= @casa_case.decorate.transition_aged_youth_icon %> <%= t(".title") %></h1>
     <%- if policy(:case_contact).new? & @casa_case.active? %>
       <%= link_to(t(".button.new_contact"),
                   new_case_contact_path(case_contact: {casa_case_id: @casa_case.id}),
-                  class: "btn btn-primary casa-case-button") %>
+                  class: "btn btn-primary pull-left casa-case-button") %>
     <%- end %>
     <% if @casa_case.active? %>
-      <%= link_to t(".button.edit_case"), edit_casa_case_path(@casa_case), class: "btn btn-primary casa-case-button" %>
+      <%= link_to t(".button.edit_case"), edit_casa_case_path(@casa_case), class: "btn btn-primary pull-left casa-case-button" %>
     <% end %>
     <% if @casa_case.has_transitioned? %>
       <%= link_to(casa_case_emancipation_path(@casa_case),
-              class: "btn btn-primary casa-case-button") do %>
+              class: "btn btn-primary pull-left casa-case-button") do %>
         <%= t(".button.emancipation") %>
         <span class="badge badge-light">
           <%= @casa_case.decorate.emancipation_checklist_count %>
@@ -24,7 +24,7 @@
         <%= button_tag t(".button.generate_report"), type: :submit,
                        data: {button_name: t(".button.generate_report")},
                        id: "btnGenerateReport",
-                       class: "btn btn-success pull-right" %>
+                       class: "btn btn-success pull-right casa-case-generate-button" %>
         <i id="spinner" class='fas fa-spin d-none pull-right'>⏳</i>
       <% end %>
     <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -7,7 +7,8 @@
                   class: "btn btn-primary pull-left casa-case-button") %>
     <%- end %>
     <% if @casa_case.active? %>
-      <%= link_to t(".button.edit_case"), edit_casa_case_path(@casa_case), class: "btn btn-primary pull-left casa-case-button" %>
+      <%= link_to t(".button.edit_case"), edit_casa_case_path(@casa_case),
+              class: "btn btn-primary pull-left casa-case-button" %>
     <% end %>
     <% if @casa_case.has_transitioned? %>
       <%= link_to(casa_case_emancipation_path(@casa_case),


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2495

### What changed, and why?
Modified styling of Case Details buttons so they top align

### How will this affect user permissions?
- Volunteer permissions: na
- Supervisor permissions: na
- Admin permissions: na

### How is this tested? (please write tests!) 💖💪
only styling changes

### Screenshots please :)
<img width="1124" alt="Screen Shot 2021-09-08 at 10 29 54 AM" src="https://user-images.githubusercontent.com/14005075/132556767-1dad947f-3668-418e-a80b-0e6b13d1fa09.png">
<img width="1075" alt="Screen Shot 2021-09-08 at 10 19 45 AM" src="https://user-images.githubusercontent.com/14005075/132556771-ef9a9d16-e3b7-496b-95b6-dfd147256f9b.png">
<img width="1181" alt="Screen Shot 2021-09-08 at 10 17 21 AM" src="https://user-images.githubusercontent.com/14005075/132556775-580eae78-4e8d-4a46-af34-eb808887bd1b.png">




### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
