### PR TITLE
Cc email changes

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -83,7 +83,15 @@ class VolunteersController < ApplicationController
   def reminder
     authorize @volunteer
     with_cc = params[:with_cc].present?
-    VolunteerMailer.case_contacts_reminder(@volunteer, with_cc).deliver
+
+    cc_recipients = []
+    if with_cc
+      if current_user.casa_admin?
+        cc_recipients.append(current_user.email)
+      end
+      cc_recipients.append(@volunteer.supervisor.email) if @volunteer.supervisor
+    end
+    VolunteerMailer.case_contacts_reminder(@volunteer, cc_recipients).deliver
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Reminder sent to volunteer."
   end

--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -14,6 +14,10 @@ label {
   font-weight: 900;
 }
 
+.unbold {
+  font-weight: 100;
+}
+
 .fa-car {
   color: $primary;
 }

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -16,7 +16,7 @@ class VolunteerMailer < UserMailer
   def case_contacts_reminder(user, with_cc)
     @user = user
     @casa_organization = user.casa_org
-    if with_cc
+    if with_cc && user.supervisor
       mail(to: @user.email, cc: @user.supervisor.email, subject: "Reminder to input case contacts")
     else
       mail(to: @user.email, subject: "Reminder to input case contacts")

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -13,13 +13,9 @@ class VolunteerMailer < UserMailer
     mail(to: @user.email, subject: "Your court report is due on: #{court_report_due_date}")
   end
 
-  def case_contacts_reminder(user, with_cc)
+  def case_contacts_reminder(user, cc_recipients)
     @user = user
     @casa_organization = user.casa_org
-    if with_cc && user.supervisor
-      mail(to: @user.email, cc: @user.supervisor.email, subject: "Reminder to input case contacts")
-    else
-      mail(to: @user.email, subject: "Reminder to input case contacts")
-    end
+    mail(to: @user.email, cc: cc_recipients, subject: "Reminder to input case contacts")
   end
 end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -97,19 +97,22 @@
 
     <div>
       <h6><strong><%= t(".assigned_volunteers") %>:</strong></h6>
+      <div class="container">
       <% policy_scope(@casa_case.assigned_volunteers).each do |volunteer| %>
+        <div class="row mb-3">
         <% if current_user.volunteer? %>
-          <p><%= volunteer.display_name %></p>
+            <div class="col-12"><%= volunteer.display_name %></div>
         <% else %>
-          <%= form_tag reminder_volunteer_path(volunteer),
-                  method: :patch, id: "cc-check" do %>
-            <p>
+            <div class="col-2">
               <%= link_to "#{volunteer.display_name} ", edit_volunteer_path(volunteer) %>
-              <%= render "volunteers/send_reminder_button", volunteer: volunteer %>
-            </p>
-          <% end %>
+            </div>
+            <div class="col-10">
+              <%= render "volunteers/volunteer_reminder_form", volunteer: volunteer %>
+            </div>
         <% end %>
+        </div>
       <% end %>
+      </div>
       <br>
 
       <% if @casa_case.case_contacts.present? %>

--- a/app/views/volunteers/_send_reminder_button.html.erb
+++ b/app/views/volunteers/_send_reminder_button.html.erb
@@ -3,5 +3,7 @@
   id: "reminder_button",
   data_toggle: "tooltip",
   title: "#{t(".tooltip")}".to_s %>
-<%= check_box_tag 'with_cc', 1 %>
-<%= volunteer.decorate.cc_reminder_text %>
+<%= label_tag 'with_cc', class: 'unbold' do %>
+  <%= check_box_tag 'with_cc', 1 %>
+  <%= volunteer.decorate.cc_reminder_text %>
+<% end %>

--- a/app/views/volunteers/_volunteer_reminder_form.erb
+++ b/app/views/volunteers/_volunteer_reminder_form.erb
@@ -1,0 +1,3 @@
+<%= form_tag reminder_volunteer_path(volunteer), method: :patch, id: "cc-check" do %>
+  <%= render "volunteers/send_reminder_button", volunteer: volunteer %>
+<% end %>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -3,9 +3,7 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1>Editing Volunteer</h1>
-    <%= form_tag reminder_volunteer_path(@volunteer), method: :patch, id: "cc-check" do %>
-      <%= render "send_reminder_button", volunteer: @volunteer %>
-    <% end %>
+    <%= render "volunteer_reminder_form", volunteer: @volunteer %>
   </div>
 </div>
 <div class="card card-container">

--- a/spec/mailers/volunteer_mailer_spec.rb
+++ b/spec/mailers/volunteer_mailer_spec.rb
@@ -26,24 +26,17 @@ RSpec.describe VolunteerMailer, type: :mailer do
   end
 
   describe ".case_contacts_reminder" do
