### PR TITLE
ignore storage folder locally for standardrb

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,2 +1,3 @@
 ignore:
+  - 'storage/**/*'
   - 'lib/tasks/deployment/20201005203405_populate_case_contact_contact_type.rake'


### PR DESCRIPTION
### What changed, and why?
standardrb no longer looks in the storage folder
The storage folder can actually reach a few MB in size