### PR TITLE
#2882: Add 'Change to Admin' button

### DIFF
--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -2,7 +2,7 @@
 
 class SupervisorsController < ApplicationController
   before_action :available_volunteers, only: [:edit, :update, :index]
-  before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate, :resend_invitation]
+  before_action :set_supervisor, only: [:edit, :update, :activate, :deactivate, :resend_invitation, :change_to_admin]
   before_action :all_volunteers_ever_assigned, only: [:update]
   before_action :supervisor_has_unassigned_volunteers, only: [:edit]
 
@@ -79,6 +79,13 @@ class SupervisorsController < ApplicationController
     @supervisor.invite!
 
     redirect_to edit_supervisor_path(@supervisor), notice: "Invitation sent"
+  end
+
+  def change_to_admin
+    authorize @supervisor
+    @supervisor.change_to_admin!
+
+    redirect_to edit_casa_admin_path(@supervisor), notice: "Supervisor was changed to Admin."
   end
 
   def datatable

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -27,6 +27,10 @@ class Supervisor < User
     end
   end
 
+  def change_to_admin!
+    becomes!(CasaAdmin).save
+  end
+
   def pending_volunteers
     Volunteer.where(invited_by_id: id).or(
       Volunteer.where(id: volunteers.pluck(:id))

--- a/app/policies/supervisor_policy.rb
+++ b/app/policies/supervisor_policy.rb
@@ -27,4 +27,5 @@ class SupervisorPolicy < UserPolicy
   alias_method :create?, :new?
   alias_method :edit?, :index?
   alias_method :datatable?, :index?
+  alias_method :change_to_admin?, :is_admin?
 end

--- a/app/views/supervisors/_manage_active.html.erb
+++ b/app/views/supervisors/_manage_active.html.erb
@@ -27,4 +27,10 @@
                 method: :patch,
                 class: "btn btn-outline-danger" %>
   <% end %>
+  <% if current_user.casa_admin? %>
+    <%= link_to "Change to Admin",
+                change_to_admin_supervisor_path(user),
+                method: :patch,
+                class: "btn btn-outline-danger" %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
       patch :activate
       patch :deactivate
       patch :resend_invitation
+      patch :change_to_admin
     end
   end
   resources :supervisor_volunteers, only: %i[create] do

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe Supervisor, type: :model do
       expect(supervisor.pending_volunteers).to eq([volunteer])
     end
   end
+
+  describe "change to admin" do
+    it "returns true if the change was successful" do
+      expect(subject.change_to_admin!).to be_truthy
+    end
+
+    it "changes the supervisor to an admin" do
+      subject.change_to_admin!
+
+      user = User.find(subject.id) # subject.reload will cause RecordNotFound because it's looking in the wrong table
+      expect(user).not_to be_supervisor
+      expect(user).to be_casa_admin
+    end
+  end
 end

--- a/spec/policies/supervisor_policy_spec.rb
+++ b/spec/policies/supervisor_policy_spec.rb
@@ -67,16 +67,16 @@ RSpec.describe SupervisorPolicy do
     end
   end
 
-  permissions :create?, :new?, :resend_invitation?, :activate?, :deactivate? do
-    it "allows admins to create supervisors" do
+  permissions :create?, :new?, :resend_invitation?, :activate?, :deactivate?, :change_to_admin? do
+    it "allows admins to modify supervisors" do
       is_expected.to permit(casa_admin, Supervisor)
     end
 
-    it "does not allow supervisors to create supervisors" do
+    it "does not allow supervisors to modify supervisors" do
       is_expected.to_not permit(supervisor, Supervisor)
     end
 
-    it "does not allow volunteers to create supervisors" do
+    it "does not allow volunteers to modify supervisors" do
       is_expected.to_not permit(volunteer, Supervisor)
     end
   end

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -206,4 +206,36 @@ RSpec.describe "/supervisors", type: :request do
       expect(response).to redirect_to(edit_supervisor_path(supervisor))
     end
   end
+
+  describe "PATCH /change_to_admin" do
+    let(:user) { User.find(supervisor.id) } # find the user after their type has changed
+
+    context "when signed in as an admin" do
+      before do
+        sign_in admin
+        patch change_to_admin_supervisor_path(supervisor)
+      end
+
+      it "changes the supervisor to an admin" do
+        expect(user).not_to be_supervisor
+        expect(user).to be_casa_admin
+      end
+
+      it "redirects to the edit page for an admin" do
+        expect(response).to redirect_to(edit_casa_admin_path(supervisor))
+      end
+    end
+
+    context "when signed in as a supervisor" do
+      before do
+        sign_in supervisor
+        patch change_to_admin_supervisor_path(supervisor)
+      end
+
+      it "does not changes the supervisor to an admin" do
+        expect(user).to be_supervisor
+        expect(user).not_to be_casa_admin
+      end
+    end
+  end
 end

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
     end
 
+    it "can convert the supervisor to an admin", js: true do
+      supervisor = create(:supervisor, casa_org_id: organization.id)
+
+      sign_in user
+
+      visit edit_supervisor_path(supervisor)
+      click_on "Change to Admin"
+
+      expect(page).to have_text("Supervisor was changed to Admin.")
+      expect(User.find(supervisor.id)).to be_casa_admin
+    end
+
     context "logged in as a supervisor" do
       let(:supervisor) { create(:supervisor) }
       it "can't deactivate a supervisor", js: true do

--- a/spec/views/supervisors/edit.html.erb_spec.rb
+++ b/spec/views/supervisors/edit.html.erb_spec.rb
@@ -77,4 +77,30 @@ RSpec.describe "supervisors/edit", type: :view do
       expect(rendered).to have_text("Password reset last sent \n  never")
     end
   end
+
+  describe "'Change to Admin' button" do
+    let(:supervisor) { build_stubbed :supervisor }
+
+    before do
+      assign :supervisor, supervisor
+      assign :available_volunteers, []
+    end
+
+    it "shows for an admin editing a supervisor" do
+      render template: "supervisors/edit"
+
+      expect(rendered).to have_text("Change to Admin")
+      expect(rendered).to include(change_to_admin_supervisor_path(supervisor))
+    end
+
+    it "does not show for a supervisor editing a supervisor" do
+      enable_pundit(view, supervisor)
+      allow(view).to receive(:current_user).and_return(supervisor)
+
+      render template: "supervisors/edit"
+
+      expect(rendered).not_to have_text("Change to Admin")
+      expect(rendered).not_to include(change_to_admin_supervisor_path(supervisor))
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2882

### What changed, and why?
Adds a 'Change to Admin' button to the Supervisor edit form, which is only visible when logged in as an admin. This lets a Supervisor become an Admin!

### How will this affect user permissions?
- Volunteer permissions: volunteers **may not change** supervisors to admins
- Supervisor permissions: supervisors **may not change** supervisors to admins
- Admin permissions: admins **may change** supervisors to admins

### How is this tested? (please write tests!) 💖💪
This is tested in view, system, request, policy, and model specs.

### Screenshots please :)
#### While editing as an admin
![image](https://user-images.githubusercontent.com/3433687/145602589-51f173b5-988a-4059-ae5e-08a3a413e9a8.png)

#### After changing the supervisor to an admin
![image](https://user-images.githubusercontent.com/3433687/145602870-e23a2659-0743-4575-a57f-af3554f3ec97.png)

#### While editing as a supervisor
![image](https://user-images.githubusercontent.com/3433687/145605244-8b54be55-b495-4ea4-a6d8-4a1427707f59.png)

### Feelings gif (optional)
![placid smiling cartoon cat](https://media4.giphy.com/media/CS0KJyVcShBMOl59vc/giphy.gif)