### PR TITLE
Rescue from RecordNotFound and update 404 page styles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :route_not_found
 
   impersonates :user
 
@@ -36,5 +37,11 @@ class ApplicationController < ActionController::Base
   def not_authorized
     flash[:notice] = t("default", scope: "pundit")
     redirect_to(request.referrer || root_url)
+  end
+
+  def route_not_found
+    respond_to do |format|
+      format.html { render file: "#{Rails.root}/public/404", layout: false, status: :not_found }
+    end
   end
 end

--- a/public/404.html
+++ b/public/404.html
@@ -30,7 +30,7 @@
     .rails-default-error-page div.dialog {
       width: 95%;
       max-width: 33em;
-      margin: 15em auto;
+      margin: 10% auto;
     }
 
     .rails-default-error-page div.dialog > div {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2784 

### What changed, and why?
The following changes were made, as requested in the Issue:
- rescue from `ActiveRecord::RecordNotFound` to stop throwing an exception
- the error message container has been moved up on the screen, to make sure it doesn't get covered by the footer

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪


### Screenshots
<img width="754" alt="Screenshot 2021-12-10 at 12 38 01" src="https://user-images.githubusercontent.com/22390758/145575329-f8cce76c-210e-4ad2-94c4-50e8d5932b6a.png">

### Feedback
The password needs to be updated in tickets or any documentation. It's been changed for 123456 to 12345678