### PR TITLE
remove redundant expects

### DIFF
--- a/app/javascript/__tests__/case_button_states.test.js
+++ b/app/javascript/__tests__/case_button_states.test.js
@@ -22,7 +22,6 @@ describe('casa_case generate report button applies correct classes and attribute
     $(document).ready(() => {
       button.classList.add('d-none')
       showBtn(button)
-      expect(button.classList.contains('d-none')).toBe(false)
       expect($(button).is(':visible')).toBe(true)
     })
   })
@@ -30,7 +29,6 @@ describe('casa_case generate report button applies correct classes and attribute
   test('hide button', () => {
     $(document).ready(() => {
       hideBtn(button)
-      expect(button.classList.contains('d-none')).toBe(true)
       expect($(button).is(':visible')).toBe(false)
     })
   })


### PR DESCRIPTION
### What changed, and why?
removed checks for class `d-none`(display none) because the line below has a better check to see if the button is visible