### PR TITLE
update bot and add manual run option

### DIFF
--- a/.github/workflows/add-help-wanted-labels.yml
+++ b/.github/workflows/add-help-wanted-labels.yml
@@ -2,6 +2,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 * * * *'
+  workflow_dispatch:
 
 jobs:
   add_help_wanted_labels:
@@ -9,9 +10,10 @@ jobs:
     name: Add help wanted labels
     steps:
       - name: Add help wanted labels
-        uses: rubyforgood/add-label-to-cards@v1
+        uses: rubyforgood/add-label-to-cards@v2
         id: add-help-wanted-labels
         with:
           token: ${{secrets.GITHUB_TOKEN}}
+          column_name: 'To do'
           label_to_add: 'Help Wanted'
-          column_id: '15690587'
+          project_name: 'CASA Volunteer Portal'

--- a/.github/workflows/add-help-wanted-labels.yml
+++ b/.github/workflows/add-help-wanted-labels.yml
@@ -2,7 +2,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 * * * *'
-  workflow_dispatch:
+  workflow_dispatch: # Enable manual runs of the bot
 
 jobs:
   add_help_wanted_labels:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2634

### What changed, and why?
 - add option to manually run the bot
 - number of cards issues to label no longer limited to 100
 - process exits on fatal errors
 - columns can be specified using project name and column name
 - a summary of labeling and errors are printed in the output
 - documentation for code and bot usage

### How is this tested? (please write tests!) 💖💪
Manual runs at https://github.com/FireLemons/gh-actions-sandbox/actions/workflows/add-help-wanted-labels.yml