### PR TITLE
Increase minimum password length

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ Login Emails:
 - supervisor1@example.com view site as a supervisor
 - casa_admin1@example.com view site as an admin
 
-password for all users: 123456  
+password for all users: 12345678  
 
 ### Questions? Join Slack!
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,7 @@ Login Emails:
 - supervisor1@example.com view site as a supervisor
 - casa_admin1@example.com view site as an admin
 
-password for all users: 123456  
+password for all users: 12345678  
 
 ### Questions? Join Slack!
 

--- a/app/javascript/__tests__/password_confirmation.test.js
+++ b/app/javascript/__tests__/password_confirmation.test.js
@@ -34,22 +34,22 @@ describe('ensure the password field matches the confirmation field on the client
   }
 
   test('password fields match', () => {
-    passwordField.value = '123456'
-    confirmationField.value = '123456'
+    passwordField.value = '12345678'
+    confirmationField.value = '12345678'
     checkPasswordsAndDisplayPopup(submitButton, passwordField, confirmationField)
     expect(isDisabled(submitButton)).toBe(false)
     expect(document.getElementsByClassName('swal2-container').length).toBe(0)
   })
 
   test("password fields don't match", () => {
-    passwordField.value = '123456'
+    passwordField.value = '12345678'
     confirmationField.value = 'bad'
     checkPasswordsAndDisplayPopup(submitButton, passwordField, confirmationField, true)
     expect(document.getElementsByClassName('swal2-container').length).toBe(1)
   })
 
   test("password fields don't match and pop-up suppressed", () => {
-    passwordField.value = '123456'
+    passwordField.value = '12345678'
     confirmationField.value = 'bad'
     checkPasswordsAndDisplayPopup(submitButton, passwordField, confirmationField)
     expect(document.getElementsByClassName('swal2-container').length).toBe(0)

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -8,12 +8,6 @@
         <%= f.hidden_field :reset_password_token %>
 
         <div class="field form-group">
-          <%= f.label :current_password, "Current password" %><br>
-          <%= f.password_field :current_password, autofocus: true, autocomplete: "current-password",
-class: "form-control", required: true %>
-        </div>
-
-        <div class="field form-group">
           <%= f.label :password, "New password" %><br>
           <% if @minimum_password_length %>
             <em>(<%= @minimum_password_length %> characters minimum)</em><br>
@@ -23,7 +17,7 @@ class: "form-control", required: true %>
             autocomplete: "new-password",
             class: "form-control password-new",
             required: true,
-            minlength: 6 %>
+            minlength: @minimum_password_length %>
         </div>
 
         <div class="field form-group">
@@ -32,7 +26,7 @@ class: "form-control", required: true %>
             autocomplete: "new-password",
             class: "form-control password-confirmation",
             required: true,
-            minlength: 6 %>
+            minlength: @minimum_password_length %>
         </div>
 
         <div class="actions">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -49,11 +49,13 @@
         </div>
         <div class="field form-group">
           <%= f.label :password, "New Password" %><br>
-          <%= f.password_field :password, autocomplete: "off", class: "form-control password-new", minlength: User.password_length.min %>
+          <%= f.password_field :password, autocomplete: "off", class: "form-control password-new",
+minlength: User.password_length.min %>
         </div>
         <div class="field form-group">
           <%= f.label :password_confirmation, "New Password Confirmation" %><br>
-          <%= f.password_field :password_confirmation, class: "form-control password-confirmation", minlength: User.password_length.min %>
+          <%= f.password_field :password_confirmation, class: "form-control password-confirmation",
+minlength: User.password_length.min %>
         </div>
         <div class="action_container">
           <%= f.submit "Update Password", class: "btn btn-danger submit-password" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -49,11 +49,11 @@
         </div>
         <div class="field form-group">
           <%= f.label :password, "New Password" %><br>
-          <%= f.password_field :password, autocomplete: "off", class: "form-control password-new", minlength: 6 %>
+          <%= f.password_field :password, autocomplete: "off", class: "form-control password-new", minlength: User.password_length.min %>
         </div>
         <div class="field form-group">
           <%= f.label :password_confirmation, "New Password Confirmation" %><br>
-          <%= f.password_field :password_confirmation, class: "form-control password-confirmation", minlength: 6 %>
+          <%= f.password_field :password_confirmation, class: "form-control password-confirmation", minlength: User.password_length.min %>
         </div>
         <div class="action_container">
           <%= f.submit "Update Password", class: "btn btn-danger submit-password" %>

--- a/bin/login
+++ b/bin/login
@@ -69,7 +69,7 @@ class LoginExecutor
   def visit_and_log_in(user)
     visit user.url
     fill_in "Email", with: user.email
-    fill_in "Password", with: "123456"
+    fill_in "Password", with: "12345678"
     click_on "Log in"
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -215,7 +215,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/cypress/integration/volunteer/edit_profile.spec.js
+++ b/cypress/integration/volunteer/edit_profile.spec.js
@@ -10,9 +10,9 @@ context.skip("Logging into cypress as a volunteer", () => {
     cy.contains("Change Password").click();
     cy.contains("Current Password").should("exist");
     cy.contains("New Password").should("exist");
-    cy.get(".password-new").type("123456")
+    cy.get(".password-new").type("12345678")
     cy.contains("New Password Confirmation").should("exist");
-    cy.get(".password-confirmation").type("123456")
+    cy.get(".password-confirmation").type("12345678")
     cy.contains("Update Profile").click();
     cy.contains("Profile was successfully updated.").should("exist");
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,12 +25,12 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 Cypress.Commands.add('loginAsVolunteer', () => {
   cy.get('#user_email').type('volunteer2@example.com')
-  cy.get('#user_password').type('123456')
+  cy.get('#user_password').type('12345678')
   cy.get('.actions > .btn').click()
 })
 
 Cypress.Commands.add('loginAsVolunteerProgrammatically', () => {
   cy.get('#user_email').type('volunteer1@example.com')
-  cy.get('#user_password').type('123456')
+  cy.get('#user_password').type('12345678')
   cy.get('.actions > .btn').click()
 })

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -4,7 +4,7 @@
 # Email addresses generated will be globally unique across all orgs.
 
 class DbPopulator
-  SEED_PASSWORD = "123456"
+  SEED_PASSWORD = "12345678"
   WORD_LENGTH_TUNING = 10
   LINE_BREAK_TUNING = 5
   PREFIX_OPTIONS = ("A".ord.."Z".ord).to_a.map(&:chr)

--- a/spec/factories/all_casa_admin.rb
+++ b/spec/factories/all_casa_admin.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :all_casa_admin, class: "AllCasaAdmin" do
     sequence(:email) { |n| "email#{n}@example.com" }
-    password { "123456" }
-    password_confirmation { "123456" }
+    password { "12345678" }
+    password_confirmation { "12345678" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:email) { |n| "email#{n}@example.com" }
     sequence(:display_name) { |n| "User #{n}" }
-    password { "123456" }
-    password_confirmation { "123456" }
+    password { "12345678" }
+    password_confirmation { "12345678" }
     case_assignments { [] }
 
     trait :inactive do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "/users", type: :request do
       patch update_password_users_path(user),
         params: {
           user: {
-            current_password: "123456",
+            current_password: "12345678",
             password: "new_pass",
             password_confirmation: "new_pass"
           }

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "all_casa_admin_edit_spec", type: :system do
     it "notifies password changed by email", :aggregate_failures do
       click_on "Change Password"
 
-      fill_in "Password", with: "1234567"
-      fill_in "Password Confirmation", with: "1234567"
+      fill_in "Password", with: "12345678"
+      fill_in "Password Confirmation", with: "12345678"
 
       click_on "Update Password"
 

--- a/spec/system/all_casa_admins/sessions/new_spec.rb
+++ b/spec/system/all_casa_admins/sessions/new_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "all_casa_admins/sessions/new", type: :system do
       visit "/all_casa_admins/sign_in"
 
       fill_in "Email", with: all_casa_admin.email
-      fill_in "Password", with: "123456"
+      fill_in "Password", with: "12345678"
       within ".actions" do
         click_on "Log in"
       end
@@ -43,7 +43,7 @@ RSpec.describe "all_casa_admins/sessions/new", type: :system do
       visit "/all_casa_admins/sign_in"
 
       fill_in "Email", with: volunteer.email
-      fill_in "Password", with: "123456"
+      fill_in "Password", with: "12345678"
       within ".actions" do
         click_on "Log in"
       end

--- a/spec/system/sessions/new_spec.rb
+++ b/spec/system/sessions/new_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "sessions/new", type: :system do
         expect(page).to_not have_text "sign in before continuing"
 
         fill_in "Email", with: user.email
-        fill_in "Password", with: "123456"
+        fill_in "Password", with: "12345678"
         within ".actions" do
           click_on "Log in"
         end
@@ -40,7 +40,7 @@ RSpec.describe "sessions/new", type: :system do
       expect(page).to_not have_text "sign in before continuing"
 
       fill_in "Email", with: user.email
-      fill_in "Password", with: "123456"
+      fill_in "Password", with: "12345678"
       within ".actions" do
         click_on "Log in"
       end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "users/edit", type: :system do
       click_on "Change Password"
 
       fill_in "Current Password", with: "12345"
-      fill_in "New Password", with: "1234567"
-      fill_in "New Password Confirmation", with: "1234567"
+      fill_in "New Password", with: "123456789"
+      fill_in "New Password Confirmation", with: "123456789"
 
       click_on "Update Password"
       expect(page).to have_content "1 error prohibited this password change from being saved:"
@@ -33,22 +33,22 @@ RSpec.describe "users/edit", type: :system do
     it "displays password errors messages when user is unable to set a password" do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123"
       fill_in "New Password Confirmation", with: "1234"
 
       click_on "Update Password"
       expect(page).to have_content "2 errors prohibited this password change from being saved:"
       expect(page).to have_text("Password confirmation doesn't match Password")
-      expect(page).to have_text("Password is too short (minimum is 6 characters)")
+      expect(page).to have_text("Password is too short (minimum is #{User.password_length.min} characters)")
     end
 
     it "notifies a user when they update their password" do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
-      fill_in "New Password", with: "1234567"
-      fill_in "New Password Confirmation", with: "1234567"
+      fill_in "Current Password", with: "12345678"
+      fill_in "New Password", with: "123456789"
+      fill_in "New Password Confirmation", with: "123456789"
 
       click_on "Update Password"
 
@@ -58,9 +58,9 @@ RSpec.describe "users/edit", type: :system do
     it "notifies password changed by email", :aggregate_failures do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
-      fill_in "New Password", with: "1234567"
-      fill_in "Password Confirmation", with: "1234567"
+      fill_in "Current Password", with: "12345678"
+      fill_in "New Password", with: "123456789"
+      fill_in "Password Confirmation", with: "123456789"
 
       click_on "Update Password"
 
@@ -93,9 +93,9 @@ RSpec.describe "users/edit", type: :system do
     it "notifies password changed by email", :aggregate_failures do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
-      fill_in "New Password", with: "1234567"
-      fill_in "Password Confirmation", with: "1234567"
+      fill_in "Current Password", with: "12345678"
+      fill_in "New Password", with: "123456789"
+      fill_in "Password Confirmation", with: "123456789"
 
       click_on "Update Password"
 
@@ -136,22 +136,22 @@ RSpec.describe "users/edit", type: :system do
     it "displays password errors messages when admin is unable to set a password" do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123"
       fill_in "Password Confirmation", with: "1234"
 
       click_on "Update Password"
       expect(page).to have_content "2 errors prohibited this password change from being saved:"
       expect(page).to have_text("Password confirmation doesn't match Password")
-      expect(page).to have_text("Password is too short (minimum is 6 characters)")
+      expect(page).to have_text("Password is too short (minimum is #{User.password_length.min} characters)")
     end
 
     it "display success message when admin update password" do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
-      fill_in "New Password", with: "1234567"
-      fill_in "Password Confirmation", with: "1234567"
+      fill_in "Current Password", with: "12345678"
+      fill_in "New Password", with: "123456789"
+      fill_in "Password Confirmation", with: "123456789"
 
       click_on "Update Password"
 
@@ -161,9 +161,9 @@ RSpec.describe "users/edit", type: :system do
     it "notifies password changed by email", :aggregate_failures do
       click_on "Change Password"
 
-      fill_in "Current Password", with: "123456"
-      fill_in "New Password", with: "1234567"
-      fill_in "Password Confirmation", with: "1234567"
+      fill_in "Current Password", with: "12345678"
+      fill_in "New Password", with: "123456789"
+      fill_in "Password Confirmation", with: "123456789"
 
       click_on "Update Password"
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2950
Resolves #2951

### What changed, and why?
The minimum password length is now 8 #2950. This change will not affect current users with passwords smaller than 8 characters since their hashes were already created, it will only validate new users and password updates. I've also updated the seeds to have users with the password: "12345678". The password "minlength" HTML properties are no longer hardcoded. The "current password" field has been removed from the password restoration form #2951.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Rails, JavaScript, and Cypress tests have been updated to validate the new password length, so I had to change many different files.
