### PR TITLE
Add json response for CasaCase actions that hits the database

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -78,10 +78,21 @@ class CasaCasesController < ApplicationController
     authorize @casa_case, :update_case_status?
 
     if @casa_case.deactivate
-      flash_message = "Case #{@casa_case.case_number} has been deactivated."
-      redirect_to edit_casa_case_path(@casa_case), notice: flash_message
+      respond_to do |format|
+        format.html do
+          flash_message = "Case #{@casa_case.case_number} has been deactivated."
+          redirect_to edit_casa_case_path(@casa_case), notice: flash_message
+        end
+
+        format.json do
+          render json: "Case #{@casa_case.case_number} has been deactivated.", status: :ok
+        end
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -100,10 +100,21 @@ class CasaCasesController < ApplicationController
     authorize @casa_case, :update_case_status?
 
     if @casa_case.reactivate
-      flash_message = "Case #{@casa_case.case_number} has been reactivated."
-      redirect_to edit_casa_case_path(@casa_case), notice: flash_message
+      respond_to do |format|
+        format.html do
+          flash_message = "Case #{@casa_case.case_number} has been reactivated."
+          redirect_to edit_casa_case_path(@casa_case), notice: flash_message
+        end
+
+        format.json do
+          render json: "Case #{@casa_case.case_number} has been reactivated.", status: :ok
+        end
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -57,12 +57,20 @@ class CasaCasesController < ApplicationController
   def update
     authorize @casa_case
     original_attributes = @casa_case.full_attributes_hash
+
     if @casa_case.update_cleaning_contact_types(casa_case_update_params)
       updated_attributes = @casa_case.full_attributes_hash
       changed_attributes_list = html_formatted_list(changed_attributes_messages(original_attributes, updated_attributes))
-      redirect_to edit_casa_case_path, notice: "CASA case was successfully updated.#{changed_attributes_list}"
+
+      respond_to do |format|
+        format.html { redirect_to edit_casa_case_path, notice: "CASA case was successfully updated.#{changed_attributes_list}" }
+        format.json { render json: @casa_case, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -172,8 +172,10 @@ class CasaCase < ApplicationRecord
   end
 
   def deactivate
-    update(active: false)
-    case_assignments.map { |ca| ca.update(active: false) }
+    transaction do
+      update(active: false)
+      case_assignments.find_each { |ca| ca.update(active: false) }
+    end
   end
 
   def reactivate

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -172,10 +172,8 @@ class CasaCase < ApplicationRecord
   end
 
   def deactivate
-    transaction do
-      update(active: false)
-      case_assignments.find_each { |ca| ca.update(active: false) }
-    end
+    update(active: false)
+    case_assignments.map { |ca| ca.update(active: false) }
   end
 
   def reactivate

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -380,6 +380,14 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_not_found
       end
 
+      it "also respond as json", :aggregate_failures do
+        patch reactivate_casa_case_path(casa_case, format: :json), params: params
+
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match("Case #{casa_case.case_number} has been reactivated.")
+      end
+
       context "when reactivation fails" do
         before do
           allow_any_instance_of(CasaCase).to receive(:reactivate).and_return(false)
@@ -389,6 +397,14 @@ RSpec.describe "/casa_cases", type: :request do
           patch deactivate_casa_case_path(casa_case), params: params
           casa_case.reload
           expect(casa_case.active).to eq false
+        end
+
+        it "also respond as json", :aggregate_failures do
+          patch reactivate_casa_case_path(casa_case, format: :json), params: params
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to match([].to_json)
         end
       end
     end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>Changed Hearing type</li><li>Changed Judge</li><li>2 Court orders added or updated</li></ul>")
         end
 
-        it 'also respond as json', :aggregate_failures do
+        it "also respond as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -236,7 +236,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to be_successful
         end
 
-        it 'also respond as json', :aggregate_failures do
+        it "also respond as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: invalid_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -322,6 +322,14 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_not_found
       end
 
+      it "also respond as json", :aggregate_failures do
+        patch deactivate_casa_case_path(casa_case, format: :json), params: params
+
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match("Case #{casa_case.case_number} has been deactivated.")
+      end
+
       context "when deactivation fails" do
         before do
           allow_any_instance_of(CasaCase).to receive(:deactivate).and_return(false)
@@ -331,6 +339,14 @@ RSpec.describe "/casa_cases", type: :request do
           patch deactivate_casa_case_path(casa_case), params: params
           casa_case.reload
           expect(casa_case.active).to eq true
+        end
+
+        it "also respond as json", :aggregate_failures do
+          patch deactivate_casa_case_path(casa_case, format: :json), params: params
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to match([].to_json)
         end
       end
     end
@@ -436,7 +452,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
         end
 
-        it 'also respond as json', :aggregate_failures do
+        it "also respond as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -541,7 +557,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
         end
 
-        it 'also respond as json', :aggregate_failures do
+        it "also respond as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -112,11 +112,12 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.judge).to eq judge
         end
 
-        it "also respond to json", :aggregate_failures do
+        it "also respond as json", :aggregate_failures do
           post casa_cases_url(format: :json), params: {casa_case: valid_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
           expect(response).to have_http_status(:created)
+          expect(response.body).to match(valid_attributes[:case_number].to_json)
         end
       end
 
@@ -219,12 +220,28 @@ RSpec.describe "/casa_cases", type: :request do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>Changed Hearing type</li><li>Changed Judge</li><li>2 Court orders added or updated</li></ul>")
         end
+
+        it 'also respond as json', :aggregate_failures do
+          patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to match(new_attributes[:case_number].to_json)
+        end
       end
 
       context "with invalid parameters" do
         it "renders a successful response displaying the edit template" do
           patch casa_case_url(casa_case), params: {casa_case: invalid_attributes}
           expect(response).to be_successful
+        end
+
+        it 'also respond as json', :aggregate_failures do
+          patch casa_case_url(casa_case, format: :json), params: {casa_case: invalid_attributes}
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to match(["Case number can't be blank"].to_json)
         end
       end
 
@@ -418,6 +435,14 @@ RSpec.describe "/casa_cases", type: :request do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
         end
+
+        it 'also respond as json', :aggregate_failures do
+          patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to match(new_attributes[:case_number].to_json)
+        end
       end
 
       it "does not update across organizations" do
@@ -514,6 +539,14 @@ RSpec.describe "/casa_cases", type: :request do
         it "redirects to the casa_case" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes}
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
+        end
+
+        it 'also respond as json', :aggregate_failures do
+          patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
+
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to match(new_attributes[:case_number].to_json)
         end
       end
 


### PR DESCRIPTION
References https://github.com/rubyforgood/casa/issues/2647

### What changed, and why?

Adding json response for `update`, `deactivate` and `reactivate` of `CasaCaseController`

### How is this tested? (please write tests!) 💖💪

Unit tests for the controller class
