### PR TITLE
Don't require birth year-month on cases

### DIFF
--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -10,7 +10,6 @@ const emancipationPage = {
 //  @throws   {TypeError}  for a parameter of the incorrect type
 //  @throws   {Error}      for trying to resolve more async operations than the amount currently awaiting
 function resolveAsyncOperation (error) {
-
   if (error instanceof Error) {
     error = error.message
   }

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -37,7 +37,6 @@ class CasaCase < ApplicationRecord
   belongs_to :hearing_type, optional: true
   belongs_to :judge, optional: true
   belongs_to :casa_org
-  validates :birth_month_year_youth, presence: true
 
   has_many :casa_case_contact_types
   has_many :contact_types, through: :casa_case_contact_types, source: :contact_type

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to belong_to(:hearing_type).optional }
   it { is_expected.to belong_to(:judge).optional }
   it { is_expected.to validate_presence_of(:case_number) }
-  it { is_expected.to validate_presence_of(:birth_month_year_youth) }
   it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id).case_insensitive }
   it { is_expected.to have_many(:case_court_orders).dependent(:destroy) }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "/casa_cases", type: :request do
 
             expect(response.content_type).to eq("application/json; charset=utf-8")
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.body).to eq(["Case number can't be blank", "Birth month year youth can't be blank"].to_json)
+            expect(response.body).to eq(["Case number can't be blank"].to_json)
           end
         end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2794

### What changed, and why?
This makes the "birth month year youth" field not required on Casa cases. It was causing this bug: https://github.com/rubyforgood/casa/issues/2794 and also doesn't seem to always render on the form? https://github.com/rubyforgood/casa/blob/main/app/views/casa_cases/_form.html.erb#L21-L36

But I may have misinterpreted, happy to make changes if this doesn't feel like the right solution :)

### How will this affect user permissions?
- Volunteer permissions: No change
- Supervisor permissions: No change
- Admin permissions: No change

### How is this tested? (please write tests!) 💖💪
Unit tests edited, tried saving case in dev environment without the field.

### Screenshots please :)
N/A

### Feelings gif (optional)
![happy](https://c.tenor.com/sTLtxR40RAwAAAAM/happymonday-cute.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9