-    let(:mail) { VolunteerMailer.case_contacts_reminder(volunteer, false) }
-    let(:mail_with_cc) { VolunteerMailer.case_contacts_reminder(volunteer_with_supervisor, true) }
-    let(:mail_with_cc_no_supervisor) { VolunteerMailer.case_contacts_reminder(volunteer, true) }
-
     it "sends an email reminding volunteer" do
+      mail = VolunteerMailer.case_contacts_reminder(volunteer, [])
       expect(mail.body.encoded).to match("Hello #{volunteer.display_name}")
       expect(mail.body.encoded).to match("as a reminder")
-      expect(mail.cc).to be_nil
+      expect(mail.cc).to be_empty
     end
 
-    it "sends a cc to supervisor" do
-      expect(mail_with_cc.cc).to include(volunteer_with_supervisor.supervisor.email.to_s)
-    end
-
-    it "does not fail with cc selected and no supervisor" do
-      expect(mail_with_cc_no_supervisor.body.encoded).to match("Hello #{volunteer.display_name}")
-      expect(mail_with_cc_no_supervisor.body.encoded).to match("as a reminder")
-      expect(mail_with_cc_no_supervisor.cc).to be_nil
+    it "sends and cc's recipients" do
+      cc_recipients = %w[supervisor@example.com admin@example.com]
+      mail = VolunteerMailer.case_contacts_reminder(volunteer, cc_recipients)
+      expect(mail.cc).to match_array(cc_recipients)
     end
   end
 

--- a/spec/mailers/volunteer_mailer_spec.rb
+++ b/spec/mailers/volunteer_mailer_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe VolunteerMailer, type: :mailer do
   describe ".case_contacts_reminder" do
     let(:mail) { VolunteerMailer.case_contacts_reminder(volunteer, false) }
     let(:mail_with_cc) { VolunteerMailer.case_contacts_reminder(volunteer_with_supervisor, true) }
+    let(:mail_with_cc_no_supervisor) { VolunteerMailer.case_contacts_reminder(volunteer, true) }
 
     it "sends an email reminding volunteer" do
       expect(mail.body.encoded).to match("Hello #{volunteer.display_name}")
@@ -37,6 +38,12 @@ RSpec.describe VolunteerMailer, type: :mailer do
 
     it "sends a cc to supervisor" do
       expect(mail_with_cc.cc).to include(volunteer_with_supervisor.supervisor.email.to_s)
+    end
+
+    it "does not fail with cc selected and no supervisor" do
+      expect(mail_with_cc_no_supervisor.body.encoded).to match("Hello #{volunteer.display_name}")
+      expect(mail_with_cc_no_supervisor.body.encoded).to match("as a reminder")
+      expect(mail_with_cc_no_supervisor.cc).to be_nil
     end
   end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -225,9 +225,11 @@ RSpec.describe "volunteers/edit", type: :system do
   describe "send reminder as a supervisor" do
     let(:supervisor) { create(:supervisor, casa_org: organization) }
 
-    it "allows a supervisor to send case contact reminder to a volunteer" do
+    before(:each) do
       sign_in supervisor
+    end
 
+    it "emails the volunteer" do
       visit edit_volunteer_path(volunteer)
 
       expect(page).to have_button("Send Reminder")
@@ -239,48 +241,50 @@ RSpec.describe "volunteers/edit", type: :system do
       expect(ActionMailer::Base.deliveries.first.cc).to be_empty
     end
 
-    it "allows a supervisor to send case contact reminder to a volunteer with cc" do
-      sign_in supervisor
-
+    it "emails volunteer and cc's the supervisor" do
       visit edit_volunteer_path(volunteer)
 
-      expect(page).to have_button("Send Reminder")
-      expect(page).to have_text(/Send CC to Supervisor$/)
-
-      check "with_cc" 
+      check "with_cc"
       click_on "Send Reminder"
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
     end
+
+    it "emails the volunteer without a supervisor" do
+      volunteer_without_supervisor = create(:volunteer)
+      visit edit_volunteer_path(volunteer_without_supervisor)
+
+      check "with_cc"
+      click_on "Send Reminder"
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.cc).to be_empty
+    end
   end
 
-  it "send reminder as an admin" do
-    sign_in admin
+  describe "send reminder as admin" do
+    before(:each) do
+      sign_in admin
+      visit edit_volunteer_path(volunteer)
+    end
 
-    visit edit_volunteer_path(volunteer)
+    it "emails the volunteer" do
+      expect(page).to have_button("Send Reminder")
+      expect(page).to have_text("Send CC to Supervisor and Admin")
 
