### PR TITLE
Group and organize contact types on Edit Case Details page

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -83,4 +83,8 @@ class CasaCaseDecorator < Draper::Decorator
   def emancipation_checklist_count
     "#{object.casa_case_emancipation_categories.count} / #{EmancipationCategory.count}"
   end
+
+  def show_contact_type?(contact_type_id)
+    object.casa_case_contact_types.map(&:contact_type_id).include?(contact_type_id)
+  end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -133,10 +133,6 @@ class CasaCase < ApplicationRecord
     past_court_dates.order("date").last
   end
 
-  def has_contact_type?(contact_type)
-    casa_case_contact_types.map(&:contact_type_id).include?(contact_type.id)
-  end
-
   def has_hearing_type?
     hearing_type
   end

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -164,7 +164,7 @@
             form: form,
             model: casa_case,
             contact_type_groups: @contact_types.map(&:contact_type_group).sort_by(&:name).uniq,
-            selected_case_contact_types: casa_case.contact_types,
+            selected_case_contact_types: [],
             checkbox_tag_name: "casa_case[casa_case_contact_types_attributes][][contact_type_id]" %>
       <% end %>
 

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -160,21 +160,12 @@
       <% end %>
 
       <% if Pundit.policy(current_user, casa_case).update_contact_types? %>
-        <div id="contact-type-form" class="field contact-type form-group">
-          <h2 id="contact-type-label"><%= form.label :contact_types %></h2>
-          <% @contact_types.each_with_index do |contact_type, index| %>
-            <div class="form-check">
-              <%= check_box_tag "casa_case[casa_case_contact_types_attributes][][contact_type_id]",
-                                contact_type.id,
-                                @casa_case.has_contact_type?(contact_type),
-                                id: "casa_case_contact_types_#{index}",
-                                class: ["form-check-input", "casa-case-contact-type"] %>
-              <label class="form-check-label" for="casa_case_contact_types_<%= index %>">
-                <%= contact_type.name %>
-              </label>
-            </div>
-          <% end %>
-        </div>
+        <%= render "case_contacts/contact_types",
+            form: form,
+            model: casa_case,
+            contact_type_groups: @contact_types.map(&:contact_type_group).sort_by(&:name).uniq,
+            selected_case_contact_types: casa_case.contact_types,
+            checkbox_tag_name: "casa_case[casa_case_contact_types_attributes][][contact_type_id]" %>
       <% end %>
 
       <br>

--- a/app/views/case_contacts/_contact_types.html.erb
+++ b/app/views/case_contacts/_contact_types.html.erb
@@ -1,0 +1,29 @@
+<div id="contact-type-form" class="field contact-type form-group">
+  <h2 id="contact-type-label"><%= form.label :contact_types %></h2>
+  <table>
+    <tr>
+      <% contact_type_groups.each do |group| %>
+        <td class="align-top d-inline-block pr-5 pb-4">
+          <h5> <%= group.name %> </h5>
+          <% group.contact_types.alphabetically.filter do |ct|
+              selected_case_contact_types.blank? ||
+                  selected_case_contact_types.include?(ct)
+            end.each do |contact_type| %>
+            <div class="form-check">
+              <%=
+                check_box_tag checkbox_tag_name,
+                  contact_type.id,
+                  model.decorate.show_contact_type?(contact_type.id),
+                  id: dom_id(contact_type, :case_contact),
+                  class: ["form-check-input", "case-contact-contact-type"]
+              %>
+              <label class="form-check-label" for="<%= dom_id(contact_type, :case_contact) %>">
+                <%= contact_type.name %>
+              </label>
+            </div>
+          <% end %>
+        </td>
+      <% end %>
+    </tr>
+  </table>
+</div>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -22,35 +22,12 @@
     <% end %>
   </div>
 
-  <div id="contact-type-form" class="field contact-type form-group">
-    <h2 id="contact-type-label"><%= form.label :contact_types %></h2>
-    <table>
-      <tr>
-        <% @current_organization_groups.each do |group| %>
-          <td class="align-top d-inline-block pr-5 pb-4">
-            <h5> <%= group.name %> </h5>
-            <% group.contact_types.alphabetically.filter do |ct|
-                @selected_case_contact_types.blank? ||
-                    @selected_case_contact_types.include?(ct)
-              end.each do |contact_type| %>
-              <div class="form-check">
-                <%=
-                  check_box_tag "case_contact[case_contact_contact_type_attributes][][contact_type_id]",
-                    contact_type.id,
-                    @case_contact.decorate.show_contact_type?(contact_type.id),
-                    id: dom_id(contact_type, :case_contact),
-                    class: ["form-check-input", "case-contact-contact-type"]
-                %>
-                <label class="form-check-label" for="<%= dom_id(contact_type, :case_contact) %>">
-                  <%= contact_type.name %>
-                </label>
-              </div>
-            <% end %>
-          </td>
-        <% end %>
-      </tr>
-    </table>
-  </div>
+  <%= render "contact_types",
+      form: form,
+      model: @case_contact,
+      contact_type_groups:  @current_organization_groups,
+      selected_case_contact_types: @selected_case_contact_types,
+      checkbox_tag_name: "case_contact[case_contact_contact_type_attributes][][contact_type_id]" %>
 
   <div class="field contact-type form-group">
     <h2><%= form.label :contact_made %></h2>

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -42,4 +42,14 @@ FactoryBot.define do
       end
     end
   end
