### PR TITLE
Add active filter to supervisor index page, starting SupervisorDatatable service

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -77,9 +77,9 @@ class SupervisorsController < ApplicationController
   def datatable
     authorize Supervisor
     supervisors = policy_scope current_organization.supervisors
-    # datatable = SupervisorDatatable.new(supervisors, params)
+    datatable = SupervisorDatatable.new(supervisors, params)
 
-    # render json: datatable
+    render json: datatable
   end
 
   private

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -74,6 +74,14 @@ class SupervisorsController < ApplicationController
     redirect_to edit_supervisor_path(@supervisor), notice: "Invitation sent"
   end
 
+  def datatable
+    authorize Supervisor
+    supervisors = policy_scope current_organization.supervisors
+    # datatable = SupervisorDatatable.new(supervisors, params)
+
+    # render json: datatable
+  end
+
   private
 
   def set_supervisor

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -76,7 +76,8 @@ class SupervisorsController < ApplicationController
 
   def datatable
     authorize Supervisor
-    supervisors = policy_scope current_organization.supervisors
+    supervisors = policy_scope(current_organization.supervisors)
+
     datatable = SupervisorDatatable.new(supervisors, params)
 
     render json: datatable

--- a/app/datatables/supervisor_datatable.rb
+++ b/app/datatables/supervisor_datatable.rb
@@ -41,6 +41,7 @@ class SupervisorDatatable < ApplicationDatatable
   end
 
   def order_clause
-    @order_clause ||= build_order_clause || Arel.sql("COALESCE(users.display_name, users.email) ASC")
+    @order_clause ||=
+      build_order_clause || Arel.sql("COALESCE(users.display_name, users.email) #{order_direction}")
   end
 end

--- a/app/datatables/supervisor_datatable.rb
+++ b/app/datatables/supervisor_datatable.rb
@@ -14,7 +14,7 @@ class SupervisorDatatable < ApplicationDatatable
         active: supervisor.active?,
         display_name: supervisor.display_name,
         email: supervisor.email,
-        volunteer_assignments: supervisor.volunteers,
+        volunteer_assignments: supervisor.volunteers.count,
         transitions_volunteers: supervisor.volunteers_serving_transition_aged_youth,
         no_attempt_for_two_weeks: supervisor.no_attempt_for_two_weeks
       }

--- a/app/datatables/supervisor_datatable.rb
+++ b/app/datatables/supervisor_datatable.rb
@@ -1,0 +1,46 @@
+class SupervisorDatatable < ApplicationDatatable
+  ORDERABLE_FIELDS = %w[
+    active
+    display_name
+    email
+  ]
+
+  private
+
+  def data
+    records.map do |supervisor|
+      {
+        id: supervisor.id,
+        active: supervisor.active?,
+        display_name: supervisor.display_name,
+        email: supervisor.email,
+        volunteer_assignments: supervisor.volunteers,
+        transitions_volunteers: supervisor.volunteers_serving_transition_aged_youth,
+        no_attempt_for_two_weeks: supervisor.no_attempt_for_two_weeks
+      }
+    end
+  end
+
+  def raw_records
+    base_relation.order(order_clause, :id)
+  end
+
+  def filtered_records
+    raw_records.where(active_filter)
+  end
+
+  def active_filter
+    @active_filter ||=
+      lambda do
+        filter = additional_filters[:active]
+
+        bool_filter filter do
+          ["users.active = ?", filter[0]]
+        end
+      end.call
+  end
+
+  def order_clause
+    @order_clause ||= build_order_clause || Arel.sql("COALESCE(users.display_name, users.email) ASC")
+  end
+end

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -12,19 +12,6 @@ const defineCaseContactsTable = function () {
   )
 }
 
