### PR TITLE
Allow admins and supervisors to impersonate volunteers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "bugsnag" # tracking errors in prod
 gem "sablon" # Word document templating tool for Case Court Reports
 gem "paranoia" # For soft-deleting purpose
 gem "request_store"
-gem 'pretender'
+gem "pretender"
 
 group :development, :test do
   gem "bullet" # Detect and fix N+1 queries

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "bugsnag" # tracking errors in prod
 gem "sablon" # Word document templating tool for Case Court Reports
 gem "paranoia" # For soft-deleting purpose
 gem "request_store"
+gem 'pretender'
 
 group :development, :test do
   gem "bullet" # Detect and fix N+1 queries

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pretender (0.3.4)
+      actionpack (>= 4.2)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -459,6 +461,7 @@ DEPENDENCIES
   paper_trail
   paranoia
   pg
+  pretender
   pry
   pry-byebug
   puma

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,8 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
 
+  impersonates :user
+
   def after_sign_out_path_for(resource_or_scope)
     if resource_or_scope == :all_casa_admin
       new_all_casa_admin_session_path

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -1,6 +1,6 @@
 class VolunteersController < ApplicationController
-  before_action :set_volunteer, except: %i[index new create datatable]
-  after_action :verify_authorized
+  before_action :set_volunteer, except: %i[index new create datatable stop_impersonating]
+  after_action :verify_authorized, except: %i[stop_impersonating]
 
   def index
     authorize Volunteer
@@ -94,6 +94,17 @@ class VolunteersController < ApplicationController
     VolunteerMailer.case_contacts_reminder(@volunteer, cc_recipients).deliver
 
     redirect_to edit_volunteer_path(@volunteer), notice: "Reminder sent to volunteer."
