### PR TITLE
Rounded corners on supervisor bars fix

### DIFF
--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -1,6 +1,29 @@
 $indictator_negative_color: #f44336;
 $indicator_positive_color: #4caf50;
 
+.supervisor_case_contact_stats {
+  display: flex;
+
+  div {
+    span {
+      float: right;
+      text-align: center;
+
+      &:first-child {
+        background: $indicator_positive_color;
+        border-bottom-left-radius: 0.25em;
+        border-top-left-radius: 0.25em;
+      };
+
+      &:last-child {
+        background: $indictator_negative_color;
+        border-bottom-right-radius: 0.25em;
+        border-top-right-radius: 0.25em;
+      }
+    }
+  }
+}
+
 .supervisor_indicator_container {
   display: flex;
 }
@@ -10,31 +33,12 @@ $indicator_positive_color: #4caf50;
   align-items: center;
   font-size: 1rem;
   margin-bottom: 0.25rem;
-}
 
-.supervisor_indicator_legend_negative,
-.supervisor_indicator_legend_positive {
-  font-size: smaller;
-  padding: .25em;
-  flex-grow: 1;
-}
-
-.supervisor_indicator_negative,
-.supervisor_indicator_legend_negative {
-  background: $indictator_negative_color;
-  float: right;
-  text-align: center;
-  border-bottom-right-radius: 0.25em;
-  border-top-right-radius: 0.25em;
-}
-
-.supervisor_indicator_positive,
-.supervisor_indicator_legend_positive {
-  background: $indicator_positive_color;
-  float: left;
-  text-align: center;
-  border-bottom-left-radius: 0.25em;
-  border-top-left-radius: 0.25em;
+  span {
+    font-size: smaller;
+    padding: .25em;
+    flex-grow: 1;
+  }
 }
 
 .supervisor_indicator_legend_negative_positive,

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -11,6 +11,15 @@ $indicator_positive_color: #4caf50;
       flex-grow: 1;
     }
 
+    &:last-child {
+      display: inline;
+      font-size: smaller;
+      margin: auto;
+      background-color: #cfd8dc;
+      border-radius: 100vw;
+      padding: 0.2em 1em;
+    }
+
     span {
       float: right;
       text-align: center;
@@ -31,7 +40,6 @@ $indicator_positive_color: #4caf50;
 }
 
 .supervisor_indicator_legend {
-  display: flex;
   align-items: center;
   font-size: 1rem;
   margin-bottom: 0.25rem;
@@ -41,16 +49,6 @@ $indicator_positive_color: #4caf50;
     padding: .25em;
     flex-grow: 1;
   }
-}
-
-.supervisor_indicator_transition_aged_youth,
-.supervisor_indicator_legend_transition_aged_youth {
-  display: inline;
-  font-size: smaller;
-  margin: auto;
-  background-color: #cfd8dc;
-  border-radius: 100vw;
-  padding: 0.2em 1em;
 }
 
 .supervisor_table_row {

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -38,6 +38,10 @@ $indicator_positive_color: #4caf50;
         background-color: $indictator_negative_color;
       }
 
+      &.no-volunteers {
+        background-color: #ccc;
+      }
+
       &:last-child {
         margin-left: 0.5em;
         background-color: #cfd8dc;

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -11,13 +11,6 @@ $indicator_positive_color: #4caf50;
       flex-grow: 1;
     }
 
-    &:last-child {
-      margin: auto;
-      background-color: #cfd8dc;
-      border-radius: 100vw;
-      padding: 0.2em 1em;
-    }
-
     span {
       padding-top: .25em;
       text-align: center;
@@ -28,10 +21,17 @@ $indicator_positive_color: #4caf50;
         border-top-left-radius: 0.25em;
       }
 
-      &:last-child {
+      &:nth-child(2) {
         background: $indictator_negative_color;
         border-bottom-right-radius: 0.25em;
         border-top-right-radius: 0.25em;
+      }
+
+      &:last-child {
+        margin-left: 0.5em;
+        background-color: #cfd8dc;
+        border-radius: 100vw;
+        padding: 0.2em 1em;
       }
     }
   }
