### PR TITLE
Add impersonate link to volunteer edit page

### DIFF
--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -5,6 +5,10 @@
     <h1>Editing Volunteer</h1>
     <%= render "volunteer_reminder_form", volunteer: @volunteer %>
   </div>
+  <div class="col-sm-12 form-header">
+    <%= link_to "Impersonate", impersonate_volunteer_path(@volunteer),
+      class: "btn btn-primary casa-case-button" %>
+  </div>
 </div>
 <div class="card card-container">
   <div class="card-body">

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -287,4 +287,60 @@ RSpec.describe "volunteers/edit", type: :system do
       expect(ActionMailer::Base.deliveries.first.cc).to include(admin.email)
     end
   end
+
+  describe "impersonate button" do
+    let(:volunteer) { create(:volunteer, casa_org: organization, display_name: "John Doe") }
+
+    before do
+      sign_in user
+      visit edit_volunteer_path(volunteer)
+    end
+
+    context "when user is an admin" do
+      let(:user) { create(:casa_admin, casa_org: organization) }
+
+      it "shows the impersonate button" do
+        expect(page).to have_link("Impersonate")
+      end
+
+      it "impersonates the volunteer" do
+        click_on "Impersonate"
+
+        within(".sidebar-wrapper") do
+          expect(page).to have_text(
+            "You (#{user.display_name}) are signed in as John Doe. " \
+              "Click here to stop impersonating."
+          )
+        end
+      end
+    end
+
+    context "when user is a supervisor" do
+      let(:user) { create(:supervisor, casa_org: organization) }
+
+      it "shows the impersonate button" do
+        expect(page).to have_link("Impersonate")
+      end
+
+      it "impersonates the volunteer" do
+        click_on "Impersonate"
+
+        within(".sidebar-wrapper") do
+          expect(page).to have_text(
+            "You (#{user.display_name}) are signed in as John Doe. " \
+              "Click here to stop impersonating."
+          )
+        end
+      end
+    end
+
+    context "when user is a volunteer" do
+      let(:user) { create(:volunteer, casa_org: organization) }
+
+      it "does not show the impersonate button", :aggregate_failures do
+        expect(page).not_to have_link("Impersonate")
+        expect(current_path).not_to eq(edit_volunteer_path(volunteer))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/casa/issues/2813

### What changed, and why?

Add an Impersonate link button on the volunteer edit page. To improve UX once they are editing the volunteer.

### How is this tested? (please write tests!) 💖💪

With capybara specs, ensuring all user roles

### Screenshots please :)

![image](https://user-images.githubusercontent.com/47258878/138573868-6c7eb348-43fe-45b8-badb-4d8e94d7ae95.png)
