### PR TITLE
2917/standardize filter html

### DIFF
--- a/app/views/casa_cases/_filter.html.erb
+++ b/app/views/casa_cases/_filter.html.erb
@@ -7,16 +7,18 @@
           <%= t("common.status") %>
         </button>
         <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Active" checked>
-              <%= t("common.active") %>
-            </a>
-          </li>
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Inactive">
-              <%= t("common.inactive") %>
-            </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "status_option_active", "Active", true,
+                    class: "form-check-input",
+                    data: { value: "Active" } %>
+            <%= label_tag "status_option_active", t("common.active"), class: "form-check-label" %>
+          </div>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "status_option_inactive", "Inactive", false,
+                      class: "form-check-input",
+                      data: { value: "Inactive" } %>
+            <%= label_tag "status_option_inactive", t("common.inactive"), class: "form-check-label" %>
+          </div>
         </div>
       </div>
       <div class="dropdown pull-left mr-2">
@@ -24,15 +26,18 @@
           <%= t("casa_cases.shared.assigned_single") %>
         </button>
         <div class="dropdown-menu assigned-to-volunteer-options" aria-labelledby="dropdownMenuButton">
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>
-              <%= t("common.yes_text") %>
-            </a>
-          </li>
-          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>
-            <%= t("common.no_text") %>
-          </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "assigned_to_volunteer_option_yes", "Yes", true,
+                       class: "form-check-input",
+                       data: { value: "Yes" } %>
+            <%= label_tag "assigned_to_volunteer_option_yes", t("common.yes_text"), class: "form-check-label" %>
+          </div>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "assigned_to_volunteer_option_no", "No", true,
+                       class: "form-check-input",
+                       data: { value: "No" } %>
+            <%= label_tag "assigned_to_volunteer_option_no", t("common.no_text"), class: "form-check-label" %>
+          </div>
         </div>
       </div>
       <div class="dropdown pull-left mr-2">
@@ -40,15 +45,18 @@
           <%= t("casa_cases.shared.assigned_multiple") %>
         </button>
         <div class="dropdown-menu more-than-one-volunteer-options" aria-labelledby="dropdownMenuButton">
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>
-              <%= t("common.yes_text") %>
-            </a>
-          </li>
-          <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>
-            <%= t("common.no_text") %>
-          </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "more_than_one_volunteer_option_yes", "Yes", true,
+                       class: "form-check-input",
+                       data: { value: "Yes" } %>
+            <%= label_tag "more_than_one_volunteer_option_yes", t("common.yes_text"), class: "form-check-label" %>
+          </div>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "more_than_one_volunteer_option_no", "No", true,
+                       class: "form-check-input",
+                       data: { value: "No" } %>
+            <%= label_tag "more_than_one_volunteer_option_no", t("common.no_text"), class: "form-check-label" %>
+          </div>
         </div>
       </div>
       <div class="dropdown pull-left mr-2">
@@ -56,16 +64,18 @@
           <%= t("casa_cases.shared.assigned_transition_aged_youth") %>
         </button>
         <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1">
-              <input type="checkbox" data-value="Yes 🦋" checked><%= t("common.yes_text") %>
-            </a>
-          </li>
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No 🐛" checked>
-              <%= t("common.no_text") %>
-            </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "transition_youth_option_yes", "Yes 🦋", true,
+                       class: "form-check-input",
+                       data: { value: "Yes 🦋" } %>
+            <%= label_tag "transition_youth_option_yes", t("common.yes_text"), class: "form-check-label" %>
+          </div>
+          <div class="dropdown-item form-check">
+            <%= check_box_tag "transition_youth_option_no", "No", true,
+                       class: "form-check-input",
+                       data: { value: "No 🐛" } %>
+            <%= label_tag "transition_youth_option_no", t("common.no_text"), class: "form-check-label" %>
+          </div>
         </div>
       </div>
       <div class="dropdown pull-left mr-2">
@@ -76,11 +86,14 @@
         <% end %>
         <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
           <% t("casa_cases.shared.prefix_options").each do |_, option| %>
-            <li>
-              <a class="small" data-value="option1" tabIndex="-1">
-                <input type="checkbox" data-value="<%= option %>" checked><%= option %>
-              </a>
-            </li>
+            <div class="dropdown-item form-check">
+              <% option_for_name = option.downcase.gsub(/[^a-z]+/, '') -%>
+              <% tag_name = "case_case_prefix_option_#{option_for_name}" -%>
+              <%= check_box_tag tag_name, option, true,
+                         class: "form-check-input",
+                         data: { value: option} %>
+              <%= label_tag tag_name, option, class: "form-check-label" %>
+            </div>
           <% end %>
         </div>
       </div>

