### PR TITLE
Remove functionality that locks old case contacts and shows them as a…

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -12,7 +12,6 @@ class CaseContact < ApplicationRecord
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future
   validate :reimbursement_only_when_miles_driven
-  validate :check_if_allow_edit, on: :update
 
   belongs_to :creator, class_name: "User"
   has_one :supervisor_volunteer, -> {
@@ -150,17 +149,6 @@ class CaseContact < ApplicationRecord
   def contact_made_chosen
     errors.add(:base, "Must enter whether the contact was made.") if contact_made.nil?
     !contact_made.nil?
-  end
-
-  def quarter_editable?
-    # case contacts should no longer be editable after the current quarter plus a grace period
-    Time.zone.now < occurred_at.end_of_quarter + 30.days
-  end
-
-  def check_if_allow_edit
-    return if quarter_editable?
-
-    errors.add(:base, message: "cannot edit case contacts created before the current quarter plus 30 days")
   end
 
   def supervisor_id

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -3,24 +3,15 @@
     <div class="row d-flex justify-content-between no-gutters">
       <div class="col-8">
         <div class="media">
-          <% header_color_class = contact.quarter_editable? ? "text-primary" : "text-secondary" %>
-
-          <i class="mt-1 mr-3 <%= header_color_class %> <%= contact.decorate.medium_icon_classes %>"></i>
+          <i class="mt-1 mr-3 <%= "text-primary" %> <%= contact.decorate.medium_icon_classes %>"></i>
           <div class="media-body">
             <h5 class="mt-0 card-title">
-              <strong class="<%= header_color_class %>">
+              <strong class="<%= "text-primary" %>">
                 <%= t(".deleted_text") if policy(contact).restore? && contact.deleted? %>
                 <%= contact.contact_groups_with_types.keys.join(", ") %>
-                <%= t("case_contacts.archived") unless contact.quarter_editable? %>
               </strong>
               <%= link_to(t("button.undelete"), restore_case_contact_path(contact.id), method: :post,
                           class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
-              <% unless contact.quarter_editable? %>
-                <br>
-                <small aria-hidden="true" class="card-title__hint text-muted">
-                  <%= t("case_contacts.quarter_not_editable") %>
-                </small>
-              <% end %>
             </h5>
             <h6 class="card-subtitle mb-2 text-muted">
               <%= contact.decorate.contact_types %>
@@ -46,14 +37,12 @@
       </div>
       <div class="row justify-content-between">
         <% if Pundit.policy(current_user, contact).update? %>
-          <% if contact.quarter_editable? %>
-            <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
-            <div class="col-sm-5">
-              <%= link_to edit_case_contact_path(contact), class: "btn btn-outline-primary" do %>
-                <strong><%= t("button.edit") %></strong>
-              <% end %>
-            </div>
-          <% end %>
+          <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
+          <div class="col-sm-5">
+            <%= link_to edit_case_contact_path(contact), class: "btn btn-outline-primary" do %>
+              <strong><%= t("button.edit") %></strong>
+            <% end %>
+          </div>
         <% end %>
       </div>
       <div class="row pl-3">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -137,7 +137,6 @@ en:
       select_case: Select a Case
       title: Edit Volunteer Assignments for
   case_contacts:
-    archived: (Archived)
     index:
       filter:
         contact_date: Date of contact
@@ -171,7 +170,6 @@ en:
       singular_label: CASA case
     new:
       title: New Case Contact
-    quarter_not_editable: Archived contacts can't be edited. Case contacts are archived after the end of each quarter.
   casa_orgs:
     contact_type_groups:
       button:

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -68,17 +68,10 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact.errors[:base]).to eq(["Must enter whether the contact was made."])
   end
 
-  it "can be updated when occured_at is before the last day of the month in the quarter that the case contact was created" do
+  it "can be updated even if it is old" do
     case_contact = build(:case_contact)
-    case_contact.update!(occurred_at: Time.zone.now)
+    case_contact.update!(occurred_at: Time.zone.now - 1.year)
     expect(case_contact).to be_valid
-  end
-
-  it "can't be updated when occurred_at is after the last day of the month in the quarter that the case contact was created" do
-    case_contact = build(:case_contact)
-    case_contact.update(occurred_at: Time.zone.now - 1.year)
-    expect(case_contact).to_not be_valid
-    expect(case_contact.errors[:base]).to eq(["cannot edit case contacts created before the current quarter plus 30 days"])
   end
 
   it "can be updated for 30 days after end of quarter" do

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -58,22 +58,5 @@ RSpec.describe "case_contacts/edit", type: :system do
       expect(case_contact.medium_type).to eq "letter"
       expect(case_contact.contact_made).to eq true
     end
-
-    context "when the case contact occurred last quarter" do
-      let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 5.months.ago) }
-
-      before do
-        sign_in volunteer
-        visit case_contacts_path
-      end
-
-      it "contact does not have 'Edit' link" do
-        expect(page).not_to have_link "Edit", href: edit_case_contact_path(case_contact)
-      end
-
-      it "contact has hint with card information" do
-        expect(page).to have_css("small.card-title__hint")
-      end
-    end
   end
 end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -78,22 +78,6 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
           end
         end
       end
-
-      context "with old case contact", js: true do
-        let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 1.year.ago) }
-
-        before do
-          sign_in volunteer
-          visit case_contacts_path
-        end
-
-        it "displays correct color for contact" do
-          within ".card-title" do
-            title = find("strong.text-secondary")
-            expect(title).to have_content(contact_group_text.to_s)
-          end
-        end
-      end
     end
   end
 

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         it "displays correct color for contact" do
           within ".card-title" do
             title = find("strong.text-secondary")
-            expect(title).to have_content("#{contact_group_text}")
+            expect(title).to have_content(contact_group_text.to_s)
           end
         end
       end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         end
       end
 
-      context "with archived case contact", js: true do
+      context "with old case contact", js: true do
         let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 1.year.ago) }
 
         before do
@@ -90,12 +90,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         it "displays correct color for contact" do
           within ".card-title" do
             title = find("strong.text-secondary")
-            expect(title).to have_content("#{contact_group_text} (Archived)")
+            expect(title).to have_content("#{contact_group_text}")
           end
-        end
-
-        it "displays an information hint about the archived contacts" do
-          expect(page).to have_content("Archived contacts can't be edited. Case contacts are archived after the end of each quarter.")
         end
       end
     end

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -31,26 +31,6 @@ RSpec.describe "case_contacts/case_contact", type: :view do
         expect(rendered).to have_button("Make Reminder")
       end
     end
-
-    context "occured_at is after the last day of the month in the quarter that the case contact was created" do
-      let(:case_contact) { build_stubbed(:case_contact, occurred_at: Time.zone.now - 1.year) }
-
-      it "does not show edit button" do
-        assign :case_contact, case_contact
-        assign :casa_cases, [case_contact.casa_case]
-
-        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-        expect(rendered).to have_no_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
-      end
-
-      it "does not show make reminder button" do
-        assign :case_contact, case_contact
-        assign :casa_cases, [case_contact.casa_case]
-
-        render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-        expect(rendered).to_not have_text("Make Reminder")
-      end
-    end
   end
 
   describe "delete and undelete buttons" do


### PR DESCRIPTION
…rchived, because none of our current CASAs want it anymore

### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/2903

### What changed, and why?
Remove functionality that locks old case contacts and shows them as archived, because none of our current CASAs want it anymore

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
removing specs / existing suite

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9