### PR TITLE
Fix: Download Mileage report button only works once per page load

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,6 +31,7 @@ require('src/dashboard')
 require('src/sidebar')
 require('src/readMore')
 require('src/tooltip')
+require('src/reports')
 
 // Uncomment to copy all static images under ../images to the output folder and
 // reference them with the image_pack_tag or asset_pack_path helpers in views.

--- a/app/javascript/src/reports.js
+++ b/app/javascript/src/reports.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('click', (event) => {
+    if (event.target.matches('.report-form-submit')) {
+      return handleReportFormSubmit(event)
+    }
+  })
+})
+
+const handleReportFormSubmit = (event) => {
+  event.preventDefault()
+
+  const buttonText = event.target.value
+
+  event.target.disabled = 'disabled'
+  event.target.value = 'Downloading mileage report'
+  event.target.form.submit()
+
+  setTimeout(() => {
+    event.target.disabled = false
+    event.target.value = buttonText
+  }, 3000)
+}

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class="card card-container my-4">
   <div class="card-body">
-    <%= form_with url: mileage_reports_path(format: :csv), method: :get, local: true do |f| %>
-      <%= f.submit t(".download_mileage_report_button"), class: "btn btn-primary",
+    <%= form_with url: mileage_reports_path(format: :csv), method: :get do |f| %>
+      <%= f.submit t(".download_mileage_report_button"), class: "btn btn-primary report-form-submit",
         data: {disable_with: "Downloading mileage report"} %>
     <% end %>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2721

### What changed, and why?

Turns out that the mileage report button does not submit via an ajax call. To acheive the desired effect of temporarily disabling the button to prevent double submissions I wrapped the submission in a JS function and added a time delay to reenable the button.

### How is this tested? (please write tests!) 💖💪

Currently tested manually.

### Screenshots please :)
