### PR TITLE
Spec refactor

### DIFF
--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -5,21 +5,28 @@ RSpec.describe "case_contacts/new", type: :system do
   include ActionView::Helpers::SanitizeHelper
 
   context "when admin" do
-    let(:organization) { build(:casa_org) }
-    let(:admin) { create(:casa_admin, casa_org: organization) }
-    let(:casa_case) { create(:casa_case, casa_org: organization) }
-    let(:contact_type_group) { build(:contact_type_group, casa_org: organization) }
-    let!(:empty) { build(:contact_type_group, name: "Empty", casa_org: organization) }
-    let!(:grp_with_hidden) { build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization) }
-    let!(:hidden_type) { create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden) }
-    let!(:school) { create(:contact_type, name: "School", contact_type_group: contact_type_group) }
-    let!(:therapist) { create(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
+    it "is successful", js: true do
+      organization = build(:casa_org)
+      admin = create(:casa_admin, casa_org: organization)
+      casa_case = create(:casa_case, casa_org: organization)
+      contact_type_group = build(:contact_type_group, casa_org: organization)
+      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
+      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
+      hidden_type = create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
+      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
 
-    before do
       travel_to Date.new(2021, 1, 1)
       sign_in admin
 
       visit casa_case_path(casa_case.id)
+
+      # does not show empty contact type groups
+      expect(page).to_not have_text("Empty")
+
+      # does not show contact type groups with only hidden contact types
+      expect(page).to_not have_text("Hidden")
+
       click_on "New Case Contact"
 
       check "School"
@@ -27,9 +34,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "Yes"
       select "Video", from: "case_contact[medium_type]"
       fill_in "case_contact_occurred_at", with: "04/04/2020"
-    end
 
-    it "is successful", js: true do
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -42,15 +47,27 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(CaseContact.first.duration_minutes).to eq 105
     end
 
-    it "does not show empty contact type groups" do
-      expect(page).to_not have_text("Empty")
-    end
-
-    it "does not show contact type groups with only hidden contact types" do
-      expect(page).to_not have_text("Hidden")
-    end
-
     it "should display full text in table if notes are less than 100 characters", js: true do
+      organization = build(:casa_org)
+      admin = create(:casa_admin, casa_org: organization)
+      casa_case = create(:casa_case, casa_org: organization)
+      contact_type_group = build(:contact_type_group, casa_org: organization)
+      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
+      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
+      hidden_type = create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
+      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+      travel_to Date.new(2021, 1, 1)
+      sign_in admin
+
+      visit casa_case_path(casa_case.id)
+      click_on "New Case Contact"
+
+      check "School"
+      check "Therapist"
+      choose "Yes"
+      select "Video", from: "case_contact[medium_type]"
+      fill_in "case_contact_occurred_at", with: "04/04/2020"
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -69,6 +86,23 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "should allow expanding or hiding if notes are more than 100 characters", js: true do
+      organization = build(:casa_org)
+      admin = create(:casa_admin, casa_org: organization)
+      casa_case = create(:casa_case, casa_org: organization)
+      contact_type_group = build(:contact_type_group, casa_org: organization)
+      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+      travel_to Date.new(2021, 1, 1)
+      sign_in admin
+
+      visit casa_case_path(casa_case.id)
+      click_on "New Case Contact"
+
+      check "School"
+      check "Therapist"
+      choose "Yes"
+      select "Video", from: "case_contact[medium_type]"
+      fill_in "case_contact_occurred_at", with: "04/04/2020"
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
 
@@ -99,6 +133,23 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with invalid inputs" do
       it "does not submit the form" do
+        organization = build(:casa_org)
+        admin = create(:casa_admin, casa_org: organization)
+        casa_case = create(:casa_case, casa_org: organization)
+        contact_type_group = build(:contact_type_group, casa_org: organization)
+        school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+        therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+        travel_to Date.new(2021, 1, 1)
+        sign_in admin
+
+        visit casa_case_path(casa_case.id)
+        click_on "New Case Contact"
+
+        check "School"
+        check "Therapist"
+        choose "Yes"
+        select "Video", from: "case_contact[medium_type]"
+        fill_in "case_contact_occurred_at", with: "04/04/2020"
         fill_in "case-contact-duration-hours", with: "0"
         fill_in "case-contact-duration-minutes", with: "5"
 
@@ -110,6 +161,23 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with HTML in notes" do
       it "renders HTML correctly on the index page", js: true do
+        organization = build(:casa_org)
+        admin = create(:casa_admin, casa_org: organization)
+        casa_case = create(:casa_case, casa_org: organization)
+        contact_type_group = build(:contact_type_group, casa_org: organization)
+        school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
+        therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+        travel_to Date.new(2021, 1, 1)
+        sign_in admin
+
+        visit casa_case_path(casa_case.id)
+        click_on "New Case Contact"
+
+        check "School"
+        check "Therapist"
+        choose "Yes"
+        select "Video", from: "case_contact[medium_type]"
+        fill_in "case_contact_occurred_at", with: "04/04/2020"
         note_content = "<h1>Hello world</h1>"
 
         fill_in "case-contact-duration-hours", with: "1"
@@ -131,27 +199,26 @@ RSpec.describe "case_contacts/new", type: :system do
   end
 
   context "mutliple contact type groups" do
-    let(:organization) { build(:casa_org) }
-    let(:admin) { build(:casa_admin, casa_org: organization) }
-    let(:casa_case) { build(:casa_case, casa_org: organization) }
-
-    before do
-      travel_to Date.new(2021, 1, 1)
-      sign_in admin
-    end
-
     it "should check the correct box when clicking the label" do
+      organization = build(:casa_org)
+      admin = build(:casa_admin, casa_org: organization)
+      casa_case = build(:casa_case, casa_org: organization)
       group_1 = build_stubbed(:contact_type_group, casa_org: organization)
       create(:contact_type, name: "School", contact_type_group: group_1)
       group_2 = build(:contact_type_group, casa_org: organization)
       create(:contact_type, name: "Parent", contact_type_group: group_2)
 
+      travel_to Date.new(2021, 1, 1)
+      sign_in admin
       visit new_case_contact_path(casa_case.id)
 
       expect { check "Parent" }.not_to raise_error
     end
 
     it "shows the contact type groups, and their contact type alphabetically", :aggregate_failures do
+      organization = build(:casa_org)
+      admin = build(:casa_admin, casa_org: organization)
+      casa_case = build(:casa_case, casa_org: organization)
       group_1 = create(:contact_type_group, name: "Placement", casa_org: organization)
       group_2 = create(:contact_type_group, name: "Education", casa_org: organization)
       create(:contact_type, name: "School", contact_type_group: group_1)
@@ -159,6 +226,8 @@ RSpec.describe "case_contacts/new", type: :system do
       create(:contact_type, name: "Caregiver Family", contact_type_group: group_2)
       create(:contact_type, name: "Foster Parent", contact_type_group: group_2)
 
+      travel_to Date.new(2021, 1, 1)
+      sign_in admin
       visit(new_case_contact_path(casa_case.id))
 
       expect(index_of("Education")).to be < index_of("Placement")
@@ -173,12 +242,11 @@ RSpec.describe "case_contacts/new", type: :system do
   end
 
   context "volunteer user" do
-    let(:organization) { build(:casa_org) }
-    let!(:empty) { build(:contact_type_group, name: "Empty", casa_org: organization) }
-    let!(:grp_with_hidden) { build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization) }
-    let!(:hidden_type) { build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden) }
-
     it "is successful", js: true do
