### PR TITLE
Preserve case contact notes 

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -29,7 +29,6 @@ require('src/emancipations')
 require('src/select')
 require('src/dashboard')
 require('src/sidebar')
-require('src/sessions')
 require('src/readMore')
 require('src/tooltip')
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,6 +22,7 @@ require('select2')
 require('select2/dist/css/select2')
 
 require('src/case_contact')
+require('src/case_contact_autosave')
 require('src/case_emancipation')
 require('src/casa_case')
 require('src/emancipations')

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -1,42 +1,30 @@
 
 $('document').ready(() => {
   if ($('.case_contacts-new').length > 0) {
-    const formId = 'casa-contact-form' // ID of the form
-    const form = document.querySelector('#casa-contact-form')
-    const formIdentifier = `${formId}` // Identifier used to identify the form
-    const saveButton = document.querySelector('#case-contact-save') // select save button
-    const alertBox = document.querySelector('#case-contact-draft-alerts') // select alert display div
+    const formId = 'casa-contact-form'
+    const form = document.querySelector(`#${formId}`)
     const caseNotes = document.querySelector('#case_contact_notes')
 
-    saveButton.onclick = event => {
-      event.preventDefault()
-      const data = {}
-      data[formIdentifier] = caseNotes.value
-      window.localStorage.setItem(formIdentifier, JSON.stringify(data[formIdentifier]))
-      const message = 'Form draft has been saved!'
-      displayAlert(message)
+    const populateForm = () => {
+      if (window.localStorage.key(formId)) {
+        const savedData = JSON.parse(window.localStorage.getItem(formId)) // get and parse the saved data from localStorage
+        caseNotes.value = savedData
+      }
     }
 
-    const displayAlert = message => {
-      alertBox.innerText = message // add the message into the alert box
-      alertBox.style.display = 'block' // make the alert box visible
-      setTimeout(function () {
-        alertBox.style.display = 'none' // hide the alert box after 1 second
+    const autoSave = () => {
+      setInterval(function () {
+        const data = {}
+        data[formId] = caseNotes.value
+        window.localStorage.setItem(formId, JSON.stringify(data[formId]))
       }, 5000)
     }
 
-    const populateForm = () => {
-      if (window.localStorage.key(formIdentifier)) {
-        const savedData = JSON.parse(window.localStorage.getItem(formIdentifier)) // get and parse the saved data from localStorage
-        caseNotes.value = savedData
-        const message = 'Form has been refilled with saved data!'
-        displayAlert(message)
-      }
-    }
+    document.onload = autoSave()
     document.onload = populateForm() // populate the form when the document is loaded
 
     form.onsubmit = event => {
-      window.localStorage.removeItem(formIdentifier)
+      window.localStorage.removeItem(formId)
     }
   }
 })

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -1,0 +1,30 @@
+
+$('document').ready(() => {
+  if ($('.case_contacts-new').length > 0) {
+    const formId = 'casa-contact-form' // ID of the form
+    const url = window.location.href // href for the page
+    const formIdentifier = `${url} ${formId}` // Identifier used to identify the form
+    const saveButton = document.querySelector('#case-contact-save') // select save button
+    const alertBox = document.querySelector('#case-contact-draft-alerts') // select alert display div
+    // const form = document.querySelector(`#${formId}`) // select form
+    // let formElements = form.elements; // get the elements in the form
+    const caseNotes = document.querySelector('#case_contact_notes')
+
+    saveButton.onclick = event => {
+      event.preventDefault()
+      const data = {}
+      data[formIdentifier] = caseNotes.value
+      window.localStorage.setItem(formIdentifier, JSON.stringify(data[formIdentifier]))
+      const message = 'Form draft has been saved!'
+      displayAlert(message)
+    }
+
+    const displayAlert = message => {
+      alertBox.innerText = message // add the message into the alert box
+      alertBox.style.display = 'block' // make the alert box visible
+      setTimeout(function () {
+        alertBox.style.display = 'none' // hide the alert box after 1 second
+      }, 5000)
+    }
+  }
+})

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -2,12 +2,10 @@
 $('document').ready(() => {
   if ($('.case_contacts-new').length > 0) {
     const formId = 'casa-contact-form' // ID of the form
-    const url = window.location.href // href for the page
-    const formIdentifier = `${url} ${formId}` // Identifier used to identify the form
+    const form = document.querySelector('#casa-contact-form')
+    const formIdentifier = `${formId}` // Identifier used to identify the form
     const saveButton = document.querySelector('#case-contact-save') // select save button
     const alertBox = document.querySelector('#case-contact-draft-alerts') // select alert display div
-    // const form = document.querySelector(`#${formId}`) // select form
-    // let formElements = form.elements; // get the elements in the form
     const caseNotes = document.querySelector('#case_contact_notes')
 
     saveButton.onclick = event => {
@@ -25,6 +23,20 @@ $('document').ready(() => {
       setTimeout(function () {
         alertBox.style.display = 'none' // hide the alert box after 1 second
       }, 5000)
+    }
+
+    const populateForm = () => {
+      if (window.localStorage.key(formIdentifier)) {
+        const savedData = JSON.parse(window.localStorage.getItem(formIdentifier)) // get and parse the saved data from localStorage
+        caseNotes.value = savedData
+        const message = 'Form has been refilled with saved data!'
+        displayAlert(message)
+      }
+    }
+    document.onload = populateForm() // populate the form when the document is loaded
+
+    form.onsubmit = event => {
+      window.localStorage.removeItem(formIdentifier)
     }
   }
 })

--- a/app/javascript/src/sessions.js
+++ b/app/javascript/src/sessions.js
@@ -1,6 +1,0 @@
-/* global $, localStorage */
-$('document').ready(() => {
-  $('form#new_user').on('submit', function () {
-    localStorage.clear()
-  })
-})

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -150,11 +150,13 @@
   <div class="field notes form-group">
     <h2><%= form.label :notes %></h2>
     <%= form.text_area :notes, :rows => 5, placeholder: t("forms.case_contact.notes_placeholder"), class: "form-control" %>
+    <div id="case-contact-draft-alerts"></div>
   </div>
 
   <div class="actions">
     <%= form.submit t("button.submit"), class: "btn btn-primary", id: "case-contact-submit",
 "data-target": "#confirm-submit" %>
+    <%= link_to "Save", "#", class: "btn btn-primary", id: "case-contact-save" %>
     <%= return_to_dashboard_button %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -150,13 +150,11 @@
   <div class="field notes form-group">
     <h2><%= form.label :notes %></h2>
     <%= form.text_area :notes, :rows => 5, placeholder: t("forms.case_contact.notes_placeholder"), class: "form-control" %>
-    <div id="case-contact-draft-alerts"></div>
   </div>
 
   <div class="actions">
     <%= form.submit t("button.submit"), class: "btn btn-primary", id: "case-contact-submit",
 "data-target": "#confirm-submit" %>
-    <%= link_to "Save", "#", class: "btn btn-primary", id: "case-contact-save" %>
     <%= return_to_dashboard_button %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -278,6 +278,39 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(case_contact.duration_minutes).to eq 105
     end
 
+    it "autosaves notes", js: true do
+      volunteer = create(:volunteer, :with_casa_cases)
+      volunteer_casa_case_one = volunteer.casa_cases.first
+      create_contact_types(volunteer_casa_case_one.casa_org)
+
+      sign_in volunteer
+
+      visit new_case_contact_path(volunteer_casa_case_one.id)
+
+      check volunteer_casa_case_one.case_number
+      check "School"
+      check "Therapist"
+      choose "Yes"
+      select "In Person", from: "Contact medium"
+      fill_in "case-contact-duration-hours", with: "1"
+      fill_in "case-contact-duration-minutes", with: "45"
+      fill_in "Occurred at", with: "04/04/2020"
+      fill_in "Miles driven", with: "30"
+      select "Yes", from: "Want driving reimbursement"
+      fill_in "Notes", with: "Hello world"
+
+      # Allow 5 seconds for the Notes to be saved in localstorage
+      sleep 5
+
+      click_on "Log out"
+
+      sign_in volunteer
+
+      visit new_case_contact_path
+
+      expect(page).to have_field("Notes", with: "Hello world")
+    end
+
     it "submits the form when no note was added", js: true do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2417 

### What changed, and why?
Preserves the case contact notes even if the form times out. This ensures the user doesn't lose lengthy notes in the event of session timeout or stepping away for ☕ .

Details:
  - Saves the case contact notes to localstorage as the user fills in the form. The content of the notes is updated every 5 seconds.
  - Re-popultes the data saved in local storage when the page is reloaded or the user is logged out and has to log back in. The stored data is saved across browser sessions and does not expire.
  - Clears the saved data after the form is submitted; this is done by removing this item so if other local storage is added later it will be preserved at this point.
  - Removes the local storage clearing at login from `sessions.js`. This was added for the DataTable previously and is no longer required.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
<img width="1597" alt="Screen Shot 2021-09-25 at 1 41 42 PM" src="https://user-images.githubusercontent.com/49253356/134781042-5657f635-c75b-4e9c-bbd3-760b13f88b4d.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
