### PR TITLE
Typo and js loading hotfix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,8 +44,4 @@ module ApplicationHelper
   def og_tag(type, options = {})
     tag.meta(property: "og:#{type}", **options)
   end
-
-  def contains_success_param?
-    params[:success] == "true"
-  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -42,5 +42,3 @@ require('src/reports')
 // NOTE: all image asset url helpers in Rails views must prefix image/$blah with media/src/.
 // TODO: figure out why?
 const images = require.context('../src/images', true) // eslint-disable-line no-unused-vars
-
-window.$ = $

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -137,6 +137,10 @@ $('document').ready(() => {
   }
 
   $('#btnGenerateReport').on('click', handleGenerateReport)
+
+  if (/\/casa_cases\/.*\?.*success=true/.test(window.location.href)) {
+    $('#thank_you').modal();
+  }
 })
 
 export {

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -139,7 +139,7 @@ $('document').ready(() => {
   $('#btnGenerateReport').on('click', handleGenerateReport)
 
   if (/\/casa_cases\/.*\?.*success=true/.test(window.location.href)) {
-    $('#thank_you').modal();
+    $('#thank_you').modal()
   }
 })
 

--- a/app/views/casa_cases/_thank_you_modal.html.erb
+++ b/app/views/casa_cases/_thank_you_modal.html.erb
@@ -2,12 +2,6 @@
   <div class="modal fade" id="thank_you" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="staticBackdropLabel">Dear vonlunteer</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
         <div class="modal-body">
           <%= "#{t("create", scope: "case_contact")} #{t("thank_you_#{rand(1..8)}", scope: "case_contact")}" %>
         </div>

--- a/app/views/casa_cases/_thank_you_modal.html.erb
+++ b/app/views/casa_cases/_thank_you_modal.html.erb
@@ -12,7 +12,3 @@
     </div>
   </div>
 </div>
-
-<script>
-  $('#thank_you').modal();
-</script>

--- a/app/views/casa_cases/_thank_you_modal.html.erb
+++ b/app/views/casa_cases/_thank_you_modal.html.erb
@@ -13,8 +13,6 @@
   </div>
 </div>
 
-<%= content_for :javascript do %>
-  <script>
-    $('#thank_you').modal();
-  </script>
-<% end %>
+<script>
+  $('#thank_you').modal();
+</script>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <%= render "thank_you_modal" if contains_success_param? %>
+  <%= render "thank_you_modal" %>
 
   <div class="col-sm-12 form-header">
     <h1 class="pull-left"><%= @casa_case.decorate.transition_aged_youth_icon %> <%= t(".title") %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,6 @@
       <%= yield %>
     </div>
   </div>
-  <%= yield :javascript %>
 <% else %>
   <%= render 'layouts/login_header' %>
   <%= render 'layouts/flash_messages' %>

--- a/spec/views/casa_cases/show.html.erb_spec.rb
+++ b/spec/views/casa_cases/show.html.erb_spec.rb
@@ -8,34 +8,4 @@ RSpec.describe "casa_cases/show", type: :view do
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
   end
-
-  context "when the URL contains ?success=true" do
-    let(:user) { build_stubbed(:volunteer, casa_org: organization) }
-    let(:casa_case) { create(:casa_case, casa_org: organization) }
-
-    before do
-      allow_any_instance_of(ApplicationHelper).to receive(:contains_success_param?).and_return(true)
-    end
-
-    it "renders thank you modal" do
-      assign :casa_case, casa_case
-
-      render
-
-      expect(rendered).to match /"thank-you-modal-wrapper"/
-    end
-  end
-
-  context "when the URL does not contain ?success=true" do
-    let(:user) { build_stubbed(:volunteer, casa_org: organization) }
-    let(:casa_case) { create(:casa_case, casa_org: organization) }
-
-    it "does not render thank you modal" do
-      assign :casa_case, casa_case
-
-      render
-
-      expect(rendered).not_to match /"thank-you-modal-wrapper"/
-    end
-  end
 end


### PR DESCRIPTION
### What changed, and why?
Successful case contact entry detected on frontend instead of backend to stop relying on jQuery global export from webpack js loading before script tag in html

Removed modal header

### How is this tested? (please write tests!) 💖💪
Not yet

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/147890007-471ed47c-6470-46ba-a0e4-47c6af9296fa.png)
