### PR TITLE
auto label not ready to build issues

### DIFF
--- a/.github/workflows/add-labels-based-on-column.yml
+++ b/.github/workflows/add-labels-based-on-column.yml
@@ -16,6 +16,11 @@ jobs:
           columns_labels: >
             [
               {
+                "column_name": "Not ready to build",
+                "labels": ["not-ready-to-build"],
+                "project_name": "CASA Volunteer Portal"
+              },
+              {
                 "column_name": "To do",
                 "labels": ["Help Wanted"],
                 "project_name": "CASA Volunteer Portal"


### PR DESCRIPTION
### What changed, and why?
ensure all issues in the not ready to build column has the not-ready-to-build label

### How is this tested? (please write tests!) 💖💪
Nope