### PR TITLE
Disable form for unassigned volunteers

### DIFF
--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -93,7 +93,7 @@
 
     <h3><%= t(".assign_a_volunteer") %></h3>
 
-   <fieldset <%= 'disabled' unless @available_volunteers.any? %>>
+   <fieldset class="border-0" <%= 'disabled' unless @available_volunteers.any? %>>
       <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
 
         <div class='form-group'>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -93,24 +93,23 @@
 
     <h3><%= t(".assign_a_volunteer") %></h3>
 
-    <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
-      <% if @available_volunteers.any? %>
+   <fieldset <%= 'disabled' unless @available_volunteers.any? %>>
+      <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
+
         <div class='form-group'>
-        <label for='supervisor_volunteer_volunteer_id'><%= t(".select_a_volunteer") %></label>
-        <select name='supervisor_volunteer[volunteer_id]' class='form-control select2'>
-          <% @available_volunteers.each do |volunteer| %>
-            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
-          <% end %>
-        </select>
+          <label for='supervisor_volunteer_volunteer_id'><%= t(".select_a_volunteer") %></label>
+          <select name='supervisor_volunteer[volunteer_id]' class='form-control select2'>
+            <% @available_volunteers.each do |volunteer| %>
+              <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+            <% end %>
+          </select>
         </div>
         <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
         <%= form.submit t(".assign_volunteer"), class: 'btn btn-primary' %>
       <% end %>
-    <% end %>
-
+   </fieldset>
     <% unless @available_volunteers.any? %>
       <p class="text-danger"><%= t(".no_volunteers_available") %></p>
     <% end %>
-
   </div>
 </div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -111,7 +111,6 @@
     <% unless @available_volunteers.any? %>
       <p class="text-danger"><%= t(".no_volunteers_available") %></p>
     <% end %>
-        
-    
+
   </div>
 </div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -94,20 +94,24 @@
     <h3><%= t(".assign_a_volunteer") %></h3>
 
     <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
-
-      <div class='form-group'>
+      <% if @available_volunteers.any? %>
+        <div class='form-group'>
         <label for='supervisor_volunteer_volunteer_id'><%= t(".select_a_volunteer") %></label>
         <select name='supervisor_volunteer[volunteer_id]' class='form-control select2'>
           <% @available_volunteers.each do |volunteer| %>
             <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
           <% end %>
         </select>
-      </div>
-      <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
-      <%= form.submit t(".assign_volunteer"), class: 'btn btn-primary' %>
+        </div>
+        <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
+        <%= form.submit t(".assign_volunteer"), class: 'btn btn-primary' %>
+      <% end %>
     <% end %>
+
     <% unless @available_volunteers.any? %>
       <p class="text-danger"><%= t(".no_volunteers_available") %></p>
     <% end %>
+        
+    
   </div>
 </div>

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "supervisors/edit", type: :system do
         it "does not error out when adding non-existent volunteer" do
           visit edit_supervisor_path(supervisor)
           click_on "Assign Volunteer"
-          click_on "Assign Volunteer"
+          expect(page.find_button("Assign Volunteer", disabled: true)).to be_present
           expect(page).to have_text("There are no active, unassigned volunteers available.")
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3111

### What changed, and why?
Disabled the drop-down and "assign volunteer' button when there are no volunteers available.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9