### PR TITLE
Adds additional margin beneath table rows on Volunteer pages Mobile view

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "base/variables";
+@import "base/breakpoints";
 
 @import "bootstrap";
 @import "node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker";
@@ -25,3 +26,4 @@
 @import "pages/casa_orgs";
 @import "pages/password";
 @import "pages/past_court_dates";
+@import "pages/volunteers";

--- a/app/javascript/src/stylesheets/base/breakpoints.scss
+++ b/app/javascript/src/stylesheets/base/breakpoints.scss
@@ -1,0 +1,4 @@
+$small: 640px;
+$medium: 1024px;
+$mobile: $medium;
+$large: 1200px;

--- a/app/javascript/src/stylesheets/pages/casa_cases.scss
+++ b/app/javascript/src/stylesheets/pages/casa_cases.scss
@@ -67,7 +67,7 @@ body.casa_cases {
   }
 }
 
-@media only screen and (max-width: 640px) {
+@media only screen and (max-width: $small) {
   body.casa_cases {
     .court-mandates {
       textarea, .add-court-mandate {

--- a/app/javascript/src/stylesheets/pages/volunteers.scss
+++ b/app/javascript/src/stylesheets/pages/volunteers.scss
@@ -1,0 +1,18 @@
+body.volunteers {
+  @media only screen and (max-width: $mobile) {
+    table#volunteers {
+      tbody tr {
+        padding-bottom: 2.5rem;
+        border-bottom: none;
+
+        td {
+          border-left: none;
+          border-right: none;
+        }
+        td:last-child {
+          border-bottom: none;
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -51,9 +51,11 @@ div.row.volunteer-filters {
 
 /* As 'mobile-label' class is mobile only, not display them on desktop view */
 
-table.table {
-  span.mobile-label {
-    display: none;
+@media only screen and (min-width: $mobile) {
+  table.table {
+    span.mobile-label {
+      display: none;
+    }
   }
 }
 
@@ -61,7 +63,7 @@ table.table {
   margin: 6px 0;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: $mobile) {
   .login-header {
     font-size: 0.75em !important;
   }

--- a/app/javascript/src/stylesheets/shared/navbar.scss
+++ b/app/javascript/src/stylesheets/shared/navbar.scss
@@ -22,7 +22,7 @@
   width: 40px;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: $mobile) {
   .navbar.mobile {
     display: flex;
     position: sticky;

--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -111,7 +111,7 @@
 }
 
 // Media Queries
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: $mobile) {
   .sidebar-wrapper {
     display: none;
     width: 100%;


### PR DESCRIPTION
### What github issue is this PR for, if any?
Closes #2723

### What changed, and why?
Creates an SCSS file specifically for mobile widths in the volunteers
table. I used padding-bottom because it visually made the most sense (I
also tried margin and padding-top). I also removed the border-left and
border-right of the TD tags in this case, since they were doubling up,
and the border-bottom of the last TD since that was interrupting the
look.

Looks pretty clean! (See screencaps)

ADDITIONAL WORK:
I created a breakpoints SCSS file and defined the media query
breakpoint values that were already in use. I used vague qualitative
names %w[small medium large] but added an additional one for 'mobile' to
provide some context about when its used. These breakpoint variable
names are already rolled out to where the literal values were being
used.

I also added a media query around the display: none of the mobile label;
it was being hidden away in the global scope and not re-enabled for
mobile widths.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Manually tested, visual inspection. Can't reliably do this in specs. :)

### Screenshots please :)
Before:
![image](https://user-images.githubusercontent.com/502363/136706127-3acf2c6b-09b0-4639-a1ec-67c5f55440b5.png)

After (note both the spacing and the difference in the left/right borders)
![image](https://user-images.githubusercontent.com/502363/136706105-a81cfadb-cfec-4571-ab84-60a99d763935.png)


### Feelings gif (optional)
![alt text](https://media0.giphy.com/media/KPrtEz4aw6QPZG7Xn7/giphy.gif)
