### PR TITLE
Add missing specs to the emancipation controller

### DIFF
--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -50,32 +50,31 @@ class EmancipationsController < ApplicationController
     check_item_action = params[:check_item_action]
     begin
       case check_item_action
-        when ADD_CATEGORY
-          current_case.add_emancipation_category(params[:check_item_id])
-          render json: "success".to_json # TODO use {status: success} instead - update UI to match
-        when ADD_OPTION
-          current_case.add_emancipation_option(params[:check_item_id])
-          render json: "success".to_json
-        when DELETE_CATEGORY
-          current_case.remove_emancipation_category(params[:check_item_id])
-          current_case.emancipation_options.delete(EmancipationOption.category_options(params[:check_item_id]))
-          render json: "success".to_json
-        when DELETE_OPTION
-          current_case.remove_emancipation_option(params[:check_item_id])
-          render json: "success".to_json
-        when SET_OPTION
-          current_case.emancipation_options.delete(EmancipationOption.category_options(EmancipationOption.find(params[:check_item_id]).emancipation_category_id))
-          current_case.add_emancipation_option(params[:check_item_id])
-          render json: "success".to_json
-        else
-          render json: {error: "Check item action: #{check_item_action} is not a supported action"}
+      when ADD_CATEGORY
+        current_case.add_emancipation_category(params[:check_item_id])
+        render json: "success".to_json # TODO use {status: success} instead - update UI to match
+      when ADD_OPTION
+        current_case.add_emancipation_option(params[:check_item_id])
+        render json: "success".to_json
+      when DELETE_CATEGORY
+        current_case.remove_emancipation_category(params[:check_item_id])
+        current_case.emancipation_options.delete(EmancipationOption.category_options(params[:check_item_id]))
+        render json: "success".to_json
+      when DELETE_OPTION
+        current_case.remove_emancipation_option(params[:check_item_id])
+        render json: "success".to_json
+      when SET_OPTION
+        option = EmancipationOption.find(params[:check_item_id])
+        current_case.emancipation_options.delete(EmancipationOption.category_options(option.emancipation_category_id))
+        current_case.add_emancipation_option(params[:check_item_id])
+        render json: "success".to_json
+      else
+        render json: {error: "Check item action: #{check_item_action} is not a supported action"}
       end
+    rescue ActiveRecord::RecordInvalid
+      render json: {error: "The record already exists as an association on the case"}
     rescue ActiveRecord::RecordNotFound
-      render json: {error: "Could not find option from id given by param check_item_id"}
-    rescue ActiveRecord::RecordNotUnique
-      render json: {error: "Option already added to case"}
-    rescue => error # TODO catch only specific errors?
-      render json: {error: error.message}
+      render json: {error: "Tried to destroy an association that does not exist"}
     end
   end
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -96,10 +96,11 @@ class CasaCase < ApplicationRecord
   end
 
   def add_emancipation_option(option_id)
-    option_category = EmancipationOption.find(option_id).emancipation_category
+    option = EmancipationOption.find(option_id)
+    option_category = option.emancipation_category
 
     if !(option_category.mutually_exclusive && EmancipationOption.options_with_category_and_case(option_category, id).any?)
-      emancipation_options << EmancipationOption.find(option_id)
+      emancipation_options << option
     else
       raise "Attempted adding multiple options belonging to a mutually exclusive category"
     end
@@ -153,11 +154,17 @@ class CasaCase < ApplicationRecord
   end
 
   def remove_emancipation_category(category_id)
-    emancipation_categories.destroy(EmancipationCategory.find(category_id))
+    category = EmancipationCategory.find(category_id)
+    raise ActiveRecord::RecordNotFound unless emancipation_categories.include?(category)
+
+    emancipation_categories.destroy(category)
   end
 
   def remove_emancipation_option(option_id)
-    emancipation_options.destroy(EmancipationOption.find(option_id))
+    option = EmancipationOption.find(option_id)
+    raise ActiveRecord::RecordNotFound unless emancipation_options.include?(option)
+
+    emancipation_options.destroy(option)
   end
 
   def update_cleaning_contact_types(args)

