### PR TITLE
Avoid to test classes with parentheses when possible

### DIFF
--- a/spec/datatables/supervisor_datatable_spec.rb
+++ b/spec/datatables/supervisor_datatable_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "SupervisorDatatable" do
+RSpec.describe SupervisorDatatable do
   subject { described_class.new(org.supervisors, params).as_json }
 
   let(:org) { create(:casa_org) }

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "VolunteerDatatable" do
+RSpec.describe VolunteerDatatable do
   let(:org) { CasaOrg.first }
   let(:supervisors) { Supervisor.all }
   let(:assigned_volunteers) { Volunteer.joins(:supervisor) }

--- a/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
+require "./lib/tasks/data_post_processors/case_contact_populator"
 
-RSpec.describe "CaseContactPopulator" do
+RSpec.describe CaseContactPopulator do
   before do
     Rake::Task.clear
     Casa::Application.load_tasks
   end
 
   it "does nothing on an empty database" do
-    CaseContactPopulator.populate
+    described_class.populate
 
     expect(ContactType.count).to eq(0)
     expect(ContactTypeGroup.count).to eq(0)
@@ -16,7 +17,7 @@ RSpec.describe "CaseContactPopulator" do
   it "does nothing if there are no contact types" do
     case_contact = create(:case_contact, contact_types: [])
 
-    CaseContactPopulator.populate
+    described_class.populate
 
     expect(case_contact.contact_types).to be_empty
     expect(ContactType.count).to eq(0)
@@ -31,7 +32,7 @@ RSpec.describe "CaseContactPopulator" do
     casa_case = create(:casa_case, casa_org: casa_org2)
     create(:case_contact, casa_case: casa_case, contact_types: [contact_type])
 
-    CaseContactPopulator.populate
+    described_class.populate
 
     expect(ContactTypeGroup.count).to eq(2)
     expect(ContactTypeGroup.last.casa_org).to eq(casa_org2)
@@ -49,7 +50,7 @@ RSpec.describe "CaseContactPopulator" do
     casa_case = create(:casa_case, casa_org: ctg2.casa_org)
     create(:case_contact, casa_case: casa_case, contact_types: [contact_type])
 
-    CaseContactPopulator.populate
+    described_class.populate
 
     expect(ContactTypeGroup.count).to eq(2)
     expect(ContactType.count).to eq(2)


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/casa/issues/3130

### What changed, and why?

to improve our test suit, and use `described_class` when it's possible.
