### PR TITLE
Fix incorrect calendar invite dates

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -40,6 +40,18 @@ class CasaCaseDecorator < Draper::Decorator
     end
   end
 
+  def calendar_next_court_date
+    {start: calendar_format(object.next_court_date.date), end: calendar_format(object.next_court_date.date + 1.day)}
+  end
+
+  def calendar_court_report_due_date
+    {start: calendar_format(object.court_report_due_date), end: calendar_format(object.court_report_due_date + 1.day)}
+  end
+
+  def calendar_format(date)
+    I18n.l(date, format: :long, default: "")
+  end
+
   def formatted_updated_at
     I18n.l(object.updated_at, format: :standard, default: nil)
   end

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -41,10 +41,12 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def calendar_next_court_date
+    return nil unless object.next_court_date
     {start: calendar_format(object.next_court_date.date), end: calendar_format(object.next_court_date.date + 1.day)}
   end
 
   def calendar_court_report_due_date
+    return nil unless object.court_report_due_date
     {start: calendar_format(object.court_report_due_date), end: calendar_format(object.court_report_due_date + 1.day)}
   end
 

--- a/app/javascript/src/addToCalendarButton.js
+++ b/app/javascript/src/addToCalendarButton.js
@@ -7,8 +7,8 @@ function createCalendarEvents () {
   calendarButtons.forEach((btn) => {
     const calendarEvent = new Add2Calendar({
       title: btn.dataset.title,
-      start: btn.dataset.date,
-      end: btn.dataset.date,
+      start: btn.dataset.start,
+      end: btn.dataset.end,
       description: btn.dataset.title,
       isAllDay: true
     })

--- a/app/views/casa_cases/_calendar_button.html.erb
+++ b/app/views/casa_cases/_calendar_button.html.erb
@@ -1,5 +1,5 @@
 <!-- Button code -->
 <% if date.present? %>
-  <%= tag.div class: "cal-btn", id: id, data: { title: title, date: date, tooltip: tooltip } do %>
+  <%= tag.div class: "cal-btn", id: id, data: { title: title, start: date[:start], end: date[:end], tooltip: tooltip } do %>
   <% end %>
 <% end %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -60,11 +60,10 @@
     <h6>
       <strong><%= t(".label.next_court_date") %>:</strong>
       <%= I18n.l(@casa_case.next_court_date&.date, format: :day_and_date, default: '') %>
-      <%= render "calendar_button", date:  I18n.l(@casa_case.next_court_date&.date,
-                                                  format: :default, default: ''),
-                                                  id: "btnNextCourtDate",
-                                                  tooltip: "Add Next Court Date to Calendar",
-                                                  title: "Next Court Date for [#{@casa_case.case_number}]" %>
+      <%= render "calendar_button", date: @casa_case.decorate.calendar_next_court_date,
+                                    id: "btnNextCourtDate",
+                                    tooltip: "Add Next Court Date to Calendar",
+                                    title: "Next Court Date for [#{@casa_case.case_number}]" %>
     </h6>
     </p>
 
@@ -72,11 +71,10 @@
     <h6>
       <strong><%= t(".label.court_report_due_date") %>:</strong>
       <%= I18n.l(@casa_case.court_report_due_date, format: :day_and_date, default: '') %>
-      <%= render "calendar_button", date: I18n.l(@casa_case.court_report_due_date,
-                                                format: :default, default: ''),
-                                                id: "btnCourtReportDueDate",
-                                                tooltip: "Add Court Report Due Date to Calendar",
-                                                title: "Court Report Due Date for [#{@casa_case.case_number}]" %>
+      <%= render "calendar_button", date: @casa_case.decorate.calendar_court_report_due_date,
+                                    id: "btnCourtReportDueDate",
+                                    tooltip: "Add Court Report Due Date to Calendar",
+                                    title: "Court Report Due Date for [#{@casa_case.case_number}]" %>
     </h6>
     </p>
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3093 

### What changed, and why?
Calendar invite dates were previously incorrect due to:
1. A timezone issue resulting from using `format: :default` instead of `format: :long`; and
2. The Google calendar end date being *exclusive* for all-day events and thus needing to be adjusted
(see the Recommended answer here: https://support.google.com/calendar/thread/128416249/calendar-url-generator-which-parameters?hl=en)


### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Manual testing (had to verify correct dates on external site)

### Screenshots please :)
![image](https://user-images.githubusercontent.com/44326005/150283303-b8adfbef-f7a6-4635-8c31-f674a4f051df.png)
![image](https://user-images.githubusercontent.com/44326005/150283330-3f4d86e9-d1cc-4c64-9d81-1217964ca215.png)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9