### PR TITLE
Migrate Casa Court Date column to Court Date reference

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -100,7 +100,6 @@ class CasaCasesController < ApplicationController
       :case_number,
       :transition_aged_youth,
       :birth_month_year_youth,
-      :court_date,
       :court_report_due_date,
       :hearing_type_id,
       :judge_id

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -34,7 +34,7 @@ class CourtDatesController < ApplicationController
     authorize @court_date
 
     if @court_date.save
-      redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Past court date was successfully created."
+      redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully created."
     else
       render :new
     end
@@ -43,7 +43,7 @@ class CourtDatesController < ApplicationController
   def update
     authorize @court_date
     if @court_date.update(court_dates_params)
-      redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Past court date was successfully updated."
+      redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully updated."
     else
       render :edit
     end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -69,10 +69,6 @@ class CasaCase < ApplicationRecord
       .where("birth_month_year_youth <= ?", 14.years.ago)
   }
 
-  scope :due_date_passed, -> {
-    where("court_date < ?", Time.current)
-  }
-
   scope :active, -> {
     where(active: true)
   }
@@ -101,16 +97,6 @@ class CasaCase < ApplicationRecord
     end
   end
 
-  def clear_court_dates
-    if court_date && court_date < Time.current
-      update(
-        court_date: nil,
-        court_report_due_date: nil,
-        court_report_status: :not_submitted
-      )
-    end
-  end
-
   def court_report_status=(value)
     super
     if court_report_not_submitted?
@@ -129,16 +115,12 @@ class CasaCase < ApplicationRecord
     court_reports.order("created_at").last
   end
 
-  def latest_court_date
-    court_dates.order("date").last
-  end
-
   def next_court_date
     court_dates.where("date >= ?", Date.today).order(:date).first
   end
 
   def most_recent_past_court_date
-    court_dates.where("date < ?", Date.today).order(:date).first
+    court_dates.where("date < ?", Date.today).order(:date).last
   end
 
   def has_hearing_type?
@@ -162,7 +144,6 @@ class CasaCase < ApplicationRecord
   end
 
   def update_cleaning_contact_types(args)
-    args = parse_date(errors, "court_date", args)
     args = parse_date(errors, "court_report_due_date", args)
 
     return false unless errors.messages.empty?

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -133,6 +133,14 @@ class CasaCase < ApplicationRecord
     court_dates.order("date").last
   end
 
+  def next_court_date
+    court_dates.where("date >= ?", Date.today).order(:date).first
+  end
+
+  def most_recent_past_court_date
+    court_dates.where("date < ?", Date.today).order(:date).first
+  end
+
   def has_hearing_type?
     hearing_type
   end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -69,6 +69,11 @@ class CasaCase < ApplicationRecord
       .where("birth_month_year_youth <= ?", 14.years.ago)
   }
 
+  scope :due_date_passed, -> {
+    # No more future court dates
+    where.not(id: CourtDate.where("date >= ?", Date.today).pluck(:casa_case_id))
+  }
+
   scope :active, -> {
     where(active: true)
   }
@@ -94,6 +99,15 @@ class CasaCase < ApplicationRecord
       emancipation_options << EmancipationOption.find(option_id)
     else
       raise "Attempted adding multiple options belonging to a mutually exclusive category"
+    end
+  end
+
+  def clear_court_dates
+    if next_court_date.nil?
+      update(
+        court_report_due_date: nil,
+        court_report_status: :not_submitted
+      )
     end
   end
 

--- a/app/models/case_court_report.rb
+++ b/app/models/case_court_report.rb
@@ -21,7 +21,7 @@ class CaseCourtReport
   private
 
   def prepare_context(is_default_template)