--- a/spec/controllers/emancipations_controller_spec.rb
+++ b/spec/controllers/emancipations_controller_spec.rb
@@ -5,89 +5,239 @@ RSpec.describe EmancipationsController, type: :controller do
   let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
   let(:test_case_category) { build(:casa_case_emancipation_category) }
   let(:casa_case) { create(:casa_case, casa_org: organization) }
-  subject { post :save, params: params }
+  let(:casa_case_id) { casa_case.id.to_s }
+  let(:params) do
+    {
+      casa_case_id: casa_case_id
+    }
+  end
 
   before do
     allow(controller).to receive(:authenticate_user!).and_return(true)
     allow(controller).to receive(:current_user).and_return(volunteer)
   end
 
-  it "raises Missing param casa_case_id error message" do
-    post :save, params: {casa_case_id: "string"}
-    expect(response.body).to eq({error: "Could not find case from id given by casa_case_id"}.to_json)
-  end
-
-  it "raises add_option error message" do
-    post :save, params: {casa_case_id: "-1"}
-    expect(response.body).to eq({error: "Could not find case from id given by casa_case_id"}.to_json)
-  end
-
-  context "empty params" do
-    let(:params) { {} }
-
-    it "raises error" do
-      expect { subject }.to raise_error(ActionController::UrlGenerationError)
-    end
-  end
-
-  context "no check_item_id" do
-    let(:params) { {casa_case_id: "-1"} }
-
-    it "errors for unfindable casa case" do
-      subject
-      expect(response.body).to eq({error: "Could not find case from id given by casa_case_id"}.to_json)
-    end
-  end
-
-  describe "check_item_action" do
-    it "raises missing param error message" do
-      post :save, params: {casa_case_id: casa_case.id.to_s}
-      expect(response.body).to eq({error: "Sorry, you are not authorized to perform this action. Did the session expire?"}.to_json)
-    end
-  end
-
-  it "raises param check_item_id error message" do
-    post :save, params: {casa_case_id: "1", check_item_action: "1"}
-    expect(response.body).to eq({error: "Could not find case from id given by casa_case_id"}.to_json)
-  end
-
-  it "raises must be positive integer error message" do
-    post :save, params: {casa_case_id: casa_case.id.to_s, check_item_action: "1", check_item_id: "-1"}
-    expect(response.body).to eq({error: "Sorry, you are not authorized to perform this action. Did the session expire?"}.to_json)
-  end
-
-  context "non transitioning case" do
-    let(:params) { {casa_case_id: volunteer.casa_cases.first.id} }
-
-    it "errors for unfindable check item" do
-      volunteer.casa_cases.first.update_attribute(:birth_month_year_youth, 8.years.ago)
-
-      subject
-      expect(response.body).to eq({error: "The current case is not marked as transitioning"}.to_json)
-    end
-  end
-
-  context "transition ages youth case" do
-    let(:casa_case) { volunteer.casa_cases.first }
+  describe "#show" do
+    subject(:show) { get :show, params: {casa_case_id: casa_case_id, format: format} }
 
     before do
-      casa_case.update!(transition_aged_youth: true)
+      allow(controller).to receive(:authorize)
+      allow(controller).to receive(:verify_authorized)
     end
 
-    context "with unfindable check item" do
-      let(:params) { {casa_case_id: casa_case.id} }
+    context "the format is docx" do
+      let(:format) { :docx }
+      let(:sablon_template) { double("Sablon::Template") }
+      let(:html_body) { double("EmancipationChecklistDownloadHtml", call: "<html>some html</html>") }
+      let(:emancipation_checklist) { [] }
+      let(:expected_context) { { case_number: casa_case.case_number, emancipation_checklist: emancipation_checklist } }
+      let(:rendered_to_string_context) { "context to string" }
 
