### PR TITLE
#3098: Test active and inactive bar lengths on supervisor index

### DIFF
--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe "supervisors/index", type: :view do
         expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact").length).to eq(1)
         expect(parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact").length).to eq(1)
       end
+
+      it "accurately displays the number of active and inactive volunteers per supervisor" do
+        create(:volunteer, :with_cases_and_contacts, supervisor: supervisor)
+        assign :supervisors, [supervisor]
+        render template: "supervisors/index"
+
+        parsed_html = Nokogiri.HTML5(rendered)
+
+        active_bar = parsed_html.css("#supervisors .supervisor_case_contact_stats .attempted-contact")
+        inactive_bar = parsed_html.css("#supervisors .supervisor_case_contact_stats .no-attempted-contact")
+        active_flex = active_bar.attribute("style").value.split.last
+        inactive_flex = inactive_bar.attribute("style").value.split.last
+        active_content = active_bar.children[0].text.strip
+        inactive_content = inactive_bar.children[0].text.strip
+
+        expect(active_flex).to eq(active_content)
+        expect(inactive_flex).to eq(inactive_content)
+        expect(active_flex.to_i).to eq(2)
+        expect(inactive_flex.to_i).to eq(1)
+      end
     end
 
     context "when a supervisor only has volunteers who have not submitted a case contact in 14 days" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3098

### What changed, and why?
Added a test to see that the bar length style attribute matched the number of active/inactive supervisors displayed.

### How will this affect user permissions?
- Volunteer permissions: does not affect.
- Supervisor permissions: does not affect.
- Admin permissions: does not affect.

### How is this tested? (please write tests!) 💖💪
Only a test, not a feature, but more specifically compare the number in the flex style attribute to the number in the child element text.

### Screenshots please :)
No new features, but this is the display being tested for reference (pulled from #3098).
![149056423-08debd9f-1439-415e-9c48-d75ba84e7b1b](https://user-images.githubusercontent.com/10855116/151237685-aed8853f-0f3b-4ea3-82b4-5599fa11adb1.png)