-    latest_hearing_date = @casa_case.latest_court_date
+    latest_hearing_date = @casa_case.most_recent_past_court_date
 
     {
       created_date: I18n.l(Date.today, format: :full, default: nil),

--- a/app/models/case_court_report.rb
+++ b/app/models/case_court_report.rb
@@ -56,7 +56,7 @@ class CaseCourtReport
   end
 
   def filter_out_old_case_contacts(interviewees)
-    most_recent_court_date = @casa_case.court_dates.order(:date).last&.date
+    most_recent_court_date = @casa_case.most_recent_past_court_date&.date
     if most_recent_court_date
       interviewees.where("occurred_at > ?", most_recent_court_date)
     else
@@ -66,7 +66,7 @@ class CaseCourtReport
 
   def prepare_case_details
     {
-      court_date: I18n.l(@casa_case.court_date, format: :full, default: nil),
+      court_date: I18n.l(@casa_case.next_court_date&.date, format: :full, default: nil),
       case_number: @casa_case.case_number,
       dob: I18n.l(@casa_case.birth_month_year_youth, format: :youth_date_of_birth, default: nil),
       is_transitioning: @casa_case.in_transition_age?

--- a/app/models/court_date.rb
+++ b/app/models/court_date.rb
@@ -41,7 +41,7 @@ class CourtDate < ApplicationRecord
   end
 
   def display_name
-    "#{casa_case.case_number} - Past Court Date - #{I18n.l(date.to_date)}"
+    "#{casa_case.case_number} - Court Date - #{I18n.l(date.to_date)}"
   end
 
   private

--- a/app/views/casa_cases/_court_dates.html.erb
+++ b/app/views/casa_cases/_court_dates.html.erb
@@ -1,4 +1,4 @@
-<label><%= t(".past_court_dates") %>:</label>
+<label><%= t(".court_dates") %>:</label>
 <% if casa_case.court_dates.size > 0 %>
   <ul>
     <% casa_case.court_dates.ordered_ascending.each do |pcd| %>
@@ -14,11 +14,11 @@
     <% end %>
   </ul>
 <% else %>
-  <%= t(".no_past_court_dates") %>
+  <%= t(".no_court_dates") %>
 <% end %>
 <div class="add-container past-court-dates">
   <a class="btn btn-primary add-button" href="<%= new_casa_case_court_date_path(casa_case) %>">
     <i class="fa fa-plus" aria-hidden="true"></i>
   </a>
-  <strong><%= t(".add_past_court_date") %></strong>
+  <strong><%= t(".add_court_date") %></strong>
 </div>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -64,23 +64,6 @@
       <% end %>
 
       <div class="field form-group">
-        <% if policy(casa_case).update_court_date? %>
-          <%= form.label :court_date, "Add Court Date (past or future)" %>
-          <br>
-          <span class="datetime-year-month">
-            <%= form.date_select :court_date,
-                                 {
-                                     order: [:day, :month, :year],
-                                     start_year: Date.current.year + 3,
-                                     end_year: 2000,
-                                     prompt: {day: t("common.day"), month: t("common.month"), year: t("common.year")}
-                                 },
-                                 class: "select2 date-input" %>
-          </span>
-        <% end %>
-      </div>
-
-      <div class="field form-group">
         <% if policy(casa_case).update_court_report_due_date? %>
           <%= form.label :court_report_due_date, t(".court_report_due_date") %>
           <br>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -57,7 +57,7 @@
     <p>
     <h6>
       <strong><%= t(".label.next_court_date") %>:</strong>
-      <%= I18n.l(@casa_case.court_date, format: :day_and_date, default: '') %>
+      <%= I18n.l(@casa_case.next_court_date&.date, format: :day_and_date, default: '') %>
     </h6>
     </p>
 

--- a/app/views/court_dates/show.html.erb
+++ b/app/views/court_dates/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-12 form-header">
     <h1><%= t(".title") %></h1>
-    <%= link_to t(".button.edit_past_court_date"),
+    <%= link_to t(".button.edit_court_date"),
         edit_casa_case_court_date_path(@casa_case, @court_date),
         class: "btn btn-primary casa-case-button pull-right" %>
   </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -41,10 +41,10 @@ en:
       pick_displayed_columns: Pick displayed columns
     new:
       title: New CASA Case
-    no_past_court_dates: No past court dates
+    no_court_dates: No court dates
     court_dates:
-      add_past_court_date: Add a past court date
-      past_court_dates: Past court dates
+      add_court_date: Add a court date
+      court_dates: Court dates
     shared:
       assigned_multiple: Assigned to more than 1 Volunteer
       assigned_single: Assigned to Volunteer
@@ -369,16 +369,16 @@ en:
       no_notifications: You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.
   court_dates:
     edit:
-      title: Editing Past Court Date
+      title: Editing Court Date
     form:
       button:
         create: Create
         update: Update
     new:
-      title: New Past Court Date
+      title: New Court Date
     show:
       button:
-        edit_past_court_date: Edit
+        edit_court_date: Edit
       label:
         casa_case_court_order:
           implementation_status: Implementation Status
@@ -389,8 +389,8 @@ en:
         hearing_type: Hearing Type
         judge: Judge
         none: None
-        no_case_court_mandates: There are no court orders associated with this past court date.
-      title: Past Court Date
+        no_case_court_mandates: There are no court orders associated with this court date.
+      title: Court Date
   reports:
     index:
       assigned_to_label: "Assigned To:"

--- a/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
+++ b/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
@@ -1,0 +1,12 @@
+class ChangeCasaCasesCourtDateToReference < ActiveRecord::Migration[6.1]
+  def up
+    CasaCase.find_each do |casa_case|
+      CourtDate.create(
+        date: casa_case.court_date,
+        casa_case: casa_case,
+        hearing_type: casa_case.hearing_type,
+        judge: casa_case.judge,
+      )
+    end
+  end
+end

--- a/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
+++ b/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
@@ -5,7 +5,7 @@ class ChangeCasaCasesCourtDateToReference < ActiveRecord::Migration[6.1]
         date: casa_case.court_date,
         casa_case: casa_case,
         hearing_type: casa_case.hearing_type,
-        judge: casa_case.judge,
+        judge: casa_case.judge
       )
     end
   end

--- a/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
+++ b/db/migrate/20211012180102_change_casa_cases_court_date_to_reference.rb
@@ -5,7 +5,8 @@ class ChangeCasaCasesCourtDateToReference < ActiveRecord::Migration[6.1]
         date: casa_case.court_date,
         casa_case: casa_case,
         hearing_type: casa_case.hearing_type,
-        judge: casa_case.judge
+        judge: casa_case.judge,
+        case_court_orders: casa_case.case_court_orders
       )
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_11_195857) do
+ActiveRecord::Schema.define(version: 2021_10_12_180102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -4,3 +4,14 @@ task transition_youth: :environment do
   CasaCase.should_transition.update_all(transition_aged_youth: true)
   puts "done."
 end
+
+desc "Clear court dates and report information when date has passed, run by heroku scheduler"
+task clear_passed_dates: :environment do
+  puts "Checking case due dates..."
+
+  CasaCase.due_date_passed.each do |cc|
+    cc.clear_court_dates
+  end
+
+  puts "done."
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -4,21 +4,3 @@ task transition_youth: :environment do
   CasaCase.should_transition.update_all(transition_aged_youth: true)
   puts "done."
 end
-
-desc "Clear court dates and report information when date has passed, run by heroku scheduler"
-task clear_passed_dates: :environment do
-  puts "Checking case due dates..."
-
-  CasaCase.due_date_passed.each do |cc|
-    CourtDate.create!(
-      date: cc.court_date,
-      casa_case_id: cc.id,
-      case_court_orders: cc.case_court_orders,
-      hearing_type_id: cc.hearing_type_id,
-      judge_id: cc.judge_id
-    )
-    cc.clear_court_dates
-  end
-
-  puts "done."
-end

--- a/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
+++ b/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require File.join(Rails.root, 'db', 'migrate', '20211012180102_change_casa_cases_court_date_to_reference')
+require File.join(Rails.root, "db", "migrate", "20211012180102_change_casa_cases_court_date_to_reference")
 
 RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
   subject(:migration) { described_class.new }
@@ -12,12 +12,12 @@ RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
   describe "#up" do
     context "when there are casa cases with court dates" do
       before do
-        5.times {|index| create(:casa_case, court_date: index.days.from_now) }
+        5.times { |index| create(:casa_case, court_date: index.days.from_now) }
       end
 
       it "creates a court date for each casa case" do
         expect(CasaCase.count).to eq 5
-        expect{ migration.up }.to change(CourtDate, :count).by(5)
+        expect { migration.up }.to change(CourtDate, :count).by(5)
 
         CasaCase.find_each do |casa_case|
           court_date = casa_case.court_dates.first
@@ -36,7 +36,7 @@ RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
       it "does not create a court date for any casa case" do
         expect(CasaCase.count).to eq 5
 
-        expect{ migration.up }.not_to change(CourtDate, :count)
+        expect { migration.up }.not_to change(CourtDate, :count)
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
       it "creates a court date for each casa case" do
         expect(CasaCase.count).to eq 5
         expect(CourtDate.count).to eq 10
-        expect{ migration.up }.to change(CourtDate, :count).by(5)
+        expect { migration.up }.to change(CourtDate, :count).by(5)
 
         CasaCase.find_each do |casa_case|
           expect(casa_case.court_dates.count).to eq 3

--- a/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
+++ b/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
   describe "#up" do
     context "when there are casa cases with court dates" do
       before do
-        5.times { |index| create(:casa_case, court_date: index.days.from_now) }
+        5.times { |index| create(:casa_case, :with_one_court_order, court_date: index.days.from_now) }
       end
 
       it "creates a court date for each casa case" do
@@ -24,6 +24,7 @@ RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
           expect(court_date.date).to eq casa_case.court_date
           expect(court_date.hearing_type).to eq casa_case.hearing_type
           expect(court_date.judge).to eq casa_case.judge
+          expect(court_date.case_court_orders).to eq casa_case.case_court_orders
         end
       end
     end

--- a/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
+++ b/spec/migrations/change_casa_cases_court_date_to_reference_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+require File.join(Rails.root, 'db', 'migrate', '20211012180102_change_casa_cases_court_date_to_reference')
+
+RSpec.describe ChangeCasaCasesCourtDateToReference, type: :migration do
+  subject(:migration) { described_class.new }
+
+  before do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+  end
+
+  describe "#up" do
+    context "when there are casa cases with court dates" do
+      before do
+        5.times {|index| create(:casa_case, court_date: index.days.from_now) }
+      end
+
+      it "creates a court date for each casa case" do
+        expect(CasaCase.count).to eq 5
+        expect{ migration.up }.to change(CourtDate, :count).by(5)
+
+        CasaCase.find_each do |casa_case|
+          court_date = casa_case.court_dates.first
+          expect(court_date.date).to eq casa_case.court_date
+          expect(court_date.hearing_type).to eq casa_case.hearing_type
+          expect(court_date.judge).to eq casa_case.judge
+        end
+      end
+    end
+
+    context "when there are casa cases with null court dates" do
+      before do
+        5.times { create(:casa_case) }
+      end
+
+      it "does not create a court date for any casa case" do
+        expect(CasaCase.count).to eq 5
+
+        expect{ migration.up }.not_to change(CourtDate, :count)
+      end
+    end
+
+    context "when there are casa cases that already have references to other court dates" do
+      before do
+        5.times do |index|
+          casa_case = create(:casa_case, court_date: index.days.ago)
+          2.times { |jindex| create(:court_date, casa_case: casa_case, date: jindex.weeks.ago) }
+        end
+      end
+
+      it "creates a court date for each casa case" do
+        expect(CasaCase.count).to eq 5
+        expect(CourtDate.count).to eq 10
+        expect{ migration.up }.to change(CourtDate, :count).by(5)
+
+        CasaCase.find_each do |casa_case|
+          expect(casa_case.court_dates.count).to eq 3
+          expect(casa_case.court_dates.last.date).to eq casa_case.court_date
+        end
+      end
+    end
+  end
+end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -16,24 +16,6 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to have_many(:case_court_orders).dependent(:destroy) }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }
 
