### PR TITLE
Don't show deactivated supervisors in Edit Volunteer dropdown for assigning supervisors

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -33,7 +33,7 @@ class VolunteersController < ApplicationController
 
   def edit
     authorize @volunteer
-    @supervisors = policy_scope current_organization.supervisors
+    @supervisors = policy_scope current_organization.supervisors.active
   end
 
   def update

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -96,13 +96,16 @@ RSpec.describe "volunteers/edit", type: :system do
     expect(page).to have_content("Bolu Bolu was unassigned from Haka Haka")
   end
 
-  it "shows the admin the option to assign an unassigned volunteer to a different supervisor" do
-    volunteer = create(:volunteer)
+  it "shows the admin the option to assign an unassigned volunteer to a different active supervisor" do
+    volunteer = create(:volunteer, casa_org: organization)
+    deactivated_supervisor = create(:supervisor, active: false, casa_org: organization, display_name: "Inactive Supervisor")
+    active_supervisor = create(:supervisor, active: true, casa_org: organization, display_name: "Active Supervisor")
 
     sign_in admin
 
     visit edit_volunteer_path(volunteer)
-
+    expect(page).not_to have_select("supervisor_volunteer[supervisor_id]", with_options: [deactivated_supervisor.display_name])
+    expect(page).to have_select("supervisor_volunteer[supervisor_id]", options: [active_supervisor.display_name])
     expect(page).to have_content("Select a Supervisor")
     expect(page).to have_content("Assign a Supervisor")
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
none sorry but check out slack https://rubyforgood.slack.com/archives/CVB0QJGVD/p1638999026235400?thread_ts=1638996627.227400&cid=CVB0QJGVD

### What changed, and why?
Don't show deactivated supervisors in Edit Volunteer dropdown for assigning supervisors

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
rspec

### Screenshots please :)
![Screen Shot 2021-12-08 at 8 19 00 PM](https://user-images.githubusercontent.com/578159/145333782-8004711f-e366-4c76-9f41-6116bb7ba201.png)
![Screen Shot 2021-12-08 at 8 18 47 PM](https://user-images.githubusercontent.com/578159/145333784-8958c574-6986-4ddd-984b-31a390e5462b.png)
![Screen Shot 2021-12-08 at 8 18 34 PM](https://user-images.githubusercontent.com/578159/145333786-0f6f0edf-6b1d-488d-bad5-bb005ed65156.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9