+      organization = build(:casa_org)
+      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
+      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
+      hidden_type = build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -218,6 +286,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "submits the form when no note was added", js: true do
+      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -247,6 +316,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "submits the form when note is added and confirmed", js: true do
+      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -278,6 +348,7 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "does not submit the form when note is added but not confirmed" do
+      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -308,6 +379,7 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with invalid inputs" do
       it "re-renders the form with errors, but preserving all previously entered selections", js: true do
+        organization = build(:casa_org)
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         future_date = 2.days.from_now
@@ -361,6 +433,7 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with contact made not checked" do
       it "does not re-render form, preserves all previously entered selections", js: true do
+        organization = build(:casa_org)
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         create_contact_types(volunteer_casa_case_one.casa_org)

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -5,18 +5,17 @@ RSpec.describe "case_contacts/new", type: :system do
   include ActionView::Helpers::SanitizeHelper
 
   context "when admin" do
-    it "is successful", js: true do
+    it "does not display empty or hidden contact type groups; can create CaseContact", js: true do
       organization = build(:casa_org)
       admin = create(:casa_admin, casa_org: organization)
       casa_case = create(:casa_case, casa_org: organization)
       contact_type_group = build(:contact_type_group, casa_org: organization)
-      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
+      build(:contact_type_group, name: "Empty", casa_org: organization)
       grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
-      hidden_type = create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
+      create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
       school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
       therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
 
-      travel_to Date.new(2021, 1, 1)
       sign_in admin
 
       visit casa_case_path(casa_case.id)
