### PR TITLE
Adjust "CaseContact.has_transitioned" scope reference column

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -56,7 +56,9 @@ class CaseContact < ApplicationRecord
   }
   scope :has_transitioned, ->(has_transitioned = nil) {
     if /true|false/.match?(has_transitioned.to_s)
-      joins(:casa_case).where(casa_cases: {transition_aged_youth: has_transitioned})
+      operator = has_transitioned ? "<=" : ">"
+
+      joins(:casa_case).where("casa_cases.birth_month_year_youth #{operator} ?", 14.years.ago)
     end
   }
   scope :want_driving_reimbursement, ->(want_driving_reimbursement = nil) {

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -172,8 +172,8 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     describe "has transitioned behavior" do
-      let(:case_case_1) { build(:casa_case, transition_aged_youth: false) }
-      let(:case_case_2) { build(:casa_case, transition_aged_youth: true) }
+      let(:case_case_1) { build(:casa_case, birth_month_year_youth: 15.years.ago) }
+      let(:case_case_2) { build(:casa_case, birth_month_year_youth: 10.years.ago) }
 
       before(:each) do
         create(:case_contact, {casa_case: case_case_1})
@@ -181,20 +181,20 @@ RSpec.describe CaseContactReport, type: :model do
       end
 
       it "returns only case contacts the youth has transitioned" do
-        report = CaseContactReport.new({has_transitioned: false})
-        contacts = report.case_contacts
+        contacts = CaseContactReport.new(has_transitioned: false).case_contacts
+
         expect(contacts.length).to eq(1)
       end
 
       it "returns only case contacts the youth has transitioned" do
-        report = CaseContactReport.new({has_transitioned: true})
-        contacts = report.case_contacts
+        contacts = CaseContactReport.new(has_transitioned: true).case_contacts
+
         expect(contacts.length).to eq(1)
       end
 
       it "returns case contacts with both youth has transitioned and youth has not transitioned" do
-        report = CaseContactReport.new({has_transitioned: ""})
-        contacts = report.case_contacts
+        contacts = CaseContactReport.new(has_transitioned: "").case_contacts
+
         expect(contacts.length).to eq(2)
       end
     end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -188,33 +188,35 @@ RSpec.describe CaseContact, type: :model do
     end
 
     describe ".has_transitioned" do
-      let(:casa_case_1) { create(:casa_case, transition_aged_youth: true) }
-      let(:casa_case_2) { create(:casa_case, transition_aged_youth: false) }
+      let(:casa_case_1) { create(:casa_case, birth_month_year_youth: 15.years.ago) }
+      let(:casa_case_2) { create(:casa_case, birth_month_year_youth: 10.years.ago) }
 
       context "with both option" do
-        it "returns case contacts filtered by contact made option" do
-          case_contact_1 = create(:case_contact, {casa_case: casa_case_1})
-          case_contact_2 = create(:case_contact, {casa_case: casa_case_2})
+        let!(:case_contact_1) { create(:case_contact, {casa_case: casa_case_1}) }
+        let!(:case_contact_2) { create(:case_contact, {casa_case: casa_case_2}) }
 
-          expect(CaseContact.has_transitioned("")).to match_array([case_contact_1, case_contact_2])
+        it "returns case contacts filtered by contact made option" do
+          expect(described_class.has_transitioned).to match_array(
+            [case_contact_1, case_contact_2]
+          )
         end
       end
 
-      context "with yes option" do
-        it "returns case contacts filtered by contact made option" do
-          case_contact = create(:case_contact, {casa_case: casa_case_1})
-          create(:case_contact, {casa_case: casa_case_2})
+      context "with true option" do
+        let!(:case_contact_1) { create(:case_contact, {casa_case: casa_case_1}) }
+        let!(:case_contact_2) { create(:case_contact, {casa_case: casa_case_2}) }
 
-          expect(CaseContact.has_transitioned(true)).to match_array([case_contact])
+        it "returns case contacts filtered by contact made option" do
+          expect(described_class.has_transitioned(true)).to match_array([case_contact_1])
         end
       end
 
-      context "with no option" do
-        it "returns case contacts filtered by contact made option" do
-          create(:case_contact, {casa_case: casa_case_1})
-          case_contact = create(:case_contact, {casa_case: casa_case_2})
+      context "with false option" do
+        let!(:case_contact_1) { create(:case_contact, {casa_case: casa_case_1}) }
+        let!(:case_contact_2) { create(:case_contact, {casa_case: casa_case_2}) }
 
-          expect(CaseContact.has_transitioned(false)).to match_array([case_contact])
+        it "returns case contacts filtered by contact made option" do
+          expect(described_class.has_transitioned(false)).to match_array([case_contact_2])
         end
       end
     end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/casa/issues/3129

### What changed, and why?

- change `has_transitioned` scope reference column from `:transition_aged_youth` to `:birth_month_year_youth`. Because the old column is deprecated.

### How is this tested? (please write tests!) 💖💪

Ensuring the existing tests are all green