-  describe "scopes" do
-    describe ".due_date_passed" do
-      subject { described_class.due_date_passed }
-
-      context "when casa_case is present" do
-        let(:casa_case) { create(:casa_case, court_date: Time.current - 3.days) }
-
-        it { is_expected.to include(casa_case) }
-      end
-
-      context "when casa_case is not present" do
-        let(:casa_case) { create(:casa_case, court_date: Time.current + 3.days) }
-
-        it { is_expected.not_to include(casa_case) }
-      end
-    end
-  end
-
   describe ".unassigned_volunteers" do
     let!(:casa_case) { create(:casa_case) }
     let!(:volunteer_same_org) { create(:volunteer, display_name: "Yelena Belova", casa_org: casa_case.casa_org) }
@@ -200,31 +182,6 @@ RSpec.describe CasaCase, type: :model do
     end
   end
 
-  describe "#clear_court_dates" do
-    context "when court date has passed" do
-      it "clears court date" do
-        casa_case = build(:casa_case, court_date: "2020-09-13 02:11:58")
-        casa_case.clear_court_dates
-
-        expect(casa_case.court_date).to be nil
-      end
-
-      it "clears report due date" do
-        casa_case = build(:casa_case, court_date: "2020-09-13 02:11:58", court_report_due_date: "2020-09-13 02:11:58")
-        casa_case.clear_court_dates
-
-        expect(casa_case.court_report_due_date).to be nil
-      end
-
-      it "sets court report as unsubmitted" do
-        casa_case = build(:casa_case, court_date: "2020-09-13 02:11:58", court_report_status: :submitted)
-        casa_case.clear_court_dates
-
-        expect(casa_case.court_report_status).to eq "not_submitted"
-      end
-    end
-  end
-
   describe "#court_report_status" do
     let(:casa_case) { build(:casa_case) }
     subject { casa_case.court_report_status = court_report_status }
