### PR TITLE
Add Column to Manage Volunteers Chart on Edit Supervisor Page Reflecting Current Supervisor for Unassigned Volunteers

### DIFF
--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -59,6 +59,7 @@
         <tr>
           <th><%= t(".volunteer_name") %></th>
           <th><%= t(".volunteer_email") %></th>
+          <th><%= t(".currently_assigned_to") %></th>
           <th><%= t(".unassign") %></th>
         </tr>
         </thead>
@@ -67,6 +68,13 @@
           <tr>
             <td><%= link_to volunteer.display_name, edit_volunteer_path(volunteer) %></td>
             <td><%= volunteer.email %></td>
+            <td>
+              <% if volunteer.has_supervisor? %>
+                <%= volunteer.supervisor.display_name %>
+              <% else %>
+                <%= "No One" %>
+              <% end %>
+            </td>
             <td>
               <% if volunteer.supervised_by?(@supervisor) %>
                 <%= button_to t(".unassign"),

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -59,7 +59,9 @@
         <tr>
           <th><%= t(".volunteer_name") %></th>
           <th><%= t(".volunteer_email") %></th>
-          <th><%= t(".currently_assigned_to") %></th>
+          <% if button_text == t(".hide_unassigned") %>
+            <th><%= t(".currently_assigned_to") %></th>
+          <% end %>
           <th><%= t(".unassign") %></th>
         </tr>
         </thead>
@@ -68,13 +70,11 @@
           <tr>
             <td><%= link_to volunteer.display_name, edit_volunteer_path(volunteer) %></td>
             <td><%= volunteer.email %></td>
-            <td>
-              <% if volunteer.has_supervisor? %>
-                <%= volunteer.supervisor.display_name %>
-              <% else %>
-                <%= "No One" %>
-              <% end %>
-            </td>
+            <% if button_text == t(".hide_unassigned") %>
+              <td>
+                <%= volunteer.has_supervisor? ? volunteer.supervisor.display_name : "No One" %>
+              </td>
+            <% end %>
             <td>
               <% if volunteer.supervised_by?(@supervisor) %>
                 <%= button_to t(".unassign"),

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -403,6 +403,7 @@ en:
       unassigned: Unassigned
       volunteer_email: Volunteer Email
       volunteer_name: Volunteer Name
+      currently_assigned_to: Currently Assigned To
       volunteer_title:
         zero: Assigned Volunteers
         one: All Volunteers

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe "supervisors/edit", type: :system do
 
           expect(page).to have_text "Assigned Volunteers"
           expect(page).to_not have_button("Include unassigned")
+          expect(page).to_not have_text("Currently Assigned To")
           supervisor.volunteers.each do |volunteer|
             expect(page).to have_text volunteer.email
           end
@@ -241,6 +242,7 @@ RSpec.describe "supervisors/edit", type: :system do
             expect(page).to have_button("Hide unassigned")
             expect(page).to have_text("All Volunteers")
             expect(page).to have_text unassigned_volunteer.email
+            expect(page).to have_text "Currently Assigned To"
           end
         end
       end
@@ -262,6 +264,13 @@ RSpec.describe "supervisors/edit", type: :system do
 
             expect(page).to have_button("Hide unassigned")
             expect(page).to have_text unassigned_volunteer.email
+            expect(page).to have_text "No One"
+            expect(page).to have_text "Currently Assigned To"
+
+            click_on "Hide unassigned"
+
+            expect(page).to_not have_text "Currently Assigned To"
+            expect(page).to_not have_text "No One"
           end
         end
       end


### PR DESCRIPTION
### What GitHub issue is this PR for if any?
Resolves #2524

### What changed, and why?
Currently, the edit supervisor page has a section at the bottom that shows all their assigned volunteers. If Include Unassigned is selected, it also shows all volunteers previously assigned to this supervisor who no longer is. We would like to add a column to this chart that displays the current supervisor of volunteers previously assigned to this supervisor. If a volunteer that was formerly assigned to this supervisor is not currently assigned to a supervisor this column should read No one.



### How will this affect user permissions?
- Supervisor:
- Admin:

### How is this tested? (please write tests!) 💖💪


### Screenshots, please :)

**1. When Include unassigned button clicked** 

<img width="1062" alt="Screenshot 2021-10-02 at 9 40 21 AM" src="https://user-images.githubusercontent.com/39373592/135703221-7e853802-158a-4b9f-8cbc-85fdfffeb1cc.png">

**2. When hide unassigned button clicked** 

<img width="1062" alt="Screenshot 2021-10-02 at 9 40 30 AM" src="https://user-images.githubusercontent.com/39373592/135703222-3bb90b86-c060-4d81-b68a-a946becdfe7f.png">
