### PR TITLE
Add basic preference set model and associations

### DIFF
--- a/app/models/preference_set.rb
+++ b/app/models/preference_set.rb
@@ -1,0 +1,24 @@
+class PreferenceSet < ApplicationRecord
+
+  belongs_to :user
+
+end
+
+# == Schema Information
+#
+# Table name: preference_sets
+#
+#  id                     :bigint           not null, primary key
+#  case_volunteer_columns :jsonb            not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  user_id                :bigint
+#
+# Indexes
+#
+#  index_preference_sets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/preference_set.rb
+++ b/app/models/preference_set.rb
@@ -1,7 +1,5 @@
 class PreferenceSet < ApplicationRecord
-
   belongs_to :user
-
 end
 
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
     where(is_active: true)
   }, foreign_key: "volunteer_id", dependent: :destroy
   has_one :supervisor, through: :supervisor_volunteer
+  has_one :preference_set, dependent: :destroy
 
   scope :active, -> { where(active: true) }
 

--- a/db/migrate/20211024060815_create_preference_sets.rb
+++ b/db/migrate/20211024060815_create_preference_sets.rb
@@ -2,7 +2,7 @@ class CreatePreferenceSets < ActiveRecord::Migration[6.1]
   def change
     create_table :preference_sets do |t|
       t.references :user, index: true, foreign_key: true
-      t.jsonb :case_volunteer_columns, null: false, default: '{}'
+      t.jsonb :case_volunteer_columns, null: false, default: "{}"
 
       t.timestamps
     end

--- a/db/migrate/20211024060815_create_preference_sets.rb
+++ b/db/migrate/20211024060815_create_preference_sets.rb
@@ -1,0 +1,10 @@
+class CreatePreferenceSets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :preference_sets do |t|
+      t.references :user, index: true, foreign_key: true
+      t.jsonb :case_volunteer_columns, null: false, default: '{}'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -265,6 +265,14 @@ ActiveRecord::Schema.define(version: 2021_10_25_143709) do
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient"
   end
 
+  create_table "preference_sets", force: :cascade do |t|
+    t.bigint "user_id"
+    t.jsonb "case_volunteer_columns", default: "{}", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_preference_sets_on_user_id"
+  end
+
   create_table "sent_emails", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "casa_org_id", null: false
@@ -351,6 +359,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_143709) do
   add_foreign_key "emancipation_options", "emancipation_categories"
   add_foreign_key "followups", "users", column: "creator_id"
   add_foreign_key "judges", "casa_orgs"
+  add_foreign_key "preference_sets", "users"
   add_foreign_key "sent_emails", "casa_orgs"
   add_foreign_key "sent_emails", "users"
   add_foreign_key "supervisor_volunteers", "users", column: "supervisor_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -333,8 +333,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_143709) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/spec/factories/preference_sets.rb
+++ b/spec/factories/preference_sets.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :preference_set do
+    user
     case_volunteer_columns { {} }
   end
 end

--- a/spec/factories/preference_sets.rb
+++ b/spec/factories/preference_sets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :preference_set do
+    case_volunteer_columns { {} }
+  end
+end

--- a/spec/models/preference_set_spec.rb
+++ b/spec/models/preference_set_spec.rb
@@ -1,29 +1,29 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PreferenceSet, type: :model do
   let(:preference_set) { PreferenceSet.create(params) }
 
-  describe 'allows setting values for case_volunteer_columns' do
+  describe "allows setting values for case_volunteer_columns" do
     let(:params) do
       {
         case_volunteer_columns: {
-          case_number: 'show',
-          hearing_type_name: 'hide',
-          judge_name: 'show',
-          status: 'show',
-          transition_aged_youth: 'show',
-          assigned_to: 'show',
-          actions: 'hide'
+          case_number: "show",
+          hearing_type_name: "hide",
+          judge_name: "show",
+          status: "show",
+          transition_aged_youth: "show",
+          assigned_to: "show",
+          actions: "hide"
         }
       }
     end
 
-    it { expect(preference_set.case_volunteer_columns['case_number']).to eq 'show' }
-    it { expect(preference_set.case_volunteer_columns['hearing_type_name']).to eq 'hide' }
-    it { expect(preference_set.case_volunteer_columns['judge_name']).to eq 'show' }
-    it { expect(preference_set.case_volunteer_columns['status']).to eq 'show' }
-    it { expect(preference_set.case_volunteer_columns['transition_aged_youth']).to eq 'show' }
-    it { expect(preference_set.case_volunteer_columns['assigned_to']).to eq 'show' }
-    it { expect(preference_set.case_volunteer_columns['actions']).to eq 'hide' }
+    it { expect(preference_set.case_volunteer_columns["case_number"]).to eq "show" }
+    it { expect(preference_set.case_volunteer_columns["hearing_type_name"]).to eq "hide" }
+    it { expect(preference_set.case_volunteer_columns["judge_name"]).to eq "show" }
+    it { expect(preference_set.case_volunteer_columns["status"]).to eq "show" }
+    it { expect(preference_set.case_volunteer_columns["transition_aged_youth"]).to eq "show" }
+    it { expect(preference_set.case_volunteer_columns["assigned_to"]).to eq "show" }
+    it { expect(preference_set.case_volunteer_columns["actions"]).to eq "hide" }
   end
 end

--- a/spec/models/preference_set_spec.rb
+++ b/spec/models/preference_set_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe PreferenceSet, type: :model do
+  let(:preference_set) { PreferenceSet.create(params) }
+
+  describe 'allows setting values for case_volunteer_columns' do
+    let(:params) do
+      {
+        case_volunteer_columns: {
+          case_number: 'show',
+          hearing_type_name: 'hide',
+          judge_name: 'show',
+          status: 'show',
+          transition_aged_youth: 'show',
+          assigned_to: 'show',
+          actions: 'hide'
+        }
+      }
+    end
+
+    it { expect(preference_set.case_volunteer_columns['case_number']).to eq 'show' }
+    it { expect(preference_set.case_volunteer_columns['hearing_type_name']).to eq 'hide' }
+    it { expect(preference_set.case_volunteer_columns['judge_name']).to eq 'show' }
+    it { expect(preference_set.case_volunteer_columns['status']).to eq 'show' }
+    it { expect(preference_set.case_volunteer_columns['transition_aged_youth']).to eq 'show' }
+    it { expect(preference_set.case_volunteer_columns['assigned_to']).to eq 'show' }
+    it { expect(preference_set.case_volunteer_columns['actions']).to eq 'hide' }
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Component of #2698

### What changed, and why?

Adds a basic preference set model to facilitate the saving of user preferences. The associated issue requires the saving of hidden columns. 

I have only implemented the basic model so far because the page the related issue references has not been created yet.

### How is this tested? (please write tests!) 💖💪

Unit test