### PR TITLE
Bugfix - Impersonation Password Update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
       return render "edit"
     end
 
-    bypass_sign_in(@user)
+    bypass_sign_in(@user) if @user == true_user
 
     UserMailer.password_changed_reminder(@user).deliver
     flash[:success] = "Password was successfully updated."

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe "/users", type: :request do
 
           subject
         end
+
+        it "bypasses sign in if the current user is the true user" do
+          expect_any_instance_of(UsersController).to receive(:bypass_sign_in).with(user)
+          subject
+        end
+
+        it "does not bypass sign in when the current user is not the true user" do
+          allow_any_instance_of(UsersController).to receive(:true_user).and_return(User.new)
+          expect_any_instance_of(UsersController).to_not receive(:bypass_sign_in).with(user)
+          subject
+        end
       end
 
       context "when failure" do
@@ -157,6 +168,17 @@ RSpec.describe "/users", type: :request do
           allow(UserMailer).to receive(:password_changed_reminder).with(user).and_return(mailer)
           expect(mailer).to receive(:deliver)
 
+          subject
+        end
+
+        it "bypasses sign in if the current user is the true user" do
+          expect_any_instance_of(UsersController).to receive(:bypass_sign_in).with(user)
+          subject
+        end
+
+        it "does not bypass sign in when the current user is not the true user" do
+          allow_any_instance_of(UsersController).to receive(:true_user).and_return(User.new)
+          expect_any_instance_of(UsersController).to_not receive(:bypass_sign_in).with(user)
           subject
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Follow-up to https://github.com/rubyforgood/casa/pull/2749
https://github.com/rubyforgood/casa/issues/1397

### What changed, and why?
Bugfix for "When logged in as an Admin/Supervisor (A) and impersonating a User (B) and than updating user B's password User A's session becomes User B."

Normally, when a password is updated, Devise logs the user out. CASA forces a sign_in after the update so that the user doesn't have to enter it manually. We just need to make sure we only sign_in if we are the true user (not impersonating).

### How will this affect user permissions?
Not applicable