### PR TITLE
Added "accept" attribute to org logo field.

### DIFF
--- a/app/views/casa_orgs/edit.html.erb
+++ b/app/views/casa_orgs/edit.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="custom-file mb-5">
         <%= form.label :logo %>
-        <%= form.file_field :logo, class: "form-control" %>
+        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg" %>
       </div>
       <div class="custom-file mb-5">
         <%= form.label :court_report_template %>


### PR DESCRIPTION
By restricting the file field to png, gif, and jpeg we should be able to
avoid issues with problematic file types being uploaded as logos.  This
needs to be supplemented with a check on the back end, possibly using a
gem such as activestorage-validator.

Resolves #2909
