### PR TITLE
update tests for supervisors bar graph

### DIFF
--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,8 +43,8 @@
 </div>
 <div class="legend supervisor_case_contact_stats">
   <div>
-    <span class="attempted-contact"># Volunteers attempting contact(within 2 weeks)</span>
-    <span class="no-attempted-contact"># Volunteers not attempting contact(within 2 weeks)</span>
+    <span class="attempted-contact"># Volunteers attempting contact (within 2 weeks)</span>
+    <span class="no-attempted-contact"># Volunteers not attempting contact (within 2 weeks)</span>
     <span>Transition aged youth</span>
   </div>
 </div>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -43,8 +43,8 @@
 </div>
 <div class="legend supervisor_case_contact_stats">
   <div>
-    <span class="attempted-contact">Have attempted contact in the last 14 days</span>
-    <span class="no-attempted-contact">Have not attempted contact in the last 14 days</span>
+    <span class="attempted-contact"># Volunteers attempting contact(within 2 weeks)</span>
+    <span class="no-attempted-contact"># Volunteers not attempting contact(within 2 weeks)</span>
     <span>Transition aged youth</span>
   </div>
 </div>

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -20,14 +20,6 @@ RSpec.describe "supervisors/index", type: :view do
       expect(rendered).to have_link("New Supervisor", href: new_supervisor_path)
     end
 
-    it "shows the legend for the colored bars at all times" do
-      render template: "supervisors/index"
-
-      expect(rendered).to match("Have attempted contact in the last 14 days")
-      expect(rendered).to match("Have not attempted contact in the last 14 days")
-      expect(rendered).to match("(Transition aged youth)")
-    end
-
     xit "shows positive and negative numbers for each supervisor" do # TODO FireLemons
       supervisor = create(:supervisor)
       create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -38,16 +38,21 @@ RSpec.describe "supervisors/index", type: :view do
       end
     end
 
-    xit "omits the positive bar if there are no active volunteers with contact w/in 14 days" do # TODO FireLemons
-      supervisor = create(:supervisor)
-      create(:volunteer, :with_casa_cases, supervisor: supervisor)
+    context "when a supervisor only has volunteers who have not submitted a case contact in 14 days" do
+      let(:supervisor) { create(:supervisor) }
+      let!(:volunteer_without_recently_created_contacts) {
+        create(:volunteer, :with_casa_cases, supervisor: supervisor)
+      }
 
-      assign :supervisors, [supervisor]
-      render template: "supervisors/index"
+      it "omits the positive bar if there are no active volunteers with contact w/in 14 days" do
+        assign :supervisors, [supervisor]
+        render template: "supervisors/index"
 
