### PR TITLE
Excludes deactivated supervisors from dropdown

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -30,21 +30,23 @@
           </a>
         </li>
         <% current_organization.supervisors.each do |supervisor| %>
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1">
-              <% if policy(User).edit_name?(supervisor) %>
-                <input
-                  type="checkbox"
-                  data-value="<%= supervisor.display_name %>"
-                  checked>
-              <% else %>
-                <input
-                  type="checkbox"
-                  data-value="<%= supervisor.display_name %>">
-              <% end %>
-              <%= supervisor.display_name %>
-            </a>
-          </li>
+          <% if supervisor.active == true %>
+            <li>
+              <a class="small" data-value="option1" tabIndex="-1">
+                <% if policy(User).edit_name?(supervisor) %>
+                  <input
+                    type="checkbox"
+                    data-value="<%= supervisor.display_name %>"
+                    checked>
+                <% else %>
+                  <input
+                    type="checkbox"
+                    data-value="<%= supervisor.display_name %>">
+                <% end %>
+                <%= supervisor.display_name %>
+              </a>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     </div>

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -23,4 +23,24 @@ RSpec.describe "volunteers", type: :view do
 
     it { is_expected.to have_selector("a", text: "New Volunteer") }
   end
+
+  describe "supervisor's dropdown" do
+    let!(:supervisor_volunteer) { create(:supervisor_volunteer, volunteer: volunteer, supervisor: supervisor) }
+
+    context "when the supervisor is active" do
+      let(:supervisor) { build(:supervisor) }
+
+      it "shows up in the supervisor dropdown" do
+        expect(subject).to include(supervisor.display_name)
+      end
+    end
+
+    context "when the supervisor is not active" do
+      let(:supervisor) { build(:supervisor, active: false) }
+
+      it "doesn't show up in the dropdown" do
+        expect(subject).not_to include(supervisor.display_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2552

### What changed, and why?
Deactivated supervisors will not appear in the volunteers' filter dropdown.

### How will this affect user permissions?
No permissions affected.

### How is this tested? (please write tests!) 💖💪
Check if when the supervisor is active, the name appear

### Screenshots please :)
