### PR TITLE
Add Text to Supervisor and Admin Reactivation Messages

### DIFF
--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -34,7 +34,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
     if @casa_admin.activate
       CasaAdminMailer.account_setup(@casa_admin).deliver
 
-      redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was activated."
+      redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was activated. They have been sent an email."
     else
       render :edit
     end

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -43,7 +43,7 @@ class CasaAdminsController < ApplicationController
     if @casa_admin.activate
       CasaAdminMailer.account_setup(@casa_admin).deliver
 
-      redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was activated."
+      redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was activated. They have been sent an email."
     else
       render :edit
     end

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -52,7 +52,7 @@ class SupervisorsController < ApplicationController
     if @supervisor.activate
       SupervisorMailer.account_setup(@supervisor).deliver
 
-      redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was activated."
+      redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was activated. They have been sent an email."
     else
       render :edit, notice: "Supervisor could not be activated."
     end

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "All-Casa Admin" do
         patch activate_all_casa_admins_casa_org_casa_admin_path(casa_org, casa_admin)
 
         expect(response).to redirect_to edit_all_casa_admins_casa_org_casa_admin_path(casa_org, casa_admin)
-        expect(flash[:notice]).to eq("Admin was activated.")
+        expect(flash[:notice]).to eq("Admin was activated. They have been sent an email.")
         expect(casa_admin.reload.active).to eq(true)
       end
 

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "/supervisors", type: :request do
 
     it "activates an inactive supervisor" do
       patch activate_supervisor_path(inactive_supervisor)
-
+      expect(flash[:notice]).to eq("Supervisor was activated. They have been sent an email.")
       inactive_supervisor.reload
       expect(inactive_supervisor.active).to be true
     end


### PR DESCRIPTION
### What GitHub issue is this PR for if any?
Resolves #2503

### What changed, and why?
Currently when a Supervisor or Admin is reactivated a banner appears which says "(Supervisor/Admin) was activated." as shown in the screenshot below. We would like to add to this banner the text "They have been sent an email."



### How will this affect user permissions?
- Admin:

### How is this tested? (please write tests!) 💖💪


### Screenshots, please :)

<img width="1115" alt="Screenshot 2021-10-01 at 11 09 49 PM" src="https://user-images.githubusercontent.com/39373592/135663851-587f6155-efa6-4742-9abf-de0b2cbe5027.png">
