### PR TITLE
use datepicker instead of select for court report due date selection

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -67,16 +67,13 @@
         <% if policy(casa_case).update_court_report_due_date? %>
           <%= form.label :court_report_due_date, t(".court_report_due_date") %>
           <br>
-          <span class="datetime-year-month">
-            <%= form.date_select :court_report_due_date,
-                                 {
-                                     order: [:day, :month, :year],
-                                     start_year: Date.current.year + 3,
-                                     end_year: 2000,
-                                     prompt: {day: 'Day', month: 'Month', year: 'Year'}
-                                 },
-                                 class: "select2 date-input" %>
-          </span>
+          <div class="field form-group">
+            <% court_report_due_date = casa_case.court_report_due_date || Time.zone.now %>
+            <%= form.text_field :court_report_due_date,
+                            value: court_report_due_date.to_date,
+                            data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+                            class: "form-control" %>
+          </div>
         <% end %>
       </div>
 

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Submitted")
       expect(page).to have_text("Court Date")
       expect(page).to have_text("Court Report Due Date")
-      expect(page).to have_text("Day")
-      expect(page).to have_text("Month")
-      expect(page).to have_text("Year")
+      expect(page).to have_field("Court Report Due Date")
       expect(page).to have_text("Court Mandate Text One")
       expect(page).not_to have_text("Deactivate Case")
 
@@ -59,9 +57,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Reactivate CASA Case")
       expect(page).to_not have_text("Court Date")
       expect(page).to_not have_text("Court Report Due Date")
-      expect(page).to_not have_text("Day")
-      expect(page).to_not have_text("Month")
-      expect(page).to_not have_text("Year")
+      expect(page).to_not have_field("Court Report Due Date")
     end
 
     it "reactivates a case", js: true do
@@ -74,9 +70,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Deactivate CASA Case")
       expect(page).to have_text("Court Date")
       expect(page).to have_text("Court Report Due Date")
-      expect(page).to have_text("Day")
-      expect(page).to have_text("Month")
-      expect(page).to have_text("Year")
+      expect(page).to have_field("Court Report Due Date")
     end
   end
 
@@ -100,9 +94,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       select "Submitted", from: "casa_case_court_report_status"
       check "Youth"
 
-      select "8", from: "casa_case_court_report_due_date_3i"
-      select "September", from: "casa_case_court_report_due_date_2i"
-      select next_year, from: "casa_case_court_report_due_date_1i"
+      fill_in "Court Report Due Date", with: Date.new(next_year.to_i, 9, 8).strftime("%Y/%m/%d\n")
 
       page.find("#add-mandate-button").click
       find("#court-orders-list-container").first("textarea").send_keys("Court Mandate Text One")
@@ -119,11 +111,8 @@ RSpec.describe "Edit CASA Case", type: :system do
 
       expect(page).to have_text("Court Date")
       expect(page).to have_text("Court Report Due Date")
-      expect(page).to have_text("Day")
-      expect(page).to have_text("Month")
-      expect(page).to have_text("Year")
-      expect(page).to have_text("November")
-      expect(page).to have_text("September")
+      expect(page).to have_field("Court Report Due Date")
+      expect(page).to have_field("Court Report Due Date", with: "#{next_year}-09-08")
       expect(page).to have_text("Court Mandate Text One")
       expect(page).to have_text("Partially implemented")
 
@@ -179,36 +168,6 @@ RSpec.describe "Edit CASA Case", type: :system do
         expect(page).to have_select("Judge", selected: "-Select Judge-")
         expect(casa_case.reload.judge).to be_nil
       end
-    end
-
-    it "will return error message if date fields are not fully selected" do
-      visit casa_case_path(casa_case)
-      expect(page).to have_text("Court Report Status: Not submitted")
-      visit edit_casa_case_path(casa_case)
-
-      select "April", from: "casa_case_court_report_due_date_2i"
-
-      within ".actions" do
-        click_on "Update CASA Case"
-      end
-
-      expect(page).to have_text("Court report due date was not a valid date.")
-    end
-
-    it "will return error message if date fields are not valid" do
-      visit casa_case_path(casa_case)
-      expect(page).to have_text("Court Report Status: Not submitted")
-      visit edit_casa_case_path(casa_case)
-
-      select "31", from: "casa_case_court_report_due_date_3i"
-      select "April", from: "casa_case_court_report_due_date_2i"
-      select next_year, from: "casa_case_court_report_due_date_1i"
-
-      within ".actions" do
-        click_on "Update CASA Case"
-      end
-
-      expect(page).to have_text("Court report due date was not a valid date.")
     end
 
     it "views deactivated case" do
@@ -508,9 +467,7 @@ of it unless it was included in a previous court report.")
         click_on "Update CASA Case"
       end
 
-      expect(page).to have_text("Day")
-      expect(page).to have_text("Month")
-      expect(page).to have_text("Year")
+      expect(page).to have_field("Court Report Due Date")
       expect(page).not_to have_text("Deactivate Case")
 
       expect(page).to have_css("#add-mandate-button")

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -17,13 +17,11 @@ RSpec.describe "casa_cases/new", type: :system do
   context "when all fields are filled" do
     it "is successful", js: true do
       travel_to Time.zone.local(2020, 12, 1) do
-        next_year = (Date.today.year + 1).to_s
+        next_year = Date.new(Date.today.year + 1, 4, 1)
         fourteen_years = (Date.today.year - 14).to_s
         fill_in "Case number", with: case_number
 
-        select "1", from: "casa_case_court_report_due_date_3i"
-        select "April", from: "casa_case_court_report_due_date_2i"
-        select next_year, from: "casa_case_court_report_due_date_1i"
+        fill_in "Court Report Due Date", with: next_year.strftime("%Y/%m/%d\n")
 
         select "March", from: "casa_case_birth_month_year_youth_2i"
         select fourteen_years, from: "casa_case_birth_month_year_youth_1i"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3188 #3189.

### What changed, and why?
In the form for casa_cases I replaced selects with a datepicker.

### How is this tested? (please write tests!) 💖💪
I made some changes in existing system tests. 
Testing create and edit casa cases with selection of court report due date through datepicker.
I remove some specs because for example now you can't select a date like 31 April.


### Screenshots please :)
![form_snip](https://user-images.githubusercontent.com/16540719/153721275-45065e44-eeb9-4318-99c4-34e569789beb.PNG)