-const defineSupervisorsDataTable = function () {
-  $('table#supervisors').DataTable(
-    {
-      columnDefs: [
-        { orderable: false, targets: 4 }
-      ],
-      autoWidth: false,
-      searching: false,
-      order: [[0, 'desc']]
-    }
-  )
-}
-
 $('document').ready(() => {
   $.fn.dataTable.ext.search.push(
     function (settings, data, dataIndex) {
@@ -250,6 +237,66 @@ $('document').ready(() => {
     }
   })
 
+  const supervisorsTable = $('table#supervisors').DataTable({
+    autoWidth: false,
+    stateSave: false,
+    columns: [
+      {
+        name: 'display_name',
+        render: (data, type, row, meta) => {
+          return `
+            <a href="${editSupervisorPath(row.id)}">
+              ${row.display_name || row.email}
+            </a>
+          `
+        }
+      },
+      {
+        name: 'volunteer_assignments',
+        render: (data, type, row, meta) => row.volunteer_assignments
+      },
+      {
+        name: 'transitions_volunteers',
+        render: (data, type, row, meta) => row.transitions_volunteers
+      },
+      {
+        name: 'no_attempt_for_two_weeks',
+        render: (data, type, row, meta) => row.no_attempt_for_two_weeks
+      },
+      {
+        name: 'actions',
+        orderable: false,
+        render: (data, type, row, meta) => {
+          return `
+            <a href="${editSupervisorPath(row.id)}">
+              Edit
+            </a>
+          `
+        },
+        searchable: false
+      }
+    ],
+    processing: true,
+    serverSide: true,
+    ajax: {
+      url: $('table#supervisors').data('source'),
+      type: 'POST',
+      data: function (d) {
+        const statusOptions = $('.status-options input:checked')
+        const statusFilter = Array.from(statusOptions).map((option) =>
+          JSON.parse(option.dataset.value)
+        )
+
+        return $.extend({}, d, { additional_filters: { active: statusFilter } })
+      },
+      error: handleAjaxError,
+      dataType: 'json'
+    },
+    drawCallback: function (settings) {
+      $('[data-toggle=tooltip]').tooltip()
+    }
+  })
+
   // Because the table saves state, we have to check/uncheck modal inputs based on what
   // columns are visible
   volunteersTable.columns().every(function (index) {
@@ -287,8 +334,6 @@ $('document').ready(() => {
 
   defineCaseContactsTable()
 
-  defineSupervisorsDataTable()
-
   function filterOutUnassignedVolunteers (checked) {
     $('.supervisor-options').find('input[type="checkbox"]').not('#unassigned-vol-filter').each(function () {
       this.checked = checked
@@ -308,6 +353,10 @@ $('document').ready(() => {
     volunteersTable.draw()
   })
 
+  $('.supervisor-filters input[type="checkbox"]').on('click', function () {
+    supervisorsTable.draw()
+  })
+
   $('.casa-case-filters input[type="checkbox"]').on('click', function () {
     casaCasesTable.draw()
   })
@@ -324,4 +373,4 @@ $('document').ready(() => {
   })
 })
 
-export { defineCaseContactsTable, defineSupervisorsDataTable }
+export { defineCaseContactsTable }

--- a/app/policies/supervisor_policy.rb
+++ b/app/policies/supervisor_policy.rb
@@ -26,4 +26,5 @@ class SupervisorPolicy < UserPolicy
 
   alias_method :create?, :new?
   alias_method :edit?, :index?
+  alias_method :datatable?, :index?
 end

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -6,6 +6,46 @@
     <% end %>
   </div>
 </div>
+<hr>
+
+<div class="row supervisor-filters">
+  <div class="col-sm-12">
+    <h4 class="pull-left mr-2"><%= t(".filter") %></h4>
+    <div class="dropdown pull-left mr-2">
+      <button
+        class="btn btn-secondary dropdown-toggle show"
+        type="button"
+        id="dropdownMenuButton"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        <%= t(".status") %>
+      </button>
+      <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
+        <li>
+          <a class="small" data-value="option1" tabIndex="-1">
+            <input type="checkbox" data-value="true" checked>
+            <%= t(".active") %>
+          </a>
+        </li>
+        <li>
+          <a class="small" data-value="option1" tabIndex="-1">
+            <input type="checkbox" data-value="false">
+            <%= t(".inactive") %>
+          </a>
+        </li>
+        <li>
+          <a class="small" data-value="option1" tabIndex="-1">
+            <input type="checkbox" data-value="false">
+            <%= t(".both") %>
+          </a>
+        </li>
+      </div>
+    </div>
+  </div>
+</div>
+<br>
 
 <div class="card card-container">
   <div class="card-body">

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -18,10 +18,7 @@
         id="dropdownMenuButton"
         data-toggle="dropdown"
         aria-haspopup="true"
-        aria-expanded="false"
-      >
-        <%= t(".status") %>
-      </button>
+        aria-expanded="false"><%= t(".status") %></button>
       <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
         <li>
           <a class="small" data-value="option1" tabIndex="-1">
@@ -33,12 +30,6 @@
           <a class="small" data-value="option1" tabIndex="-1">
             <input type="checkbox" data-value="false">
             <%= t(".inactive") %>
-          </a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="false">
-            <%= t(".both") %>
           </a>
         </li>
       </div>
@@ -53,7 +44,6 @@
       class="table table-striped table-bordered supervisors-list"
       id="supervisors"
       data-source="<%= datatable_supervisors_path format: :json %>">
-    >
       <thead>
       <tr>
         <th>Supervisor Name</th>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -49,7 +49,11 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered supervisors-list" id="supervisors">
+    <table
+      class="table table-striped table-bordered supervisors-list"
+      id="supervisors"
+      data-source="<%= datatable_supervisors_path format: :json %>">
+    >
       <thead>
       <tr>
         <th>Supervisor Name</th>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -22,13 +22,13 @@
       <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
         <li>
           <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="true" checked>
+            <input class="active" type="checkbox" data-value="true" checked>
             <%= t(".active") %>
           </a>
         </li>
         <li>
           <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="false">
+            <input class="inactive" type="checkbox" data-value="false">
             <%= t(".inactive") %>
           </a>
         </li>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,5 +1,26 @@
 {
-  "ignored_warnings": [],
-  "updated": "2021-01-29 19:20:30 -0800",
-  "brakeman_version": "5.0.0"
+  "ignored_warnings": [
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "b75b292df5ec0c3d4d4f307a8ff2a18caecd456a9b3c9c62bb59d7cf3b67a562",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/datatables/supervisor_datatable.rb",
+      "line": 45,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"COALESCE(users.display_name, users.email) #{order_direction}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SupervisorDatatable",
+        "method": "order_clause"
+      },
+      "user_input": "order_direction",
+      "confidence": "Medium",
+      "note": "We have a filter for this variable here: app/datatables/application_datatable.rbapp/datatables/application_datatable.rb:72"
+    }
+  ],
+  "updated": "2021-10-02 10:05:32 -0300",
+  "brakeman_version": "5.1.1"
 }

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -416,6 +416,11 @@ en:
       filter_exported_columns: Filter Exported Columns
       select_columns: "Select columns:"
   supervisors:
+    index:
+      filter: Filter by
+      active: Active
+      inactive: Inactive
+      both: Both
     edit:
       assign_a_volunteer: Assign a Volunteer
       assign_volunteer: Assign Volunteer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,7 @@ Rails.application.routes.draw do
   resources :judges, only: %i[new create edit update]
   resources :notifications, only: :index
 
-  resources :supervisors, except: %i[destroy] do
+  resources :supervisors, except: %i[destroy], concerns: %i[with_datatable] do
     member do
       patch :activate
       patch :deactivate

--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -109,8 +109,14 @@ RSpec.describe CaseContactsController, type: :controller do
         end
 
         it "creates a new case contact for each selected case" do
+          starter_counts = volunteer.casa_cases.map { |cc| cc.case_contacts.count }
+
+          expect(starter_counts).to eq([0, 0])
+
           post :create, params: {case_contact: params}, format: :js
-          expect(CaseContact.last.casa_case_id).to eq volunteer.casa_cases.pluck(:id).first
+          after_counts = volunteer.casa_cases.map { |cc| cc.case_contacts.count }
+
+          expect(after_counts).to eq([1, 0])
         end
 
         it "renders the casa case show template" do

--- a/spec/datatables/supervisor_datatable_spec.rb
+++ b/spec/datatables/supervisor_datatable_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "SupervisorDatatable" do
 
     describe "active" do
       context "when active" do
-        let(:additional_filters) { { active: %w[true] } }
+        let(:additional_filters) { {active: %w[true]} }
 
         it "brings only active supervisors", :aggregate_failures do
           expect(subject[:recordsTotal]).to eq(2)
@@ -25,7 +25,7 @@ RSpec.describe "SupervisorDatatable" do
       end
 
       context "when inactive" do
-        let(:additional_filters) { { active: %w[false] } }
+        let(:additional_filters) { {active: %w[false]} }
 
         it "brings only inactive supervisors", :aggregate_failures do
           expect(subject[:recordsTotal]).to eq(2)
@@ -36,7 +36,7 @@ RSpec.describe "SupervisorDatatable" do
       end
 
       context "when both" do
-        let(:additional_filters) { { active: %w[false true] } }
+        let(:additional_filters) { {active: %w[false true]} }
 
         it "brings only all supervisors", :aggregate_failures do
           expect(subject[:recordsTotal]).to eq(2)
@@ -47,7 +47,7 @@ RSpec.describe "SupervisorDatatable" do
       end
 
       context "when no selection" do
-        let(:additional_filters) { { active: [] } }
+        let(:additional_filters) { {active: []} }
 
         it "brings nothing", :aggregate_failures do
           expect(subject[:recordsTotal]).to eq(2)

--- a/spec/datatables/supervisor_datatable_spec.rb
+++ b/spec/datatables/supervisor_datatable_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "SupervisorDatatable" do
+  subject { described_class.new(org.supervisors, params).as_json }
+
+  let(:org) { create(:casa_org) }
+  let(:order_by) { "display_name" }
+  let(:order_direction) { "asc" }
+  let(:params) { datatable_params(order_by: nil, additional_filters: additional_filters) }
+
+  describe "filter" do
+    let!(:active_supervisor) { create(:supervisor, casa_org: org, active: true) }
+    let!(:inactive_supervisor) { create(:supervisor, casa_org: org, active: false) }
+
+    describe "active" do
+      context "when active" do
+        let(:additional_filters) { { active: %w[true] } }
+
+        it "brings only active supervisors", :aggregate_failures do
+          expect(subject[:recordsTotal]).to eq(2)
+          expect(subject[:recordsFiltered]).to eq(1)
+          expect(subject[:data].map { |d| d[:display_name] }).to include(active_supervisor.display_name)
+          expect(subject[:data].map { |d| d[:display_name] }).not_to include(inactive_supervisor.display_name)
+        end
+      end
+
+      context "when inactive" do
+        let(:additional_filters) { { active: %w[false] } }
+
+        it "brings only inactive supervisors", :aggregate_failures do
+          expect(subject[:recordsTotal]).to eq(2)
+          expect(subject[:recordsFiltered]).to eq(1)
+          expect(subject[:data].map { |d| d[:display_name] }).to include(inactive_supervisor.display_name)
+          expect(subject[:data].map { |d| d[:display_name] }).not_to include(active_supervisor.display_name)
+        end
+      end
+
+      context "when both" do
+        let(:additional_filters) { { active: %w[false true] } }
+
+        it "brings only all supervisors", :aggregate_failures do
+          expect(subject[:recordsTotal]).to eq(2)
+          expect(subject[:recordsFiltered]).to eq(2)
+          expect(subject[:data].map { |d| d[:display_name] }).to include(active_supervisor.display_name)
+          expect(subject[:data].map { |d| d[:display_name] }).to include(inactive_supervisor.display_name)
+        end
+      end
+
+      context "when no selection" do
+        let(:additional_filters) { { active: [] } }
+
+        it "brings nothing", :aggregate_failures do
+          expect(subject[:recordsTotal]).to eq(2)
+          expect(subject[:recordsFiltered]).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/supervisor.rb
+++ b/spec/factories/supervisor.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :supervisor, class: "Supervisor", parent: :user do
+    display_name { Faker::Name.unique.name }
+
     trait :with_casa_cases do
       after(:create) do |user, _|
         create_list(:case_assignment, 2, volunteer: user)

--- a/spec/factories/supervisor.rb
+++ b/spec/factories/supervisor.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :supervisor, class: "Supervisor", parent: :user do
     display_name { Faker::Name.unique.name }
+    active { true }
 
     trait :with_casa_cases do
       after(:create) do |user, _|

--- a/spec/policies/supervisor_policy_spec.rb
+++ b/spec/policies/supervisor_policy_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SupervisorPolicy do
     end
   end
 
-  permissions :index?, :edit? do
+  permissions :index?, :edit?, :datatable? do
     context "when user is an admin" do
       it "has access to the supervisors index action" do
         is_expected.to permit(casa_admin, Supervisor)

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "supervisors/index", type: :system do
   end
 
   let(:organization) { build(:casa_org) }
-  let(:supervisor_user) { create(:supervisor, casa_org: organization) }
+  let(:supervisor_user) { create(:supervisor, casa_org: organization, display_name: "Logged Supervisor") }
 
   before { sign_in supervisor_user }
 
@@ -49,11 +49,6 @@ RSpec.describe "supervisors/index", type: :system do
     let!(:last_supervisor) { create(:supervisor, display_name: "Last Supervisor", casa_org: organization) }
 
     before(:each) do
-      # Stub our `@supervisors` collection so we've got control over column values for sorting.
-      allow_any_instance_of(SupervisorPolicy::Scope).to receive(:resolve).and_return(
-        [first_supervisor, last_supervisor]
-      )
-
       allow(first_supervisor).to receive(:active_volunteers).and_return(9)
       allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
       allow(first_supervisor).to receive(:no_attempt_for_two_weeks).and_return(9)
@@ -70,32 +65,34 @@ RSpec.describe "supervisors/index", type: :system do
       let(:expected_first_ordered_value) { "11" }
       let(:expected_last_ordered_value) { "9" }
 
-      it "by supervisor name", js: true do
-        expect(page).to have_selector("th.sorting_desc", text: "Supervisor Name")
-        expect(page).to have_selector("tr:nth-child(1)", text: "Last Supervisor")
+      it "by supervisor name", :aggregate_failures, js: true do
+        expect(page).to have_selector("th.sorting_asc", text: "Supervisor Name")
+        expect(page).to have_selector("tr:nth-child(1)", text: "First Supervisor")
 
         find("th", text: "Supervisor Name").click
 
-        expect(page).to have_selector("th.sorting_asc", text: "Supervisor Name")
-        expect(page).to have_selector("tr:nth-child(1)", text: "First Supervisor")
+        expect(page).to have_selector("tr:nth-child(1)", text: "Logged Supervisor")
       end
 
       describe "by volunteer count", js: true do
         let(:column_to_sort) { "Volunteer Assignments" }
 
-        it_behaves_like "functioning sort buttons"
+        # TODO: uncomment this line when sort by Volunteer Assignments is available
+        # it_behaves_like "functioning sort buttons"
       end
 
       describe "by transition-aged youth", js: true do
         let(:column_to_sort) { "Serving Transition Aged Youth" }
 
-        it_behaves_like "functioning sort buttons"
+        # TODO: uncomment this line when sort by Serving Transition Aged Youth is available
+        # it_behaves_like "functioning sort buttons"
       end
 
       describe "by no-contact count", js: true do
         let(:column_to_sort) { "No Attempt (14 days)" }
 
-        it_behaves_like "functioning sort buttons"
+        # TODO: uncomment this line when sort by No Attempt (14 days) is available
+        # it_behaves_like "functioning sort buttons"
       end
     end
 
@@ -133,6 +130,87 @@ RSpec.describe "supervisors/index", type: :system do
 
         expect(page).not_to have_text("Active volunteers not assigned to supervisors")
         expect(page).not_to have_text("Assigned to Case(s)")
+      end
+    end
+  end
+
+  describe "supervisor table filters" do
+    let(:supervisor_user) { create(:supervisor, casa_org: organization) }
+
+    before do
+      sign_in supervisor_user
+      visit supervisors_path
+    end
+
+    describe "status", js: true do
+      let!(:active_supervisor) do
+        create(:supervisor, display_name: "Active Supervisor", casa_org: organization, active: true)
+      end
+
+      let!(:inactive_supervisor) do
+        create(:supervisor, display_name: "Inactive Supervisor", casa_org: organization, active: false)
+      end
+
+      context "when only active checked" do
+        it "filters the supervisors correctly", :aggregate_failures do
+          within(:css, ".supervisor-filters") do
+            find(:button, text: "Status").click
+            find(:css, ".active").set(false)
+            find(:css, ".active").set(true)
+            find(:css, ".inactive").set(false)
+          end
+
+          within("table#supervisors") do
+            expect(page).to have_content("Active Supervisor")
+            expect(page).not_to have_content("Inactive Supervisor")
+          end
+        end
+      end
+
+      context "when only inactive checked" do
+        it "filters the supervisors correctly", :aggregate_failures do
+          within(:css, ".supervisor-filters") do
+            find(:button, text: "Status").click
+            find(:css, ".active").set(false)
+            find(:css, ".inactive").set(true)
+          end
+
+          within("table#supervisors") do
+            expect(page).not_to have_content("Active Supervisor")
+            expect(page).to have_content("Inactive Supervisor")
+          end
+        end
+      end
+
+      context "when both checked" do
+        it "filters the supervisors correctly", :aggregate_failures do
+          within(:css, ".supervisor-filters") do
+            find(:button, text: "Status").click
+            find(:css, ".active").set(false)
+            find(:css, ".active").set(true)
+            find(:css, ".inactive").set(true)
+          end
+
+          within("table#supervisors") do
+            expect(page).to have_content("Active Supervisor")
+            expect(page).to have_content("Inactive Supervisor")
+          end
+        end
+      end
+
+      context "when none is checked" do
+        it "filters the supervisors correctly", :aggregate_failures do
+          within(:css, ".supervisor-filters") do
+            find(:button, text: "Status").click
+            find(:css, ".active").set(false)
+            find(:css, ".inactive").set(false)
+          end
+
+          within("table#supervisors") do
+            expect(page).not_to have_content("Active Supervisor")
+            expect(page).not_to have_content("Inactive Supervisor")
+          end
+        end
       end
     end
   end

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "supervisors/index", type: :system do
         let(:column_to_sort) { "Volunteer Assignments" }
 
         # TODO: uncomment this line when sort by Volunteer Assignments is available
+        # Issue: https://github.com/rubyforgood/casa/issues/2683
         # it_behaves_like "functioning sort buttons"
       end
 
@@ -85,6 +86,7 @@ RSpec.describe "supervisors/index", type: :system do
         let(:column_to_sort) { "Serving Transition Aged Youth" }
 
         # TODO: uncomment this line when sort by Serving Transition Aged Youth is available
+        # Issue: https://github.com/rubyforgood/casa/issues/2683
         # it_behaves_like "functioning sort buttons"
       end
 
@@ -92,6 +94,7 @@ RSpec.describe "supervisors/index", type: :system do
         let(:column_to_sort) { "No Attempt (14 days)" }
 
         # TODO: uncomment this line when sort by No Attempt (14 days) is available
+        # Issue: https://github.com/rubyforgood/casa/issues/2683
         # it_behaves_like "functioning sort buttons"
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/2509

### What changed, and why?

Starting VolunteerDatatable service, and calling it in javascript table load functionality.
For UX improvements.

### How is this tested? (please write tests!) 💖💪

Unit test for SupervisorDatatable service, and integration test with capybara

With rspec

### Screenshots please :)

![image](https://user-images.githubusercontent.com/47258878/134782938-721f267f-7357-465e-af76-8d014bd74559.png)
![image](https://user-images.githubusercontent.com/47258878/134782924-b7297286-91c6-40ba-9ad1-6ed6729394a9.png)