-      it "errors for unfindable check item" do
+      before do
+        allow(Sablon).to receive(:template).and_return(sablon_template)
+        allow(EmancipationChecklistDownloadHtml).to receive(:new).with(casa_case, []).and_return(html_body)
+        allow(Sablon).to receive(:content).with(:html, html_body.call).and_return(emancipation_checklist)
+        allow(sablon_template).to receive(:render_to_string).with(expected_context, type: :docx).and_return(rendered_to_string_context)
+      end
+
+      it "will send the appropriate docx data" do
+        expect(@controller).to receive(:send_data) { @controller.head :ok }
+        show
+      end
+    end
+  end
+
+  describe "#not_authorized" do
+    subject(:show) { get :show, params: {casa_case_id: casa_case_id, format: :json} }
+
+    before do
+      allow_any_instance_of(Volunteer).to receive(:casa_org).and_return nil
+    end
+
+    it "will do redirect to the root" do
+      expect(show).to redirect_to(root_url)
+    end
+
+    context "the backtrace ends in 'save'" do
+      before do
+        allow_any_instance_of(Organizational::UnknownOrganization).to receive(:backtrace).and_return(["", "save'"])
+      end
+
+      it "will render the correct json message" do
+        show
+        expect(response.body).to eq({error: "Sorry, you are not authorized to perform this action. Did the session expire?"}.to_json)
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { post :save, params: params }
+
+    let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, active: true, casa_case: casa_case) }
+    let(:check_item_action) { "" }
+    let(:check_item_id) { "" }
+    let(:emancipation_categories) { [] }
+    let(:emancipation_options) { [] }
+    let(:casa_case) do
+      create(
+        :casa_case,
+        casa_org: organization,
+        emancipation_options: emancipation_options,
+        emancipation_categories: emancipation_categories
+      )
+    end
+    let(:params) do
+      {
+        casa_case_id: casa_case_id,
+        check_item_action: check_item_action,
+        check_item_id: check_item_id
+      }
+    end
+
+    context "the casa case does not exist" do
+      let(:casa_case_id) { "blah" }
+
+      it "returns the correct error response" do
         subject
-        expect(response.body).to eq({error: "Check item action:  is not a supported action"}.to_json)
+        expect(response.body).to eq({error: "Could not find case from id given by casa_case_id"}.to_json)
       end
     end
 
-    context "with check item action and invalid check item id" do
-      let(:params) { {casa_case_id: casa_case.id, check_item_action: "add_category", check_item_id: "-1"} }
-      it "succeeds" do
+    context ".in_transition_age? returns true" do
+      let(:casa_case) do
+        create(
+          :casa_case,
+          casa_org: organization,
+          emancipation_options: emancipation_options,
+          emancipation_categories: emancipation_categories,
+          birth_month_year_youth: 13.years.ago
+        )
+      end
+
+      it "returns the correct error response" do
         subject
