### PR TITLE
Change actions to buttons for visual separation

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -195,10 +195,10 @@ $('document').ready(() => {
         render: (data, type, row, meta) => {
           return `
           <span class="mobile-label">Actions</span>
-            <a href="${editVolunteerPath(row.id)}">
+            <a href="${editVolunteerPath(row.id)}" class="btn btn-primary">
               Edit
             </a>
-            <a href="${impersonateVolunteerPath(row.id)}">
+            <a href="${impersonateVolunteerPath(row.id)}" class="btn btn-secondary">
               Impersonate
             </a>
           `


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2812

### What changed, and why?
Changed the edit and impersonate links to be buttons so they are easier to separate visually

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
None, visual bug

### Screenshots please :)
<img width="327" alt="Screen Shot 2021-10-26 at 4 31 14 PM" src="https://user-images.githubusercontent.com/5439589/138976989-63724ecb-0342-4064-b4dc-31954b705b7b.png">
<img width="955" alt="Screen Shot 2021-10-26 at 4 31 48 PM" src="https://user-images.githubusercontent.com/5439589/138977007-deefd420-bd50-48a2-868f-b4ce24367b0e.png">

### Feelings gif (optional)
![button](https://media2.giphy.com/media/9DavVitIZ26jH0aK7s/200w.webp?cid=ecf05e47dwjrlhiafbgyatxcucxnlzsk8sue3wwtm1m7d4um&rid=200w.webp&ct=g)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9