### PR TITLE
Added hearing type to court dates list.

### DIFF
--- a/app/views/casa_cases/_court_dates.html.erb
+++ b/app/views/casa_cases/_court_dates.html.erb
@@ -4,6 +4,9 @@
     <% casa_case.court_dates.ordered_ascending.each do |pcd| %>
       <p>
         <%= link_to(pcd.decorate.formatted_date, casa_case_court_date_path(casa_case, pcd)) %>
+        <% if pcd.hearing_type %>
+          (<%= pcd.hearing_type.name %>)
+        <% end %>
 
         <% if report = pcd.latest_associated_report %>
           <%= link_to(rails_blob_path(report, disposition: 'attachment')) do %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2953 

### What changed, and why?
Added the name of hearing types (when not nil) to displayed court_dates listed in a casa_case's show page.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Found no existing tests for casa_case show page. Assumed they were unnecessary for render only view.

### Screenshots please :)
![casa_case_added_hearing_type](https://user-images.githubusercontent.com/19979089/146464005-f0f2c2f8-bf3d-430f-a43e-f7a797385a93.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
`![yay](https://media.giphy.com/media/Ge86XF8AVY1KE/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9