### PR TITLE
case contact notes autosaver only deletes saved notes after a successful submit

### DIFF
--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -24,7 +24,7 @@ $('document').ready(() => {
     document.onload = populateForm() // populate the form when the document is loaded
 
     form.onsubmit = event => {
-      if (document.querySelector('.header-flash').textContent.includes("successfully created")) {
+      if (document.querySelector('.header-flash').textContent.includes('successfully created')) {
         window.localStorage.removeItem(formId)
       }
     }

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -24,7 +24,9 @@ $('document').ready(() => {
     document.onload = populateForm() // populate the form when the document is loaded
 
     form.onsubmit = event => {
-      window.localStorage.removeItem(formId)
+      if (document.querySelector('.header-flash').textContent.includes("successfully created")) {
+        window.localStorage.removeItem(formId)
+      }
     }
   }
 })

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -332,6 +332,8 @@ RSpec.describe "case_contacts/new", type: :system do
       sleep 5
       click_on "Submit"
 
+      expect(page).to have_text("At least one case must be selected")
+
       visit new_case_contact_path
 
       expect(page).to have_field("Notes", with: "Hello world")

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -311,6 +311,32 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(page).to have_field("Notes", with: "Hello world")
     end
 
+    it "delete local storage notes after successfuly submited", js: true do
+      volunteer = create(:volunteer)
+      sign_in volunteer
+
+      visit new_case_contact_path
+
+      check "School"
+      check "Therapist"
+      choose "Yes"
+      select "In Person", from: "Contact medium"
+      fill_in "case-contact-duration-hours", with: "1"
+      fill_in "case-contact-duration-minutes", with: "45"
+      fill_in "Occurred at", with: "04/04/2020"
+      fill_in "Miles driven", with: "30"
+      select "Yes", from: "Want driving reimbursement"
+      fill_in "Notes", with: "Hello world"
+
+      # Allow 5 seconds for the Notes to be saved in localstorage
+      sleep 5
+      click_on "Submit"
+
+      visit new_case_contact_path
+
+      expect(page).to have_field("Notes", with: "Hello world")
+    end
+
     it "submits the form when no note was added", js: true do
       volunteer = create(:volunteer, :with_casa_cases)
       volunteer_casa_case_one = volunteer.casa_cases.first

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -317,13 +317,10 @@ RSpec.describe "case_contacts/new", type: :system do
 
       visit new_case_contact_path
 
-      check "Parent"
-      check "Sibling"
       choose "Yes"
       select "In Person", from: "Contact medium"
       fill_in "case-contact-duration-hours", with: "1"
       fill_in "case-contact-duration-minutes", with: "45"
-      fill_in "Occurred at", with: "04/04/2020"
       fill_in "Miles driven", with: "30"
       select "Yes", from: "Want driving reimbursement"
       fill_in "Notes", with: "Hello world"
@@ -331,7 +328,7 @@ RSpec.describe "case_contacts/new", type: :system do
       # Allow 5 seconds for the Notes to be saved in localstorage
       sleep 5
       click_on "Submit"
-
+      click_on "Continue Submitting"
       expect(page).to have_text("At least one case must be selected")
 
       visit new_case_contact_path

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -317,8 +317,8 @@ RSpec.describe "case_contacts/new", type: :system do
 
       visit new_case_contact_path
 
-      check "School"
-      check "Therapist"
+      check "Parent"
+      check "Sibling"
       choose "Yes"
       select "In Person", from: "Contact medium"
       fill_in "case-contact-duration-hours", with: "1"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2654

### What changed, and why?
After submitting a case contact, see if the page displayed a success message or an error. If the page displayed a success message, delete the case contact notes from localstorage.



### How will this affect user permissions?
- Volunteer:
- Supervisor:
- Admin:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