@@ -40,11 +40,11 @@ $indicator_positive_color: #4caf50;
     align-items: center;
     margin-bottom: 0.25rem;
 
-    div:last-child {
-      padding: .5em;
-    }
-
     span {
+      &:last-child {
+        padding: .5em;
+      }
+
       padding: .5em 1em;
       flex-grow: 1;
     }

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -5,6 +5,12 @@ $indicator_positive_color: #4caf50;
   display: flex;
 
   div {
+    &:first-child {
+      display: flex;
+      margin-right: 1em;
+      flex-grow: 1;
+    }
+
     span {
       float: right;
       text-align: center;
@@ -24,10 +30,6 @@ $indicator_positive_color: #4caf50;
   }
 }
 
-.supervisor_indicator_container {
-  display: flex;
-}
-
 .supervisor_indicator_legend {
   display: flex;
   align-items: center;
@@ -39,13 +41,6 @@ $indicator_positive_color: #4caf50;
     padding: .25em;
     flex-grow: 1;
   }
-}
-
-.supervisor_indicator_legend_negative_positive,
-.supervisor_indicator_negative_positive {
-  display: flex;
-  margin-right: 1em;
-  flex-grow: 1;
 }
 
 .supervisor_indicator_transition_aged_youth,

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -12,24 +12,30 @@ $indicator_positive_color: #4caf50;
     }
 
     span {
+      border-radius: 0.25em;
       padding-top: .25em;
       text-align: center;
 
       &.attempted-contact {
-        background: $indicator_positive_color;
+        background-color: $indicator_positive_color;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
 
         & + span.no-attempted-contact {
           border-top-left-radius: 0;
           border-bottom-left-radius: 0;
         }
+
+        & + span.attempted-contact-end {
+          background-color: $indicator_positive_color;
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+          width: 0.25em;
+        }
       }
 
       &.no-attempted-contact {
-        background: $indictator_negative_color;
-      }
-
-      &:not(:last-child) {
-        border-radius: 0.25em;
+        background-color: $indictator_negative_color;
       }
 
       &:last-child {

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -15,16 +15,21 @@ $indicator_positive_color: #4caf50;
       padding-top: .25em;
       text-align: center;
 
-      &:first-child {
+      &.attempted-contact {
         background: $indicator_positive_color;
+
+        & + span.no-attempted-contact {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      }
+
+      &.no-attempted-contact {
+        background: $indictator_negative_color;
       }
 
       &:not(:last-child) {
         border-radius: 0.25em;
-      }
-
-      &:nth-child(2) {
-        background: $indictator_negative_color;
       }
 
       &:last-child {

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -12,8 +12,6 @@ $indicator_positive_color: #4caf50;
     }
 
     &:last-child {
-      display: inline;
-      font-size: smaller;
       margin: auto;
       background-color: #cfd8dc;
       border-radius: 100vw;
@@ -21,14 +19,14 @@ $indicator_positive_color: #4caf50;
     }
 
     span {
-      float: right;
+      padding-top: .25em;
       text-align: center;
 
       &:first-child {
         background: $indicator_positive_color;
         border-bottom-left-radius: 0.25em;
         border-top-left-radius: 0.25em;
-      };
+      }
 
       &:last-child {
         background: $indictator_negative_color;
@@ -37,35 +35,34 @@ $indicator_positive_color: #4caf50;
       }
     }
   }
-}
 
-.supervisor_indicator_legend {
-  align-items: center;
-  font-size: 1rem;
-  margin-bottom: 0.25rem;
+  &.legend {
+    align-items: center;
+    margin-bottom: 0.25rem;
 
-  span {
-    font-size: smaller;
-    padding: .25em;
-    flex-grow: 1;
+    div:last-child {
+      padding: .5em;
+    }
+
+    span {
+      padding: .5em;
+      flex-grow: 1;
+    }
   }
 }
 
 .supervisor_table_row {
   display: flex;
-}
 
-.supervisor_table_row th:nth-of-type(1),
-.supervisor_table_row td:nth-of-type(1) {
-  flex: 3;
-}
+  td:nth-of-type(1), th:nth-of-type(1) {
+    flex: 3;
+  }
 
-.supervisor_table_row th:nth-of-type(2),
-.supervisor_table_row td:nth-of-type(2) {
-  flex: 2;
-}
+  td:nth-of-type(2), th:nth-of-type(2) {
+    flex: 2;
+  }
 
-.supervisor_table_row th:nth-of-type(3),
-.supervisor_table_row td:nth-of-type(3) {
-  flex: 1;
+  td:nth-of-type(3), th:nth-of-type(3) {
+    flex: 1;
+  }
 }

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -45,7 +45,7 @@ $indicator_positive_color: #4caf50;
     }
 
     span {
-      padding: .5em;
+      padding: .5em 1em;
       flex-grow: 1;
     }
   }

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -59,7 +59,7 @@ $indicator_positive_color: #4caf50;
   }
 
   td:nth-of-type(2), th:nth-of-type(2) {
-    flex: 2;
+    flex: 3;
   }
 
   td:nth-of-type(3), th:nth-of-type(3) {

--- a/app/javascript/src/stylesheets/pages/supervisors.scss
+++ b/app/javascript/src/stylesheets/pages/supervisors.scss
@@ -17,14 +17,14 @@ $indicator_positive_color: #4caf50;
 
       &:first-child {
         background: $indicator_positive_color;
-        border-bottom-left-radius: 0.25em;
-        border-top-left-radius: 0.25em;
+      }
+
+      &:not(:last-child) {
+        border-radius: 0.25em;
       }
 
       &:nth-child(2) {
         background: $indictator_negative_color;
-        border-bottom-right-radius: 0.25em;
-        border-top-right-radius: 0.25em;
       }
 
       &:last-child {
@@ -39,6 +39,7 @@ $indicator_positive_color: #4caf50;
   &.legend {
     align-items: center;
     margin-bottom: 0.25rem;
+    margin-top: 1em;
 
     span {
       &:last-child {

--- a/app/javascript/src/stylesheets/shared/layout.scss
+++ b/app/javascript/src/stylesheets/shared/layout.scss
@@ -60,7 +60,7 @@ div.row.volunteer-filters {
 }
 
 #dropdownMenuButton {
-  margin: 6px 0;
+  margin-bottom: 0.5em;
 }
 
 @media only screen and (max-width: $mobile) {

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -67,13 +67,6 @@
         <tr class="supervisor_table_row">
           <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
           <% active_volunteers = (supervisor.active_volunteers - no_attempt_volunteers).nonzero? %>
-          <% if active_volunteers %>
-            <% no_attempt_percentage = ((no_attempt_volunteers.to_f / supervisor.active_volunteers.to_f) * 100).to_i %>
-            <% active_percentage = (100 - no_attempt_percentage).to_i %>
-          <% else %>
-            <% no_attempt_percentage = 100 %>
-            <% active_percentage = 0 %>
-          <% end %>
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
           <td id="name-<%= supervisor.id %>">
             <span class="mobile-label">Supervisor Name</span>
@@ -82,12 +75,12 @@
           <td class="supervisor_case_contact_stats">
             <div>
               <% if active_volunteers %>
-                <span style="width: <%= active_percentage %>%">
+                <span style="flex-grow:<%= active_volunteers %>">
                   <%= active_volunteers %>
                 </span>
               <% end %>
               <% if no_attempt_volunteers.nonzero? %>
-                <span style="width: <%= no_attempt_percentage %>%">
+                <span style="flex-grow:<%= no_attempt_volunteers %>">
                   <%= no_attempt_volunteers %>
                 </span>
               <% end %>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,8 +43,8 @@
 </div>
 <div class="legend supervisor_case_contact_stats">
   <div>
-    <span class="attempted-contact">Have attempted contact in the last 14 days</span>
-    <span class="no-attempted-contact">Have not attempted contact in the last 14 days</span>
+    <span class="attempted-contact">Volunteers attempting contact(within 2 weeks)</span>
+    <span class="no-attempted-contact">Volunteers attempting contact(within 2 weeks)</span>
     <span>Transition aged youth</span>
   </div>
 </div>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,7 +43,7 @@
   </div>
 </div>
 <br>
-<div class="supervisor_indicator_legend supervisor_case_contact_stats">
+<div class="legend supervisor_case_contact_stats">
   <div>
     <span>Have attempted contact in the last 14 days</span>
     <span>Have not attempted contact in the last 14 days</span>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -47,8 +47,8 @@
   <div>
     <span>Have attempted contact in the last 14 days</span>
     <span>Have not attempted contact in the last 14 days</span>
+    <span>Transition aged youth</span>
   </div>
-  <div>Transition aged youth</div>
 </div>
 <div class="card card-container">
   <div class="card-body">
@@ -65,7 +65,7 @@
       <tbody>
       <% @supervisors.each do |supervisor| %>
         <tr class="supervisor_table_row">
-          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
+          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks.nonzero? %>
           <% active_volunteers = (supervisor.active_volunteers - no_attempt_volunteers).nonzero? %>
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
           <td id="name-<%= supervisor.id %>">
@@ -74,18 +74,14 @@
           </td>
           <td class="supervisor_case_contact_stats">
             <div>
-              <% if active_volunteers %>
-                <span style="flex-grow:<%= active_volunteers %>">
-                  <%= active_volunteers %>
-                </span>
-              <% end %>
-              <% if no_attempt_volunteers.nonzero? %>
-                <span style="flex-grow:<%= no_attempt_volunteers %>">
-                  <%= no_attempt_volunteers %>
-                </span>
-              <% end %>
-          </div>
-            <div><%= transition_volunteers %></div>
+              <span style="<%= active_volunteers ? "flex-grow: #{active_volunteers}" : "display:none" %>">
+                <%= active_volunteers %>
+              </span>
+              <span style="<%= no_attempt_volunteers ? "flex-grow: #{no_attempt_volunteers}" : "display: none" %>">
+                <%= no_attempt_volunteers %>
+              </span>
+              <span><%= transition_volunteers %></span>
+            </div>
           </td>
           <td>
             <span class="mobile-label">Actions</span>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,7 +43,7 @@
 </div>
 <div class="legend supervisor_case_contact_stats">
   <div>
-    <span class="attempted-contact" >Have attempted contact in the last 14 days</span>
+    <span class="attempted-contact">Have attempted contact in the last 14 days</span>
     <span class="no-attempted-contact">Have not attempted contact in the last 14 days</span>
     <span>Transition aged youth</span>
   </div>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -44,7 +44,7 @@
 </div>
 <br>
 <div class="supervisor_indicator_legend supervisor_case_contact_stats">
-  <div class="supervisor_indicator_legend_negative_positive">
+  <div>
     <span>Have attempted contact in the last 14 days</span>
     <span>Have not attempted contact in the last 14 days</span>
   </div>
@@ -79,8 +79,8 @@
             <span class="mobile-label">Supervisor Name</span>
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
-          <td class="supervisor_indicator_container supervisor_case_contact_stats">
-            <div class="supervisor_indicator_negative_positive">
+          <td class="supervisor_case_contact_stats">
+            <div>
               <% if active_volunteers %>
                 <span style="width: <%= active_percentage %>%">
                   <%= active_volunteers %>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -13,7 +13,6 @@
   </div>
 </div>
 <hr>
-
 <div class="row supervisor-filters">
   <div class="col-sm-12">
     <h4 class="pull-left mr-2"><%= t(".filter") %></h4>
@@ -42,11 +41,10 @@
     </div>
   </div>
 </div>
-<br>
 <div class="legend supervisor_case_contact_stats">
   <div>
-    <span>Have attempted contact in the last 14 days</span>
-    <span>Have not attempted contact in the last 14 days</span>
+    <span class="attempted-contact" >Have attempted contact in the last 14 days</span>
+    <span class="no-attempted-contact">Have not attempted contact in the last 14 days</span>
     <span>Transition aged youth</span>
   </div>
 </div>
@@ -74,12 +72,19 @@
           </td>
           <td class="supervisor_case_contact_stats">
             <div>
-              <span style="<%= active_volunteers ? "flex-grow: #{active_volunteers}" : "display:none" %>">
-                <%= active_volunteers %>
-              </span>
-              <span style="<%= no_attempt_volunteers ? "flex-grow: #{no_attempt_volunteers}" : "display: none" %>">
-                <%= no_attempt_volunteers %>
-              </span>
+              <% if active_volunteers %>
+                <span class="attempted-contact" style="flex-grow: <%= active_volunteers %>">
+                  <%= active_volunteers %>
+                </span>
+              <% end %>
+              <% if no_attempt_volunteers %>
+                <span class="no-attempted-contact" style="flex-grow: <%= no_attempt_volunteers %>">
+                  <%= no_attempt_volunteers %>
+                </span>
+              <% end %>
+              <% if !(active_volunteers || no_attempt_volunteers) %>
+                <span class="no-volunteers" style="flex-grow: 1">No assigned volunteers</span>
+              <% end %>
               <span><%= transition_volunteers %></span>
             </div>
           </td>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -63,7 +63,7 @@
       <tbody>
       <% @supervisors.each do |supervisor| %>
         <tr class="supervisor_table_row">
-          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks.nonzero? %>
+          <% no_attempt_volunteers = supervisor.no_attempt_for_two_weeks %>
           <% active_volunteers = (supervisor.active_volunteers - no_attempt_volunteers).nonzero? %>
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
           <td id="name-<%= supervisor.id %>">
@@ -77,12 +77,15 @@
                   <%= active_volunteers %>
                 </span>
               <% end %>
-              <% if no_attempt_volunteers %>
+              <% if no_attempt_volunteers.nonzero? %>
                 <span class="no-attempted-contact" style="flex-grow: <%= no_attempt_volunteers %>">
                   <%= no_attempt_volunteers %>
                 </span>
+              <% else %>
+                <span class="attempted-contact-end"></span>
               <% end %>
-              <% if !(active_volunteers || no_attempt_volunteers) %>
+
+              <% if !(active_volunteers || no_attempt_volunteers.nonzero?) %>
                 <span class="no-volunteers" style="flex-grow: 1">No assigned volunteers</span>
               <% end %>
               <span><%= transition_volunteers %></span>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -48,7 +48,7 @@
     <span>Have attempted contact in the last 14 days</span>
     <span>Have not attempted contact in the last 14 days</span>
   </div>
-  <div class="supervisor_indicator_legend_transition_aged_youth">Transition aged youth</div>
+  <div>Transition aged youth</div>
 </div>
 <div class="card card-container">
   <div class="card-body">
@@ -92,7 +92,7 @@
                 </span>
               <% end %>
           </div>
-            <div class="supervisor_indicator_transition_aged_youth"><%= transition_volunteers %></div>
+            <div><%= transition_volunteers %></div>
           </td>
           <td>
             <span class="mobile-label">Actions</span>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,28 +43,25 @@
   </div>
 </div>
 <br>
-
-<div class="supervisor_indicator_legend">
-<div class="supervisor_indicator_legend_negative_positive">
-  <span class="supervisor_indicator_legend_positive">Have attempted contact in the last 14 days</span>
-  <span class="supervisor_indicator_legend_negative">Have not attempted contact in the last 14 days</span>
+<div class="supervisor_indicator_legend supervisor_case_contact_stats">
+  <div class="supervisor_indicator_legend_negative_positive">
+    <span>Have attempted contact in the last 14 days</span>
+    <span>Have not attempted contact in the last 14 days</span>
+  </div>
+  <div class="supervisor_indicator_legend_transition_aged_youth">Transition aged youth</div>
 </div>
-<div class="supervisor_indicator_legend_transition_aged_youth">Transition aged youth</div>
-</div>
-
 <div class="card card-container">
   <div class="card-body">
     <table
       class="table table-striped table-bordered supervisors-list"
       id="supervisors">
       <thead>
-      <tr class="supervisor_table_row">
-        <th>Supervisor Name</th>
-        <th></th>
-        <th>Actions</th>
-      </tr>
+        <tr class="supervisor_table_row">
+          <th>Supervisor Name</th>
+          <th></th>
+          <th>Actions</th>
+        </tr>
       </thead>
-
       <tbody>
       <% @supervisors.each do |supervisor| %>
         <tr class="supervisor_table_row">
@@ -77,30 +74,26 @@
             <% no_attempt_percentage = 100 %>
             <% active_percentage = 0 %>
           <% end %>
-
           <% transition_volunteers = supervisor.volunteers_serving_transition_aged_youth %>
-
           <td id="name-<%= supervisor.id %>">
             <span class="mobile-label">Supervisor Name</span>
             <%= link_to(supervisor.display_name, edit_supervisor_path(supervisor)) %>
           </td>
-
-          <td class="supervisor_indicator_container">
+          <td class="supervisor_indicator_container supervisor_case_contact_stats">
             <div class="supervisor_indicator_negative_positive">
               <% if active_volunteers %>
-                <span class="supervisor_indicator_positive" style="width: <%= active_percentage %>%">
+                <span style="width: <%= active_percentage %>%">
                   <%= active_volunteers %>
                 </span>
               <% end %>
               <% if no_attempt_volunteers.nonzero? %>
-                <span class="supervisor_indicator_negative" style="width: <%= no_attempt_percentage %>%">
+                <span style="width: <%= no_attempt_percentage %>%">
                   <%= no_attempt_volunteers %>
                 </span>
               <% end %>
           </div>
             <div class="supervisor_indicator_transition_aged_youth"><%= transition_volunteers %></div>
           </td>
-
           <td>
             <span class="mobile-label">Actions</span>
             <%= link_to 'Edit', edit_supervisor_path(supervisor) %>
@@ -111,7 +104,6 @@
     </table>
   </div>
 </div>
-
 <div class="row">
   <div class="col-sm-12 dashboard-table-header">
     <div class="card card-container">
@@ -119,9 +111,9 @@
         <% if @available_volunteers.any? %>
           <table class="table table-striped table-bordered" id="unassigned-volunteers">
             <thead>
-            <th></th>
-            <th>Active volunteers not assigned to supervisors</th>
-            <th>Assigned to Case(s)</th>
+              <th></th>
+              <th>Active volunteers not assigned to supervisors</th>
+              <th>Assigned to Case(s)</th>
             </thead>
             <tbody>
             <% @available_volunteers.each_with_index do |volunteer, index| %>


### PR DESCRIPTION
### What changed, and why?
 - Made supervisor legend text larger
 - fixed non rounded corners for stat bars with only green or red bars
 - minimized code
 - fixed filter dropdown buttons not being vertically aligned for entire site
 - if a supervisor has no volunteers, text now shows up explaining so
 - fixed transition aged youth count on new line in mobile view 

### How is this tested? (please write tests!) 💖💪
Manually

### Screenshots please :)
# Old
![image](https://user-images.githubusercontent.com/8918762/148631514-769d90a7-0223-42bf-9200-ee26cf0a00d7.png)
![image](https://user-images.githubusercontent.com/8918762/148723601-cb17ddc5-f28b-4097-8bd9-3435834a3109.png)

# New
![image](https://user-images.githubusercontent.com/8918762/148631506-e8d36274-9551-47be-9b16-c3b1f29f7d7e.png)
![image](https://user-images.githubusercontent.com/8918762/148723560-935d36e9-5959-4e9c-a4fa-b2cbb1164b5b.png)
![image](https://user-images.githubusercontent.com/8918762/148723689-b539d8d0-9c88-45af-a81b-42f753192756.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9