### PR TITLE
Add casa admin endpoints as json

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -30,11 +30,19 @@ class CasaAdminsController < ApplicationController
     service = ::CreateCasaAdminService.new(current_organization, params, current_user)
     @casa_admin = service.build
     authorize @casa_admin
+
     begin
       service.create!
-      redirect_to casa_admins_path, notice: "New admin created successfully"
+
+      respond_to do |format|
+        format.html { redirect_to casa_admins_path, notice: "New admin created successfully" }
+        format.json { render json: @casa_admin, status: :created }
+      end
     rescue ActiveRecord::RecordInvalid
-      render new_casa_admin_path
+      respond_to do |format|
+        format.html { render :new }
+        format.json { render json: service.casa_admin.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -55,12 +55,23 @@ class CasaAdminsController < ApplicationController
 
   def activate
     authorize @casa_admin
+
     if @casa_admin.activate
       CasaAdminMailer.account_setup(@casa_admin).deliver
 
-      redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was activated. They have been sent an email."
+      respond_to do |format|
+        format.html do
+          redirect_to edit_casa_admin_path(@casa_admin),
+            notice: "Admin was activated. They have been sent an email."
+        end
+
+        format.json { render json: @casa_admin, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   rescue Errno::ECONNREFUSED => error
     redirect_to_casa_admin_edition_page(error)

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -82,9 +82,15 @@ class CasaAdminsController < ApplicationController
     if @casa_admin.deactivate
       CasaAdminMailer.deactivation(@casa_admin).deliver
 
-      redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was deactivated."
+      respond_to do |format|
+        format.html { redirect_to edit_casa_admin_path(@casa_admin), notice: "Admin was deactivated." }
+        format.json { render json: @casa_admin, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   rescue Errno::ECONNREFUSED => error
     redirect_to_casa_admin_edition_page(error)

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -14,10 +14,17 @@ class CasaAdminsController < ApplicationController
 
   def update
     authorize @casa_admin
+
     if @casa_admin.update(update_casa_admin_params)
-      redirect_to casa_admins_path, notice: "New admin created successfully"
+      respond_to do |format|
+        format.html { redirect_to casa_admins_path, notice: "New admin created successfully" }
+        format.json { render json: @casa_admin, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/services/create_casa_admin_service.rb
+++ b/app/services/create_casa_admin_service.rb
@@ -1,4 +1,6 @@
 class CreateCasaAdminService
+  attr_reader :casa_admin
+
   def initialize(current_organization, params, current_user)
     @current_organization = current_organization
     @params = params
@@ -10,6 +12,7 @@ class CreateCasaAdminService
       .with_password(SecureRandom.hex(10))
       .with_organization(@current_organization)
       .without(:active, :type)
+
     @casa_admin = CasaAdmin.new(processed_params)
   end
 


### PR DESCRIPTION
References https://github.com/rubyforgood/casa/issues/2647

### What changed, and why?

Add JSON response for `casa_admins_controller` actions that hit the database, this way a mobile application can consume that controller as well.

### How is this tested? (please write tests!) 💖💪

With RSpec requests