### PR TITLE
Remove notes from local storage after submitting case contact

### DIFF
--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -24,8 +24,6 @@ $('document').ready(() => {
   }
 
   if (/\/casa_cases\/\d+$/.test(window.location.pathname)) {
-    if ($('.header-flash').text().includes('Case contact was successfully created.')) {
-      window.localStorage.removeItem(formId)
-    }
+    window.localStorage.removeItem(formId)
   }
 })

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -324,11 +324,16 @@ RSpec.describe "case_contacts/new", type: :system do
     end
 
     it "delete local storage notes after successfuly submited", js: true do
-      volunteer = create(:volunteer)
-      sign_in volunteer
+      volunteer = create(:volunteer, :with_casa_cases)
+      volunteer_casa_case_one = volunteer.casa_cases.first
+      create_contact_types(volunteer_casa_case_one.casa_org)
 
+      sign_in volunteer
       visit new_case_contact_path
 
+      check volunteer_casa_case_one.case_number
+      check "School"
+      check "Therapist"
       choose "Yes"
       choose "In Person"
       fill_in "case-contact-duration-hours-display", with: "1"
@@ -341,11 +346,12 @@ RSpec.describe "case_contacts/new", type: :system do
       sleep 5
       click_on "Submit"
       click_on "Continue Submitting"
-      expect(page).to have_text("At least one case must be selected")
+
+      expect(page).to have_text "successfully created"
 
       visit new_case_contact_path
 
-      expect(page).to have_field("Notes", with: "Hello world")
+      expect(page).to_not have_field("Notes", with: "Hello world")
     end
 
     it "submits the form when no note was added", js: true do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3206 

### What changed, and why?
We removed the unnecessary check for the header flash text and fixed the spec to reflect the desired behavior.

### How is this tested? (please write tests!) 💖💪
Update a spec to reflect the situation for when a case contact is successfully submitted.
