### PR TITLE
change volunteer table order default

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -108,6 +108,7 @@ $('document').ready(() => {
   const volunteersTable = $('table#volunteers').DataTable({
     autoWidth: false,
     stateSave: false,
+    order: [[6, 'desc']],
     columns: [
       {
         name: 'display_name',


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2695

### What changed, and why?
As asked in #2695, I changed the default sort in volunteer table

### How will this affect user permissions?
- Volunteer permissions: nothing
- Supervisor permissions: They will see with new sort settings as default
- Admin permissions: They will see with new sort settings as default

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
