### PR TITLE
Add json response for all_casa_admins_controller

### DIFF
--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -15,12 +15,26 @@ class AllCasaAdminsController < ApplicationController
   def create
     service = ::CreateAllCasaAdminService.new(params, current_user)
     @all_casa_admin = service.build
+
     begin
       service.create!
-      redirect_to authenticated_all_casa_admin_root_path,
-        notice: "New All CASA admin created successfully"
+
+      respond_to do |format|
+        format.html do
+          redirect_to authenticated_all_casa_admin_root_path,
+            notice: "New All CASA admin created successfully"
+        end
+
+        format.json { render json: @all_casa_admin, status: :created }
+      end
     rescue ActiveRecord::RecordInvalid
-      render :new
+      respond_to do |format|
+        format.html { render :new }
+
+        format.json do
+          render json: @all_casa_admin.errors.full_messages, status: :unprocessable_entity
+        end
+      end
     end
   end
 
@@ -28,10 +42,19 @@ class AllCasaAdminsController < ApplicationController
     @user = current_all_casa_admin
 
     if @user.update(all_casa_admin_params)
-      flash[:success] = "Profile was successfully updated."
-      redirect_to edit_all_casa_admins_path
+      respond_to do |format|
+        format.html do
+          flash[:success] = "Profile was successfully updated."
+          redirect_to edit_all_casa_admins_path
+        end
+
+        format.json { render json: @user, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 
@@ -42,11 +65,21 @@ class AllCasaAdminsController < ApplicationController
       bypass_sign_in(@user)
 
       UserMailer.password_changed_reminder(@user).deliver
-      flash[:success] = "Password was successfully updated."
 
-      redirect_to edit_all_casa_admins_path
+      respond_to do |format|
+        format.html do
+          flash[:success] = "Password was successfully updated."
+
+          redirect_to edit_all_casa_admins_path
+        end
+
+        format.json { render json: "Password was successfully updated.", status: :ok }
+      end
     else
-      render "edit"
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "/all_casa_admins", type: :request do
           }
         end.to change(AllCasaAdmin, :count).by(1)
       end
+
+      it "also responds as json", :aggregate_failures do
+        post all_casa_admins_path(format: :json), params: {
+          all_casa_admin: {
+            email: "admin1@example.com"
+          }
+        }
+
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("admin1@example.com".to_json)
+      end
     end
 
     context "with invalid parameters" do
@@ -48,6 +60,18 @@ RSpec.describe "/all_casa_admins", type: :request do
         expect(response).to be_successful
         expect(response).to render_template "all_casa_admins/new"
       end
+
+      it "also responds as json", :aggregate_failures do
+        post all_casa_admins_path(format: :json), params: {
+          all_casa_admin: {
+            email: ""
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("Email can't be blank".to_json)
+      end
     end
   end
 
@@ -59,6 +83,15 @@ RSpec.describe "/all_casa_admins", type: :request do
 
         expect(admin.email).to eq "newemail@example.com"
       end
+
+      it "also responds as json", :aggregate_failures do
+        patch all_casa_admins_path(format: :json),
+          params: {all_casa_admin: {email: "newemail@example.com"}}
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("newemail@example.com".to_json)
+      end
     end
 
     context "with invalid parameters" do
@@ -68,6 +101,16 @@ RSpec.describe "/all_casa_admins", type: :request do
         expect(response).to have_http_status(:ok)
 
         expect(admin.email).to_not eq "newemail@example.com"
+      end
+
+      it "also responds as json", :aggregate_failures do
+        other_admin = create(:all_casa_admin)
+        patch all_casa_admins_path(format: :json),
+          params: {all_casa_admin: {email: other_admin.email}}
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("Email has already been taken".to_json)
       end
     end
   end
@@ -99,6 +142,14 @@ RSpec.describe "/all_casa_admins", type: :request do
 
         subject
       end
+
+      it "also responds as json", :aggregate_failures do
+        patch update_password_all_casa_admins_path(format: :json), params: params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("Password was successfully updated.")
+      end
     end
 
     context "with invalid parameters", :aggregate_failures do
@@ -126,6 +177,14 @@ RSpec.describe "/all_casa_admins", type: :request do
         expect(mailer).not_to receive(:deliver)
 
         subject
+      end
+
+      it "also responds as json", :aggregate_failures do
+        patch update_password_all_casa_admins_path(format: :json), params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eq("application/json; charset=utf-8")
+        expect(response.body).to match("Password confirmation doesn't match Password".to_json)
       end
     end
   end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.judge).to eq judge
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           post casa_cases_url(format: :json), params: {casa_case: valid_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -221,7 +221,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>Changed Hearing type</li><li>Changed Judge</li><li>2 Court orders added or updated</li></ul>")
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -236,7 +236,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to be_successful
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: invalid_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -322,7 +322,7 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_not_found
       end
 
-      it "also respond as json", :aggregate_failures do
+      it "also responds as json", :aggregate_failures do
         patch deactivate_casa_case_path(casa_case, format: :json), params: params
 
         expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -341,7 +341,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.active).to eq true
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch deactivate_casa_case_path(casa_case, format: :json), params: params
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -380,7 +380,7 @@ RSpec.describe "/casa_cases", type: :request do
         expect(response).to be_not_found
       end
 
-      it "also respond as json", :aggregate_failures do
+      it "also responds as json", :aggregate_failures do
         patch reactivate_casa_case_path(casa_case, format: :json), params: params
 
         expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -399,7 +399,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(casa_case.active).to eq false
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch reactivate_casa_case_path(casa_case, format: :json), params: params
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -468,7 +468,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -573,7 +573,7 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response).to redirect_to(edit_casa_case_path(casa_case))
         end
 
-        it "also respond as json", :aggregate_failures do
+        it "also responds as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: new_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")

--- a/spec/system/supervisors/index_spec.rb
+++ b/spec/system/supervisors/index_spec.rb
@@ -193,14 +193,14 @@ RSpec.describe "supervisors/index", type: :system do
         it "filters the supervisors correctly", :aggregate_failures do
           within(:css, ".supervisor-filters") do
             click_on "Status"
+            find(:css, ".active").set(false)
             find(:css, ".active").set(true)
             find(:css, ".inactive").set(false)
-            click_on "Status"
           end
 
           within("table#supervisors") do
-            expect(page).to have_content("Active Supervisor")
-            expect(page).not_to have_content("Inactive Supervisor")
+            expect(page).to have_text("Active Supervisor")
+            expect(page).not_to have_text("Inactive Supervisor")
           end
         end
       end


### PR DESCRIPTION
References: https://github.com/rubyforgood/casa/issues/2647

### What changed, and why?

Add JSON response for `all_casa_admins_controller` actions that hit the database, this way a mobile application can consume that controller as well.

Fix a `spec` of supervisors table filter, that was an intermittency

### How is this tested? (please write tests!) 💖💪

With `RSpec request specs