@@ -283,17 +240,17 @@ RSpec.describe CasaCase, type: :model do
     end
   end
 
-  describe "#latest_court_date" do
+  describe "#most_recent_past_court_date" do
     let(:casa_case) { create(:casa_case) }
 
     it "returns the latest past court date" do
-      latest_court_date = create(:court_date, date: 3.months.ago)
+      most_recent_past_court_date = create(:court_date, date: 3.months.ago)
 
       casa_case.court_dates << create(:court_date, date: 9.months.ago)
-      casa_case.court_dates << latest_court_date
+      casa_case.court_dates << most_recent_past_court_date
       casa_case.court_dates << create(:court_date, date: 15.months.ago)
 
-      expect(casa_case.latest_court_date).to eq(latest_court_date)
+      expect(casa_case.most_recent_past_court_date).to eq(most_recent_past_court_date)
     end
   end
 

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CaseCourtReport, type: :model do
       let!(:far_past_case_contact) { create :case_contact, occurred_at: 5.days.ago, casa_case_id: casa_case_with_contacts.id }
 
       before do
-        casa_case_with_contacts.update!(court_date: 1.day.from_now)
+        create(:court_date, casa_case: casa_case_with_contacts, date: 1.day.from_now)
       end
 
       describe "without past court date" do
@@ -43,7 +43,7 @@ RSpec.describe CaseCourtReport, type: :model do
         let!(:court_date) { create(:court_date, date: 2.days.ago, casa_case_id: casa_case_with_contacts.id) }
 
         it "has all case contacts created since the previous court date" do
