### PR TITLE
Adds basic Bootstrap 4 styling for all check boxes.

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -83,8 +83,10 @@
       <% if casa_case.new_record? %>
         <%# Only show the field when creating, but not when updating %>
         <div class="field form-group">
-          <%= form.label :transition_aged_youth %>
-          <%= form.check_box :transition_aged_youth %>
+          <div class="form-check">
+            <%= form.check_box :transition_aged_youth, class: 'form-check-input' %>
+            <%= form.label :transition_aged_youth, class: 'form-check-label' %>
+          </div>
         </div>
       <% end %>
 

--- a/app/views/casa_orgs/edit.html.erb
+++ b/app/views/casa_orgs/edit.html.erb
@@ -25,8 +25,10 @@
         <%= form.file_field :court_report_template, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.check_box :show_driving_reimbursement %>
-        <%= form.label :show_driving_reimbursement %>
+        <div class="form-check">
+          <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
+          <%= form.label :show_driving_reimbursement, class: 'form-check-label' %>
+        </div>
       </div>
       <div class="actions">
         <%= form.submit t("button.submit"), class: "btn btn-primary" %>

--- a/app/views/contact_type_groups/_form.html.erb
+++ b/app/views/contact_type_groups/_form.html.erb
@@ -11,8 +11,10 @@
       </div>
 
       <div class="field form-group">
-        <%= form.check_box :active %>
-        <%= form.label :active %>
+        <div class="form-check">
+          <%= form.check_box :active, class: 'form-check-input' %>
+          <%= form.label :active, class: 'form-check-label' %>
+        </div>
       </div>
 
       <div class="actions">

--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -13,8 +13,10 @@
         <%= form.select :contact_type_group_id, set_group_options, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.check_box :active %>
-        <%= form.label :active %>
+        <div class="form-check">
+          <%= form.check_box :active, class: 'form-check-input' %>
+          <%= form.label :active, class: 'form-check-label' %>
+        </div>
       </div>
 
       <div class="actions">

--- a/app/views/hearing_types/_form.html.erb
+++ b/app/views/hearing_types/_form.html.erb
@@ -9,8 +9,10 @@
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.check_box :active %>
-        <%= form.label :active %>
+        <div class="form-check">
+          <%= form.check_box :active, class: 'form-check-input' %>
+          <%= form.label :active, class: 'form-check-label' %>
+        </div>
       </div>
       <div class="actions">
         <%= form.submit t("button.submit"), class: "btn btn-primary" %>

--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -9,8 +9,10 @@
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.check_box :active %>
-        <%= form.label :active %>
+        <div class="form-check">
+          <%= form.check_box :active, class: 'form-check-input' %>
+          <%= form.label :active, class: 'form-check-label' %>
+        </div>
       </div>
       <div class="actions">
         <%= form.submit t("button.submit"), class: "btn btn-primary" %>

--- a/app/views/mileage_rates/_form.html.erb
+++ b/app/views/mileage_rates/_form.html.erb
@@ -15,8 +15,10 @@
   </div>
 
   <div class="field form-group">
-    <%= form.label :is_active, 'Currently active?' %>
-    <%= form.check_box :is_active %>
+    <div class="form-check">
+      <%= form.check_box :is_active, class: 'form-check-input' %>
+      <%= form.label :is_active, 'Currently active?', class: 'form-check-label' %>
+    </div>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
This change moves all checkbox + label pairs to the standard Bootstrap 4 layout - checkbox before label and each with "form-check-input" or "form-check-label" class.  Additionally, it is embedded in a div with "form-check" class.