### PR TITLE
Add .slugignore to prevent docs, tests from triggering Heroku deploy

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,4 @@
+*.md
 /docs
 /cypress
 /spec


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2857

### What changed, and why?


### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
This can only be validated when `docs/*` `spec/*` `cypress/*` changes are pushed to Heroku.

### Screenshots please :)
N/A

### Feelings gif (optional)
N/A

### Feedback please? (optional)
The [Welcome Contributor!](https://github.com/rubyforgood/casa#welcome-contributors) section from `README.md` is very nice :D