-          expect(casa_case_with_contacts.court_dates.length).to eq(1)
+          expect(casa_case_with_contacts.court_dates.length).to eq(2)
           expect(report.context[:case_contacts].length).to eq(4)
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe CaseCourtReport, type: :model do
           casa_case_with_contacts.casa_org.update_attribute(:address, document_data[:org_address])
           casa_case_with_contacts.update_attribute(:birth_month_year_youth, document_data[:case_birthday])
           casa_case_with_contacts.update_attribute(:case_number, document_data[:case_number])
-          casa_case_with_contacts.update_attribute(:court_date, document_data[:case_hearing_date])
+          create(:court_date, casa_case: casa_case_with_contacts, date: document_data[:case_hearing_date])
           case_contact.contact_types << contact_type
           casa_case_with_contacts.case_contacts << case_contact
           casa_case_with_contacts.case_court_orders << court_order
@@ -169,7 +169,7 @@ RSpec.describe CaseCourtReport, type: :model do
           casa_case.casa_org.update_attribute(:address, document_data[:org_address])
           casa_case.update_attribute(:birth_month_year_youth, document_data[:case_birthday])
           casa_case.update_attribute(:case_number, document_data[:case_number])
-          casa_case.update_attribute(:court_date, document_data[:case_hearing_date])
+          create(:court_date, casa_case: casa_case, date: document_data[:case_hearing_date])
           case_contact.contact_types << contact_type
           casa_case.case_contacts << case_contact
           casa_case.case_court_orders << court_order

