### PR TITLE
Add ReimbursementPolicy and apply it to ReimbursementsController

### DIFF
--- a/app/controllers/reimbursements_controller.rb
+++ b/app/controllers/reimbursements_controller.rb
@@ -3,6 +3,8 @@ class ReimbursementsController < ApplicationController
   end
 
   def index
+    authorize :reimbursement
+
     @complete_status = params[:status] == "complete"
     @reimbursements = policy_scope(CaseContact)
       .want_driving_reimbursement(true)
@@ -11,6 +13,8 @@ class ReimbursementsController < ApplicationController
   end
 
   def change_complete_status
+    authorize :reimbursement
+
     @case_contact = policy_scope(CaseContact).find(params[:reimbursement_id])
     @case_contact.update(reimbursement_params)
     @case_contact.save!(validate: false)

--- a/app/policies/reimbursement_policy.rb
+++ b/app/policies/reimbursement_policy.rb
@@ -1,0 +1,9 @@
+class ReimbursementPolicy < ApplicationPolicy
+  def index?
+    is_admin?
+  end
+
+  def change_complete_status?
+    index?
+  end
+end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -45,7 +45,7 @@
           <% if policy(:application).see_court_reports_page? %>
             <%= link_to t(".link.generate_court_reports"), case_court_reports_path, class: "list-group-item" %>
           <% end %>
-          <% if policy(:application).is_admin? %>
+          <% if policy(:reimbursement).index? %>
             <%= link_to t(".link.reimbursement_queue"), reimbursements_path, class: "list-group-item" %>
           <% end %>
           <% if policy(:application).see_reports_page? %>

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe ReimbursementPolicy do
+  subject { described_class }
+
+  let(:casa_admin) { build_stubbed(:casa_admin) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+  let(:supervisor) { build_stubbed(:supervisor) }
+
+  permissions :index?, :change_complete_status? do
+    it { is_expected.to permit(casa_admin) }
+    it { is_expected.to_not permit(supervisor) }
+    it { is_expected.to_not permit(volunteer) }
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/casa/issues/2938

### What changed, and why?

Add ReimbursementPolicy, and apply it to `reimbursements_controller`. To improve the user's permissions.

### How will this affect user permissions?
- Volunteer permissions: won't be able to access `/reimbursements` anymore
- Supervisor permissions: won't be able to access `/reimbursements` anymore
- Admin permissions: -

### How is this tested? (please write tests!) 💖💪

Unit test for policy class, and trying to access the page with volunteers and supervisors.

### Screenshots please :)

![image](https://user-images.githubusercontent.com/47258878/141701149-4e6f3566-61db-420a-a1f2-5e210ecdebef.png)
