### PR TITLE
Past notifications should reflect current name of user

### DIFF
--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -7,7 +7,7 @@ class CaseContacts::FollowupsController < ApplicationController
 
     case_contact.followups.create(creator: current_user, status: :requested, note: params[:note])
     FollowupNotification
-      .with(followup: case_contact.requested_followup, created_by_name: current_user.display_name)
+      .with(followup: case_contact.requested_followup, created_by: current_user)
       .deliver(case_contact.creator)
 
     redirect_to casa_case_path(case_contact.casa_case)

--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -28,7 +28,7 @@ class CaseContacts::FollowupsController < ApplicationController
   def create_notification
     return if current_user == @followup.creator
     FollowupResolvedNotification
-      .with(followup: @followup, created_by_name: current_user.display_name)
+      .with(followup: @followup, created_by: current_user)
       .deliver(@followup.creator)
   end
 end

--- a/app/notifications/base_notification.rb
+++ b/app/notifications/base_notification.rb
@@ -1,0 +1,15 @@
+class BaseNotification < Noticed::Base
+  def title
+    t(".title")
+  end
+
+  private
+
+  def created_by_name
+    if params.key?(:created_by)
+      params[:created_by][:display_name]
+    else # keep backward compatibility with older notifications
+      params[:created_by_name]
+    end
+  end
+end

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -52,7 +52,7 @@ class FollowupNotification < Noticed::Base
   def created_by_name
     if params.key?(:created_by)
       params[:created_by][:display_name]
-    else  # keep backward compatibility with older notifications
+    else # keep backward compatibility with older notifications
       params[:created_by_name]
     end
   end

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -3,7 +3,7 @@
 # FollowupNotification.with(followup: @followup).deliver_later(current_user)
 # FollowupNotification.with(followup: @followup).deliver(current_user)
 
-class FollowupNotification < Noticed::Base
+class FollowupNotification < BaseNotification
   # Add your delivery methods
   #
   deliver_by :database
@@ -17,10 +17,6 @@ class FollowupNotification < Noticed::Base
 
   # Define helper methods to make rendering easier.
   #
-  def title
-    t(".title")
-  end
-
   def message
     note = params[:followup][:note]
 
@@ -47,13 +43,5 @@ class FollowupNotification < Noticed::Base
 
   def message_heading
     t(".message", created_by_name: created_by_name)
-  end
-
-  def created_by_name
-    if params.key?(:created_by)
-      params[:created_by][:display_name]
-    else # keep backward compatibility with older notifications
-      params[:created_by_name]
-    end
   end
 end

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -13,7 +13,7 @@ class FollowupNotification < Noticed::Base
 
   # Add required params
   #
-  param :followup, :created_by_name
+  param :followup, :created_by
 
   # Define helper methods to make rendering easier.
   #
@@ -46,6 +46,14 @@ class FollowupNotification < Noticed::Base
   end
 
   def message_heading
-    t(".message", created_by_name: params[:created_by_name])
+    t(".message", created_by_name: created_by_name)
+  end
+
+  def created_by_name
+    if params.key?(:created_by)
+      params[:created_by][:display_name]
+    else  # keep backward compatibility with older notifications
+      params[:created_by_name]
+    end
   end
 end

--- a/app/notifications/followup_resolved_notification.rb
+++ b/app/notifications/followup_resolved_notification.rb
@@ -3,7 +3,7 @@
 # FollowupResolvedNotification.with(followup: @followup).deliver_later(current_user)
 # FollowupResolvedNotification.with(followup: @followup).deliver(current_user)
 
-class FollowupResolvedNotification < Noticed::Base
+class FollowupResolvedNotification < BaseNotification
   # Add your delivery methods
   #
   deliver_by :database
@@ -17,25 +17,11 @@ class FollowupResolvedNotification < Noticed::Base
 
   # Define helper methods to make rendering easier.
   #
-  def title
-    t(".title")
-  end
-
   def message
     t(".message", created_by_name: created_by_name)
   end
 
   def url
     edit_case_contact_path(params[:followup][:case_contact_id], notification_id: record.id)
-  end
-
-  private
-
-  def created_by_name
-    if params.key?(:created_by)
-      params[:created_by][:display_name]
-    else # keep backward compatibility with older notifications
-      params[:created_by_name]
-    end
   end
 end

