### PR TITLE
fix format of expected string in test

### DIFF
--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     it "can see Add to Calendar buttons", js: true do
-      expect(page).to have_content("Add Court Report Due Date for #{casa_case.case_number} to Calendar")
+      expect(page).to have_content("Add Court Report Due Date for [#{casa_case.case_number}] to Calendar")
       expect(page).to have_content("Add Next Court Date for #{casa_case.case_number} to Calendar")
     end
 


### PR DESCRIPTION
### What changed, and why?
Fixed the test below not expecting square brackets around the case number
```
  1) casa_cases/show when admin can see Add to Calendar buttons
     Failure/Error: expect(page).to have_content("Add Court Report Due Date for #{casa_case.case_number} to Calendar")
       expected to find text "Add Court Report Due Date for CINA-1 to Calendar" in 
         "Inbox\nSupervisors\nVolunteers\nCases\nAdmins\nLocation\nCASA Org 854\nRole\nCasa Admin\nEdit Profile\nGenerate Court Reports\nReimbursement Queue\nExport Data\nSystem Imports\nEdit Organization\nReport a site issue\nUser 877 email1106@example.com\nLog out\n🦋 CASA Case Details\nNew Case Contact\nEdit Case Details\nEmancipation 0 / 3\nGenerate Report\nCase number: CINA-1\nHearing Type: Emergency Hearing 850\nJudge: Arthur Langworth\nTransition Aged Youth: Yes 🦋\nNext Court Date: Friday, 28-OCT-2022 Add Next Court Date for [CINA-1] to Calendar\nCourt Report Due Date: Sunday, 28-NOV-2021 
         Add Court Report Due Date for [CINA-1] to Calendar
         \nCourt Report Status: Not submitted\nCourt Orders:\n❌ Amoveo voluptates vicissitudo. Comis cresco vero. Avarus utrimque deduco. Corporis deserunt adfectus. Casus sulum volup. Absorbeo temeritas architecto. Tres conatus copiose. Speciosus curvo vesica. Vergo conspergo omnis. Comis stultus aufero. Defaeco circumvenio ratione. Taceo cum approbo. Capitulus arcus tenax.\nCourt dates:\nOctober 28, 2022\nAssigned Volunteers:\nBob Loblaw\nSend CC to Supervisor and Admin\n\nDownload All\nGroup 458\nType 350\nOctober 28, 2021 | 60 minutes | No Contact Made\nMake Reminder\nEdit\nDelete\nCreated by: Bob Loblaw"

     [Screenshot Image]: /home/runner/work/casa/casa/tmp/screenshots/failures_r_spec_example_groups_casa_cases_show_3_when_admin_can_see_add_to_calendar_buttons_655.png


     # ./spec/system/casa_cases/show_spec.rb:51:in `block (3 levels) in <top (required)>'

```