### PR TITLE
Issue 2894: Bug: No Attempt (14 Days) Not Reflecting Correct Volunteer Numbers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,12 +92,11 @@ class User < ApplicationRecord
     no_attempt_count = 0
     volunteers.map do |volunteer|
       if volunteer.supervisor.active? &&
-         volunteer.case_assignments.any? { |assignment| assignment.active? } &&
-         ( volunteer.case_contacts.none? ||
-           volunteer.case_contacts.maximum(:occurred_at) < (Time.zone.now - 14.days)
-         )
-      then
-        no_attempt_count +=1
+          volunteer.case_assignments.any? { |assignment| assignment.active? } &&
+          (volunteer.case_contacts.none? ||
+          volunteer.case_contacts.maximum(:occurred_at) < (Time.zone.now - 14.days))
+
+        no_attempt_count += 1
       end
     end
     no_attempt_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,14 +89,18 @@ class User < ApplicationRecord
     # Get ACTIVE volunteers that have ACTIVE supervisor assignments with at least one ACTIVE case
     # 1st condition: Volunteer has not created a contact AT ALL within the past 14 days
 
-    volunteers
-      .includes(:case_assignments)
-      .joins("LEFT JOIN case_contacts cc on cc.creator_id = users.id AND cc.occurred_at > (CURRENT_DATE - INTERVAL '14 days')")
-      .group("users.id, supervisor_volunteers_users.id, case_assignments.id")
-      .where(active: true)
-      .where(supervisor_volunteers: {is_active: true})
-      .where(case_assignments: {active: true})
-      .length
+    no_attempt_count = 0
+    volunteers.map do |volunteer|
+      if volunteer.supervisor.active? &&
+         volunteer.case_assignments.any? { |assignment| assignment.active? } &&
+         ( volunteer.case_contacts.none? ||
+           volunteer.case_contacts.maximum(:occurred_at) < (Time.zone.now - 14.days)
+         )
+      then
+        no_attempt_count +=1
+      end
+    end
+    no_attempt_count
   end
 
   def past_names

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,13 +93,22 @@ RSpec.describe User, type: :model do
     describe "#no_attempt_for_two_weeks" do
       let(:supervisor) { create(:supervisor) }
 
-      it "returns one for a volunteer that has attempted contact in at least one contact_case within the last 2 weeks" do
+      it "returns zero for a volunteer that has attempted contact in at least one contact_case within the last 2 weeks" do
         volunteer_1 = create(:volunteer, :with_casa_cases, supervisor: supervisor)
 
         case_of_interest_1 = volunteer_1.casa_cases.first
-        build_stubbed(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: false, occurred_at: 1.week.ago)
-        expect(supervisor.no_attempt_for_two_weeks).to eq(1)
         create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: true, occurred_at: 1.week.ago)
+        expect(supervisor.no_attempt_for_two_weeks).to eq(0)
+      end
+
+      it "returns one for a supervisor with two volunteers, only one of which has a contact newer than 2 weeks old" do
+        volunteer_1 = create(:volunteer, :with_casa_cases, supervisor: supervisor)
+        volunteer_2 = create(:volunteer, :with_casa_cases, supervisor: supervisor)
+
+        case_of_interest_1 = volunteer_1.casa_cases.first
+        case_of_interest_2 = volunteer_2.casa_cases.first
+        create(:case_contact, creator: volunteer_1, casa_case: case_of_interest_1, contact_made: true, occurred_at: 1.week.ago)
+        create(:case_contact, creator: volunteer_2, casa_case: case_of_interest_2, contact_made: true, occurred_at: 3.weeks.ago)
         expect(supervisor.no_attempt_for_two_weeks).to eq(1)
       end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2894 

### What changed, and why?
The previous query was returning any volunteer under the supervisor who had any open case assignments. I've replaced the query with some short circuited logic, and a less heavy query structure. 

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
This is unit tested in `/spec/models/user_spec.rb`

### Screenshots please :)
Screenshot showing correct numbers with the initial seed data. 
![image](https://user-images.githubusercontent.com/4956537/140000474-5c1f5a01-f927-4a69-8c9f-739118d38288.png)