### PR TITLE
Adds Request Spec verifying Judge Name in DOCX for past court dates

### DIFF
--- a/app/models/past_court_date.rb
+++ b/app/models/past_court_date.rb
@@ -4,7 +4,6 @@ require "sablon"
 
 class PastCourtDate < ApplicationRecord
   belongs_to :casa_case
-  validates :casa_case_id, presence: true
   validate :date_must_be_past
 
   has_many :case_court_mandates

--- a/spec/models/past_court_date_spec.rb
+++ b/spec/models/past_court_date_spec.rb
@@ -12,11 +12,17 @@ RSpec.describe PastCourtDate, type: :model do
   let(:path_to_report) { Rails.root.join("tmp", "test_report.docx").to_s }
 
   it { is_expected.to belong_to(:casa_case) }
-  it { is_expected.to validate_presence_of(:casa_case_id) }
   it { is_expected.to validate_presence_of(:date) }
   it { is_expected.to have_many(:case_court_mandates) }
   it { is_expected.to belong_to(:hearing_type).optional }
   it { is_expected.to belong_to(:judge).optional }
+
+  it "is invalid without a casa_case" do
+    past_court_date = build(:past_court_date, casa_case: nil)
+    expect do
+      past_court_date.casa_case = casa_case
+    end.to change{past_court_date.valid?}.from(false).to(true)
+  end
 
   before do
     travel_to Date.new(2021, 1, 1)

--- a/spec/models/past_court_date_spec.rb
+++ b/spec/models/past_court_date_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PastCourtDate, type: :model do
     past_court_date = build(:past_court_date, casa_case: nil)
     expect do
       past_court_date.casa_case = casa_case
-    end.to change{past_court_date.valid?}.from(false).to(true)
+    end.to change { past_court_date.valid? }.from(false).to(true)
   end
 
   before do

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -73,11 +73,34 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request 
         let!(:past_court_date) {
           create(:past_court_date, date: Date.yesterday, judge: nil)
         }
-        it "includes the judge's name in the document" do
+        it "includes None for the judge's name in the document" do
           show
           document = get_docx_contents_as_string(response.body, collapse: true)
           expect(document).not_to include(judge.name)
           expect(document.downcase).to include("judge: none")
+        end
+      end
+
+      context "with a hearing type" do
+        let!(:past_court_date) {
+          create(:past_court_date, date: Date.yesterday, hearing_type: hearing_type)
+        }
+        it "includes the hearing type in the document" do
+          show
+          document = get_docx_contents_as_string(response.body, collapse: true)
+          expect(document).to include(hearing_type.name)
+        end
+      end
+
+      context "without a hearing type" do
+        let!(:past_court_date) {
+          create(:past_court_date, date: Date.yesterday, hearing_type: nil)
+        }
+        it "includes None for the hearing type in the document" do
+          show
+          document = get_docx_contents_as_string(response.body, collapse: true)
+          expect(document).not_to include(hearing_type.name)
+          expect(document.downcase).to include("hearing type: none")
         end
       end
     end

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -57,6 +57,29 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request 
       let(:headers) { {accept: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"} }
 
       it { expect(response).to be_successful }
+
+      context "when a judge is attached" do
+        let!(:past_court_date) {
+          create(:past_court_date, date: Date.yesterday, judge: judge)
+        }
+        it "includes the judge's name in the document" do
+          show
+          document = get_docx_contents_as_string(response.body, collapse: true)
+          expect(document).to include(judge.name)
+        end
+      end
+
+      context "without a judge" do
+        let!(:past_court_date) {
+          create(:past_court_date, date: Date.yesterday, judge: nil)
+        }
+        it "includes the judge's name in the document" do
+          show
+          document = get_docx_contents_as_string(response.body, collapse: true)
+          expect(document).not_to include(judge.name)
+          expect(document.downcase).to include("judge: none")
+        end
+      end
     end
   end
 

--- a/spec/requests/past_court_dates_spec.rb
+++ b/spec/requests/past_court_dates_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe "/casa_cases/:casa_case_id/past_court_dates/:id", type: :request 
 
       it { expect(response).to be_successful }
 
+      it "displays the court date" do
+        show
+        document = get_docx_contents_as_string(response.body, collapse: true)
+        expect(document).to include(past_court_date.date.to_s)
+      end
+
       context "when a judge is attached" do
         let!(:past_court_date) {
           create(:past_court_date, date: Date.yesterday, judge: judge)

--- a/spec/support/word_doc_helper.rb
+++ b/spec/support/word_doc_helper.rb
@@ -33,14 +33,14 @@ module WordDocHelper
   # @return [String] The contents with all XML markup removed
   #
   def get_docx_contents_as_string(docx, collapse: false)
-    Tempfile.create('court_report.zip', 'tmp') do |file|
-      file << docx.force_encoding('UTF-8')
+    Tempfile.create("court_report.zip", "tmp") do |file|
+      file << docx.force_encoding("UTF-8")
 
       xml_document = Zip::File.open(file.path) do |docx_extracted|
-        docx_extracted.find_entry('word/document.xml').get_input_stream.read.force_encoding('UTF-8')
+        docx_extracted.find_entry("word/document.xml").get_input_stream.read.force_encoding("UTF-8")
       end
-      separate_with = collapse ? '' : "\n"
-      document = xml_document.gsub(/<[^>]*>+/, "\n").gsub(/\n+/, separate_with)
+      separate_with = collapse ? "" : "\n"
+      xml_document.gsub(/<[^>]*>+/, "\n").gsub(/\n+/, separate_with)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Closes #2517

### What changed, and why?
I added two new request specs to past_court_date_spec, similar to the
way they were done in the regular case report request spec. The DOCX
format is really hard to read and most of it is superfluous XML so I
wrote an additional helper method that strips out all the XML and
reveals just the underlying content. This spec was only needing to
verify that a specific content string was present, so it was enough.

That new helper is added alongside the existing (awesome!) helper for
this need.

The request specs themselves test both the affirmative and negative
cases of having a judge or not, since the judge's presence is optional.

ADDITIONAL CLEANUP:
I noticed that the PastCourtDate model had an extraneous presence
validation for the :casa_case_id field. As of Rails 5, belongs_to
implies a required presence for the association key unless you specify
optional: true. I modified the model spec that was verifying the
integrity of this association.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Manual testing to verify the feature worked normally (and also to see what it looked like).

Commit content is essentially just specs, so we're good here!

### Screenshots please :)
N/A

### Feelings gif (optional)
![GREEN LIGHT](https://media.giphy.com/media/bjcrpWZYOPYQZOm2fE/giphy.webp)`
