### PR TITLE
test made more DRY with localization text lookup

### DIFF
--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "casa_cases/edit", type: :view do
 
       render template: "casa_cases/edit"
 
-      expect(rendered).to include("Assign a New Volunteer")
+      expect(rendered).to include(I18n.t("casa_cases.volunteer_assignment.assign_new"))
       expect(rendered).to include(CGI.escapeHTML("Youth's Birth Month & Year"))
     end
   end


### PR DESCRIPTION
### What changed, and why?
Test checks localization files instead of hard coded string