### PR TITLE
Removes css-p from footer scss; reduces padding-top to move logo and …

### DIFF
--- a/app/javascript/src/stylesheets/pages/password.scss
+++ b/app/javascript/src/stylesheets/pages/password.scss
@@ -32,9 +32,6 @@
 
 body.devise-invitations.devise-invitations-edit footer {
   width: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
 }
 
 body.devise-passwords.devise-passwords-edit div.password-box {

--- a/app/javascript/src/stylesheets/shared/footer.scss
+++ b/app/javascript/src/stylesheets/shared/footer.scss
@@ -1,5 +1,5 @@
 footer {
-  padding: 5rem 0;
+  padding: 2rem 0;
   text-align: center;
   background-color: $primary;
   color: #fff;


### PR DESCRIPTION


### What github issue is this PR for, if any?
Resolves #2353 

### What changed, and why?
The issue was that the footer on the password page was set using css absolution positioning. Absolute positioning does weird stuff because it puts the content into a separate stacking index, meaning it doesn't sit the same with floats and z-index, among other things. It wasn't necessary, so I just struck it out entirely.

It felt like the footer content sat a little too far down the page so I reduced the padding-y from 5rem to 2rem. I think you could probably put some of teh footer content side by side too, but that felt out of scope for this


### How is this tested? (please write tests!) 💖💪
Visual change only; tested with DOM inspector manually.

### Screenshots please :)

Full-width -- the footer content can be seen by scrolling down. I think this could probably be made a little more responsive (that's a lot of whitespace above and below) but the behavior to correct in this was just the inability to edit the password fields because of coverup so I didn't touch that.

<img width="947" alt="Screen Shot 2021-09-22 at 11 08 09 PM" src="https://user-images.githubusercontent.com/502363/134449421-1ca90813-0e91-41e0-8533-8a327d6a85bf.png">

Narrowest view -- this is what would be seen on mobile I presume. I couldn't make it any narrower. It's still visible and functional.

<img width="493" alt="Screen Shot 2021-09-22 at 11 08 24 PM" src="https://user-images.githubusercontent.com/502363/134449429-7ee60bf8-4485-4235-b342-90affa8cd202.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? 
![dinosaur on bike](https://media.giphy.com/media/ZrCUYZjwrfeCs/giphy.gif)
