### PR TITLE
Show emancipation checklist based on youth age

### DIFF
--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -12,7 +12,7 @@
       <%= link_to t(".button.edit_case"), edit_casa_case_path(@casa_case),
               class: "btn btn-primary pull-left casa-case-button" %>
     <% end %>
-    <% if @casa_case.has_transitioned? %>
+    <% if @casa_case.in_transition_age? %>
       <%= link_to(casa_case_emancipation_path(@casa_case),
               class: "btn btn-primary pull-left casa-case-button") do %>
         <%= t(".button.emancipation") %>

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "casa_cases/show", type: :system do
   let(:volunteer) { build(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
   let(:casa_case) {
     create(:casa_case, :with_one_court_order, casa_org: organization,
-    case_number: "CINA-1", transition_aged_youth: true, court_report_due_date: 1.month.from_now)
+    case_number: "CINA-1", court_report_due_date: 1.month.from_now)
   }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
@@ -18,10 +18,30 @@ RSpec.describe "casa_cases/show", type: :system do
     visit casa_case_path(casa_case.id)
   end
 
-  context "when admin" do
+  shared_examples "shows emancipation checklist link" do
+    context "when youth is in transition age" do
+      it "sees link to emancipation" do
+        expect(page).to have_link("Emancipation 0 / #{emancipation_categories.size}")
+      end
+    end
+
+    context "when youth is not in transition age" do
+      before do
+        casa_case.update!(birth_month_year_youth: DateTime.current)
+        visit casa_case_path(casa_case)
+      end
+
+      it "does not see a link to emancipation checklist" do
+        expect(page).not_to have_link("Emancipation 0 / #{emancipation_categories.size}")
+      end
+    end
+  end
+
+  context "admin user" do
     let(:user) { admin }
 
     it_behaves_like "shows court dates links"
+    it_behaves_like "shows emancipation checklist link"
 
     it "can see case creator in table" do
       expect(page).to have_text("Bob Loblaw")
@@ -67,6 +87,8 @@ RSpec.describe "casa_cases/show", type: :system do
     let(:user) { create(:supervisor, casa_org: organization) }
     let!(:case_contact) { create(:case_contact, creator: user, casa_case: casa_case) }
 
+    it_behaves_like "shows emancipation checklist link"
+
     it "sees link to own edit page" do
       expect(page).to have_link(href: "/supervisors/#{user.id}/edit")
     end
@@ -111,9 +133,7 @@ RSpec.describe "casa_cases/show", type: :system do
   context "volunteer user" do
     let(:user) { volunteer }
 
-    it "sees link to emancipation" do
-      expect(page).to have_link("Emancipation 0 / #{emancipation_categories.size}")
-    end
+    it_behaves_like "shows emancipation checklist link"
 
     it "can see court orders" do
       expect(page).to have_content("Court Orders")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2488

### What changed, and why?
Showing a link to the emancipations checklist is now based on the youth's age. I believe this is a small step to deprecating the emancipation flag on the case.

### How will this affect user permissions?
It won't

### How is this tested? (please write tests!) 💖💪
I did!

### Screenshots please :)
![image](https://user-images.githubusercontent.com/22677/150624722-c4df16ec-41a5-46d1-8b74-49a99b12a12a.png)


### Feelings gif (optional)
![alt text](https://media.giphy.com/media/VGSpQZzybSUVKUrzri/giphy.gif)