### PR TITLE
Allow court dates to be from the future

### DIFF
--- a/app/models/court_date.rb
+++ b/app/models/court_date.rb
@@ -4,7 +4,7 @@ require "sablon"
 
 class CourtDate < ApplicationRecord
   belongs_to :casa_case
-  validate :date_must_be_past
+  validates :date, presence: true
 
   has_many :case_court_orders
   belongs_to :hearing_type, optional: true
@@ -15,14 +15,6 @@ class CourtDate < ApplicationRecord
   scope :ordered_ascending, -> { order("date asc") }
 
   DOCX_TEMPLATE_PATH = Rails.root.join("app", "documents", "templates", "default_past_court_date_template.docx")
-
-  def date_must_be_past
-    if date.nil?
-      errors.add(:date, "can't be blank")
-    elsif date >= Date.today
-      errors.add(:date, "must be in the past")
-    end
-  end
 
   # get reports associated with the case this belongs to before this court date but after the court date before this one
   def associated_reports

--- a/app/views/court_dates/_form.html.erb
+++ b/app/views/court_dates/_form.html.erb
@@ -12,7 +12,7 @@
       </p>
 
       <div class="field form-group">
-        <%= form.label :date, "Add Court Date (past)" %>
+        <%= form.label :date, "Add Court Date" %>
         <br>
         <span class="datetime-year-month">
           <%= form.date_select :date,

--- a/spec/models/court_date_spec.rb
+++ b/spec/models/court_date_spec.rb
@@ -28,17 +28,6 @@ RSpec.describe CourtDate, type: :model do
     travel_to Date.new(2021, 1, 1)
   end
 
-  describe "date_must_be_past" do
-    it "ensures that the date is in the past" do
-      court_date = build(:court_date, casa_case: casa_case, date: Date.today)
-      expect(court_date.valid?).to eq false
-      expect(court_date.errors.full_messages).to eq ["Date must be in the past"]
-
-      court_date = build(:court_date, casa_case: casa_case, date: Date.yesterday)
-      expect(court_date.valid?).to eq true
-    end
-  end
-
   describe ".ordered_ascending" do
     subject { described_class.ordered_ascending }
 

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -184,6 +184,22 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
       end
     end
 
+    context "for a future court date" do
+      let(:valid_attributes) do
+        {
+          date: 10.days.from_now,
+          hearing_type_id: hearing_type.id,
+          judge_id: judge.id
+        }
+      end
+
+      it "creates a new CourtDate" do
+        expect do
+          post casa_case_court_dates_path(casa_case), params: {court_date: valid_attributes}
+        end.to change(CourtDate, :count).by(1)
+      end
+    end
+
     describe "invalid request" do
       context "with invalid parameters" do
         it "does not create a new CourtDate" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Contributes to #2582

### What changed, and why?
- Change the validations on the `court_date` model to allow dates to be in the future or the past
    - Note: currently, the GUI still shows these as past court dates. I'm going to change this in the next PR 

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
model spec and request spec

### Screenshots please :)
n/a

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9