### PR TITLE
Issues/2415 Add Colored Bars to Supervisor's Screen

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -237,7 +237,6 @@ $('document').ready(() => {
     }
   })
 
-
   // Because the table saves state, we have to check/uncheck modal inputs based on what
   // columns are visible
   volunteersTable.columns().every(function (index) {
@@ -292,10 +291,6 @@ $('document').ready(() => {
 
   $('.volunteer-filters input[type="checkbox"]').not('#unassigned-vol-filter').on('click', function () {
     volunteersTable.draw()
-  })
-
-  $('.supervisor-filters input[type="checkbox"]').on('click', function () {
-    supervisorsTable.draw()
   })
 
   $('.casa-case-filters input[type="checkbox"]').on('click', function () {

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -237,65 +237,6 @@ $('document').ready(() => {
     }
   })
 
-  const supervisorsTable = $('table#supervisors').DataTable({
-    autoWidth: false,
-    stateSave: false,
-    columns: [
-      {
-        name: 'display_name',
-        render: (data, type, row, meta) => {
-          return `
-            <a href="${editSupervisorPath(row.id)}">
-              ${row.display_name || row.email}
-            </a>
-          `
-        }
-      },
-      {
-        name: 'volunteer_assignments',
-        render: (data, type, row, meta) => row.volunteer_assignments
-      },
-      {
-        name: 'transitions_volunteers',
-        render: (data, type, row, meta) => row.transitions_volunteers
-      },
-      {
-        name: 'no_attempt_for_two_weeks',
-        render: (data, type, row, meta) => row.no_attempt_for_two_weeks
-      },
-      {
-        name: 'actions',
-        orderable: false,
-        render: (data, type, row, meta) => {
-          return `
-            <a href="${editSupervisorPath(row.id)}">
-              Edit
-            </a>
-          `
-        },
-        searchable: false
-      }
-    ],
-    processing: true,
-    serverSide: true,
-    ajax: {
-      url: $('table#supervisors').data('source'),
-      type: 'POST',
-      data: function (d) {
-        const statusOptions = $('.status-options input:checked')
-        const statusFilter = Array.from(statusOptions).map((option) =>
-          JSON.parse(option.dataset.value)
-        )
-
-        return $.extend({}, d, { additional_filters: { active: statusFilter } })
-      },
-      error: handleAjaxError,
-      dataType: 'json'
-    },
-    drawCallback: function (settings) {
-      $('[data-toggle=tooltip]').tooltip()
-    }
-  })
 
   // Because the table saves state, we have to check/uncheck modal inputs based on what
   // columns are visible

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -20,10 +20,11 @@
 
 @import "pages/casa_cases";
 @import "pages/case_contacts";
+@import "pages/casa_orgs";
+@import "pages/court_dates";
 @import "pages/dashboard";
 @import "pages/emancipation";
 @import "pages/login";
-@import "pages/casa_orgs";
 @import "pages/password";
-@import "pages/court_dates";
+@import "pages/supervisors.scss";
 @import "pages/volunteers";

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -39,6 +39,7 @@ $indicator_positive_color: #00c800;
   width: 80%;
 }
 
+.supervisor_indicator_transition_aged_youth,
 .supervisor_indicator_legend_transition_aged_youth {
   display: inline;
   font-size: smaller;

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -2,12 +2,11 @@ $indictator_negative_color: #ff0000;
 $indicator_positive_color: #00c800;
 
 .supervisor_indicator_container {
-  overflow: hidden;
   width: 20em;
 }
 
 .supervisor_indicator_legend {
-  text-align: center;
+  font-size: x-small;
 }
 
 .supervisor_indicator_legend_negative,
@@ -23,6 +22,7 @@ $indicator_positive_color: #00c800;
   background: $indictator_negative_color;
   border: 1px solid;
   display: inline-block;
+  text-align: center;
 }
 
 .supervisor_indicator_positive,
@@ -30,8 +30,16 @@ $indicator_positive_color: #00c800;
   background: $indicator_positive_color;
   border: 1px solid;
   display: inline-block;
+  text-align: center;
+}
+
+.supervisor_indicator_legend_negative_positive,
+.supervisor_indicator_negative_positive {
+  display: inline-block;
+  width: 80%;
 }
 
 .supervisor_indicator_legend_transition_aged_youth {
+  display: inline;
   font-size: smaller;
 }

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -1,0 +1,36 @@
+$indictator_negative_color: #ff0000;
+$indicator_positive_color: #00c800;
+
+.supervisor_indicator_container {
+  width: 20em;
+}
+
+.supervisor_indicator_legend {
+  text-align: center;
+}
+
+.supervisor_indicator_legend_negative,
+.supervisor_indicator_legend_positive {
+  border: 1px solid;
+  font-size: smaller;
+  padding: .25em;
+  width: 50%;
+}
+
+.supervisor_indicator_negative,
+.supervisor_indicator_legend_negative {
+  background: $indictator_negative_color;
+  border: 1px solid;
+  display: inline-block;
+}
+
+.supervisor_indicator_positive,
+.supervisor_indicator_legend_positive {
+  background: $indicator_positive_color;
+  border: 1px solid;
+  display: inline-block;
+}
+
+.supervisor_indicator_legend_transition_aged_youth {
+  font-size: smaller;
+}

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -21,7 +21,7 @@ $indicator_positive_color: #00c800;
 .supervisor_indicator_legend_negative {
   background: $indictator_negative_color;
   border: 1px solid;
-  display: inline-block;
+  float: right;
   text-align: center;
 }
 
@@ -29,7 +29,7 @@ $indicator_positive_color: #00c800;
 .supervisor_indicator_legend_positive {
   background: $indicator_positive_color;
   border: 1px solid;
-  display: inline-block;
+  float: left;
   text-align: center;
 }
 

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -2,6 +2,7 @@ $indictator_negative_color: #ff0000;
 $indicator_positive_color: #00c800;
 
 .supervisor_indicator_container {
+  overflow: hidden;
   width: 20em;
 }
 

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -45,9 +45,11 @@
 <br>
 
 <div class="supervisor_indicator_legend">
-<span class="supervisor_indicator_legend_positive">Have made contact in the last 14 days</span><%#
-%><span class="supervisor_indicator_legend_negative">Have not made contact in the last 14 days</span><%#
-%><span class="supervisor_indicator_legend_transition_aged_youth">(Transition aged youth)</span>
+<div class="supervisor_indicator_legend_negative_positive">
+  <span class="supervisor_indicator_legend_positive">Have made contact in the last 14 days</span><%#
+  %><span class="supervisor_indicator_legend_negative">Have not made contact in the last 14 days</span>
+</div>
+<div class="supervisor_indicator_legend_transition_aged_youth">(Transition aged youth)</div>
 </div>
 
 <div class="card card-container">
@@ -86,9 +88,11 @@
           </td>
 
           <td class="supervisor_indicator_container">
-            <span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%"><%= active_volunteers%></span><%#
-            %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><%#
-            %><span class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</span>
+            <div class="supervisor_indicator_negative_positive">
+              <% if active_volunteers %><span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%"><%= active_volunteers%></span><%end%><%#
+              %><%if no_attempt_volunteers %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><% end %><%#
+          %></div>
+            <dive class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</div>
           </td>
 
           <td>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -44,18 +44,22 @@
 </div>
 <br>
 
+<div class="supervisor_indicator_legend">
+<span class="supervisor_indicator_legend_positive">Have made contact in the last 14 days</span><%#
+%><span class="supervisor_indicator_legend_negative">Have not made contact in the last 14 days</span><%#
+%><span class="supervisor_indicator_legend_transition_aged_youth">(Transition aged youth)</span>
+</div>
+
 <div class="card card-container">
   <div class="card-body">
     <table
       class="table table-striped table-bordered supervisors-list"
       id="supervisors"
-      data-source="<%= datatable_supervisors_path format: :json %>">
+    >
       <thead>
       <tr>
         <th>Supervisor Name</th>
-        <th>Volunteer Assignments</th>
-        <th>Serving Transition Aged Youth</th>
-        <th>No Attempt (14 days)</th>
+        <th></th>
         <th>Actions</th>
       </tr>
       </thead>
@@ -63,27 +67,22 @@
       <tbody>
       <% @supervisors.each do |supervisor| %>
         <tr>
+          <% active_volunteers = supervisor.active_volunteers %>
+          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
+          <% no_attempt_percentage = ((no_attempt_volunteers.to_f / active_volunteers.to_f) * 100).to_i %>
+          <% active_percentage = (100 - no_attempt_percentage).to_i %>
+
+          <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
+
           <td id="name-<%= supervisor.id %>">
             <span class="mobile-label">Supervisor Name</span>
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
-          <% active_volunteers = supervisor.active_volunteers %>
-          <td id="volunteer-assignments-<%= supervisor.id %>" data-order="<%= active_volunteers %>">
-            <span class="mobile-label">Volunteer Assignments</span>
-            <%= active_volunteers %>
-          </td>
-
-          <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
-          <td id="serving-transition-aged-youth-<%= supervisor.id %>" data-order="<%= transition_volunteers %>">
-            <span class="mobile-label">Serving Transition Aged Youth</span>
-            <%= transition_volunteers %>
-          </td>
-
-          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
-          <td id="no-attempt-<%= supervisor.id %>" data-order="<%= no_attempt_volunteers %>">
-            <span class="mobile-label">No Attempt (14 days)</span>
-            <%= no_attempt_volunteers %>
+          <td class="supervisor_indicator_container">
+            <span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%"><%= active_volunteers%></span><%#
+            %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><%#
+            %><span class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</span>
           </td>
 
           <td>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -87,12 +87,13 @@
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
+
           <td class="supervisor_indicator_container">
             <div class="supervisor_indicator_negative_positive">
               <% if active_volunteers %><span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%"><%= active_volunteers%></span><%end%><%#
-              %><%if no_attempt_volunteers %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><% end %><%#
+              %><% if no_attempt_volunteers.nonzero? %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><% end %><%#
           %></div>
-            <dive class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</div>
+            <div class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</div>
           </td>
 
           <td>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -46,8 +46,8 @@
 
 <div class="supervisor_indicator_legend">
 <div class="supervisor_indicator_legend_negative_positive">
-  <span class="supervisor_indicator_legend_positive">Have made contact in the last 14 days</span><%#
-  %><span class="supervisor_indicator_legend_negative">Have not made contact in the last 14 days</span>
+  <span class="supervisor_indicator_legend_positive">Have made contact in the last 14 days</span>
+  <span class="supervisor_indicator_legend_negative">Have not made contact in the last 14 days</span>
 </div>
 <div class="supervisor_indicator_legend_transition_aged_youth">(Transition aged youth)</div>
 </div>
@@ -56,8 +56,7 @@
   <div class="card-body">
     <table
       class="table table-striped table-bordered supervisors-list"
-      id="supervisors"
-    >
+      id="supervisors">
       <thead>
       <tr>
         <th>Supervisor Name</th>
@@ -79,7 +78,6 @@
             <% active_percentage = 0 %>
           <% end %>
 
-
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
 
           <td id="name-<%= supervisor.id %>">
@@ -87,12 +85,19 @@
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
 
-
           <td class="supervisor_indicator_container">
             <div class="supervisor_indicator_negative_positive">
-              <% if active_volunteers %><span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%"><%= active_volunteers%></span><%end%><%#
-              %><% if no_attempt_volunteers.nonzero? %><span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%"><%= no_attempt_volunteers%></span><% end %><%#
-          %></div>
+              <% if active_volunteers %>
+                <span class="supervisor_indicator_positive" style="width: <%= active_percentage %> %">
+                  <%= active_volunteers %>
+                </span>
+              <% end %>
+              <% if no_attempt_volunteers.nonzero? %>
+                <span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %> %">
+                  <%= no_attempt_volunteers %>
+                </span>
+              <% end %>
+          </div>
             <div class="supervisor_indicator_transition_aged_youth">(<%= transition_volunteers %>)</div>
           </td>
 

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -67,10 +67,16 @@
       <tbody>
       <% @supervisors.each do |supervisor| %>
         <tr>
-          <% active_volunteers = supervisor.active_volunteers %>
           <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
-          <% no_attempt_percentage = ((no_attempt_volunteers.to_f / active_volunteers.to_f) * 100).to_i %>
-          <% active_percentage = (100 - no_attempt_percentage).to_i %>
+          <% active_volunteers = (supervisor.active_volunteers - no_attempt_volunteers).nonzero? %>
+          <% if active_volunteers %>
+            <% no_attempt_percentage = ((no_attempt_volunteers.to_f / supervisor.active_volunteers.to_f) * 100).to_i %>
+            <% active_percentage = (100 - no_attempt_percentage).to_i %>
+          <% else %>
+            <% no_attempt_percentage = 100 %>
+            <% active_percentage = 0 %>
+          <% end %>
+
 
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
 

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -19,6 +19,51 @@ RSpec.describe "supervisors/index", type: :view do
 
       expect(rendered).to have_link("New Supervisor", href: new_supervisor_path)
     end
+
+    it "shows the legend for the colored bars at all times" do
+      render template: "supervisors/index"
+
+      expect(rendered).to match /Have made contact in the last 14 days/
+      expect(rendered).to match /Have not made contact in the last 14 days/
+      expect(rendered).to match /(Transition aged youth)/
+    end
+
+    it "shows positive and negative numbers for each supervisor" do
+      supervisor = create(:supervisor)
+      create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)
+      create(:volunteer, :with_casa_cases, supervisor: supervisor)
+
+      assign :supervisors, [supervisor]
+      render template: "supervisors/index"
+
+      expect(rendered).to match /supervisor_indicator_positive/
+      expect(rendered).to match /supervisor_indicator_negative/
+      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+    end
+
+    it "omits the positive bar if there are no active volunteers with contact w/in 14 days" do
+      supervisor = create(:supervisor)
+      create(:volunteer, :with_casa_cases, supervisor: supervisor)
+
+      assign :supervisors, [supervisor]
+      render template: "supervisors/index"
+
+      expect(rendered).not_to match /supervisor_indicator_positive/
+      expect(rendered).to match /supervisor_indicator_negative/
+      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+    end
+
+    it "omits the negative bar if all volunteers have a contact within 14 days" do
+      supervisor = create(:supervisor)
+      create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)
+
+      assign :supervisors, [supervisor]
+      render template: "supervisors/index"
+
+      expect(rendered).to match /supervisor_indicator_positive/
+      expect(rendered).not_to match /supervisor_indicator_negative$/
+      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+    end
   end
 
   context "when logged in as a supervisor" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2415

### What changed, and why?
The three columns representing total volunteers, volunteers without contact in 14 days, and transition aged youth have been replaced with a bar showing how many active and non-attempt volunteers, per the issue.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
`spec/views/supervisors/index.html.erb_spec.rb`


### Screenshots please :)
![image](https://user-images.githubusercontent.com/4956537/140656088-a22349b7-f15c-4b56-b994-fe07fc0a7dc1.png)