+
+  trait :with_contact_types do
+    after(:create) do |casa_case|
+      3.times do
+        group = create(:contact_type_group, casa_org: casa_case.casa_org)
+        contact_type = create(:contact_type, contact_type_group: group)
+        casa_case.contact_types << contact_type
+      end
+    end
+  end
 end

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -42,14 +42,4 @@ FactoryBot.define do
       end
     end
   end
-
-  trait :with_contact_types do
-    after(:create) do |casa_case|
-      3.times do
-        group = create(:contact_type_group, casa_org: casa_case.casa_org)
-        contact_type = create(:contact_type, contact_type_group: group)
-        casa_case.contact_types << contact_type
-      end
-    end
-  end
 end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe "Edit CASA Case", type: :system do
     let(:organization) { build(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
     let(:casa_case) { create(:casa_case, :with_one_court_mandate, casa_org: organization) }
-    let!(:judge) { build(:judge, casa_org: organization) }
-    let(:contact_type_group) { build(:contact_type_group, casa_org: organization) }
-    let!(:school) { build(:contact_type, name: "School", contact_type_group: contact_type_group) }
-    let!(:therapist) { build(:contact_type, name: "Therapist", contact_type_group: contact_type_group) }
+    let(:contact_type_group) { create(:contact_type_group, casa_org: organization) }
+    let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
 
     before { sign_in admin }
 
@@ -30,6 +28,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_select("Hearing type")
       expect(page).to have_select("Judge")
       select "Submitted", from: "casa_case_court_report_status"
+      check contact_type.name
 
       page.find("#add-mandate-button").click
       find("#mandates-list-container").first("textarea").send_keys("Court Mandate Text One")
@@ -45,6 +44,9 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Year")
       expect(page).to have_text("Court Mandate Text One")
       expect(page).not_to have_text("Deactivate Case")
+
+      expect(casa_case.contact_types).to eq [contact_type]
+      has_checked_field? contact_type.name
     end
 
     it "deactivates a case", js: true do

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -84,4 +84,21 @@ RSpec.describe "casa_cases/new", type: :system do
       expect(page).to have_content("Case number has already been taken")
     end
   end
+
+  context "contact types" do
+    let!(:casa_case) do
+      create(:casa_case, :with_contact_types, case_number: case_number, casa_org: casa_org)
+    end
+    let(:contact_types) { ContactType.for_organization(casa_org) }
+
+    it "are shown in groups" do
+      visit new_casa_case_path
+
+      expect(contact_types.count).to eq 3
+      contact_types.each do |contact_type|
+        expect(page).to have_content(contact_type.name)
+        expect(page).to have_content(contact_type.contact_type_group.name)
+      end
+    end
+  end
 end

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -86,19 +86,14 @@ RSpec.describe "casa_cases/new", type: :system do
   end
 
   context "contact types" do
-    let!(:casa_case) do
-      create(:casa_case, :with_contact_types, case_number: case_number, casa_org: casa_org)
-    end
-    let(:contact_types) { ContactType.for_organization(casa_org) }
+    let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
+    let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
 
     it "are shown in groups" do
       visit new_casa_case_path
 
-      expect(contact_types.count).to eq 3
-      contact_types.each do |contact_type|
-        expect(page).to have_content(contact_type.name)
-        expect(page).to have_content(contact_type.contact_type_group.name)
-      end
+      expect(page).to have_content(contact_type.name)
+      expect(page).to have_content(contact_type_group.name)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2505

### What changed, and why?
- Refactored Contact Types from New Case Contact into a partial so it can be reused
- Use new partial in Edit Case Details page

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
- System test

### Screenshots please :)
<img width="1245" alt="image" src="https://user-images.githubusercontent.com/4965672/135732990-623786bd-f5ad-4903-a649-92073a6e80aa.png">