@@ -52,12 +51,8 @@ RSpec.describe "case_contacts/new", type: :system do
       admin = create(:casa_admin, casa_org: organization)
       casa_case = create(:casa_case, casa_org: organization)
       contact_type_group = build(:contact_type_group, casa_org: organization)
-      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
-      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
-      hidden_type = create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
-      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
-      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
-      travel_to Date.new(2021, 1, 1)
+      create(:contact_type, name: "School", contact_type_group: contact_type_group)
+      create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
       sign_in admin
 
       visit casa_case_path(casa_case.id)
@@ -90,9 +85,9 @@ RSpec.describe "case_contacts/new", type: :system do
       admin = create(:casa_admin, casa_org: organization)
       casa_case = create(:casa_case, casa_org: organization)
       contact_type_group = build(:contact_type_group, casa_org: organization)
-      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
-      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
-      travel_to Date.new(2021, 1, 1)
+      create(:contact_type, name: "School", contact_type_group: contact_type_group)
+      create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+
       sign_in admin
 
       visit casa_case_path(casa_case.id)
@@ -137,9 +132,9 @@ RSpec.describe "case_contacts/new", type: :system do
         admin = create(:casa_admin, casa_org: organization)
         casa_case = create(:casa_case, casa_org: organization)
         contact_type_group = build(:contact_type_group, casa_org: organization)
-        school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
-        therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
-        travel_to Date.new(2021, 1, 1)
+        create(:contact_type, name: "School", contact_type_group: contact_type_group)
+        create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+
         sign_in admin
 
         visit casa_case_path(casa_case.id)
@@ -165,9 +160,9 @@ RSpec.describe "case_contacts/new", type: :system do
         admin = create(:casa_admin, casa_org: organization)
         casa_case = create(:casa_case, casa_org: organization)
         contact_type_group = build(:contact_type_group, casa_org: organization)
-        school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
-        therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
-        travel_to Date.new(2021, 1, 1)
+        create(:contact_type, name: "School", contact_type_group: contact_type_group)
+        create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
+
         sign_in admin
 
         visit casa_case_path(casa_case.id)
@@ -208,7 +203,6 @@ RSpec.describe "case_contacts/new", type: :system do
       group_2 = build(:contact_type_group, casa_org: organization)
       create(:contact_type, name: "Parent", contact_type_group: group_2)
 
-      travel_to Date.new(2021, 1, 1)
       sign_in admin
       visit new_case_contact_path(casa_case.id)
 
@@ -226,7 +220,6 @@ RSpec.describe "case_contacts/new", type: :system do
       create(:contact_type, name: "Caregiver Family", contact_type_group: group_2)
       create(:contact_type, name: "Foster Parent", contact_type_group: group_2)
 
-      travel_to Date.new(2021, 1, 1)
       sign_in admin
       visit(new_case_contact_path(casa_case.id))
 
@@ -244,9 +237,9 @@ RSpec.describe "case_contacts/new", type: :system do
   context "volunteer user" do
     it "is successful", js: true do
       organization = build(:casa_org)
-      empty = build(:contact_type_group, name: "Empty", casa_org: organization)
+      build(:contact_type_group, name: "Empty", casa_org: organization)
       grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
-      hidden_type = build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
+      build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -286,7 +279,6 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "submits the form when no note was added", js: true do
-      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -316,7 +308,6 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "submits the form when note is added and confirmed", js: true do
-      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -348,7 +339,6 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "does not submit the form when note is added but not confirmed" do
-      organization = build(:casa_org)
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first
       create_contact_types(volunteer_casa_case_one.casa_org)
@@ -379,7 +369,6 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with invalid inputs" do
       it "re-renders the form with errors, but preserving all previously entered selections", js: true do
-        organization = build(:casa_org)
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         future_date = 2.days.from_now
@@ -433,7 +422,6 @@ RSpec.describe "case_contacts/new", type: :system do
 
     context "with contact made not checked" do
       it "does not re-render form, preserves all previously entered selections", js: true do
-        organization = build(:casa_org)
         volunteer = create(:volunteer, :with_casa_cases)
         volunteer_casa_case_one = volunteer.casa_cases.first
         create_contact_types(volunteer_casa_case_one.casa_org)


### PR DESCRIPTION
### What changed, and why?
Refactor spec to build up test within `it` block for readability, easy of debugging, and helpful for newer developers. Going to work on some N+1 issues with the related controller, so refactoring this spec first. Also combined a few specs that were just testing a single thing to help speed up the test suite.