### PR TITLE
Add bottom padding to footer-nav

### DIFF
--- a/app/javascript/src/stylesheets/shared/sidebar.scss
+++ b/app/javascript/src/stylesheets/shared/sidebar.scss
@@ -93,7 +93,7 @@
 
   .list-group.footer-nav {
     background: #103862;
-    padding: 1rem 0;
+    padding: 1rem 0 5rem;
     width: 100%;
     a.list-group-item {
       background: none !important;


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2789

### What changed, and why?
- On mobile, when you click "Logout" from the nav menu, the phone's native footer (with back and forward buttons) appears over the "Logout" link. So you can't actually click to log out. This PR adds bottom padding to the nav menu so that phone's native footer is no longer in the way.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
On desktop, if you scroll all the way down on the sidebar:

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/4965672/137546912-6825106f-820a-41c2-9b24-e2e55a30e5c4.png">

On mobile, if you scroll all the way down on the sidebar:

<img width="274" alt="image" src="https://user-images.githubusercontent.com/4965672/137546996-79d71b05-d079-4371-ae77-2dcd67a29c55.png">

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9