### PR TITLE
#2240 moved css from style tag to inline styles.

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -6,19 +6,6 @@
     <title>Actionable emails e.g. reset password</title>
     <style>/* Email styles need to be inline */</style>
     <style type="text/css">
-        img {
-            max-width: 100%;
-        }
-
-        body {
-            background-color: #f6f6f6;
-            line-height: 1.6em;
-            -webkit-font-smoothing: antialiased;
-            -webkit-text-size-adjust: none;
-            width: 100% !important;
-            height: 100%;
-        }
-
         @media only screen and (max-width: 640px) {
             body {
                 padding: 0 !important;
@@ -41,7 +28,7 @@
     </style>
   </head>
 
-  <body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <body itemscope itemtype="http://schema.org/EmailMessage" style="background-color: #f6f6f6; line-height: 1.6em; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
     <table class="main-body" style="box-sizing: border-box; min-height: 150px; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%; height: 100%; background-color: rgb(234, 236, 237);" width="100%" height="100%" bgcolor="rgb(234, 236, 237)">
       <tbody style="box-sizing: border-box;">
         <tr class="row" style="box-sizing: border-box; vertical-align: top;" valign="top">
@@ -65,7 +52,7 @@
                       <tbody style="box-sizing: border-box;">
                         <tr style="box-sizing: border-box;">
                           <td class="cell c1776" style="box-sizing: border-box; width: 70%; vertical-align: middle;text-align:center;" width="70%" valign="middle">
-                            <img src="https://user-images.githubusercontent.com/8918762/120879374-7c813a00-c588-11eb-92d7-efa6fdfdfbf0.png" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); font-size: 50px;padding-top:10px;background:#00447c;">
+                            <img style="max-width: 100%;" src="https://user-images.githubusercontent.com/8918762/120879374-7c813a00-c588-11eb-92d7-efa6fdfdfbf0.png" alt="Logo" class="c926" style="box-sizing: border-box; color: rgb(158, 83, 129); font-size: 50px;padding-top:10px;background:#00447c;">
                           </td>
                         </tr>
                       </tbody>


### PR DESCRIPTION
Media queries can't be moved to inline

### What github issue is this PR for, if any?
Resolves #2240

### What changed, and why?
CSS for app/views/devise/mailer/reset_password_instructions.html.erb was moved to be inline rather in style tags. Style tags now only contain @media queries

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: not affected
- Admin permissions: not affected
