### PR TITLE
Add CourtDate field to New CasaCase form

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -144,7 +144,8 @@ class CasaCasesController < ApplicationController
       :birth_month_year_youth,
       :court_report_due_date,
       :hearing_type_id,
-      :judge_id
+      :judge_id,
+      court_dates_attributes: [:date]
     )
   end
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -42,6 +42,7 @@ class CasaCase < ApplicationRecord
   has_many :casa_case_contact_types
   has_many :contact_types, through: :casa_case_contact_types, source: :contact_type
   accepts_nested_attributes_for :casa_case_contact_types
+  accepts_nested_attributes_for :court_dates
 
   has_many :case_court_orders, -> { order "id asc" }, dependent: :destroy
   accepts_nested_attributes_for :case_court_orders, reject_if: :all_blank

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -63,6 +63,19 @@
         <% end %>
       <% end %>
 
+      <% if policy(casa_case).update_court_date? && casa_case.new_record? %>
+        <%= form.fields_for :court_dates, casa_case.court_dates.new do |cdf| %>
+          <div class="field form-group">
+            <%= cdf.label :date, t(".court_date") %>
+            <br>
+            <div class="field form-group">
+              <%= cdf.text_field :date,
+                              data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+                              class: "form-control" %>
+          </div>
+        <% end %>
+      <% end %>
+
       <div class="field form-group">
         <% if policy(casa_case).update_court_report_due_date? %>
           <%= form.label :court_report_due_date, t(".court_report_due_date") %>

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "casa_cases/new", type: :system do
   let(:admin) { create(:casa_admin, casa_org: casa_org) }
   let(:case_number) { "12345" }
   let!(:next_year) { (Date.today.year + 1).to_s }
+  let(:court_date) { 21.days.from_now }
 
   before do
     sign_in admin
@@ -21,6 +22,7 @@ RSpec.describe "casa_cases/new", type: :system do
         fourteen_years = (Date.today.year - 14).to_s
         fill_in "Case number", with: case_number
 
+        fill_in "Court Date", with: court_date.strftime("%Y/%m/%d")
         fill_in "Court Report Due Date", with: next_year.strftime("%Y/%m/%d\n")
 
         select "March", from: "casa_case_birth_month_year_youth_2i"
@@ -33,6 +35,7 @@ RSpec.describe "casa_cases/new", type: :system do
         end
 
         expect(page.body).to have_content(case_number)
+        expect(page).to have_content(I18n.l(court_date, format: :day_and_date))
         expect(page).to have_content("CASA case was successfully created.")
         expect(page).to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time
         expect(page).to have_content("Transition Aged Youth: Yes")


### PR DESCRIPTION
Fixes #3188

### What changed, and why?

New court date field on casa case form so that a court date can be added when a casa case is created.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

System test

### Screenshots please :)

<img width="624" alt="Screen Shot 2022-02-28 at 10 25 51 PM" src="https://user-images.githubusercontent.com/19519317/155991103-9b8a860b-a6c8-4814-95cc-ab5345cc41be.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9