### PR TITLE
#2883: Add 'Change to Supervisor' button

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -103,6 +103,13 @@ class CasaAdminsController < ApplicationController
     redirect_to edit_casa_admin_path(@casa_admin), notice: "Invitation sent"
   end
 
+  def change_to_supervisor
+    authorize @casa_admin
+    @casa_admin.change_to_supervisor!
+
+    redirect_to edit_supervisor_path(@casa_admin), notice: "Admin was changed to Supervisor."
+  end
+
   private
 
   def redirect_to_casa_admin_edition_page(error)

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -10,6 +10,10 @@ class CasaAdmin < User
   def deactivate
     update(active: false)
   end
+
+  def change_to_supervisor!
+    becomes!(Supervisor).save
+  end
 end
 
 # == Schema Information

--- a/app/policies/casa_admin_policy.rb
+++ b/app/policies/casa_admin_policy.rb
@@ -11,6 +11,7 @@ class CasaAdminPolicy < UserPolicy
   alias_method :resend_invitation?, :index?
   alias_method :restore?, :is_admin?
   alias_method :datatable?, :index?
+  alias_method :change_to_supervisor?, :is_admin?
 
   def deactivate?
     see_deactivate_option? && CasaAdmin.in_organization(current_organization).active.size > 1

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -44,6 +44,13 @@
                         method: :patch,
                         class: "btn btn-outline-danger" %>
           <% end %>
+
+          <% if current_user.casa_admin? %>
+            <%= link_to "Change to Supervisor",
+                        change_to_supervisor_casa_admin_path(casa_admin),
+                        method: :patch,
+                        class: "btn btn-outline-danger" %>
+          <% end %>
         </div>
       <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       patch :deactivate
       patch :activate
       patch :resend_invitation
+      patch :change_to_supervisor
     end
   end
 

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe CasaAdmin, type: :model do
       expect(user.errors.full_messages).to include("Invitation token is invalid")
     end
   end
+
+  describe "change to supervisor" do
+    subject(:admin) { create(:casa_admin) }
+
+    it "returns true if the change was successful" do
+      expect(subject.change_to_supervisor!).to be_truthy
+    end
+
+    it "changes the supervisor to an admin" do
+      subject.change_to_supervisor!
+
+      user = User.find(subject.id) # subject.reload will cause RecordNotFound because it's looking in the wrong table
+      expect(user).not_to be_casa_admin
+      expect(user).to be_supervisor
+    end
+  end
 end

--- a/spec/policies/casa_admin_policy_spec.rb
+++ b/spec/policies/casa_admin_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CasaAdminPolicy do
   let(:volunteer) { build(:volunteer, casa_org: organization) }
   let(:supervisor) { build(:supervisor, casa_org: organization) }
 
-  permissions :index?, :new?, :create?, :edit?, :update?, :activate?, :resend_invitation? do
+  permissions :index?, :new?, :create?, :edit?, :update?, :activate?, :resend_invitation?, :change_to_supervisor? do
     it "allows casa_admins" do
       is_expected.to permit(casa_admin)
     end

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -359,4 +359,39 @@ RSpec.describe "/casa_admins", type: :request do
       end
     end
   end
+
+  describe "PATCH /change_to_supervisor" do
+    let(:casa_admin) { create(:casa_admin) }
+    let(:user) { User.find(casa_admin.id) } # find the user after their type has changed
+
+    context "when signed in as an admin" do
+      before do
+        sign_in_as_admin
+        patch change_to_supervisor_casa_admin_path(casa_admin)
+      end
+
+      it "changes the admin to a supervisor" do
+        expect(user).not_to be_casa_admin
+        expect(user).to be_supervisor
+      end
+
+      it "redirects to the edit page for a supervisor" do
+        expect(response).to redirect_to(edit_supervisor_path(casa_admin))
+      end
+    end
+
+    context "when signed in as a supervisor" do
+      let(:supervisor) { create(:supervisor) }
+
+      before do
+        sign_in supervisor
+        patch change_to_supervisor_casa_admin_path(casa_admin)
+      end
+
+      it "does not change the admin to a supervisor" do
+        expect(user).to be_casa_admin
+        expect(user).not_to be_supervisor
+      end
+    end
+  end
 end

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe "casa_admins/edit", type: :system do
     expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
   end
 
+  it "can convert the admin to a supervisor", js: true do
+    another = create(:casa_admin)
+    visit edit_casa_admin_path(another)
+
+    click_on "Change to Supervisor"
+
+    expect(page).to have_text("Admin was changed to Supervisor.")
+    expect(User.find(another.id)).to be_supervisor
+  end
+
   it "is not able to edit last sign in" do
     visit edit_casa_admin_path(admin)
 

--- a/spec/views/casa_admins/edit.html.erb_spec.rb
+++ b/spec/views/casa_admins/edit.html.erb_spec.rb
@@ -17,4 +17,33 @@ RSpec.describe "casa_admins/edit", type: :view do
     expect(rendered).to have_text("Invitation accepted \n  never")
     expect(rendered).to have_text("Password reset last sent \n  never")
   end
+
+  describe "'Change to Supervisor' button" do
+    let(:supervisor) { build_stubbed :supervisor }
+
+    before do
+      assign :casa_admin, admin
+      assign :available_volunteers, []
+    end
+
+    it "shows for an admin editing an admin" do
+      enable_pundit(view, admin)
+      allow(view).to receive(:current_user).and_return(admin)
+
+      render template: "casa_admins/edit"
+
+      expect(rendered).to have_text("Change to Supervisor")
+      expect(rendered).to include(change_to_supervisor_casa_admin_path(admin))
+    end
+
+    it "does not show for a supervisor editing an admin" do
+      enable_pundit(view, admin)
+      allow(view).to receive(:current_user).and_return(supervisor)
+
+      render template: "casa_admins/edit"
+
+      expect(rendered).not_to have_text("Change to Supervisor")
+      expect(rendered).not_to include(change_to_supervisor_casa_admin_path(admin))
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2883.

### What changed, and why?
Adds a 'Change to Supervisor' button to the Admin edit form, which is only visible when logged in as an admin. This lets an Admin become a Supervisor.

### How will this affect user permissions?
- Volunteer permissions: volunteers **may not change** admins to supervisors
- Supervisor permissions: supervisors **may not change** admins to supervisors
- Admin permissions: admins **may change** admins to supervisors

### How is this tested? (please write tests!) 💖💪
This is tested in view, system, request, policy, and model specs.

### Screenshots please :)
#### Admin edit form
![image](https://user-images.githubusercontent.com/3433687/150576612-ec082a08-4c25-47e0-ae44-6c53e55f5e88.png)

#### After changing the supervisor to an admin
![image](https://user-images.githubusercontent.com/3433687/150576656-3183d4cc-edc8-47d8-b7c3-958dd94bf217.png)

### Feelings gif (optional)
![blond short-haired kid at a computer giving a thumbs up](https://media.giphy.com/media/11ISwbgCxEzMyY/giphy.gif)