### PR TITLE
Hide Calendar Buttons when Casa Case dates are null

### DIFF
--- a/app/views/casa_cases/_calendar_button.html.erb
+++ b/app/views/casa_cases/_calendar_button.html.erb
@@ -1,7 +1,9 @@
 <!-- Button code -->
-<div title="Add to Calendar" class="addeventatc">
-    Add <%= title %> to Calendar
-    <span class="start"><%= date %></span>
-    <span class="all_day_event">true</span>
-    <span class="title"><%= title %></span>
-</div>
+<% if date.present? %>
+    <div title="Add to Calendar" class="addeventatc">
+        Add <%= title %> to Calendar
+        <span class="start"><%= date %></span>
+        <span class="all_day_event">true</span>
+        <span class="title"><%= title %></span>
+    </div>
+<% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -57,8 +57,8 @@
     <p>
     <h6>
       <strong><%= t(".label.next_court_date") %>:</strong>
-      <%= I18n.l(@casa_case.court_date, format: :day_and_date, default: '') %>
-      <%= render "calendar_button", date:  I18n.l(@casa_case.court_date,
+      <%= I18n.l(@casa_case.next_court_date&.date, format: :day_and_date, default: '') %>
+      <%= render "calendar_button", date:  I18n.l(@casa_case.next_court_date&.date,
                                     format: :day_and_date, default: ''), title: "Next Court Date" %>
     </h6>
     </p>

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "casa_cases/show", type: :system do
   let(:volunteer) { build(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
   let(:casa_case) {
     create(:casa_case, :with_one_court_order, casa_org: organization,
-    case_number: "CINA-1", transition_aged_youth: true)
+    case_number: "CINA-1", transition_aged_youth: true, court_report_due_date: 1.month.from_now)
   }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
@@ -50,6 +50,18 @@ RSpec.describe "casa_cases/show", type: :system do
     it "can see Add to Calendar buttons", js: true do
       expect(page).to have_content("Add Court Report Due Date to Calendar")
       expect(page).to have_content("Add Next Court Date to Calendar")
+    end
+
+    context "when there is no future court date or court report due date" do
+      before do
+        casa_case = create(:casa_case, casa_org: organization)
+        visit casa_case_path(casa_case.id)
+      end
+
+      it "can not see Add to Calendar buttons", js: true do
+        expect(page).not_to have_content("Add Court Report Due Date to Calendar")
+        expect(page).not_to have_content("Add Next Court Date to Calendar")
+      end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2799

### What changed, and why?
- If a casa case court date or court report due date is null, do not show "Add Date to Calendar" button

    <img width="1095" alt="image" src="https://user-images.githubusercontent.com/4965672/137825596-fa813842-c6fa-480c-9857-0fcd863662bc.png">

- If there are dates, buttons still show

    <img width="1123" alt="image" src="https://user-images.githubusercontent.com/4965672/137825637-dc930417-e1cf-426d-9d8c-d21f06080219.png">


### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
System test

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9