--- a/app/notifications/followup_resolved_notification.rb
+++ b/app/notifications/followup_resolved_notification.rb
@@ -13,7 +13,7 @@ class FollowupResolvedNotification < Noticed::Base
 
   # Add required params
   #
-  param :followup, :created_by_name
+  param :followup, :created_by
 
   # Define helper methods to make rendering easier.
   #
@@ -22,10 +22,20 @@ class FollowupResolvedNotification < Noticed::Base
   end
 
   def message
-    t(".message", created_by_name: params[:created_by_name])
+    t(".message", created_by_name: created_by_name)
   end
 
   def url
     edit_case_contact_path(params[:followup][:case_contact_id], notification_id: record.id)
+  end
+
+  private
+
+  def created_by_name
+    if params.key?(:created_by)
+      params[:created_by][:display_name]
+    else # keep backward compatibility with older notifications
+      params[:created_by_name]
+    end
   end
 end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "/case_contacts", type: :request do
         case_contact = create(:case_contact)
         followup = create(:followup, case_contact: case_contact, creator: admin)
         FollowupResolvedNotification
-          .with(followup: followup, created_by_name: volunteer.display_name)
+          .with(followup: followup, created_by: volunteer)
           .deliver(followup.creator)
 
         get edit_case_contact_url(case_contact, notification_id: admin.notifications.first.id)

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -12,18 +12,39 @@ RSpec.describe "notifications/index", type: :system do
     let(:notification_message) { "#{volunteer.display_name} resolved a follow up. Click to see more." }
     let!(:followup) { create(:followup, creator: admin, case_contact: case_contact) }
 
-    it "lists my notifications" do
+    before do
       sign_in volunteer
 
       visit case_contacts_path
       click_button "Resolve"
+    end
 
+    it "lists my notifications" do
       sign_in admin
       visit notifications_path
 
       expect(page).to have_text(notification_message)
       expect(page).to have_text("Followup resolved")
       expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
+    end
+
+    context "when volunteer changes its name" do
+      let(:created_by_name) { "Foo bar" }
+      let(:new_notification_message) { I18n.t("notifications.followup_resolved_notification.message", created_by_name: created_by_name) }
+
+      it "lists notifications showing it's current name" do
+        visit edit_users_path
+        fill_in "Display name", with: created_by_name
+        click_on "Update Profile"
+        expect(page).to have_content "Profile was successfully updated"
+
+        sign_in admin
+        visit notifications_path
+
+        expect(page).to have_text(new_notification_message)
+        expect(page).not_to have_text(notification_message)
+        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
+      end
     end
   end
 

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "notifications/index", type: :system do
     end
 
     context "when admin changes its name" do
-      let(:created_by_name) { 'Foo bar' }
+      let(:created_by_name) { "Foo bar" }
       let(:new_notification_message) { I18n.t("notifications.followup_notification.message", created_by_name: created_by_name) }
 
       before do

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -81,6 +81,34 @@ RSpec.describe "notifications/index", type: :system do
         expect(page).to have_text("New followup")
       end
     end
+
+    context "when admin changes its name" do
+      let(:created_by_name) { 'Foo bar' }
+      let(:new_notification_message) { I18n.t("notifications.followup_notification.message", created_by_name: created_by_name) }
+
+      before do
+        click_button "Follow up"
+        click_button "Confirm"
+      end
+
+      it "lists followup notifications showing admin current name" do
+        # Wait until page reloads
+        expect(page).to have_content "Resolve"
+
+        visit edit_users_path
+        fill_in "Display name", with: created_by_name
+        click_on "Update Profile"
+        expect(page).to have_content "Profile was successfully updated"
+
+        sign_in volunteer
+        visit notifications_path
+
+        expect(page).to have_text(new_notification_message)
+        expect(page).not_to have_text(inline_notification_message)
+        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
+        expect(page).to have_text("New followup")
+      end
+    end
   end
 
   context "when there are no notifications" do


### PR DESCRIPTION
Allows to get the users current name when showing the notification message

### What github issue is this PR for, if any?
Resolves #2471

### What changed, and why?
Notifications should reflect the current name of the user that created it. To accomplish this instead of passing the name of the user as a parameter we pass the user instance.

### How will this affect user permissions?
No permission affected

### How is this tested? (please write tests!) 💖💪
with tests

### Screenshots please :)



