### PR TITLE
fix weird t.string `"{:null=>false}"` bug

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -346,8 +346,7 @@ ActiveRecord::Schema.define(version: 2021_10_29_033530) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"


### PR DESCRIPTION
Seems to have fixed itself when running migrations locally.
Hopefully it doesn't go back to the other way.

### What github issue is this PR for, if any?
No official issue, but here's the issue that was opened up on paper trail for the weirdness:
https://github.com/paper-trail-gem/paper_trail/issues/1347

