### PR TITLE
Refactor all notification js into module

### DIFF
--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -115,17 +115,3 @@ test('notify should throw a TypeError when param message is not a string', (done
     }
   })
 })
-
-test('showLoadingToast makes the loading toast visible', (done) => {
-  $(document).ready(() => {
-    const loadingToast = $('#async-waiting-indicator')
-    try {
-      expect(loadingToast.css('display')).toBe('none')
-      notifier.showLoadingToast()
-      expect(loadingToast.attr('style')).toBe('')
-      done()
-    } catch (error) {
-      done(error)
-    }
-  })
-})

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -152,6 +152,7 @@ describe('stopAsyncOperation', () => {
         }, 2000)
 
         notifier.stopAsyncOperation()
+        expect(savedToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
       } catch (error) {
         done(error)
       }
@@ -159,7 +160,35 @@ describe('stopAsyncOperation', () => {
   })
 
   test('stopAsyncOperation should display the saved toast for 2 seconds after the last call in a quick succession of calls when not passed an error', (done) => {
-    done()
+    $(document).ready(() => {
+      const savedToast = $('#async-success-indicator')
+
+      try {
+        notifier.startAsyncOperation()
+        notifier.startAsyncOperation()
+        notifier.startAsyncOperation()
+        expect(savedToast.css('display')).toBe('none')
+
+        setTimeout(() => {
+          expect(savedToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
+          done()
+        }, 4000)
+
+        notifier.stopAsyncOperation()
+        expect(savedToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
+
+        // call stopAsyncOperation before the previous stopAsyncOperation call dismisses the saved Toast
+        setTimeout(() => {
+          notifier.stopAsyncOperation()
+        }, 1000)
+
+        setTimeout(() => {
+          notifier.stopAsyncOperation()
+        }, 2000)
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 
   test('stopAsyncOperation should display a red notification when passed an error', (done) => {

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -211,10 +211,37 @@ describe('stopAsyncOperation', () => {
   })
 
   test('stopAsyncOperation should hide the loading toast when there are no more async operations to wait on', (done) => {
-    done()
+    $(document).ready(() => {
+      const loadingToast = $('#async-waiting-indicator')
+
+      try {
+        notifier.startAsyncOperation()
+        notifier.startAsyncOperation()
+        expect(loadingToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
+
+        notifier.stopAsyncOperation()
+        notifier.stopAsyncOperation()
+
+        expect(loadingToast.css('display')).toBe('none')
+
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 
   test('stopAsyncOperation should throw an error and display it in a red notification when trying to stop an async operation when it\'s sexpecting to resolve none', (done) => {
-    done()
+    $(document).ready(() => {
+      try {
+        expect(() => {
+          notifier.stopAsyncOperation()
+        }).toThrow()
+
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 })

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -116,7 +116,7 @@ test('notify should throw a TypeError when param message is not a string', (done
   })
 })
 
-test('showLoadingToast makes loading toast visible', (done) => {
+test('showLoadingToast makes the loading toast visible', (done) => {
   $(document).ready(() => {
     const loadingToast = $('#async-waiting-indicator')
     try {
@@ -130,7 +130,7 @@ test('showLoadingToast makes loading toast visible', (done) => {
   })
 })
 
-test('showSavedToast makes saved toast visible', (done) => {
+test('showSavedToast makes the saved toast visible', (done) => {
   $(document).ready(() => {
     const savedToast = $('#async-success-indicator')
     try {
@@ -143,4 +143,3 @@ test('showSavedToast makes saved toast visible', (done) => {
     }
   })
 })
-

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -7,8 +7,7 @@ let asyncNotificationsElement
 let notifier
 
 beforeEach(() => {
-  document.body.innerHTML =
-    `<div id="async-notifications">
+  document.body.innerHTML = `<div id="async-notifications">
       <div id="async-waiting-indicator" style="display: none">
         Saving <div class="load-spinner"></div>
       </div>
@@ -23,8 +22,8 @@ beforeEach(() => {
   })
 })
 
-test('notify should display a green notification when passed a message and level=\'info\'', (done) => {
-  const notificationMessage = '\'Y$deH[|%ROii]jy'
+test("notify should display a green notification when passed a message and level='info'", (done) => {
+  const notificationMessage = "'Y$deH[|%ROii]jy"
 
   $(document).ready(() => {
     notifier.notify(notificationMessage, 'info')
@@ -42,7 +41,7 @@ test('notify should display a green notification when passed a message and level
   })
 })
 
-test('notify should display a red notification when passed a message and level=\'error\'', (done) => {
+test("notify should display a red notification when passed a message and level='error'", (done) => {
   const notificationMessage = '\\+!h0bbH"yN7dx9.'
 
   $(document).ready(() => {
@@ -116,3 +115,32 @@ test('notify should throw a TypeError when param message is not a string', (done
     }
   })
 })
+
+test('showLoadingToast makes loading toast visible', (done) => {
+  $(document).ready(() => {
+    const loadingToast = $('#async-waiting-indicator')
+    try {
+      expect(loadingToast.css('display')).toBe('none')
+      notifier.showLoadingToast()
+      expect(loadingToast.attr('style')).toBe('')
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('showSavedToast makes saved toast visible', (done) => {
+  $(document).ready(() => {
+    const savedToast = $('#async-success-indicator')
+    try {
+      expect(savedToast.css('display')).toBe('none')
+      notifier.showSavedToast()
+      expect(savedToast.attr('style')).toBe('')
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -22,92 +22,111 @@ beforeEach(() => {
   })
 })
 
-test("notify should display a green notification when passed a message and level='info'", (done) => {
-  const notificationMessage = "'Y$deH[|%ROii]jy"
+describe('notify', () => {
+  test("notify should display a green notification when passed a message and level='info'", (done) => {
+    const notificationMessage = "'Y$deH[|%ROii]jy"
 
-  $(document).ready(() => {
-    notifier.notify(notificationMessage, 'info')
+    $(document).ready(() => {
+      notifier.notify(notificationMessage, 'info')
 
-    try {
-      const successMessages = asyncNotificationsElement.find('.async-success-indicator')
+      try {
+        const successMessages = asyncNotificationsElement.find('.async-success-indicator')
 
-      // Notifications contain the "Saved" message and the new message
-      expect(successMessages.length).toBe(2)
-      expect(successMessages[1].innerHTML).toContain(notificationMessage)
-      done()
-    } catch (error) {
-      done(error)
-    }
+        // Notifications contain the "Saved" message and the new message
+        expect(successMessages.length).toBe(2)
+        expect(successMessages[1].innerHTML).toContain(notificationMessage)
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+  })
+
+  test("notify should display a red notification when passed a message and level='error'", (done) => {
+    const notificationMessage = '\\+!h0bbH"yN7dx9.'
+
+    $(document).ready(() => {
+      notifier.notify(notificationMessage, 'error')
+
+      try {
+        const failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
+
+        expect(failureMessages.length).toBe(1)
+        expect(failureMessages[0].innerHTML).toContain(notificationMessage)
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+  })
+
+  test('notify should append a dismissable message to the async-notifications widget', (done) => {
+    $(document).ready(() => {
+      notifier.notify('', 'error')
+      notifier.notify('', 'info')
+
+      try {
+        let failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
+        let successMessages = asyncNotificationsElement.find('.async-success-indicator')
+
+        expect(failureMessages.length).toBe(1)
+        expect(successMessages.length).toBe(2)
+
+        failureMessages.children('button').click()
+        failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
+
+        expect(failureMessages.length).toBe(0)
+
+        $(successMessages[1]).children('button').click()
+        successMessages = asyncNotificationsElement.find('.async-success-indicator')
+
+        expect(successMessages.length).toBe(1)
+
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+  })
+
+  test('notify should throw a RangeError when passed an unsupported message level', (done) => {
+    $(document).ready(() => {
+      try {
+        expect(() => {
+          notifier.notify('message', 'unsupported level')
+        }).toThrow(RangeError)
+
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+  })
+
+  test('notify should throw a TypeError when param message is not a string', (done) => {
+    $(document).ready(() => {
+      try {
+        expect(() => {
+          notifier.notify(6, 'info')
+        }).toThrow(TypeError)
+
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 })
 
-test("notify should display a red notification when passed a message and level='error'", (done) => {
-  const notificationMessage = '\\+!h0bbH"yN7dx9.'
-
+test('startAsyncOperation should display the loading toast', (done) => {
   $(document).ready(() => {
-    notifier.notify(notificationMessage, 'error')
+    const loadingToast = $('#async-waiting-indicator')
 
     try {
-      const failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
+      expect(loadingToast.css('display')).toBe('none')
 
-      expect(failureMessages.length).toBe(1)
-      expect(failureMessages[0].innerHTML).toContain(notificationMessage)
-      done()
-    } catch (error) {
-      done(error)
-    }
-  })
-})
-
-test('notify should append a dismissable message to the async-notifications widget', (done) => {
-  $(document).ready(() => {
-    notifier.notify('', 'error')
-    notifier.notify('', 'info')
-
-    try {
-      let failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
-      let successMessages = asyncNotificationsElement.find('.async-success-indicator')
-
-      expect(failureMessages.length).toBe(1)
-      expect(successMessages.length).toBe(2)
-
-      failureMessages.children('button').click()
-      failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
-
-      expect(failureMessages.length).toBe(0)
-
-      $(successMessages[1]).children('button').click()
-      successMessages = asyncNotificationsElement.find('.async-success-indicator')
-
-      expect(successMessages.length).toBe(1)
-
-      done()
-    } catch (error) {
-      done(error)
-    }
-  })
-})
-
-test('notify should throw a RangeError when passed an unsupported message level', (done) => {
-  $(document).ready(() => {
-    try {
-      expect(() => {
-        notifier.notify('message', 'unsupported level')
-      }).toThrow(RangeError)
-
-      done()
-    } catch (error) {
-      done(error)
-    }
-  })
-})
-
-test('notify should throw a TypeError when param message is not a string', (done) => {
-  $(document).ready(() => {
-    try {
-      expect(() => {
-        notifier.notify(6, 'info')
-      }).toThrow(TypeError)
+      notifier.startAsyncOperation()
+      expect(loadingToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
 
       done()
     } catch (error) {

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -139,17 +139,38 @@ describe('startAsyncOperation', () => {
 
 describe('stopAsyncOperation', () => {
   test('stopAsyncOperation should display the saved toast for 2 seconds when not passed an error', (done) => {
+    $(document).ready(() => {
+      const savedToast = $('#async-success-indicator')
+
+      try {
+        notifier.startAsyncOperation()
+        expect(savedToast.css('display')).toBe('none')
+
+        setTimeout(() => {
+          expect(savedToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
+          done()
+        }, 2000)
+
+        notifier.stopAsyncOperation()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 
   test('stopAsyncOperation should display the saved toast for 2 seconds after the last call in a quick succession of calls when not passed an error', (done) => {
+    done()
   })
 
   test('stopAsyncOperation should display a red notification when passed an error', (done) => {
+    done()
   })
 
   test('stopAsyncOperation should hide the loading toast when there are no more async operations to wait on', (done) => {
+    done()
   })
 
   test('stopAsyncOperation should throw an error and display it in a red notification when trying to stop an async operation when it\'s sexpecting to resolve none', (done) => {
+    done()
   })
 })

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -118,19 +118,21 @@ describe('notify', () => {
   })
 })
 
-test('startAsyncOperation should display the loading toast', (done) => {
-  $(document).ready(() => {
-    const loadingToast = $('#async-waiting-indicator')
+describe('startAsyncOperation', () => {
+  test('startAsyncOperation should display the loading toast', (done) => {
+    $(document).ready(() => {
+      const loadingToast = $('#async-waiting-indicator')
 
-    try {
-      expect(loadingToast.css('display')).toBe('none')
+      try {
+        expect(loadingToast.css('display')).toBe('none')
 
-      notifier.startAsyncOperation()
-      expect(loadingToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
+        notifier.startAsyncOperation()
+        expect(loadingToast.attr('style')).toEqual(expect.not.stringContaining('display: none'))
 
-      done()
-    } catch (error) {
-      done(error)
-    }
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 })

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -129,17 +129,3 @@ test('showLoadingToast makes the loading toast visible', (done) => {
     }
   })
 })
-
-test('showSavedToast makes the saved toast visible', (done) => {
-  $(document).ready(() => {
-    const savedToast = $('#async-success-indicator')
-    try {
-      expect(savedToast.css('display')).toBe('none')
-      notifier.showSavedToast()
-      expect(savedToast.attr('style')).toBe('')
-      done()
-    } catch (error) {
-      done(error)
-    }
-  })
-})

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -27,9 +27,9 @@ describe('notify', () => {
     const notificationMessage = "'Y$deH[|%ROii]jy"
 
     $(document).ready(() => {
-      notifier.notify(notificationMessage, 'info')
-
       try {
+        notifier.notify(notificationMessage, 'info')
+
         const successMessages = asyncNotificationsElement.find('.async-success-indicator')
 
         // Notifications contain the "Saved" message and the new message
@@ -46,9 +46,9 @@ describe('notify', () => {
     const notificationMessage = '\\+!h0bbH"yN7dx9.'
 
     $(document).ready(() => {
-      notifier.notify(notificationMessage, 'error')
-
       try {
+        notifier.notify(notificationMessage, 'error')
+
         const failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
 
         expect(failureMessages.length).toBe(1)
@@ -62,10 +62,10 @@ describe('notify', () => {
 
   test('notify should append a dismissable message to the async-notifications widget', (done) => {
     $(document).ready(() => {
-      notifier.notify('', 'error')
-      notifier.notify('', 'info')
-
       try {
+        notifier.notify('', 'error')
+        notifier.notify('', 'info')
+
         let failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
         let successMessages = asyncNotificationsElement.find('.async-success-indicator')
 
@@ -192,7 +192,22 @@ describe('stopAsyncOperation', () => {
   })
 
   test('stopAsyncOperation should display a red notification when passed an error', (done) => {
-    done()
+    const errorMessage = 'hxDEe@no$~Bl%m^]'
+
+    $(document).ready(() => {
+      try {
+        notifier.startAsyncOperation()
+        notifier.stopAsyncOperation(errorMessage)
+
+        const failureMessages = asyncNotificationsElement.find('.async-failure-indicator')
+
+        expect(failureMessages.length).toBe(1)
+        expect(failureMessages[0].innerHTML).toContain(errorMessage)
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
   })
 
   test('stopAsyncOperation should hide the loading toast when there are no more async operations to wait on', (done) => {

--- a/app/javascript/__tests__/notifier.test.js
+++ b/app/javascript/__tests__/notifier.test.js
@@ -136,3 +136,20 @@ describe('startAsyncOperation', () => {
     })
   })
 })
+
+describe('stopAsyncOperation', () => {
+  test('stopAsyncOperation should display the saved toast for 2 seconds when not passed an error', (done) => {
+  })
+
+  test('stopAsyncOperation should display the saved toast for 2 seconds after the last call in a quick succession of calls when not passed an error', (done) => {
+  })
+
+  test('stopAsyncOperation should display a red notification when passed an error', (done) => {
+  })
+
+  test('stopAsyncOperation should hide the loading toast when there are no more async operations to wait on', (done) => {
+  })
+
+  test('stopAsyncOperation should throw an error and display it in a red notification when trying to stop an async operation when it\'s sexpecting to resolve none', (done) => {
+  })
+})

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -10,10 +10,6 @@ module.exports = class Notifier {
     this.waitingSaveOperationCount = 0
   }
 
-  hideLoadingToast () {
-    this.loadingToast.hide()
-  }
-
   // Adds notification messages to the notification element
   //  @param  {string} message The message to be displayed
   //  @param  {string} level One of the following logging levels
@@ -76,7 +72,7 @@ module.exports = class Notifier {
     this.waitingSaveOperationCount--
 
     if (this.waitingSaveOperationCount === 0) {
-      this.hideLoadingToast()
+      this.loadingToast.hide()
     }
 
     if (!errorMsg) {

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -63,12 +63,21 @@ module.exports = class Notifier {
   // Shows the loading toast
   startAsyncOperation () {
     this.loadingToast.show()
+    this.waitingSaveOperationCount++
   }
 
   // Shows the saved toast for 2 seconds
   //  @param {string=}  error The error to be displayed(optional)
   stopAsyncOperation (errorMsg) {
+    if (this.waitingSaveOperationCount < 1) {
+      throw new Error('Attempted to resolve an async operation when awaiting none')
+    }
+
     this.waitingSaveOperationCount--
+
+    if (this.waitingSaveOperationCount === 0) {
+      this.hideLoadingToast()
+    }
 
     if (!errorMsg) {
       this.savedToast.show()
@@ -88,10 +97,5 @@ module.exports = class Notifier {
 
       this.notify(errorMsg, 'error')
     }
-  }
-
-  // Shows the toast indicating an async operation is in progress
-  showLoadingToast () {
-    this.loadingToast.show()
   }
 }

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -6,13 +6,17 @@ module.exports = class Notifier {
     this.loadingToast = notificationsElement.find('#async-waiting-indicator')
     this.notificationsElement = notificationsElement
     this.savedToast = notificationsElement.find('#async-success-indicator')
+    this.waitingSaveOperationCount = 0
   }
-  hideLoadingToast() {
+
+  hideLoadingToast () {
     this.loadingToast.hide()
   }
-  hideSavedToast() {
+
+  hideSavedToast () {
     this.savedToast.hide()
   }
+
   // Adds notification messages to the notification element
   //  @param  {string} message The message to be displayed
   //  @param  {string} level One of the following logging levels
@@ -57,6 +61,22 @@ module.exports = class Notifier {
       default:
         throw new RangeError('Unsupported option for param level')
     }
+  }
+
+  // Increases the count of asynchronous operations to wait for and shows the loading toast
+  startAsyncOperation () {
+    this.waitingSaveOperationCount++
+    this.loadingToast.show()
+  }
+
+  // Decrease the count of asynchronous operations to wait for and shows the saved toast for 2 seconds
+  stopAsyncOperation () {
+    this.waitingSaveOperationCount--
+    this.showSavedToast()
+
+    setTimeout(() => {
+      this.hideSavedToast()
+    }, 2000)
   }
 
   // Shows the toast indicating an async operation is in progress

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -6,7 +6,7 @@ module.exports = class Notifier {
     this.loadingToast = notificationsElement.find('#async-waiting-indicator')
     this.notificationsElement = notificationsElement
     this.savedToast = notificationsElement.find('#async-success-indicator')
-    this.waitingSaveOperationCount = 0
+    this.savedToastTimeouts = []
   }
 
   hideLoadingToast () {
@@ -65,18 +65,21 @@ module.exports = class Notifier {
 
   // Increases the count of asynchronous operations to wait for and shows the loading toast
   startAsyncOperation () {
-    this.waitingSaveOperationCount++
     this.loadingToast.show()
   }
 
   // Decrease the count of asynchronous operations to wait for and shows the saved toast for 2 seconds
   stopAsyncOperation () {
-    this.waitingSaveOperationCount--
     this.showSavedToast()
 
-    setTimeout(() => {
+    this.savedToastTimeouts.forEach((timeoutID) => {
+      clearTimeout(timeoutID)
+    })
+
+    this.savedToastTimeouts.push(setTimeout(() => {
       this.hideSavedToast()
-    }, 2000)
+      this.savedToastTimeouts.shift()
+    }, 2000))
   }
 
   // Shows the toast indicating an async operation is in progress

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -7,7 +7,12 @@ module.exports = class Notifier {
     this.notificationsElement = notificationsElement
     this.savedToast = notificationsElement.find('#async-success-indicator')
   }
-
+  hideLoadingToast() {
+    this.loadingToast.hide()
+  }
+  hideSavedToast() {
+    this.savedToast.hide()
+  }
   // Adds notification messages to the notification element
   //  @param  {string} message The message to be displayed
   //  @param  {string} level One of the following logging levels
@@ -15,6 +20,7 @@ module.exports = class Notifier {
   //    "info"   Shows a green notification
   //  @throws {TypeError}  for a parameter of the incorrect type
   //  @throws {RangeError} for unsupported logging levels
+
   notify (message, level) {
     if (typeof message !== 'string') {
       throw new TypeError('Param message must be a string')

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -13,10 +13,6 @@ module.exports = class Notifier {
     this.loadingToast.hide()
   }
 
-  hideSavedToast () {
-    this.savedToast.hide()
-  }
-
   // Adds notification messages to the notification element
   //  @param  {string} message The message to be displayed
   //  @param  {string} level One of the following logging levels
@@ -63,21 +59,21 @@ module.exports = class Notifier {
     }
   }
 
-  // Increases the count of asynchronous operations to wait for and shows the loading toast
+  // Shows the loading toast
   startAsyncOperation () {
     this.loadingToast.show()
   }
 
-  // Decrease the count of asynchronous operations to wait for and shows the saved toast for 2 seconds
+  // Shows the saved toast for 2 seconds
   stopAsyncOperation () {
-    this.showSavedToast()
+    this.savedToast.show()
 
     this.savedToastTimeouts.forEach((timeoutID) => {
       clearTimeout(timeoutID)
     })
 
     this.savedToastTimeouts.push(setTimeout(() => {
-      this.hideSavedToast()
+      this.savedToast.hide()
       this.savedToastTimeouts.shift()
     }, 2000))
   }
@@ -85,10 +81,5 @@ module.exports = class Notifier {
   // Shows the toast indicating an async operation is in progress
   showLoadingToast () {
     this.loadingToast.show()
-  }
-
-  // Shows the toast indicating an async operation has completed
-  showSavedToast () {
-    this.savedToast.show()
   }
 }

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -67,7 +67,9 @@ module.exports = class Notifier {
   //  @throws {Error}    for trying to resolve more async operations than the amount currently awaiting
   stopAsyncOperation (errorMsg) {
     if (this.waitingSaveOperationCount < 1) {
-      throw new Error('Attempted to resolve an async operation when awaiting none')
+      const resolveNonexistantOperationError = 'Attempted to resolve an async operation when awaiting none'
+      this.notify(resolveNonexistantOperationError, 'error')
+      throw new Error(resolveNonexistantOperationError)
     }
 
     this.waitingSaveOperationCount--

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -63,7 +63,8 @@ module.exports = class Notifier {
   }
 
   // Shows the saved toast for 2 seconds
-  //  @param {string=}  error The error to be displayed(optional)
+  //  @param  {string=}  error The error to be displayed(optional)
+  //  @throws {Error}    for trying to resolve more async operations than the amount currently awaiting
   stopAsyncOperation (errorMsg) {
     if (this.waitingSaveOperationCount < 1) {
       throw new Error('Attempted to resolve an async operation when awaiting none')

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -3,7 +3,9 @@ const $ = require('jquery')
 module.exports = class Notifier {
   //  @param {object} notificationsElement The notification DOM element as a jQuery object
   constructor (notificationsElement) {
+    this.loadingToast = notificationsElement.find('#async-waiting-indicator')
     this.notificationsElement = notificationsElement
+    this.savedToast = notificationsElement.find('#async-success-indicator')
   }
 
   // Adds notification messages to the notification element
@@ -49,5 +51,15 @@ module.exports = class Notifier {
       default:
         throw new RangeError('Unsupported option for param level')
     }
+  }
+
+  // Shows the toast indicating an async operation is in progress
+  showLoadingToast () {
+    this.loadingToast.show()
+  }
+
+  // Shows the toast indicating an async operation has completed
+  showSavedToast () {
+    this.savedToast.show()
   }
 }

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -7,6 +7,7 @@ module.exports = class Notifier {
     this.notificationsElement = notificationsElement
     this.savedToast = notificationsElement.find('#async-success-indicator')
     this.savedToastTimeouts = []
+    this.waitingSaveOperationCount = 0
   }
 
   hideLoadingToast () {
@@ -65,17 +66,28 @@ module.exports = class Notifier {
   }
 
   // Shows the saved toast for 2 seconds
-  stopAsyncOperation () {
-    this.savedToast.show()
+  //  @param {string=}  error The error to be displayed(optional)
+  stopAsyncOperation (errorMsg) {
+    this.waitingSaveOperationCount--
 
-    this.savedToastTimeouts.forEach((timeoutID) => {
-      clearTimeout(timeoutID)
-    })
+    if (!errorMsg) {
+      this.savedToast.show()
 
-    this.savedToastTimeouts.push(setTimeout(() => {
-      this.savedToast.hide()
-      this.savedToastTimeouts.shift()
-    }, 2000))
+      this.savedToastTimeouts.forEach((timeoutID) => {
+        clearTimeout(timeoutID)
+      })
+
+      this.savedToastTimeouts.push(setTimeout(() => {
+        this.savedToast.hide()
+        this.savedToastTimeouts.shift()
+      }, 2000))
+    } else {
+      if (!(typeof errorMsg === 'string' || errorMsg instanceof String)) {
+        throw new TypeError('Param errorMsg must be a string')
+      }
+
+      this.notify(errorMsg, 'error')
+    }
   }
 
   // Shows the toast indicating an async operation is in progress

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -22,8 +22,9 @@ function resolveAsyncOperation (error) {
   }
 
   if (error) {
-    emancipationPage.notifier.notify(error, 'error')
+    emancipationPage.notifier.stopAsyncOperation(error)
   } else {
+    emancipationPage.notifier.stopAsyncOperation()
     emancipationPage.saveOperationSuccessful = true
   }
 
@@ -31,10 +32,6 @@ function resolveAsyncOperation (error) {
 
   if (emancipationPage.waitingSaveOperationCount === 0) {
     emancipationPage.notifier.hideLoadingToast()
-
-    if (emancipationPage.saveOperationSuccessful) {
-      emancipationPage.notifier.stopAsyncOperation()
-    }
 
     emancipationPage.saveOperationSuccessful = false
   }

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -33,21 +33,11 @@ function resolveAsyncOperation (error) {
     emancipationPage.notifier.hideLoadingToast()
 
     if (emancipationPage.saveOperationSuccessful) {
-      emancipationPage.notifier.showSavedToast()
-
-      setTimeout(function () {
-        emancipationPage.notifier.hideSavedToast()
-      }, 2000)
+      emancipationPage.notifier.stopAsyncOperation()
     }
 
     emancipationPage.saveOperationSuccessful = false
   }
-}
-
-// Shows the saving notification
-function waitForAsyncOperation () {
-  emancipationPage.waitingSaveOperationCount++
-  emancipationPage.notifier.showLoadingToast()
 }
 
 // Adds or deletes an option from the current casa case
@@ -79,7 +69,8 @@ function saveCheckState (action, checkItemId) {
     }
   }
 
-  waitForAsyncOperation()
+  emancipationPage.notifier.startAsyncOperation()
+  emancipationPage.waitingSaveOperationCount++
 
   // Post request
   return $.post(emancipationPage.savePath, {

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -3,9 +3,7 @@
 const Notifier = require('./async_notifier')
 
 const emancipationPage = {
-  saveOperationSuccessful: false,
-  savePath: window.location.pathname + '/save',
-  waitingSaveOperationCount: 0
+  savePath: window.location.pathname + '/save'
 }
 
 // Called when an async operation completes. May show notifications describing how the operation completed
@@ -13,28 +11,11 @@ const emancipationPage = {
 //  @throws   {TypeError}  for a parameter of the incorrect type
 //  @throws   {Error}      for trying to resolve more async operations than the amount currently awaiting
 function resolveAsyncOperation (error) {
-  if (emancipationPage.waitingSaveOperationCount < 1) {
-    throw new Error('Attempted to resolve an async operation when awaiting none')
-  }
-
   if (error instanceof Error) {
     error = error.message
   }
 
-  if (error) {
-    emancipationPage.notifier.stopAsyncOperation(error)
-  } else {
-    emancipationPage.notifier.stopAsyncOperation()
-    emancipationPage.saveOperationSuccessful = true
-  }
-
-  emancipationPage.waitingSaveOperationCount--
-
-  if (emancipationPage.waitingSaveOperationCount === 0) {
-    emancipationPage.notifier.hideLoadingToast()
-
-    emancipationPage.saveOperationSuccessful = false
-  }
+  emancipationPage.notifier.stopAsyncOperation(error)
 }
 
 // Adds or deletes an option from the current casa case
@@ -67,7 +48,6 @@ function saveCheckState (action, checkItemId) {
   }
 
   emancipationPage.notifier.startAsyncOperation()
-  emancipationPage.waitingSaveOperationCount++
 
   // Post request
   return $.post(emancipationPage.savePath, {
@@ -93,8 +73,6 @@ function saveCheckState (action, checkItemId) {
 $('document').ready(() => {
   const asyncNotificationsElement = $('#async-notifications')
   emancipationPage.notifier = new Notifier(asyncNotificationsElement)
-  emancipationPage.asyncSuccessIndicator = asyncNotificationsElement.find('#async-success-indicator')
-  emancipationPage.asyncWaitIndicator = asyncNotificationsElement.find('#async-waiting-indicator')
 
   $('.emancipation-category').click(function () {
     const category = $(this)

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -33,7 +33,7 @@ function resolveAsyncOperation (error) {
     emancipationPage.asyncWaitIndicator.hide()
 
     if (emancipationPage.saveOperationSuccessful) {
-      emancipationPage.asyncSuccessIndicator.show()
+      emancipationPage.notifier.showSavedToast()
 
       setTimeout(function () {
         emancipationPage.asyncSuccessIndicator.hide()
@@ -47,7 +47,7 @@ function resolveAsyncOperation (error) {
 // Shows the saving notification
 function waitForAsyncOperation () {
   emancipationPage.waitingSaveOperationCount++
-  emancipationPage.asyncWaitIndicator.show()
+  emancipationPage.notifier.showLoadingToast()
 }
 
 // Adds or deletes an option from the current casa case

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -30,13 +30,13 @@ function resolveAsyncOperation (error) {
   emancipationPage.waitingSaveOperationCount--
 
   if (emancipationPage.waitingSaveOperationCount === 0) {
-    emancipationPage.asyncWaitIndicator.hide()
+    emancipationPage.notifier.hideLoadingToast()
 
     if (emancipationPage.saveOperationSuccessful) {
       emancipationPage.notifier.showSavedToast()
 
       setTimeout(function () {
-        emancipationPage.asyncSuccessIndicator.hide()
+        emancipationPage.notifier.hideSavedToast()
       }, 2000)
     }
 

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -1,5 +1,4 @@
 /* eslint-env jquery */
-
 const Notifier = require('./async_notifier')
 
 const emancipationPage = {


### PR DESCRIPTION
### What changed, and why?

 - Refactored more async notifier js into module so it could be tested
 - fixed a bug where the saved toast would disappear prematurely
 - refactored hiding and showing toasts into 2 functions: `startAsyncOperation` and `stopAsyncOperation`
 - more tests for the async notifier