### PR TITLE
Hide Deactivated Supervisors from /supervisors page by default #2714

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -11,6 +11,13 @@ class SupervisorsController < ApplicationController
   def index
     authorize Supervisor
     @supervisors = policy_scope(current_organization.supervisors)
+    @show_all = params[:all]
+    if @show_all == "true"
+      @supervisors
+    else
+      @supervisors = @supervisors.active
+      @show_all = false
+    end
   end
 
   def new

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -8,6 +8,8 @@ class Supervisor < User
   has_many :volunteers, -> { includes(:supervisor_volunteer).order(:display_name) }, through: :active_supervisor_volunteers
   has_many :volunteers_ever_assigned, -> { includes(:supervisor_volunteer).order(:display_name) }, through: :supervisor_volunteers, source: :volunteer
 
+  scope :active, -> { where(active: true) }
+
   # Activates supervisor.
   def activate
     update(active: true)

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -4,6 +4,12 @@
     <% if policy(Supervisor).create? %>
       <%= link_to "New Supervisor", new_supervisor_path, class: "btn btn-primary mb-2 mb-md-0" %>
     <% end %>
+
+    <% if @show_all %>
+      <%= link_to "Hide deactivated", supervisors_path, class: "btn btn-light mb-2 mb-md-0" %>
+    <% else %>
+      <%= link_to "Show deactivated", supervisors_path(all: "true"), class: "btn btn-light mb-2 mb-md-0" %>
+    <% end %>
   </div>
 </div>
 

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe "supervisors/index", type: :system do
   describe "supervisor table" do
     let!(:first_supervisor) { create(:supervisor, display_name: "First Supervisor", casa_org: organization) }
     let!(:last_supervisor) { create(:supervisor, display_name: "Last Supervisor", casa_org: organization) }
+    let!(:active_volunteers_for_first_supervisor) { create_list(:volunteer, 2, supervisor: first_supervisor, casa_org: organization) }
+    let!(:active_volunteers_for_last_supervisor) { create_list(:volunteer, 5, supervisor: last_supervisor, casa_org: organization) }
 
     before(:each) do
       # Stub our `@supervisors` collection so we've got control over column values for sorting.
@@ -54,13 +56,17 @@ RSpec.describe "supervisors/index", type: :system do
         Supervisor.where.not(display_name: supervisor_user.display_name).order(display_name: :asc)
       )
 
-      allow(first_supervisor).to receive(:active_volunteers).and_return(9)
-      allow(first_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(9)
-      allow(first_supervisor).to receive(:no_attempt_for_two_weeks).and_return(9)
+      active_volunteers_for_first_supervisor.map { |av|
+        casa_case = create(:casa_case, transition_aged_youth: true, casa_org: av.casa_org)
+        create(:case_contact, contact_made: false, occurred_at: 1.week.ago, casa_case_id: casa_case.id)
+        create(:case_assignment, casa_case: casa_case, volunteer: av)
+      }
 
-      allow(last_supervisor).to receive(:active_volunteers).and_return(11)
-      allow(last_supervisor).to receive(:volunteers_serving_transition_aged_youth).and_return(11)
-      allow(last_supervisor).to receive(:no_attempt_for_two_weeks).and_return(11)
+      active_volunteers_for_last_supervisor.map { |av|
+        casa_case = create(:casa_case, transition_aged_youth: true, casa_org: av.casa_org)
+        create(:case_contact, contact_made: false, occurred_at: 1.week.ago, casa_case_id: casa_case.id)
+        create(:case_assignment, casa_case: casa_case, volunteer: av)
+      }
 
       sign_in supervisor_user
       visit supervisors_path
@@ -90,8 +96,8 @@ RSpec.describe "supervisors/index", type: :system do
     end
 
     context "when sorting supervisors" do
-      let(:expected_first_ordered_value) { "11" }
-      let(:expected_last_ordered_value) { "9" }
+      let(:expected_first_ordered_value) { "5" }
+      let(:expected_last_ordered_value) { "2" }
 
       it "by supervisor name", js: true do
         expect(page).to have_selector("th.sorting_desc", text: "Supervisor Name")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2714

### What changed, and why?
As specified in the issue, there was a need to filter out deactivated supervisors by default and add a filter to be able to show them.

### How will this affect user permissions?
Permissions not affected

### How is this tested? (please write tests!) 💖💪
Here I would need a hand - where should I test it? Controller or view or both? Haven't seen supervisor controller tests

### Screenshots please :)
I added a button to Show/Hide deactivated supervisors
<img width="301" alt="CASA Volunteer Tracking 2021-10-10 21-34-54" src="https://user-images.githubusercontent.com/2719923/136710673-93326986-df46-4155-9314-b948283adc6b.png">
<img width="256" alt="CASA Volunteer Tracking 2021-10-10 21-49-33" src="https://user-images.githubusercontent.com/2719923/136711026-9a8f8b8a-f593-4eda-be06-b3cf0d038e6b.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? 
![alt text](https://media.giphy.com/media/MeD18WvcZ7od4rJaep/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9


PS. 
Will work on the tests. Although I don't get it why they fail and when I test it manually, all is good