### PR TITLE
Increase court mandates textarea size

### DIFF
--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -157,7 +157,7 @@ $('document').ready(() => {
 
   $('#btnGenerateReport').on('click', handleGenerateReport)
 
-  $('.court-mandates textarea').each(function() {
+  $('.court-mandates textarea').each(function () {
     $(this).height($(this).prop('scrollHeight'))
   })
 })

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -156,4 +156,8 @@ $('document').ready(() => {
   $('button.remove-mandate-button').on('click', removeMandateWithConfirmation)
 
   $('#btnGenerateReport').on('click', handleGenerateReport)
+
+  $('.court-mandates textarea').each(function() {
+    $(this).height($(this).prop('scrollHeight'))
+  })
 })

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -45,6 +45,15 @@ body.casa_cases {
     textarea, .add-court-mandate {
       width: 500px;
     }
+
+    .implementation-status {
+      align-self: flex-start;
+      min-height: 38px;
+    }
+
+    .remove-mandate-button {
+      align-self: flex-start;
+    }
   }
 
   .court-mandate-entry {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2383

### What changed, and why?
- Added javascript (sorry, I couldn't find a way around this) that increases the court mandates textarea depending on how much text it contains
- Updated the styling of the implementation status dropdown and delete button to align better with a larger textarea (I can remove this if you don't agree)

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
- could not find a straightforward way to test this in capybara unfortunately

### Screenshots please :)
<img width="904" alt="image" src="https://user-images.githubusercontent.com/4965672/135731177-f0a9afab-9984-425c-b093-de388d2b56fb.png">