--- a/spec/models/court_date_spec.rb
+++ b/spec/models/court_date_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe CourtDate, type: :model do
     subject { court_date.display_name }
     it "contains case number and date" do
       travel_to Time.zone.local(2020, 1, 2)
-      expect(subject).to eq("AAA123123 - Past Court Date - 2019-12-26")
+      expect(subject).to eq("AAA123123 - Court Date - 2019-12-26")
     end
   end
 end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -99,9 +99,6 @@ RSpec.describe "Edit CASA Case", type: :system do
       visit edit_casa_case_path(casa_case)
       select "Submitted", from: "casa_case_court_report_status"
       check "Youth"
-      select "4", from: "casa_case_court_date_3i"
-      select "November", from: "casa_case_court_date_2i"
-      select next_year, from: "casa_case_court_date_1i"
 
       select "8", from: "casa_case_court_report_due_date_3i"
       select "September", from: "casa_case_court_report_due_date_2i"
@@ -133,7 +130,6 @@ RSpec.describe "Edit CASA Case", type: :system do
       visit casa_case_path(casa_case)
 
       expect(page).to have_text("Court Report Status: Submitted")
-      expect(page).to have_text("4-NOV-#{next_year}")
       expect(page).to have_text("8-SEP-#{next_year}")
     end
 
@@ -190,14 +186,12 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Court Report Status: Not submitted")
       visit edit_casa_case_path(casa_case)
 
-      select "November", from: "casa_case_court_date_2i"
       select "April", from: "casa_case_court_report_due_date_2i"
 
       within ".actions" do
         click_on "Update CASA Case"
       end
 
-      expect(page).to have_text("Court date was not a valid date.")
       expect(page).to have_text("Court report due date was not a valid date.")
     end
 
@@ -205,10 +199,6 @@ RSpec.describe "Edit CASA Case", type: :system do
       visit casa_case_path(casa_case)
       expect(page).to have_text("Court Report Status: Not submitted")
       visit edit_casa_case_path(casa_case)
-
-      select "31", from: "casa_case_court_date_3i"
-      select "April", from: "casa_case_court_date_2i"
-      select next_year, from: "casa_case_court_date_1i"
 
       select "31", from: "casa_case_court_report_due_date_3i"
       select "April", from: "casa_case_court_report_due_date_2i"
