### PR TITLE
add health controller with last deploy timestamp

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ApplicationController
+  def index
+    render json: { last_deploy_timestamp: File.mtime('app') }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
     root to: "all_casa_admins/sessions#new", as: :unauthenticated_all_casa_root
   end
 
+  resources :health, only: %i[index]
+
   get "/.well-known/assetlinks.json", to: "android_app_associations#index"
   resources :casa_cases do
     resource :emancipation do

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe HealthController, type: :controller do
+  describe '#index' do
+    let(:expected_response) { { last_deploy_timestamp: File.mtime('app') }.to_json }
+
+    it 'returns a json with a timestamp' do
+      get :index
+
+      expect(response).to eq(expected_response)
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2768

### What changed, and why?
- Added the health controller with a /health route that returns the timestamp of the last deploy

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
With rspec in /spec/controllers/health_controller_spec.rb

### Screenshots please :)
There is no front

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9