### PR TITLE
Sorts Volunteer List By Assigned Cases and Display Name

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -189,7 +189,8 @@ class CasaCase < ApplicationRecord
   end
 
   def unassigned_volunteers
-    Volunteer.active.where.not(id: assigned_volunteers).order(:display_name).in_organization(casa_org)
+    volunteers_unassigned_to_case = Volunteer.active.where.not(id: assigned_volunteers).in_organization(casa_org)
+    volunteers_unassigned_to_case.with_no_assigned_cases + volunteers_unassigned_to_case.with_assigned_cases
   end
 end
 

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -39,19 +39,19 @@ class Volunteer < User
 
   scope :with_assigned_cases, -> {
     joins(:case_assignments)
-    .where("case_assignments.active is true")
-    .distinct
-    .order(:display_name)
+      .where("case_assignments.active is true")
+      .distinct
+      .order(:display_name)
   }
 
   scope :with_no_assigned_cases, -> {
-      joins("left join case_assignments "\
-            "on case_assignments.volunteer_id = users.id "\
-            "and case_assignments.active")
-     .where("case_assignments.volunteer_id is NULL")
-     .distinct
-     .order(:display_name)
-   }
+                                   joins("left join case_assignments "\
+                                         "on case_assignments.volunteer_id = users.id "\
+                                         "and case_assignments.active")
+                                     .where("case_assignments.volunteer_id is NULL")
+                                     .distinct
+                                     .order(:display_name)
+                                 }
 
   def self.email_court_report_reminder
     active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -37,6 +37,22 @@ class Volunteer < User
       .active
   }
 
+  scope :with_assigned_cases, -> {
+    joins(:case_assignments)
+    .where("case_assignments.active is true")
+    .distinct
+    .order(:display_name)
+  }
+
+  scope :with_no_assigned_cases, -> {
+      joins("left join case_assignments "\
+            "on case_assignments.volunteer_id = users.id "\
+            "and case_assignments.active")
+     .where("case_assignments.volunteer_id is NULL")
+     .distinct
+     .order(:display_name)
+   }
+
   def self.email_court_report_reminder
     active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|
       volunteer.case_assignments.active.each do |case_assignment|

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe CasaCase, type: :model do
 
   describe ".unassigned_volunteers" do
     let!(:casa_case) { create(:casa_case) }
-    let!(:volunteer_same_org) { create(:volunteer, display_name: 'Yelena Belova', casa_org: casa_case.casa_org) }
-    let!(:volunteer_same_org_1_with_cases) { create(:volunteer, :with_casa_cases, display_name: 'Natasha Romanoff', casa_org: casa_case.casa_org) }
-    let!(:volunteer_same_org_2_with_cases) { create(:volunteer, :with_casa_cases, display_name: 'Melina Vostokoff', casa_org: casa_case.casa_org) }
+    let!(:volunteer_same_org) { create(:volunteer, display_name: "Yelena Belova", casa_org: casa_case.casa_org) }
+    let!(:volunteer_same_org_1_with_cases) { create(:volunteer, :with_casa_cases, display_name: "Natasha Romanoff", casa_org: casa_case.casa_org) }
+    let!(:volunteer_same_org_2_with_cases) { create(:volunteer, :with_casa_cases, display_name: "Melina Vostokoff", casa_org: casa_case.casa_org) }
     let!(:volunteer_different_org) { create(:volunteer, casa_org: create(:casa_org)) }
 
     it "only shows volunteers for the current volunteers organization" do

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -35,12 +35,19 @@ RSpec.describe CasaCase, type: :model do
   end
 
   describe ".unassigned_volunteers" do
+    let!(:casa_case) { create(:casa_case) }
+    let!(:volunteer_same_org) { create(:volunteer, display_name: 'Yelena Belova', casa_org: casa_case.casa_org) }
+    let!(:volunteer_same_org_1_with_cases) { create(:volunteer, :with_casa_cases, display_name: 'Natasha Romanoff', casa_org: casa_case.casa_org) }
+    let!(:volunteer_same_org_2_with_cases) { create(:volunteer, :with_casa_cases, display_name: 'Melina Vostokoff', casa_org: casa_case.casa_org) }
+    let!(:volunteer_different_org) { create(:volunteer, casa_org: create(:casa_org)) }
+
     it "only shows volunteers for the current volunteers organization" do
-      casa_case = create(:casa_case)
-      volunteer_same_org = create(:volunteer, casa_org: casa_case.casa_org)
-      volunteer_different_org = create(:volunteer, casa_org: create(:casa_org))
       expect(casa_case.unassigned_volunteers).to include(volunteer_same_org)
       expect(casa_case.unassigned_volunteers).not_to include(volunteer_different_org)
+    end
+
+    it "sorts volunteers by display name with no cases to the top" do
+      expect(casa_case.unassigned_volunteers).to contain_exactly(volunteer_same_org, volunteer_same_org_2_with_cases, volunteer_same_org_1_with_cases)
     end
   end
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -247,6 +247,28 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
+  describe "#with_assigned_cases" do
+    let!(:volunteers) { create_list(:volunteer, 3) }
+    let!(:volunteer_with_cases) { create_list(:volunteer, 3, :with_casa_cases) }
+
+    subject { Volunteer.with_assigned_cases }
+
+    it "returns only volunteers assigned to active casa cases" do
+      expect(subject).to match_array(volunteer_with_cases)
+    end
+  end
+
+  describe "#with_no_assigned_cases" do
+    let!(:volunteers) { create_list(:volunteer, 3) }
+    let!(:volunteer_with_cases) { create_list(:volunteer, 3, :with_casa_cases) }
+
+    subject { Volunteer.with_no_assigned_cases }
+
+    it "returns only volunteers with no assigned active casa cases" do
+      expect(subject).to match_array(volunteers)
+    end
+  end
+
   describe "#casa_cases" do
     let(:volunteer) { create :volunteer }
     let!(:ca1) { create :case_assignment, volunteer: volunteer, active: true }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2438

### What changed, and why?
Added scopes for volunteers with assigned cases and with no assigned cases to be used for sorting list of case org volunteers. 

### How will this affect user permissions?
- Volunteer permissions: na
- Supervisor permissions: na
- Admin permissions: na

### How is this tested? (please write tests!) 💖💪
Tests added for scopes and modified method

### Screenshots please :)
no visual changes

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
