### PR TITLE
Limit linters with file extensions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     # The branches below must be a subset of the branches above
@@ -25,7 +25,7 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   schedule:
     - cron: '36 22 * * 3'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -4,17 +4,13 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-      - 'bin/**'
+    paths:
+      - '**.erb'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-      - 'bin/**'
+    paths:
+      - '**.erb'
 
 jobs:
   erb_lint:

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - '**.erb'
+      - '**.html'
   pull_request:
     branches:
       - main
     paths:
       - '**.erb'
+      - '**.html'
 
 jobs:
   erb_lint:

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths:
-      - '**.erb'
-      - '**.html'
+      - '**/*.erb'
+      - '**/*.html'
   pull_request:
     branches:
       - main
     paths:
-      - '**.erb'
-      - '**.html'
+      - '**/*.erb'
+      - '**/*.html'
 
 jobs:
   erb_lint:

--- a/.github/workflows/factory_bot_lint.yml
+++ b/.github/workflows/factory_bot_lint.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/spec_checker.yml
+++ b/.github/workflows/spec_checker.yml
@@ -6,14 +6,14 @@ on:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'doc/**'
-      - '**.md'
+      - '**/*.md'
       - 'bin/**'
 
 jobs:

--- a/.github/workflows/yarn_lint_and_test.yml
+++ b/.github/workflows/yarn_lint_and_test.yml
@@ -4,17 +4,15 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-      - 'bin/**'
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-      - 'bin/**'
+    paths:
+      - '**/*.js'
+      - '**/*.jsx'
 
 jobs:
   yarn_lint:


### PR DESCRIPTION
### What changed, and why?
 - Fixed `.md` glob pattern
 - Limit erb linter to `.erb` and `.html` file extensions
 - Limit yarn linter to only `.js` and  `.jsx` file extensions

### How is this tested? (please write tests!) 💖💪
You can check the `.md` changes at https://globster.xyz/