+  end
+
+  def impersonate
+    authorize @volunteer
+    impersonate_user(@volunteer)
+    redirect_to root_path
+  end
+
+  def stop_impersonating
+    stop_impersonating_user
+    redirect_to root_path
   end
 
   private

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -104,6 +104,7 @@ $('document').ready(() => {
   // Enable all data tables on dashboard but only filter on volunteers table
   const editSupervisorPath = id => `/supervisors/${id}/edit`
   const editVolunteerPath = id => `/volunteers/${id}/edit`
+  const impersonateVolunteerPath = id => `/volunteers/${id}/impersonate`
   const casaCasePath = id => `/casa_cases/${id}`
   const volunteersTable = $('table#volunteers').DataTable({
     autoWidth: false,
@@ -209,6 +210,9 @@ $('document').ready(() => {
           <span class="mobile-label">Actions</span>
             <a href="${editVolunteerPath(row.id)}">
               Edit
+            </a>
+            <a href="${impersonateVolunteerPath(row.id)}">
+              Impersonate
             </a>
           `
         },

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -21,6 +21,14 @@ class VolunteerPolicy < UserPolicy
     admin_or_supervisor?
   end
 
+  def impersonate?
+    admin_or_supervisor?
+  end
+
+  def stop_impersonating?
+    admin_or_supervisor_or_volunteer?
+  end
+
   alias_method :datatable?, :index?
   alias_method :new?, :index?
   alias_method :create?, :index?

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -70,7 +70,12 @@
           <%= link_to t(".link.edit_profile"), edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
         <% if current_user != true_user %>
-          <%= link_to "You (#{true_user.display_name}) are signed in as #{current_user.display_name}. Click here to stop impersonating", stop_impersonating_volunteers_path, method: :post, class: "list-group-item" %>
+          <%= link_to stop_impersonating_volunteers_path, method: :post do %>
+            <li class="list-group-item">
+              You (<%= true_user.display_name %>) are signed in as <%= current_user.display_name %>.
+              Click here to stop impersonating.
+            </li>
+          <% end %>
         <% end %>
         <%= session_link %>
       </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -70,11 +70,9 @@
           <%= link_to t(".link.edit_profile"), edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
         <% if current_user != true_user %>
-          <%= link_to stop_impersonating_volunteers_path, method: :post do %>
-            <li class="list-group-item">
+          <%= link_to stop_impersonating_volunteers_path, method: :post, class: "list-group-item" do %>
               You (<%= true_user.display_name %>) are signed in as <%= current_user.display_name %>.
               Click here to stop impersonating.
-            </li>
           <% end %>
         <% end %>
         <%= session_link %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -69,6 +69,9 @@
           </li>
           <%= link_to t(".link.edit_profile"), edit_all_casa_admins_path, class: "list-group-item" %>
         <% end %>
+        <% if current_user != true_user %>
+          <%= link_to "You (#{true_user.display_name}) are signed in as #{current_user.display_name}. Click here to stop impersonating", stop_impersonating_volunteers_path, method: :post, class: "list-group-item" %>
+        <% end %>
         <%= session_link %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,11 +90,13 @@ Rails.application.routes.draw do
     end
   end
   resources :volunteers, except: %i[destroy], concerns: %i[with_datatable] do
+    post :stop_impersonating, on: :collection
     member do
       patch :activate
       patch :deactivate
       get :resend_invitation
       patch :reminder
+      get :impersonate
     end
   end
   resources :case_assignments, only: %i[create destroy] do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -236,4 +236,36 @@ RSpec.describe "/volunteers", type: :request do
       expect(response).to redirect_to(edit_volunteer_path(volunteer))
     end
   end
+
+  describe "GET /impersonate" do
+    let!(:other_volunteer) { create(:volunteer) }
+    let!(:supervisor) { create(:supervisor) }
+
+    it "can impersonate a volunteer as an admin" do
+      sign_in admin
+
+      get impersonate_volunteer_path(volunteer)
+      expect(response).to redirect_to(root_path)
+      expect(controller.current_user).to eq(volunteer)
+    end
+
+    it "can impersonate a volunteer as a supervisor" do
+      sign_in supervisor
+
+      get impersonate_volunteer_path(volunteer)
+      expect(response).to redirect_to(root_path)
+      expect(controller.current_user).to eq(volunteer)
+    end
+
+    it "can not impersonate as a volunteer" do
+      sign_in volunteer
+
+      get impersonate_volunteer_path(other_volunteer)
+      expect(response).to redirect_to(root_path)
+      expect(controller.current_user).to eq(volunteer)
+
+      follow_redirect!
+      expect(flash[:notice]).to match(/Sorry, you are not authorized to perform this action./)
+    end
+  end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -1,9 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "layout/sidebar", type: :view do
+  module PretenderContext
+    def true_user; end
+  end
+
   before do
+    view.class.include PretenderContext
+
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:true_user).and_return(user)
     allow(view).to receive(:user_signed_in?).and_return(true)
     allow(view).to receive(:current_role).and_return(user.role)
     allow(view).to receive(:current_organization).and_return(user.casa_org)

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -210,4 +210,25 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).not_to have_css("span.badge")
     end
   end
+
+  context "impersonation" do
+    let(:user) { build_stubbed :volunteer }
+    let(:true_user) { build_stubbed :casa_admin }
+
+    it "renders a stop impersonating link when impersonating" do
+      allow(view).to receive(:true_user).and_return(true_user)
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to have_link(href: "/volunteers/stop_impersonating")
+    end
+
+    it "renders correct Role name when impersonating a volunteer" do
+      allow(view).to receive(:true_user).and_return(true_user)
+
+      render partial: "layouts/sidebar"
+
+      expect(rendered).to match '<span class="value">Volunteer</span>'
+    end
+  end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
-RSpec.describe "layout/sidebar", type: :view do
-  module PretenderContext
-    def true_user; end
+module PretenderContext
+  def true_user
   end
+end
 
+RSpec.describe "layout/sidebar", type: :view do
   before do
     view.class.include PretenderContext
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1397 

### What changed, and why?
Implements pretender gem
Allow admins and supervisors to impersonate volunteers

### How will this affect user permissions?
- Volunteer permissions: Not affected
- Supervisor permissions: Can now impersonate volunteers
- Admin permissions: Can now impersonate volunteers

### How is this tested? (please write tests!) 💖💪
Added specs for sidebar and for volunteers/impersonate route

### Screenshots please :)

![image](https://user-images.githubusercontent.com/62253265/137200641-a00ba563-6cbc-43ea-b425-3bade6fbde67.png)
![image](https://user-images.githubusercontent.com/62253265/137200785-1960afa9-0e93-4ea2-9cd9-8c1bd9736a22.png)