--- a/app/views/casa_cases/_filter_my_cases.html.erb
+++ b/app/views/casa_cases/_filter_my_cases.html.erb
@@ -6,16 +6,18 @@
         <%= t("common.status") %>
       </button>
       <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Active" checked>
-            <%= t("common.active") %>
-          </a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Inactive">
-            <%= t("common.inactive") %>
-          </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "status_option_active", "Active", true,
+                    class: "form-check-input",
+                    data: { value: "Active" } %>
+          <%= label_tag "status_option_active", t("common.active"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "status_option_inactive", "Inactive", false,
+                    class: "form-check-input",
+                    data: { value: "Inactive" } %>
+          <%= label_tag "status_option_inactive", t("common.inactive"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
@@ -23,14 +25,18 @@
         <%= t("casa_cases.shared.assigned_single") %>
       </button>
       <div class="dropdown-menu assigned-to-volunteer-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>
-          <%= t("common.yes_text") %>
-        </a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>
-          <%= t("common.no_text") %>
-        </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "assigned_to_volunteer_option_yes", "Yes", true,
+                    class: "form-check-input",
+                    data: { value: "Yes" } %>
+          <%= label_tag "assigned_to_volunteer_option_yes", t("common.yes_text"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "assigned_to_volunteer_option_no", "No", true,
+                    class: "form-check-input",
+                    data: { value: "No" } %>
+          <%= label_tag "assigned_to_volunteer_option_no", t("common.no_text"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
@@ -38,14 +44,18 @@
         <%= t("casa_cases.shared.assigned_multiple") %>
       </button>
       <div class="dropdown-menu more-than-one-volunteer-options" aria-labelledby="dropdownMenuButton">
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes" checked>
-          <%= t("common.yes_text") %>
-        </a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No" checked>
-          <%= t("common.no_text") %>
-        </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "more_than_one_volunteer_option_yes", "Yes", true,
+                     class: "form-check-input",
+                     data: { value: "Yes" } %>
+          <%= label_tag "more_than_one_volunteer_option_yes", t("common.yes_text"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "more_than_one_volunteer_option_no", "No", true,
+                     class: "form-check-input",
+                     data: { value: "No" } %>
+          <%= label_tag "more_than_one_volunteer_option_no", t("common.no_text"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
@@ -53,15 +63,18 @@
         <%= t("casa_cases.shared.assigned_transition_aged_youth") %>
       </button>
       <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="Yes 🦋" checked>
-            <%= t("common.yes_text") %>
-          </a>
-        </li>
-        <li><a class="small" data-value="option1" tabIndex="-1"><input type="checkbox" data-value="No 🐛" checked>
-          <%= t("common.no_text") %>
-        </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "transition_youth_option_yes", "Yes 🦋", true,
+                     class: "form-check-input",
+                     data: { value: "Yes 🦋" } %>
+          <%= label_tag "transition_youth_option_yes", t("common.yes_text"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "transition_youth_option_no", "No", true,
+                     class: "form-check-input",
+                     data: { value: "No 🐛" } %>
+          <%= label_tag "transition_youth_option_no", t("common.no_text"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
@@ -72,11 +85,14 @@
       <% end %>
       <div class="dropdown-menu case-number-prefix-options" aria-labelledby="dropdownMenuButton">
         <% t("casa_cases.shared.prefix_options").each do |_, option| %>
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1">
-              <input type="checkbox" data-value="<%= option %>" checked><%= option %>
-            </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <% option_for_name = option.downcase.gsub(/[^a-z]+/, '') -%>
+            <% tag_name = "case_case_prefix_option_#{option_for_name}" -%>
+            <%= check_box_tag tag_name, option, true,
+                       class: "form-check-input",
+                       data: { value: option} %>
+            <%= label_tag tag_name, option, class: "form-check-label" %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -30,13 +30,13 @@
           <%= check_box_tag "status_option_active", "true", true,
                     class: "active form-check-input",
                     data: { value: "true" } %>
-          <%= label_tag "status_option_active", t(".active") %>
+          <%= label_tag "status_option_active", t(".active"), class: "form-check-label" %>
         </div>
         <div class="dropdown-item form-check">
           <%= check_box_tag "status_option_inactive", "false", false,
                     class: "inactive form-check-input",
                     data: { value: "false" } %>
-          <%= label_tag "status_option_inactive", t(".inactive") %>
+          <%= label_tag "status_option_inactive", t(".inactive"), class: "form-check-label" %>
         </div>
       </div>
     </div>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -18,7 +18,7 @@
       <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <%= t(".supervisor") %>
       </button>
-      <ul class="dropdown-menu supervisor-options">
+      <div class="dropdown-menu supervisor-options">
         <div class="dropdown-item form-check">
           <%= check_box_tag "supervisor-option-none", "", false,
                     class: "form-check-input",
@@ -37,7 +37,7 @@
             <%= label_tag tag_name, supervisor.display_name, class: "form-check-label" %>
           </div>
         <% end %>
-      </ul>
+      </div>
     </div>
     <div class="dropdown pull-left mr-2">
       <button class="btn btn-secondary dropdown-toggle show" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -19,32 +19,23 @@
         <%= t(".supervisor") %>
       </button>
       <ul class="dropdown-menu supervisor-options">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input
-              id="unassigned-vol-filter"
-              type="checkbox"
-              data-value=""
-              unchecked>
-              <%= t(".no_supervisor") %>
-          </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "supervisor-option-none", "", false,
+                    class: "form-check-input",
+                    data: { value: "" },
+                    id: "unassigned-vol-filter" %>
+          <%= label_tag "supervisor-option-none", t(".no_supervisor"), class: "form-check-label" %>
+        </div>
         <% current_organization.supervisors.where(active: true).each do |supervisor| %>
-          <li>
-            <a class="small" data-value="option1" tabIndex="-1">
-              <% if policy(User).edit_name?(supervisor) %>
-                <input
-                  type="checkbox"
-                  data-value="<%= supervisor.display_name %>"
-                  checked>
-              <% else %>
-                <input
-                  type="checkbox"
-                  data-value="<%= supervisor.display_name %>">
-              <% end %>
-              <%= supervisor.display_name %>
-            </a>
-          </li>
+          <div class="dropdown-item form-check">
+            <% option_for_name = supervisor.display_name.downcase.gsub(/ /, '_').gsub(/[^a-z_]+/, '') -%>
+            <% tag_name = "supervisor-option-#{option_for_name}" -%>
+            <%= check_box_tag tag_name, supervisor.display_name,
+                    policy(User).edit_name?(supervisor),   # checked?
+                    class: "form-check-input",
+                    data: { value: supervisor.display_name } %>
+            <%= label_tag tag_name, supervisor.display_name, class: "form-check-label" %>
+          </div>
         <% end %>
       </ul>
     </div>
@@ -53,18 +44,18 @@
         <%= t(".status") %>
       </button>
       <div class="dropdown-menu status-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="true" checked>
-            <%= t(".active") %>
-          </a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="false">
-            <%= t(".inactive") %>
-          </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "status_option_active", "true", true,
+                    class: "form-check-input",
+                    data: { value: "true" } %>
+          <%= label_tag "status_option_active", t(".active"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "status_option_inactive", "false", false,
+                    class: "form-check-input",
+                    data: { value: "false" } %>
+          <%= label_tag "status_option_inactive", t(".inactive"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
     <div class="dropdown pull-left mr-2">
@@ -72,16 +63,18 @@
       <%= t(".transition_aged_youth") %>
       </button>
       <div class="dropdown-menu transition-youth-options" aria-labelledby="dropdownMenuButton">
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="true" checked><%= t(".yes") %>
-          </a>
-        </li>
-        <li>
-          <a class="small" data-value="option1" tabIndex="-1">
-            <input type="checkbox" data-value="false" checked><%= t(".no") %>
-          </a>
-        </li>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "transition_youth_option_yes", "true", true,
+                    class: "form-check-input",
+                    data: { value: "true" } %>
+          <%= label_tag "transition_youth_option_yes", t(".yes"), class: "form-check-label" %>
+        </div>
+        <div class="dropdown-item form-check">
+          <%= check_box_tag "transition_youth_option_no", "false", true,
+                    class: "form-check-input",
+                    data: { value: "false" } %>
+          <%= label_tag "transition_youth_option_no", t(".no"), class: "form-check-label" %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -470,14 +470,14 @@ en:
         status: Status
       inactive: Inactive
       no_supervisor: No supervisor assignment
-      "no": No
+      no: No
       pick_displayed_columns: Pick displayed columns
       select_columns: Select columns
       supervisor: Supervisor
       status: Status
       transition_aged_youth: Assigned to Transition Aged Youth
       volunteers: Volunteers
-      "yes": Yes
+      yes: Yes
     send_reminder_button:
       admin_checkbox_text: Send CC to Supervisor and Admin
       send_reminder: Send Reminder


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2917

### What changed, and why?
This change fixes the HTML in all filter dropdown checkboxes.  They are
now standard HTML and styled with standard Bootstrap 4 checkbox/label
styling.

### How is this tested? (please write tests!) 💖💪
Standard tests pass.  Functionality should be identical.

As a followup, we may want to restyle the labels that appear in filter dropdowns to get rid of bold text.