### PR TITLE
Make Emancipation Checklist mobile friendly

### DIFF
--- a/app/javascript/src/stylesheets/pages/emancipation.scss
+++ b/app/javascript/src/stylesheets/pages/emancipation.scss
@@ -27,7 +27,7 @@
     background-color: #b71c1c;
     color: white
   }
-  
+
   .async-success-indicator {
     background-color: #28a745;
     color: white
@@ -39,7 +39,7 @@
 
     .load-spinner {
       animation: spin 1.5s linear infinite;
-      border: .25em solid #f3f3f3; 
+      border: .25em solid #f3f3f3;
       border-top: .25em solid #3498db;
       border-radius: 50%;
       display: inline-block;
@@ -68,6 +68,13 @@
   }
 }
 
+.check-item {
+  label {
+    width: 80%;
+    vertical-align: middle;
+  }
+}
+
 .emancipation-category {
   border-bottom: 2px solid #bfe3ff;
   padding: .5em;
@@ -77,7 +84,9 @@
   }
 
   label {
-    margin: 0
+    margin: 0;
+    width: 80%;
+    vertical-align: middle;
   }
 
   span {

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -4,7 +4,7 @@
       <%= t(".title") %>
     </h3>
       <%= link_to @current_case.case_number, casa_case_path(@current_case) %>
-      <span style="float:right" class="mb-2">
+      <span class="d-block float-md-right my-2 mt-md-0 text-center">
         <%= link_to "Download Checklist", casa_case_emancipation_path(@current_case, format: :docx),
 class: "btn btn-primary" %>
       </span>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2617

### What changed, and why?
- Added 80% width to labels so collapse icons align with rows correctly
- Added vertical alignment to labels so text appears next to check boxes
- Added bootstrap classes to "Download Checklist" button so it would be centered on mobile

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
n/a

### Screenshots please :)
**Small screen:**

<img width="204" alt="image" src="https://user-images.githubusercontent.com/4965672/136829045-361ceefd-a3a0-48ea-9fc6-47c7a0244547.png">

<img width="180" alt="image" src="https://user-images.githubusercontent.com/4965672/136828655-bb5dd67b-41f3-4307-b7c9-7986a3739480.png">

**Medium screen:**

<img width="574" alt="image" src="https://user-images.githubusercontent.com/4965672/136828783-445b0bc2-061d-4bde-86ab-858fdab34f7b.png">

**Large screen:**

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/4965672/136828834-38ed9bb5-9ef2-477d-8ba7-015ec81f7665.png">

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9