### PR TITLE
remove login requirement for timestamp of latest deploy

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -2,6 +2,6 @@ class HealthController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    render json: {last_deploy_timestamp: Rails.application.config.latest_deploy_time}
+    render json: {latest_deploy_time: Rails.application.config.latest_deploy_time}
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,4 +1,6 @@
 class HealthController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def index
     render json: {last_deploy_timestamp: Rails.application.config.latest_deploy_time}
   end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Health", type: :request do
     end
 
     it "renders a json file" do
-      #      expect(response.header["Content-Type"]).to include("application/json")
+      expect(response.header["Content-Type"]).to include("application/json")
     end
 
     it "has key latest_deploy_time" do
-      #      expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
-      #      expect(hash_body.keys).to match_array([:latest_deploy_time])
+      expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
+      expect(hash_body.keys).to match_array([:latest_deploy_time])
     end
   end
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Health", type: :request do
     it "has key latest_deploy_time" do
       hash_body = nil # This is here for the linter
       expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
-      expect(hash_body.keys).to match_array([:latest_deploy_time])
+      expect(hash_body.keys).to match_array(["latest_deploy_time"])
     end
   end
 end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Health", type: :request do
     end
 
     it "has key latest_deploy_time" do
+      hash_body = nil # This is here for the linter
       expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
       expect(hash_body.keys).to match_array([:latest_deploy_time])
     end


### PR DESCRIPTION
### What changed, and why?
Removed the login requirement to see the timestamp of the latest deploy so the bot to be coded doesn't have to log in