### PR TITLE
Fix flaky array equivalency in case_assignment_spec.rb

### DIFF
--- a/spec/models/case_assignment_spec.rb
+++ b/spec/models/case_assignment_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe CaseAssignment, type: :model do
     it "only includes active case assignments" do
       casa_case = build(:casa_case)
       case_assignments = 2.times.map { create(:case_assignment, casa_case: casa_case, volunteer: build(:volunteer, casa_org: casa_case.casa_org)) }
-      expect(CaseAssignment.active).to eq case_assignments
+      expect(CaseAssignment.active).to match_array(case_assignments)
 
       case_assignments.first.update(active: false)
       expect(CaseAssignment.active).to eq [case_assignments.last]


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2851

### What changed, and why?
Used the rspec 3 `match_array` matcher to check the equivalency of the two arrays regardless of order

### How will this affect user permissions?
- Volunteer permissions: N/a
- Supervisor permissions: N/a
- Admin permissions: N/a

### How is this tested? (please write tests!) 💖💪
The tests passed several executions. No user-facing code change.

### Screenshots please :)
No user facing code changed
