### PR TITLE
[#2957] Add .webp to casa org logo accepted extensions

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="custom-file mb-5">
         <%= form.label :logo %>
-        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg" %>
+        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp" %>
       </div>
       <div class="custom-file mb-5">
         <%= form.label :court_report_template %>

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "casa_org/edit", type: :system do
     has_checked_field? "Show driving reimbursement"
   end
 
-  it "can upload a logo image" do
+  it "can upload a logo image", :aggregate_failure do
     page.attach_file("Logo", "spec/fixtures/company_logo.png", make_visible: true)
 
     expect(organization.logo.attachment).to be_nil

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -102,4 +102,14 @@ RSpec.describe "casa_org/edit", type: :system do
     click_on "Submit"
     has_checked_field? "Show driving reimbursement"
   end
+
+  it "can upload a logo image" do
+    page.attach_file("Logo", "spec/fixtures/company_logo.png", make_visible: true)
+
+    expect(organization.logo.attachment).to be_nil
+
+    click_on "Submit"
+
+    expect(organization.reload.logo.attachment).not_to be_nil
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2957

### What changed, and why?
In the organization edit page (`/casa_org/1/edit`), the admin can now add a `.webp` logo.

### How will this affect user permissions?
No permissions will be affected.

### How is this tested? (please write tests!) 💖💪
- Added a test to check if attaching an image for the logo worked fine

Unfortunately, I can't add a test to check if different extensions work. When using the `page.attach_file` method any file will work, since the `accept: ".png,.gif,.jpg,.jpeg,.webp"`  only tells the browser which files to show in the file selection menu.

We could also validate the file format (extension or MIME type) in the backend, if it is of any interest. It would also be easier to test.

### Screenshots please :)
When clicking the Logo "Choose File" button:
![image](https://user-images.githubusercontent.com/72531802/147111430-e8f56736-1dbd-453f-90c0-e019bd98f499.png)

Before: `.webp` files did not show up in the "Open file" window
![image](https://user-images.githubusercontent.com/72531802/147111312-8b81207f-2273-4a89-a96f-079a6a083da3.png)

After: `.webp` files now show up in the window
![image](https://user-images.githubusercontent.com/72531802/147111334-82ae3675-46df-469f-a575-7c36f87a9f02.png)