-      expect(rendered).not_to match("supervisor_indicator_positive")
-      expect(rendered).to match("supervisor_indicator_negative")
-      expect(rendered).to match("supervisor_indicator_transition_aged_youth")
+        PARSED_HTML_PAGE = Nokogiri.HTML5(rendered)
+
+        expect(PARSED_HTML_PAGE.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to equal(1)
+        expect(PARSED_HTML_PAGE.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to equal(0)
+      end
     end
 
     xit "omits the negative bar if all volunteers have a contact within 14 days" do # TODO FireLemons

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe "supervisors/index", type: :view do
     it "shows the legend for the colored bars at all times" do
       render template: "supervisors/index"
 
-      expect(rendered).to match /Have attempted contact in the last 14 days/
-      expect(rendered).to match /Have not attempted contact in the last 14 days/
-      expect(rendered).to match /(Transition aged youth)/
+      expect(rendered).to match("Have attempted contact in the last 14 days")
+      expect(rendered).to match("Have not attempted contact in the last 14 days")
+      expect(rendered).to match("(Transition aged youth)")
     end
 
     xit "shows positive and negative numbers for each supervisor" do # TODO FireLemons
@@ -36,9 +36,9 @@ RSpec.describe "supervisors/index", type: :view do
       assign :supervisors, [supervisor]
       render template: "supervisors/index"
 
-      expect(rendered).to match /supervisor_indicator_positive/
-      expect(rendered).to match /supervisor_indicator_negative/
-      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+      expect(rendered).to match("supervisor_indicator_positive")
+      expect(rendered).to match("supervisor_indicator_negative")
+      expect(rendered).to match("supervisor_indicator_transition_aged_youth")
     end
 
     xit "omits the positive bar if there are no active volunteers with contact w/in 14 days" do # TODO FireLemons
@@ -48,9 +48,9 @@ RSpec.describe "supervisors/index", type: :view do
       assign :supervisors, [supervisor]
       render template: "supervisors/index"
 
-      expect(rendered).not_to match /supervisor_indicator_positive/
-      expect(rendered).to match /supervisor_indicator_negative/
-      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+      expect(rendered).not_to match("supervisor_indicator_positive")
+      expect(rendered).to match("supervisor_indicator_negative")
+      expect(rendered).to match("supervisor_indicator_transition_aged_youth")
     end
 
     xit "omits the negative bar if all volunteers have a contact within 14 days" do # TODO FireLemons
@@ -60,9 +60,9 @@ RSpec.describe "supervisors/index", type: :view do
       assign :supervisors, [supervisor]
       render template: "supervisors/index"
 
-      expect(rendered).to match /supervisor_indicator_positive/
-      expect(rendered).not_to match /supervisor_indicator_negative$/
-      expect(rendered).to match /supervisor_indicator_transition_aged_youth/
+      expect(rendered).to match("supervisor_indicator_positive")
+      expect(rendered).not_to match("supervisor_indicator_negative")
+      expect(rendered).to match("supervisor_indicator_transition_aged_youth")
     end
   end
 

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -33,8 +33,10 @@ RSpec.describe "supervisors/index", type: :view do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        expect(rendered).to match("<span class=\"attempted-contact\"")
-        expect(rendered).to match("<span class=\"no-attempted-contact\"")
+        PARSED_HTML = Nokogiri.HTML5(rendered)
+
+        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to equal(1)
+        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to equal(1)
       end
     end
 
@@ -44,14 +46,14 @@ RSpec.describe "supervisors/index", type: :view do
         create(:volunteer, :with_casa_cases, supervisor: supervisor)
       }
 
-      it "omits the positive bar if there are no active volunteers with contact w/in 14 days" do
+      it "omits the positive bar" do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        PARSED_HTML_PAGE = Nokogiri.HTML5(rendered)
+        PARSED_HTML = Nokogiri.HTML5(rendered)
 
-        expect(PARSED_HTML_PAGE.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to equal(1)
-        expect(PARSED_HTML_PAGE.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to equal(0)
+        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to equal(1)
+        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to equal(0)
       end
     end
 

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe "supervisors/index", type: :view do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        PARSED_HTML = Nokogiri.HTML5(rendered)
+        parsed_html = Nokogiri.HTML5(rendered)
 
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(1)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(1)
       end
     end
 
@@ -50,10 +50,10 @@ RSpec.describe "supervisors/index", type: :view do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        PARSED_HTML = Nokogiri.HTML5(rendered)
+        parsed_html = Nokogiri.HTML5(rendered)
 
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(0)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(0)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(1)
       end
     end
 
@@ -67,11 +67,11 @@ RSpec.describe "supervisors/index", type: :view do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        PARSED_HTML = Nokogiri.HTML5(rendered)
+        parsed_html = Nokogiri.HTML5(rendered)
 
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(1)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact-end").length).to eq(1)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(0)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact-end").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(0)
       end
     end
 
@@ -82,11 +82,11 @@ RSpec.describe "supervisors/index", type: :view do
         assign :supervisors, [supervisor]
         render template: "supervisors/index"
 
-        PARSED_HTML = Nokogiri.HTML5(rendered)
+        parsed_html = Nokogiri.HTML5(rendered)
 
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(0)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(0)
-        expect(PARSED_HTML.css("#supervisors .supervisor_case_contact_stats .no-volunteers").length).to eq(1)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(0)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(0)
+        expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-volunteers").length).to eq(1)
       end
     end
   end

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -20,17 +20,22 @@ RSpec.describe "supervisors/index", type: :view do
       expect(rendered).to have_link("New Supervisor", href: new_supervisor_path)
     end
 
-    xit "shows positive and negative numbers for each supervisor" do # TODO FireLemons
-      supervisor = create(:supervisor)
-      create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)
-      create(:volunteer, :with_casa_cases, supervisor: supervisor)
+    context "when a supervisor has volunteers who have and have not submitted a case contact in 14 days" do
+      let(:supervisor) { create(:supervisor) }
+      let!(:volunteer_with_recently_created_contacts) {
+        create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)
+      }
+      let!(:volunteer_without_recently_created_contacts) {
+        create(:volunteer, :with_casa_cases, supervisor: supervisor)
+      }
 
-      assign :supervisors, [supervisor]
-      render template: "supervisors/index"
+      it "shows positive and negative numbers" do
+        assign :supervisors, [supervisor]
+        render template: "supervisors/index"
 
-      expect(rendered).to match("supervisor_indicator_positive")
-      expect(rendered).to match("supervisor_indicator_negative")
-      expect(rendered).to match("supervisor_indicator_transition_aged_youth")
+        expect(rendered).to match("<span class=\"attempted-contact\"")
+        expect(rendered).to match("<span class=\"no-attempted-contact\"")
+      end
     end
 
     xit "omits the positive bar if there are no active volunteers with contact w/in 14 days" do # TODO FireLemons


### PR DESCRIPTION
 - updated tests to match new code
 - labeled supervisor stats as count of volunteers
 - use nokogiri instead of html string comparison
 - added test for when a supervisor has no volunteers