-    expect(page).to have_button("Send Reminder")
-    expect(page).to have_text("Send CC to Supervisor and Admin")
+      click_on "Send Reminder"
 
-    click_on "Send Reminder"
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
 
-    expect(ActionMailer::Base.deliveries.count).to eq(1)
-  end
+    it "emails the volunteer and cc's their supervisor and admin" do
+      check "with_cc"
+      click_on "Send Reminder"
 
-  it "send reminder as an admin with cc" do
-    sign_in admin
-
-    visit edit_volunteer_path(volunteer)
-
-    expect(page).to have_button("Send Reminder")
-    expect(page).to have_text("Send CC to Supervisor and Admin")
-
-    check "with_cc"
-    click_on "Send Reminder"
-
-    expect(ActionMailer::Base.deliveries.count).to eq(1)
-    expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
-    expect(ActionMailer::Base.deliveries.first.cc).to include(admin.email)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
+      expect(ActionMailer::Base.deliveries.first.cc).to include(admin.email)
+    end
   end
 end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -236,6 +236,22 @@ RSpec.describe "volunteers/edit", type: :system do
       click_on "Send Reminder"
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.cc).to be_empty
+    end
+
+    it "allows a supervisor to send case contact reminder to a volunteer with cc" do
+      sign_in supervisor
+
+      visit edit_volunteer_path(volunteer)
+
+      expect(page).to have_button("Send Reminder")
+      expect(page).to have_text(/Send CC to Supervisor$/)
+
+      check "with_cc" 
+      click_on "Send Reminder"
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
     end
   end
 
@@ -250,5 +266,21 @@ RSpec.describe "volunteers/edit", type: :system do
     click_on "Send Reminder"
 
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
+
+  it "send reminder as an admin with cc" do
+    sign_in admin
+
+    visit edit_volunteer_path(volunteer)
+
+    expect(page).to have_button("Send Reminder")
+    expect(page).to have_text("Send CC to Supervisor and Admin")
+
+    check "with_cc"
+    click_on "Send Reminder"
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
+    expect(ActionMailer::Base.deliveries.first.cc).to include(admin.email)
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2590

### What changed, and why?

If a volunteer does not have a supervisor assigned yet, and someone sends them a reminder email and selects the "Send CC to Supervisor and Admin" checkbox an undefined method error is thrown. This happens because the VolunteerMailer is trying to access the `email` of the supervisor which is `nil`. This fix ensures that we only send the email with CC if a supervisor is assigned to the volunteer.

Previously, if an admin selected the checkbox to send a reminder to both the supervisor and themselves (admin), it only sent an email to the supervisor. Adds the admin to the cc.

Ensures that the VolunteerMailer tests work with the new changes to handling CC recipients and expands on the testing for sending reminders to volunteers in the VolunteerController Edit Spec.

The functionality for reminding a volunteer is located on two different forms: one for editing a volunteer and another for viewing a CASA case. This pulls that form into a single partial so the layout and wording on the form is consistent. This will also help with a future plan to use this same reminder button form in a new location.

### How is this tested? (please write tests!) 💖💪

Tests were added for each of the implemented cases. This was also exercised manually in the browser

### Screenshots please :)

View of assigned volunteers when viewing as a volunteer:


<img width="383" alt="Screen Shot 2021-09-24 at 4 29 39 PM" src="https://user-images.githubusercontent.com/1625840/134736041-b6cabd73-4b51-404b-a4a0-d05084e82ca9.png">


View of assigned volunteers to a casa case when signed in as a supervisor:

<img width="754" alt="Screen Shot 2021-09-24 at 4 30 48 PM" src="https://user-images.githubusercontent.com/1625840/134736176-27192dbe-0328-41b6-8362-f3422f35bf93.png">

View of assigned volunteers to a casa case when signed in as an admin:

<img width="796" alt="Screen Shot 2021-09-24 at 4 32 08 PM" src="https://user-images.githubusercontent.com/1625840/134736308-836e1911-b06a-44dc-b1ba-f18c4ba1a2ae.png">

View of edit a volunteer when signed in as an admin:


<img width="986" alt="Screen Shot 2021-09-24 at 4 32 59 PM" src="https://user-images.githubusercontent.com/1625840/134736415-7bb024fb-f61a-4fc4-910e-3a2eb9c4c3ff.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![Not bad](https://media.giphy.com/media/xTiQyBOIQe5cgiyUPS/giphy.gif?cid=ecf05e47m6scqfx1e514vy8sr7pfrp8k6birmwpmlxt0phfy&rid=giphy.gif&ct=g)
