### PR TITLE
WIP: Populate Occurred At with user's local day

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -127,7 +127,7 @@
 
   <div class="field occurred-at form-group">
     <h2><%= form.label :occurred_at %></h2>
-    <% occurred_at = @case_contact.occurred_at || Time.zone.now %>
+    <% occurred_at = @case_contact.occurred_at || Time.now %>
     <%= form.text_field :occurred_at,
                         value: occurred_at.to_date,
                         data: {provide: "datepicker", date_format: "yyyy/mm/dd"},

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -530,6 +530,30 @@ RSpec.describe "case_contacts/new", type: :system do
       end
     end
 
+    context "UTC day is ahead of current timezone day" do
+      before do
+        travel_to Time.zone.parse("2021-9-30 18:00:00 -0600")
+      end
+
+      after do
+        travel_back
+      end
+
+      it "populates the Occurred At date in the local time zone" do
+        org = build(:casa_org)
+        contact_type_group = create_contact_types(org)
+        volunteer = create(:volunteer, :with_casa_cases, casa_org: org)
+        contact_types_for_cases = contact_type_group.contact_types.reject { |ct| ct.name == "Attorney" }
+        assign_contact_types_to_cases(volunteer.casa_cases, contact_types_for_cases)
+
+        sign_in volunteer
+
+        visit new_case_contact_path
+
+        expect(page).to have_field("case_contact_occurred_at", with: "2021-09-30")
+      end
+    end
+
     private
 
     def create_contact_types(org)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2532

### What changed, and why?
- Populate "Occurred At" field on new case contact page with user's local day instead of UTC day

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
- New system test

### Screenshots please :)
n/a