@@ -218,7 +208,6 @@ RSpec.describe "Edit CASA Case", type: :system do
         click_on "Update CASA Case"
       end
 
-      expect(page).to have_text("Court date was not a valid date.")
       expect(page).to have_text("Court report due date was not a valid date.")
     end
 

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -19,9 +19,6 @@ RSpec.describe "casa_cases/new", type: :system do
       travel_to Time.zone.local(2020, 12, 1) do
         next_year = (Date.today.year + 1).to_s
         fill_in "Case number", with: case_number
-        select "3", from: "casa_case_court_date_3i"
-        select "March", from: "casa_case_court_date_2i"
-        select next_year, from: "casa_case_court_date_1i"
 
         select "1", from: "casa_case_court_report_due_date_3i"
         select "April", from: "casa_case_court_report_due_date_2i"
@@ -38,7 +35,6 @@ RSpec.describe "casa_cases/new", type: :system do
 
         expect(page.body).to have_content(case_number)
         expect(page).to have_content("CASA case was successfully created.")
-        expect(page).to have_content("Next Court Date: Wednesday, 3-MAR-2021") # accurate for frozen time
         expect(page).to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time
         expect(page).to have_content("Transition Aged Youth: Yes")
       end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "casa_cases/show", type: :system do
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
   let!(:emancipation_categories) { create_list(:emancipation_category, 3) }
+  let!(:future_court_date) { create(:court_date, date: 1.year.from_now, casa_case: casa_case) }
 
   before do
     sign_in user
@@ -38,6 +39,10 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
+    end
+
+    it "can see next court date" do
+      expect(page).to have_content("Next Court Date: #{I18n.l(future_court_date.date, format: :day_and_date)}")
     end
   end
 

--- a/spec/system/court_dates/new_spec.rb
+++ b/spec/system/court_dates/new_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "court_dates/new", type: :system do
       end
 
       expect(page.body).to have_content(casa_case.case_number)
-      expect(page).to have_content("Past court date was successfully created.")
+      expect(page).to have_content("Court date was successfully created.")
       expect(page).to have_content(judge.name)
       expect(page).to have_content(hearing_type.name)
       expect(page).to have_content(text)

--- a/spec/views/court_dates/new.html.erb_spec.rb
+++ b/spec/views/court_dates/new.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "court_dates/new", type: :view do
   let(:user) { build_stubbed(:casa_admin) }
   let(:casa_case) { create(:casa_case) }
 
-  it { is_expected.to have_selector("h1", text: "New Past Court Date") }
+  it { is_expected.to have_selector("h1", text: "New Court Date") }
   it { is_expected.to have_selector("h6", text: casa_case.case_number) }
   it { is_expected.to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}") }
   it { is_expected.to have_selector(".btn-primary") }

--- a/spec/views/court_dates/show.html.erb_spec.rb
+++ b/spec/views/court_dates/show.html.erb_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "court_dates/show", type: :view do
       expect(rendered).to include("Hearing Type")
       expect(rendered).to include("None")
 
-      expect(rendered).to include("There are no court orders associated with this past court date.")
+      expect(rendered).to include("There are no court orders associated with this court date.")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Contributes to #2582

### What changed, and why?
- Add a migration to change all casa case's court date column to a court date association
- Refactor code relying on a casa case's court date
- Remove add court date section on edit casa case page
- Change past court dates to just court dates on casa case page

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
- New migration test
- Edit existing tests

### Screenshots please :)

**Casa Case show page**

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/4965672/137183345-fd6765a7-960b-41bf-96db-f6cc23747e47.png">

**Casa Case edit page**

<img width="619" alt="image" src="https://user-images.githubusercontent.com/4965672/137183408-f7be84e1-13ef-43dd-953d-97f7587074be.png">

**Court date show page**
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/4965672/137184270-e5335566-7da9-4ae7-945e-07eb109f68df.png">

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9