### PR TITLE
Display changed attributes in flash message after updating a case

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -128,17 +128,17 @@ class CasaCasesController < ApplicationController
     changed_attributes = changed.select { |k, v| original[k] != v }.keys.delete_if { |k| k == :updated_at }
     if changed_attributes.any?
       html_string = changed_attributes.map do |att|
-        if att == :case_contact_types
+        if att == :contact_types
           changed_count = (changed[att].map { |contact| contact["contact_type_id"] } - original[att].map { |contact| contact["contact_type_id"] }).count
           next if changed_count == 0
-          "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated."
-        elsif att == :case_court_orders
+          "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated"
+        elsif att == :court_orders
           changed_count = (changed[att] - original[att]).count
-          "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated."
+          "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated"
         else
-          "Changed #{att.to_s.gsub(/_id\Z/, "").humanize}."
+          "Changed #{att.to_s.gsub(/_id\Z/, "").humanize}"
         end
-      end.join("</li><li>")
+      end.delete_if(&:nil?).join("</li><li>")
       if html_string.present?
         "<ul><li>#{html_string}</li></ul>"
       end

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -59,7 +59,6 @@ class CasaCasesController < ApplicationController
     original_attributes = @casa_case.full_attributes_hash
     if @casa_case.update_cleaning_contact_types(casa_case_update_params)
       updated_attributes = @casa_case.full_attributes_hash
-      changed_attributes_message(original_attributes, updated_attributes)
       redirect_to edit_casa_case_path, notice: "CASA case was successfully updated.#{changed_attributes_message(original_attributes, updated_attributes)}"
     else
       render :edit
@@ -139,7 +138,7 @@ class CasaCasesController < ApplicationController
         else
           "Changed #{att.to_s.gsub(/_id\Z/, "").humanize}."
         end
-      end.join("</li></li>")
+      end.join("</li><li>")
       if html_string.present?
         "<ul><li>#{html_string}</li></ul>"
       end

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -137,16 +137,22 @@ class CasaCasesController < ApplicationController
     return if changed_attributes.empty?
 
     changed_attributes.map do |att|
-      if att == :contact_types
-        changed_count = (changed[att].map { |contact| contact["contact_type_id"] } - original[att].map { |contact| contact["contact_type_id"] }).count
-        next if changed_count == 0
-        "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated"
-      elsif att == :court_orders
-        changed_count = (changed[att] - original[att]).count
-        "#{changed_count} #{att.to_s.humanize.singularize.pluralize(changed_count)} added or updated"
-      else
-        "Changed #{att.to_s.gsub(/_id\Z/, "").humanize}"
-      end
+      change_message_text(att, original[att], changed[att])
     end.delete_if(&:nil?)
+  end
+
+  def change_message_text(attribute, original_attribute, updated_attribute)
+    if attribute == :contact_types
+      new_contact_type_ids = updated_attribute.map { |contact| contact["contact_type_id"] }
+      previous_contact_type_ids = original_attribute.map { |contact| contact["contact_type_id"] }
+      changed_count = new_contact_type_ids - previous_contact_type_ids
+      return if changed_count == 0
+      "#{changed_count} #{attribute.to_s.humanize.singularize.pluralize(changed_count)} added"
+    elsif attribute == :court_orders
+      changed_count = (updated_attribute - original_attribute).count
+      "#{changed_count} #{attribute.to_s.humanize.singularize.pluralize(changed_count)} added or updated"
+    else
+      "Changed #{attribute.to_s.gsub(/_id\Z/, "").humanize}"
+    end
   end
 end

--- a/app/javascript/src/stylesheets/shared/flashes.scss
+++ b/app/javascript/src/stylesheets/shared/flashes.scss
@@ -2,6 +2,7 @@
   text-align: center;
   padding: 8px;
   margin: 12px 0;
+  list-style-position: inside;
 }
 
 .alert-dismissible .close {

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -190,7 +190,7 @@ class CasaCase < ApplicationRecord
   end
 
   def full_attributes_hash
-    attributes.symbolize_keys.merge({case_contact_types: casa_case_contact_types.map(&:attributes), case_court_orders: case_court_orders.map(&:attributes)})
+    attributes.symbolize_keys.merge({contact_types: casa_case_contact_types.map(&:attributes), court_orders: case_court_orders.map(&:attributes)})
   end
 
   # def to_param

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -189,6 +189,10 @@ class CasaCase < ApplicationRecord
     self.slug = case_number.parameterize preserve_case: true
   end
 
+  def full_attributes_hash
+    attributes.symbolize_keys.merge({case_contact_types: casa_case_contact_types.map(&:attributes), case_court_orders: case_court_orders.map(&:attributes)})
+  end
+
   # def to_param
   #   id
   #   # slug # TODO use slug eventually for routes

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -214,6 +214,11 @@ RSpec.describe "/casa_cases", type: :request do
           casa_case.reload
           expect(response).to redirect_to(edit_casa_case_path)
         end
+
+        it "displays changed attributes" do
+          patch casa_case_url(casa_case), params: {casa_case: new_attributes}
+          expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>Changed Hearing type</li><li>Changed Judge</li><li>2 Court orders added or updated</li></ul>")
+        end
       end
 
       context "with invalid parameters" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2586 

### What changed, and why?
Adds a list of changed/updated attributes to the flash message after updating as case. Note: This will only reflect additive changes, e.g. no removals, just additions and edits. It looks like the court orders are deleted async so it's not really possible there, contact types it would be possible, it's just more complicated logic.
I'm not clear on why the contact types are fully removed and re-added on every save? That made this a little more challenging but it should be handled.

### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor permissions: no change
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Added request spec

### Screenshots please :)
<img width="1110" alt="Screen Shot 2021-10-31 at 3 45 30 PM" src="https://user-images.githubusercontent.com/5439589/139604014-7afc74ac-dc34-4969-8b9c-14ca0730ae0f.png">
<img width="1096" alt="Screen Shot 2021-10-31 at 3 39 42 PM" src="https://user-images.githubusercontent.com/5439589/139604023-0a472049-1d73-4001-997c-d7b3d5ea265b.png">
<img width="1110" alt="Screen Shot 2021-10-31 at 3 45 30 PM" src="https://user-images.githubusercontent.com/5439589/139604028-5a05733b-04b7-4484-b1b7-c166763a9608.png">

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9