### PR TITLE
Remove usage of deprecated field TAY in new casa case creation

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -77,16 +77,6 @@
         <% end %>
       </div>
 
-      <% if casa_case.new_record? %>
-        <%# Only show the field when creating, but not when updating %>
-        <div class="field form-group">
-          <div class="form-check">
-            <%= form.check_box :transition_aged_youth, class: 'form-check-input' %>
-            <%= form.label :transition_aged_youth, t(".transition_aged_youth"), class: 'form-check-label' %>
-          </div>
-        </div>
-      <% end %>
-
       <div class="field form-group">
         <%= form.label :court_report_status, t(".court_report_status") %>
         <%= form.select :court_report_status,

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -26,9 +26,6 @@ RSpec.describe "casa_cases/new", type: :system do
         select "March", from: "casa_case_birth_month_year_youth_2i"
         select fourteen_years, from: "casa_case_birth_month_year_youth_1i"
 
-        check "Transition Aged Youth"
-        has_checked_field? "Transition Aged Youth"
-
         select "Submitted", from: "casa_case_court_report_status"
 
         within ".top-page-actions" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
none

### What changed, and why?
Remove usage of deprecated field TAY in new casa case creation

