### PR TITLE
removed lint from js unit test script

### DIFF
--- a/.github/workflows/yarn_lint_and_test.yml
+++ b/.github/workflows/yarn_lint_and_test.yml
@@ -29,4 +29,5 @@ jobs:
           node-version: 12.x
 
       - run: yarn
+      - run: yarn lint
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test:cypress": "$(npm bin)/cypress run",
-    "test": "standard && jest",
+    "test": "jest",
     "test:e2e": "cypress open",
     "lint": "standard",
     "lint:fix": "standard --fix",


### PR DESCRIPTION
### What changed, and why?
Running the js unit tests don't lint before hand
Having it lint before hand makes writing jest tests really slow

### Feelings gif (optional)
![shut](https://c.tenor.com/p87PjQqc4LkAAAAM/zip-mouth-secret.gif)
