### PR TITLE
Remove unnecessary conditional

### DIFF
--- a/app/views/volunteers/edit.html.erb
+++ b/app/views/volunteers/edit.html.erb
@@ -42,9 +42,7 @@
   </div>
 </div>
 
-<% if current_user.casa_admin? || current_user.supervisor? %>
-  <%= render 'notes' %>
-<% end %>
+<%= render 'notes' %>
 
 <%= render 'manage_cases' %>
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -404,6 +404,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
     it "can't see the notes section" do
       expect(page).not_to have_selector(".notes")
+      expect(page).to have_content("Sorry, you are not authorized to perform this action.")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
No issue, but response to comment [here](https://github.com/rubyforgood/casa/pull/3158#discussion_r794604249)

### What changed, and why?
Removed conditional in the view.

Dug around a little bit based on the comment and realized that this view should not be accessible by volunteers in the first place, so I don't think the check for user role in the view is necessary.

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Added a line to the existing test to confirm that a redirect is happening when a volunteer tries to access this page.

### Screenshots please :)
No new feature implemented.