### PR TITLE
Make driving reimbursement field optional

### DIFF
--- a/app/controllers/casa_orgs_controller.rb
+++ b/app/controllers/casa_orgs_controller.rb
@@ -29,7 +29,14 @@ class CasaOrgsController < ApplicationController
   end
 
   def casa_org_update_params
-    params.require(:casa_org).permit(:name, :display_name, :address, :logo, :court_report_template)
+    params.require(:casa_org).permit(
+      :name,
+      :display_name,
+      :address,
+      :logo,
+      :court_report_template,
+      :show_driving_reimbursement
+    )
   end
 
   def set_contact_type_data

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -52,11 +52,12 @@ end
 #
 # Table name: casa_orgs
 #
-#  id           :bigint           not null, primary key
-#  address      :string
-#  display_name :string
-#  footer_links :string           default([]), is an Array
-#  name         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                         :bigint           not null, primary key
+#  address                    :string
+#  display_name               :string
+#  footer_links               :string           default([]), is an Array
+#  name                       :string           not null
+#  show_driving_reimbursement :boolean          default(TRUE)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #

--- a/app/views/casa_orgs/edit.html.erb
+++ b/app/views/casa_orgs/edit.html.erb
@@ -24,6 +24,10 @@
         <%= form.label :court_report_template %>
         <%= form.file_field :court_report_template, class: "form-control" %>
       </div>
+      <div class="field form-group">
+        <%= form.check_box :show_driving_reimbursement %>
+        <%= form.label :show_driving_reimbursement %>
+      </div>
       <div class="actions">
         <%= form.submit t("button.submit"), class: "btn btn-primary" %>
       </div>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -116,13 +116,15 @@
     <%= form.number_field :miles_driven, class: "form-control", required: true, min: "0", max: 10000 %>
   </div>
 
-  <div class="field want-driving-reimbursement form-group">
-    <h2><%= form.label :want_driving_reimbursement %></h2>
-    <%= form.select :want_driving_reimbursement,
-                    options_for_select([['Yes', true], ['No', false]], case_contact.want_driving_reimbursement),
-                    {},
-                    class: "custom-select" %>
-  </div>
+  <% if current_organization.show_driving_reimbursement %>
+    <div class="field want-driving-reimbursement form-group">
+      <h2><%= form.label :want_driving_reimbursement %></h2>
+      <%= form.select :want_driving_reimbursement,
+                      options_for_select([['Yes', true], ['No', false]], case_contact.want_driving_reimbursement),
+                      {},
+                      class: "custom-select" %>
+    </div>
+  <% end %>
 
   <div class="field notes form-group">
     <h2><%= form.label :notes %></h2>

--- a/db/migrate/20211007144114_add_show_driving_reimbursement_to_casa_orgs.rb
+++ b/db/migrate/20211007144114_add_show_driving_reimbursement_to_casa_orgs.rb
@@ -1,0 +1,5 @@
+class AddShowDrivingReimbursementToCasaOrgs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :casa_orgs, :show_driving_reimbursement, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_142024) do
+ActiveRecord::Schema.define(version: 2021_10_07_144114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_142024) do
     t.string "display_name"
     t.string "address"
     t.string "footer_links", default: [], array: true
+    t.boolean "show_driving_reimbursement", default: true
   end
 
   create_table "case_assignments", force: :cascade do |t|

--- a/spec/system/casa_orgs/edit_spec.rb
+++ b/spec/system/casa_orgs/edit_spec.rb
@@ -92,4 +92,14 @@ RSpec.describe "casa_orgs/edit", type: :system do
       ]
     )
   end
+
+  it "can update show_driving_reimbursement flag" do
+    check "Show driving reimbursement"
+    click_on "Submit"
+    has_no_checked_field? "Show driving reimbursement"
+
+    check "Show driving reimbursement"
+    click_on "Submit"
+    has_checked_field? "Show driving reimbursement"
+  end
 end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -555,6 +555,22 @@ RSpec.describe "case_contacts/new", type: :system do
       end
     end
 
+    context "when driving reimbursement is hidden by the CASA org" do
+      it "does not show for case_contacts" do
+        org = build(:casa_org, show_driving_reimbursement: false)
+        contact_type_group = create_contact_types(org)
+        volunteer = create(:volunteer, :with_casa_cases, casa_org: org)
+        contact_types_for_cases = contact_type_group.contact_types.reject { |ct| ct.name == "Attorney" }
+        assign_contact_types_to_cases(volunteer.casa_cases, contact_types_for_cases)
+
+        sign_in volunteer
+
+        visit new_case_contact_path
+
+        expect(page).not_to have_field("Want driving reimbursement")
+      end
+    end
+
     private
 
     def create_contact_types(org)

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe "case_contacts/edit", type: :view do
   before do
     user = build_stubbed(:volunteer)
+    casa_org = user.casa_org
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:current_organization).and_return(casa_org)
   end
 
   it "is listing all the contact methods from the model" do

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -13,8 +13,11 @@ RSpec.describe "case_contacts/new", type: :view do
   end
 
   context "while signed-in as a volunteer" do
+    let(:casa_org) { CasaOrg.first }
+
     before do
       sign_in_as_volunteer
+      allow(view).to receive(:current_organization).and_return(casa_org)
     end
 
     let(:current_time) { Time.zone.now.strftime("%Y-%m-%d") }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2705

### What changed, and why?
- Add a new checkbox to Casa Org edit page to show or hide driving reimbursement field
- Change case contacts new and edit page to show/hide driving reimbursement field depending on current organization's flag

### How will this affect user permissions?
- The driving reimbursement field will be hidden if the current organization has hidden that field

### How is this tested? (please write tests!) 💖💪
- System tests

### Screenshots please :)
<img width="587" alt="image" src="https://user-images.githubusercontent.com/4965672/136420630-f861cf5b-f291-4c81-9f0c-0975937adec2.png">

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9