### PR TITLE
Add columns User Count and Case Contact Count to ALL Casa Admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ You'll probably hit a problem where ruby-version reads `ruby-2.7.2` but the inst
 
 ## Running the App / Verifying Installation
 1. `bin/rails server` or `bin/rails s` to start the local webserver
+   
+**Logging in with seed users**
+
+Login as a regular user at http://localhost:3000/users/sign_in. Some example seed users:
+- volunteer1@example.com  view site as a volunteer
+- supervisor1@example.com view site as a supervisor
+- casa_admin1@example.com view site as an admin
+
+Login as an all CASA admin at http://localhost:3000/all_casa_admins/sign_in. An example seed user:
+- allcasaadmin@example.com view site as an all CASA admin
+
+The password for all seed users is `12345678`
 
 **Running Tests**
  - run the ruby test suite `bin/rails spec`

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -34,6 +34,10 @@ class CasaOrg < ApplicationRecord
     )
   end
 
+  def case_contacts_count
+    case_contacts.count
+  end
+
   def org_logo
     if logo.attached?
       Rails.application.routes.url_helpers.rails_blob_path(logo, only_path: true)

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -50,6 +50,10 @@ class CasaOrg < ApplicationRecord
     end
   end
 
+  def user_count
+    users.count
+  end
+
   def set_slug
     self.slug = name.parameterize
   end

--- a/app/views/all_casa_admins/dashboard/show.html.erb
+++ b/app/views/all_casa_admins/dashboard/show.html.erb
@@ -13,6 +13,8 @@
       <tr>
         <th>Name</th>
         <th>Created At</th>
+        <th>User Count</th>
+        <th>Case Contact Count</th>
       </tr>
       </thead>
       <tbody>
@@ -20,6 +22,8 @@
         <tr>
           <td><%= link_to organization.name, all_casa_admins_casa_org_path(organization) %></td>
           <td><%= I18n.l(organization.created_at, format: :full, default: nil) %></td>
+          <td><%= organization.user_count %></td>
+          <td><%= organization.case_contacts_count %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/all_casa_admins/dashboard/show.html.erb
+++ b/app/views/all_casa_admins/dashboard/show.html.erb
@@ -8,14 +8,14 @@
 <div class="card card-container">
   <div class="card-body">
     <h2>CASA Organizations</h2>
-    <table class="table organization-list">
+    <table class="table organization-list" data-test="organization-table">
       <thead>
-      <tr>
-        <th>Name</th>
-        <th>Created At</th>
-        <th>User Count</th>
-        <th>Case Contact Count</th>
-      </tr>
+        <tr>
+          <th>Name</th>
+          <th>Created At</th>
+          <th>User Count</th>
+          <th>Case Contact Count</th>
+        </tr>
       </thead>
       <tbody>
       <% @organizations.each do |organization| %>

--- a/spec/models/casa_org_spec.rb
+++ b/spec/models/casa_org_spec.rb
@@ -37,4 +37,13 @@ RSpec.describe CasaOrg, type: :model do
       expect(org.slug).to eq "prince-george-casa"
     end
   end
+
+  describe "user_count" do
+    let(:org) { create(:casa_org) }
+    subject(:count) { org.user_count }
+    before do
+      2.times { create(:user, casa_org: org) }
+    end
+    it { is_expected.to eq 2 }
+  end
 end

--- a/spec/models/casa_org_spec.rb
+++ b/spec/models/casa_org_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe CasaOrg, type: :model do
     end
     it { is_expected.to eq 2 }
   end
+
+  describe "case_contacts_count" do
+    let(:org) { create(:casa_org) }
+    subject(:count) { org.case_contacts_count }
+    before do
+      5.times do
+        casa_case = create(:casa_case, casa_org: org)
+        3.times { create(:case_contact, casa_case: casa_case) }
+      end
+    end
+    it { is_expected.to eq 15 }
+  end
 end

--- a/spec/system/all_casa_admins/dashboard/show_spec.rb
+++ b/spec/system/all_casa_admins/dashboard/show_spec.rb
@@ -40,6 +40,29 @@ RSpec.describe "all_casa_admin/dashboard/show", type: :system do
       click_on "New CASA Organization"
       expect(page).to have_text "Create a new CASA Organization"
     end
+
+    describe "organization table" do
+      let!(:organization2) { create(:casa_org) }
+      let(:org2_row) { find("[data-test='organization-table'] tbody tr:last") }
+
+      before do
+        2.times { create(:user, casa_org: organization2) }
+        2.times { 3.times { create(:case_contact, casa_case: create(:casa_case, casa_org: organization2)) } }
+        visit "/"
+      end
+
+      it "renders a row for each organization" do
+        expect(page).to have_selector("[data-test='organization-table'] tbody tr", count: 2)
+      end
+
+      it "displays the correct number of users" do
+        expect(org2_row.find("td:nth(3)")).to have_content("2")
+      end
+
+      it "displays the correct number of case contacts" do
+        expect(org2_row.find("td:nth(4)")).to have_content("6")
+      end
+    end
   end
 
   context "as any other user" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2947

### What changed, and why?
Adds columns to all admin dashboard table and convenience methods on `CaseOrg` model to retrieve the values.

### How will this affect user permissions?
- Volunteer permissions: none
- Supervisor permissions: none
- Admin permissions: none

### How is this tested? (please write tests!) 💖💪
Adds specs for the model convenience methods

### Screenshots please :)
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/3300647/145592178-5ebb9645-a9ef-4da2-9b1c-c629afd78107.png">

### Feelings gif (optional)
![yes](https://giphy.com/embed/uJFSCnoNb98RbxoJ4p)
