### PR TITLE
Allows volunteers to modify court orders/court mandates

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -9,12 +9,12 @@ class CasaCasePolicy < ApplicationPolicy
 
     def resolve
       case @user
-        when CasaAdmin, Supervisor
-          scope.by_organization(@user.casa_org)
-        when Volunteer
-          scope.actively_assigned_to(user)
-        else
-          raise "unrecognized user type #{@user.type}"
+      when CasaAdmin, Supervisor
+        scope.by_organization(@user.casa_org)
+      when Volunteer
+        scope.actively_assigned_to(user)
+      else
+        raise "unrecognized user type #{@user.type}"
       end
     end
   end
@@ -43,11 +43,11 @@ class CasaCasePolicy < ApplicationPolicy
 
   alias_method :update_case_number?, :is_admin?
   alias_method :update_case_status?, :is_admin?
-  alias_method :update_court_date?, :admin_or_supervisor?
-  alias_method :update_hearing_type?, :admin_or_supervisor?
-  alias_method :update_judge?, :admin_or_supervisor?
-  alias_method :update_court_report_due_date?, :admin_or_supervisor?
-  alias_method :update_court_mandates?, :admin_or_supervisor?
+  alias_method :update_court_date?, :admin_or_supervisor_or_volunteer?
+  alias_method :update_hearing_type?, :admin_or_supervisor_or_volunteer?
+  alias_method :update_judge?, :admin_or_supervisor_or_volunteer?
+  alias_method :update_court_report_due_date?, :admin_or_supervisor_or_volunteer?
+  alias_method :update_court_mandates?, :admin_or_supervisor_or_volunteer?
 
   def permitted_attributes
     common_attrs = [
@@ -57,14 +57,14 @@ class CasaCasePolicy < ApplicationPolicy
     ]
 
     case @user
-      when CasaAdmin
-        common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
-        common_attrs << case_court_mandates_attributes
-      when Supervisor
-        common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
-        common_attrs << case_court_mandates_attributes
-      else
-        common_attrs
+    when CasaAdmin
+      common_attrs.concat(%i[case_number birth_month_year_youth court_date court_report_due_date hearing_type_id judge_id])
+      common_attrs << case_court_mandates_attributes
+    when Supervisor, Volunteer
+      common_attrs.concat(%i[court_date court_report_due_date hearing_type_id judge_id])
+      common_attrs << case_court_mandates_attributes
+    else
+      common_attrs
     end
   end
 

--- a/spec/policies/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy_spec.rb
@@ -40,28 +40,28 @@ RSpec.describe CasaCasePolicy do
     end
 
     context "when user is a volunteer" do
-      it "does not allow update" do
-        is_expected.not_to permit(volunteer, casa_case)
+      it "allows to update" do
+        is_expected.to permit(volunteer, casa_case)
       end
     end
   end
 
-  permissions :update_birth_month_year_youth? do
+  permissions :update_hearing_type?, :update_judge?, :update_court_mandates? do
     context "when user is an admin" do
-      it "allow update" do
+      it "allows to update" do
         is_expected.to permit(casa_admin, casa_case)
       end
     end
 
     context "when user is a supervisor" do
-      it "does not allow update" do
-        is_expected.not_to permit(supervisor, casa_case)
+      it "allows to update" do
+        is_expected.to permit(supervisor, casa_case)
       end
     end
 
     context "when user is a volunteer" do
-      it "does not allow update" do
-        is_expected.not_to permit(volunteer, casa_case)
+      it "allows to update" do
+        is_expected.to permit(volunteer, casa_case)
       end
     end
   end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -387,9 +387,9 @@ RSpec.describe "/casa_cases", type: :request do
 
           # Not permitted
           expect(casa_case.case_number).to eq "111"
-          expect(casa_case.hearing_type).to_not eq hearing_type
-          expect(casa_case.judge).to_not eq judge
-          expect(casa_case.case_court_mandates.size).to be 0
+          expect(casa_case.hearing_type).to eq hearing_type
+          expect(casa_case.judge).to eq judge
+          expect(casa_case.case_court_mandates.size).to be 2
         end
 
         it "redirects to the casa_case" do

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -518,12 +518,12 @@ of it unless it was included in a previous court report.")
         click_on "Update CASA Case"
       end
 
-      expect(page).not_to have_text("Day")
-      expect(page).not_to have_text("Month")
-      expect(page).not_to have_text("Year")
+      expect(page).to have_text("Day")
+      expect(page).to have_text("Month")
+      expect(page).to have_text("Year")
       expect(page).not_to have_text("Deactivate Case")
 
-      expect(page).not_to have_css("#add-mandate-button")
+      expect(page).to have_css("#add-mandate-button")
 
       visit casa_case_path(casa_case)
       expect(page).to have_text("Court Report Status: Submitted")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2494 and #2535

### What changed, and why?
Permissions were changed to allow volunteers to be able to modify court mandates.

### How will this affect user permissions?
- Volunteer permissions: it is possible to edit court mandates

### How is this tested? (please write tests!) 💖💪
tests have been written :)

### Screenshots please :)
![132491790-dda6ff6b-4945-4b08-9950-19ef71a21de8](https://user-images.githubusercontent.com/24357305/132742224-6c2eb92b-523a-4b95-997a-8bc3d1b00c02.png)