### PR TITLE
Add ReimbursementPolicy::Scope class and apply it to ReimbursementsController

### DIFF
--- a/app/controllers/reimbursements_controller.rb
+++ b/app/controllers/reimbursements_controller.rb
@@ -6,7 +6,8 @@ class ReimbursementsController < ApplicationController
     authorize :reimbursement
 
     @complete_status = params[:status] == "complete"
-    @reimbursements = policy_scope(CaseContact)
+
+    @reimbursements = fetch_reimbursements
       .want_driving_reimbursement(true)
       .created_max_ago(1.year.ago)
       .filter_by_reimbursement_status(@complete_status)
@@ -15,7 +16,7 @@ class ReimbursementsController < ApplicationController
   def change_complete_status
     authorize :reimbursement
 
-    @case_contact = policy_scope(CaseContact).find(params[:reimbursement_id])
+    @case_contact = fetch_reimbursements.find(params[:reimbursement_id])
     @case_contact.update(reimbursement_params)
     @case_contact.save!(validate: false)
     redirect_to reimbursements_path
@@ -25,5 +26,9 @@ class ReimbursementsController < ApplicationController
 
   def reimbursement_params
     params.require(:case_contact).permit(:reimbursement_complete, :reimbursement_id)
+  end
+
+  def fetch_reimbursements
+    policy_scope(CaseContact.joins(:casa_case), policy_scope_class: ReimbursementPolicy::Scope)
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,4 +1,17 @@
 class ApplicationPolicy
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError
+    end
+  end
+
   attr_reader :user, :record
 
   def initialize(user, record)

--- a/app/policies/reimbursement_policy.rb
+++ b/app/policies/reimbursement_policy.rb
@@ -1,4 +1,11 @@
 class ReimbursementPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      # scope must INNER JOIN casa_case
+      scope.where(casa_case: {casa_org_id: user.casa_org.id})
+    end
+  end
+
   def index?
     is_admin?
   end

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe ReimbursementPolicy do
     it { is_expected.to_not permit(supervisor) }
     it { is_expected.to_not permit(volunteer) }
   end
+
+  describe "ReimbursementPolicy::Scope #resolve" do
+    subject { described_class::Scope.new(user, scope).resolve }
+
+    let(:user) { build_stubbed(:casa_admin, casa_org: casa_org1) }
+    let(:scope) { CaseContact.joins(:casa_case) }
+    let(:casa_org1) { create(:casa_org) }
+    let(:casa_case1) { create(:casa_case, casa_org: casa_org1) }
+    let(:casa_case2) { create(:casa_case, casa_org: create(:casa_org)) }
+
+    let!(:contact1) { create(:case_contact, casa_case: casa_case1) }
+    let!(:contact2) { create(:case_contact, casa_case: casa_case2) }
+
+    it { is_expected.to include(contact1) }
+    it { is_expected.not_to include(contact2) }
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/2880

### What changed, and why?

Add `ReimbursementPolicy::Scope` class, to make it easy to filter reimbursements among admins.

### How will this affect user permissions?
- Admin permissions: Only will be able to see reimbursements from their `casa_org`

### How is this tested? (please write tests!) 💖💪

Unit tests for the class, verify if this class is called in `ReimbursementsController`, and locally browsing to the pages.

### Screenshots please :)

Admin and reimbursements from casa_org1:
![image](https://user-images.githubusercontent.com/47258878/142226505-4fcb8843-62f1-416e-8b7f-27c8e9ff73ac.png)

Admin and reimbursements from casa_org2:
![image](https://user-images.githubusercontent.com/47258878/142226627-ad502c93-68fe-4f89-b2e4-41a3f6f853cd.png)
