### PR TITLE
#3127 Add notes field to volunteers edit

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,13 @@
+class NotesController < ApplicationController
+  def create
+    volunteer = Volunteer.find(params[:volunteer_id])
+    volunteer.notes.create(note_params)
+    redirect_to edit_volunteer_path(volunteer)
+  end
+
+  private
+
+  def note_params
+    params.require(:note).permit(:content).merge({creator_id: current_user.id})
+  end
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,21 @@
+class Note < ApplicationRecord
+  belongs_to :notable, polymorphic: true
+  belongs_to :creator, class_name: "User", foreign_key: "creator_id"
+end
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id           :bigint           not null, primary key
+#  content      :string
+#  notable_type :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  creator_id   :bigint
+#  notable_id   :bigint
+#
+# Indexes
+#
+#  index_notes_on_notable  (notable_type,notable_id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   has_one :supervisor, through: :supervisor_volunteer
   has_one :preference_set, dependent: :destroy
 
+  has_many :notes, as: :notable
+
   scope :active, -> { where(active: true) }
 
   scope :inactive, -> { where(active: false) }

--- a/app/views/volunteers/_notes.html.erb
+++ b/app/views/volunteers/_notes.html.erb
@@ -1,0 +1,42 @@
+<div class="notes">
+  <h1 class="pt-5">Notes</h1>
+
+  <div class="card card-container">
+    <div class="card-body">
+      <% if @volunteer.notes != [] %>
+        <h3>Notes About This Volunteer</h3>
+        <table class="table table-striped table-bordered">
+          <thead>
+            <tr>
+              <th>Note</th>
+              <th>Creator</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @volunteer.notes.each do |note| %>
+              <tr>
+                <td><%= note.content %></td>
+                <td><%= note.creator.display_name %></td>
+                <td><%= note.created_at.strftime(t("time.formats.standard")) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+      <br>
+      <%= form_with(model: @volunteer.notes.new, local: true, url: volunteer_notes_path(@volunteer),
+id: "volunteer-note-form") do |form| %>
+        <h3>Create a New Note</h3>
+        <div class="form-group">
+          <%= form.text_area :content, :rows => 5, placeholder: t("volunteers.edit.notes_placeholder"),
+class: "form-control" %>
+        </div>
+
+        <div class="actions">
+          <%= form.submit t("volunteers.edit.note_submit"), class: "btn btn-primary", id: "note-submit" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -42,6 +42,10 @@
   </div>
 </div>
 
+<% if current_user.casa_admin? || current_user.supervisor? %>
+  <%= render 'notes' %>
+<% end %>
+
 <%= render 'manage_cases' %>
 
 <%= render 'manage_supervisor' %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -453,6 +453,9 @@ en:
         other: All Volunteers
         zero: Assigned Volunteers
   volunteers:
+    edit:
+      notes_placeholder: "Enter a note regarding the volunteer. These notes are only visible to CASA administrators and supervisors."
+      note_submit: "Save Note"
     index:
       active: Active
       button:
@@ -497,4 +500,3 @@ en:
         created_by: Created By
         created_at: Created At
         actions: Actions
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
       patch :reminder
       get :impersonate
     end
+    resources :notes, only: %i[create]
   end
   resources :case_assignments, only: %i[create destroy] do
     member do

--- a/db/migrate/20220127055733_create_notes.rb
+++ b/db/migrate/20220127055733_create_notes.rb
@@ -1,0 +1,11 @@
+class CreateNotes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notes do |t|
+      t.string :content
+      t.bigint :creator_id
+      t.references :notable, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_030922) do
+ActiveRecord::Schema.define(version: 2022_01_27_055733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -297,6 +297,16 @@ ActiveRecord::Schema.define(version: 2022_01_05_030922) do
     t.index ["user_id"], name: "index_mileage_rates_on_user_id"
   end
 
+  create_table "notes", force: :cascade do |t|
+    t.string "content"
+    t.bigint "creator_id"
+    t.string "notable_type"
+    t.bigint "notable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notable_type", "notable_id"], name: "index_notes_on_notable"
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.string "recipient_type", null: false
     t.bigint "recipient_id", null: false
