### PR TITLE
CasaOrgsController also responds as json

### DIFF
--- a/app/controllers/casa_org_controller.rb
+++ b/app/controllers/casa_org_controller.rb
@@ -13,10 +13,20 @@ class CasaOrgController < ApplicationController
 
   def update
     authorize @casa_org
+
     if @casa_org.update(casa_org_update_params)
-      redirect_to edit_casa_org_path, notice: "CASA organization was successfully updated."
+      respond_to do |format|
+        format.html do
+          redirect_to edit_casa_org_path, notice: "CASA organization was successfully updated."
+        end
+
+        format.json { render json: @casa_org, status: :ok }
+      end
     else
-      render :edit
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/spec/requests/casa_org_spec.rb
+++ b/spec/requests/casa_org_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe "CasaOrg", type: :request do
           casa_org.reload
           expect(response).to redirect_to(edit_casa_org_path)
         end
+
+        it "also responds as json", :aggregate_failures do
+          patch casa_org_url(casa_org, format: :json), params: {casa_org: valid_attributes}
+
+          expect(response.content_type).to eq "application/json; charset=utf-8"
+          expect(response).to have_http_status :ok
+          expect(response.body).to match("display_name".to_json)
+        end
       end
 
       context "with invalid parameters" do
@@ -53,6 +61,14 @@ RSpec.describe "CasaOrg", type: :request do
           patch casa_org_url(casa_org), params: {casa_org: invalid_attributes}
           expect(response).to be_successful
           expect(response.body).to match(/error_explanation/)
+        end
+
+        it "also responds as json", :aggregate_failures do
+          patch casa_org_url(casa_org, format: :json), params: {casa_org: invalid_attributes}
+
+          expect(response.content_type).to eq "application/json; charset=utf-8"
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response.body).to match "Name can't be blank".to_json
         end
       end
     end


### PR DESCRIPTION
References: https://github.com/rubyforgood/casa/issues/2647

### What changed, and why?

Add `respond_to` block for update action of CasaOrgsController. To allow this action to respond both ways (`:json` and `:html`)

### How is this tested? (please write tests!) 💖💪

Request spec for update action