### PR TITLE
Reflect Current User logged in date

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -13,8 +13,8 @@ class UserDecorator < Draper::Decorator
     I18n.l(object.updated_at, format: :full, default: nil)
   end
 
-  def formatted_last_sign_in_at
-    I18n.l(object.last_sign_in_at, format: :full, default: nil)
+  def formatted_current_sign_in_at
+    I18n.l(object.current_sign_in_at, format: :full, default: nil)
   end
 
   def formatted_invitation_accepted_at

--- a/app/views/shared/_invite_login.html.erb
+++ b/app/views/shared/_invite_login.html.erb
@@ -8,7 +8,7 @@
 </div>
 <div>
   <span class="font-weight-bold">Last logged in </span>
-  <%= resource&.decorate&.formatted_last_sign_in_at || "never" %>
+  <%= resource&.decorate&.formatted_current_sign_in_at || "never" %>
 </div>
 <div>
   <span class="font-weight-bold">Invitation accepted </span>

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "users/edit", type: :system do
   let(:volunteer) do
     create(
       :volunteer,
-      last_sign_in_at: '2020-01-01 00:00:00',
-      current_sign_in_at: '2020-01-02 00:00:00'
+      last_sign_in_at: "2020-01-01 00:00:00",
+      current_sign_in_at: "2020-01-02 00:00:00"
     )
   end
   let(:admin) { create(:casa_admin) }
@@ -78,7 +78,7 @@ RSpec.describe "users/edit", type: :system do
 
     it "displays current sign in date" do
       formatted_current_sign_in_at = I18n.l(volunteer.current_sign_in_at, format: :full, default: nil)
-      formatted_last_sign_in_at =  I18n.l(volunteer.last_sign_in_at, format: :full, default: nil)
+      formatted_last_sign_in_at = I18n.l(volunteer.last_sign_in_at, format: :full, default: nil)
       expect(page).to have_text("Last logged in #{formatted_current_sign_in_at}")
       expect(page).not_to have_text("Last logged in #{formatted_last_sign_in_at}")
     end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -2,7 +2,13 @@ require "rails_helper"
 
 RSpec.describe "users/edit", type: :system do
   let(:organization) { create(:casa_org) }
-  let(:volunteer) { create(:volunteer) }
+  let(:volunteer) do
+    create(
+      :volunteer,
+      last_sign_in_at: '2020-01-01 00:00:00',
+      current_sign_in_at: '2020-01-02 00:00:00'
+    )
+  end
   let(:admin) { create(:casa_admin) }
   let(:supervisor) { create(:supervisor) }
 
@@ -68,6 +74,13 @@ RSpec.describe "users/edit", type: :system do
 
     it "is not able to update the email if user is a volunteer" do
       expect(page).to have_field("Email", disabled: true)
+    end
+
+    it "displays current sign in date" do
+      formatted_current_sign_in_at = I18n.l(volunteer.current_sign_in_at, format: :full, default: nil)
+      formatted_last_sign_in_at =  I18n.l(volunteer.last_sign_in_at, format: :full, default: nil)
+      expect(page).to have_text("Last logged in #{formatted_current_sign_in_at}")
+      expect(page).not_to have_text("Last logged in #{formatted_last_sign_in_at}")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2551

### What changed, and why?
Changed the last login date. According to [Devise docs](https://www.rubydoc.info/github/heartcombo/devise/master/Devise/Models/Trackable) the field `last_sign_in_at` holds the timestamp of the previous sign in and `current_sign_in_at` the timestamp when the user signs in.

### How will this affect user permissions?
No permission was affected

### How is this tested? (please write tests!) 💖💪
With tests :)