@@ -377,7 +387,8 @@ ActiveRecord::Schema.define(version: 2022_01_05_030922) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+  it { is_expected.to belong_to(:notable) }
+  it { is_expected.to belong_to(:creator) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_one(:supervisor_volunteer) }
   it { is_expected.to have_one(:supervisor).through(:supervisor_volunteer) }
 
+  it { is_expected.to have_many(:notes) }
+
   it "requires display name" do
     user = build(:user, display_name: "")
     expect(user.valid?).to be false

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -346,4 +346,64 @@ RSpec.describe "volunteers/edit", type: :system do
       end
     end
   end
+
+  context "logged in as an admin" do
+    before do
+      sign_in admin
+      visit edit_volunteer_path(volunteer)
+    end
+
+    it "can save notes about a volunteer" do
+      freeze_time do
+        current_date = Date.today
+        fill_in("note[content]", with: "Great job today.")
+        within(".notes") do
+          click_on("Save Note")
+        end
+
+        expect(current_path).to eq(edit_volunteer_path(volunteer))
+        within(".notes") do
+          expect(page).to have_text("Great job today.")
+          expect(page).to have_text(admin.display_name)
+          expect(page).to have_text(I18n.l(current_date.to_date, format: :standard, default: ""))
+        end
+      end
+    end
+  end
+
+  context "logged in as a supervisor" do
+    before do
+      volunteer.supervisor = create(:supervisor)
+      sign_in volunteer.supervisor
+      visit edit_volunteer_path(volunteer)
+    end
+
+    it "can save notes about a volunteer" do
+      freeze_time do
+        current_date = Date.today
+        fill_in("note[content]", with: "Great job today.")
+        within(".notes") do
+          click_on("Save Note")
+        end
+
+        expect(current_path).to eq(edit_volunteer_path(volunteer))
+        within(".notes") do
+          expect(page).to have_text("Great job today.")
+          expect(page).to have_text(volunteer.supervisor.display_name)
+          expect(page).to have_text(I18n.l(current_date.to_date, format: :standard, default: ""))
+        end
+      end
+    end
+  end
+
+  context "logged in as volunteer" do
+    before do
+      sign_in volunteer
+      visit edit_volunteer_path(volunteer)
+    end
+
+    it "can't see the notes section" do
+      expect(page).not_to have_selector(".notes")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3127

### What changed, and why?
Added a space for Admins and Supervisors to leave notes on the Volunteer Edit page based on the request included in the issue #3127.

In support of that change:

* Added system tests for admins, supervisors, and volunteers to ensure that admins/supervisors can leave and review notes and that volunteers can't see notes.
* Added a section with information notes and a form to create a new note to the volunteers edit page.
* Created a new partial to hold that section and keep the high level logic of the volunteers edit page uncluttered.
* Added localization text for the note submit button and placeholder text for the notes form.
* Added a Note model and migration for a polymorphic notes table to allow notes to be attached to cases in the future without creating a second table (issue mentioned that this might be a request in the future).
* Added model specs for Note and User relationships.
* Added a has_many relationship to the User model to find all notes about a volunteer.
* Added a notes path nested under volunteers for the form to POST to.
* Add a NotesController to persist new notes (currently only configured to add notes to a volunteer).

### How will this affect user permissions?
- Volunteer permissions: cannot see new notes section.
- Supervisor permissions: can see existing notes and create new ones.
- Admin permissions: can see existing notes and create new ones.

### How is this tested? (please write tests!) 💖💪
Added tests to the existing `/system/volunteers/edit_spec.rb`.

* I followed the pattern I found in the `system/supervisors/edit_spec.rb` file, which groups tests using contexts based on who is logged in. That hadn't been implemented in the volunteers edit spec, but seemed like a good way to organize the new tests.
* `freeze_time` might be overkill, but would save an inconsistent spec in the improbable case that a day flips between when a comment is persisted and when it's rendered.

### Screenshots please :)
Without any existing notes.
<img width="1067" alt="Screen Shot 2022-01-27 at 1 39 14 PM" src="https://user-images.githubusercontent.com/10855116/151444795-f81339f2-9108-4323-9f92-67f58cb8fb22.png">

With notes.
<img width="1058" alt="Screen Shot 2022-01-27 at 2 25 01 PM" src="https://user-images.githubusercontent.com/10855116/151444856-faa6dbe6-b947-4bcb-8e44-31166db4ae2f.png">

