### PR TITLE
Update failing spec following weekly digest copy changes

### DIFF
--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -98,7 +98,7 @@
   </tr>
 
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-    <% @inactive_messages.each do |message| %>
+    <% @inactive_messages&.each do |message| %>
       <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
         <%= message %>
         <br>

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
 
     let(:other_supervisor) { create(:supervisor) }
 
-    xit { expect(rendered).not_to have_text(volunteer.display_name) }
+    it { expect(rendered).to include("The following volunteers have been unassigned from you", volunteer.display_name) }
   end
 
   context "when a volunteer has been unassigned" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2621 

### What changed, and why?
This test was failing because the copy of the Weekly Digest has changed. It's now updated with the correct content.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A
