### PR TITLE
Link court case from new court date page

### DIFF
--- a/app/views/past_court_dates/_form.html.erb
+++ b/app/views/past_court_dates/_form.html.erb
@@ -8,7 +8,7 @@
       </div>
 
       <p>
-        <h6><strong><%= t(".label.case_number") %>:</strong> <%= casa_case.case_number %></h6>
+        <h6><strong><%= t(".label.case_number") %>:</strong> <%= link_to casa_case.case_number, casa_case %></h6>
       </p>
 
       <div class="field form-group">

--- a/spec/views/past_court_dates/new.html.erb_spec.rb
+++ b/spec/views/past_court_dates/new.html.erb_spec.rb
@@ -15,5 +15,6 @@ RSpec.describe "past_court_dates/new", type: :view do
 
   it { is_expected.to have_selector("h1", text: "New Past Court Date") }
   it { is_expected.to have_selector("h6", text: casa_case.case_number) }
+  it { is_expected.to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}") }
   it { is_expected.to have_selector(".btn-primary") }
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2601

### What changed, and why?
On the new past court date page, link the case back to the case page.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Added test which verifies that the case number on the new court date page now links back to the case page.

### Screenshots please :)

<img width="625" alt="New case link" src="https://user-images.githubusercontent.com/49253356/134700933-423f860d-f2ce-4551-8d8d-f063cba9c86b.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