-        expect(response.body).to eq({error: "Could not find option from id given by param check_item_id"}.to_json)
+        expect(response.body).to eq({error: "The current case is not marked as transitioning"}.to_json)
+      end
+    end
+
+    context "add catagory action" do
+      let(:emancipation_category) { create(:emancipation_category) }
+      let(:check_item_id) { emancipation_category.id.to_s }
+      let(:check_item_action) { "add_category" }
+
+      it "will add the category" do
+        expect { subject }.to change { casa_case.emancipation_categories.count }.by(1)
+      end
+
+      context "the category is already added to the case" do
+        let(:emancipation_categories) { [emancipation_category] }
+
+        it "will not add the category" do
+          expect { subject }.to_not change { casa_case.emancipation_categories.count }
+        end
+
+        it "returns the correct error response" do
+          subject
+          expect(response.body).to eq({error: "The record already exists as an association on the case"}.to_json)
+        end
+      end
+    end
+
+    context "add option action" do
+      let(:emancipation_option) { create(:emancipation_option) }
+      let(:check_item_id) { emancipation_option.id.to_s }
+      let(:check_item_action) { "add_option" }
+
+      it "will add the option" do
+        expect { subject }.to change { casa_case.emancipation_options.count }.by(1)
+      end
+
+      context "the option is already added to the case" do
+        let(:emancipation_options) { [emancipation_option] }
+
+        it "will not add the option" do
+          expect { subject }.to_not change { casa_case.emancipation_options.count }
+        end
+
+        it "returns the correct error response" do
+          subject
+          expect(response.body).to eq({error: "The record already exists as an association on the case"}.to_json)
+        end
+      end
+    end
+
+    context "delete category action" do
+      let(:emancipation_category) { create(:emancipation_category) }
+      let(:check_item_id) { emancipation_category.id.to_s }
+      let(:emancipation_categories) { [emancipation_category] }
+      let(:check_item_action) { "delete_category" }
+
+      it "will remove the category" do
+        expect { subject }.to change { casa_case.emancipation_categories.count }.by(-1)
+      end
+
+      context "the category is not added added to the case" do
+        let(:emancipation_categories) { [] }
+
+        it "will not remove the category" do
+          expect { subject }.to_not change { casa_case.emancipation_categories.count }
+        end
+
+        it "return an appropriate error message" do
+          subject
+          expect(response.body).to eq({error: "Tried to destroy an association that does not exist"}.to_json)
+        end
+      end
+    end
+
+    context "delete option action" do
+      let(:emancipation_option) { create(:emancipation_option) }
+      let(:check_item_id) { emancipation_option.id.to_s }
+      let(:emancipation_options) { [emancipation_option] }
+      let(:check_item_action) { "delete_option" }
+
+      it "will remove the option" do
+        expect { subject }.to change { casa_case.emancipation_options.count }.by(-1)
+      end
+
+      context "the option is not added added to the case" do
+        let(:emancipation_options) { [] }
+
+        it "will not remove the option" do
+          expect { subject }.to_not change { casa_case.emancipation_options.count }
+        end
+
+        it "return an appropriate error message" do
+          subject
+          expect(response.body).to eq({error: "Tried to destroy an association that does not exist"}.to_json)
+        end
+      end
+    end
+
+    context "set option action" do
+      let(:emancipation_option) { create(:emancipation_option) }
+      let(:check_item_id) { emancipation_option.id.to_s }
+      let(:check_item_action) { "set_option" }
+
+      it "will add the emancipation option" do
+        expect { subject }.to change { casa_case.emancipation_options.count }.by(1)
+      end
+
+      context "the option is already added to the case" do
+        let(:emancipation_options) { [emancipation_option] }
+
+        it "will not add the option" do
+          expect { subject }.to_not change { casa_case.emancipation_options.count }
+        end
+      end
+    end
+
+    context "unknown action" do
+      let(:check_item_action) { "some unrecognized action" }
+
+      it "return an appropriate error message" do
+        subject
+        expect(response.body).to eq({error: "Check item action: #{check_item_action} is not a supported action"}.to_json)
       end
     end
   end

--- a/spec/controllers/emancipations_controller_spec.rb
+++ b/spec/controllers/emancipations_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe EmancipationsController, type: :controller do
       let(:sablon_template) { double("Sablon::Template") }
       let(:html_body) { double("EmancipationChecklistDownloadHtml", call: "<html>some html</html>") }
       let(:emancipation_checklist) { [] }
-      let(:expected_context) { { case_number: casa_case.case_number, emancipation_checklist: emancipation_checklist } }
+      let(:expected_context) { {case_number: casa_case.case_number, emancipation_checklist: emancipation_checklist} }
       let(:rendered_to_string_context) { "context to string" }
 
       before do

--- a/spec/requests/emancipations_request_spec.rb
+++ b/spec/requests/emancipations_request_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe "/casa_case/:id/emancipation", type: :request do
 
         post casa_case_emancipation_path(casa_case) + "/save", params: {check_item_action: "add_option"}
         expect(JSON.parse(response.body)).to have_key("error")
-        expect(JSON.parse(response.body)["error"]).to eq("Could not find option from id given by param check_item_id")
+        expect(JSON.parse(response.body)["error"]).to eq("Tried to destroy an association that does not exist")
       end
 
       it "sends an error when attempting to perform an action on a case that is not transitioning" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
[Resolves #1590](https://github.com/rubyforgood/casa/issues/1590)

### What changed, and why?

- emancipations_controller_spec - I have completely re worked the spec file to test all possible flows through the controller.

### How will this affect user permissions?
It wont

### How is this tested? (please write tests!) 💖💪
- unit tests have been added

### Screenshots please :)
**before < 50% coverage**
![before 2](https://user-images.githubusercontent.com/7209256/145619083-525abb97-ea13-4a94-b3f7-1db235dabee3.png)

**after - 100% coverage**
![after](https://user-images.githubusercontent.com/7209256/145619302-1e3d5945-2716-4b52-b059-17a9dc16d895.png)

