### PR TITLE
Resolves #3270 - Redirect better for non-edit links

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -6,6 +6,11 @@ class VolunteersController < ApplicationController
     authorize Volunteer
   end
 
+  def show
+    authorize @volunteer
+    redirect_to action: :edit
+  end
+
   def datatable
     authorize Volunteer
     volunteers = policy_scope current_organization.volunteers

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -33,6 +33,7 @@ class VolunteerPolicy < UserPolicy
   alias_method :new?, :index?
   alias_method :create?, :index?
   alias_method :edit?, :index?
+  alias_method :show?, :index?
   alias_method :update?, :index?
   alias_method :activate?, :index?
   alias_method :deactivate?, :index?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
       patch :unassign
     end
   end
-  resources :volunteers, except: %i[destroy show], concerns: %i[with_datatable] do
+  resources :volunteers, except: %i[destroy], concerns: %i[with_datatable] do
     post :stop_impersonating, on: :collection
     member do
       patch :activate

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VolunteerPolicy do
   let(:supervisor) { build_stubbed(:supervisor) }
   let(:volunteer) { build_stubbed(:volunteer) }
 
-  permissions :index?, :datatable?, :edit?, :update?, :activate?, :deactivate?, :create?, :new? do
+  permissions :index?, :show?, :datatable?, :edit?, :update?, :activate?, :deactivate?, :create?, :new? do
     context "when user is a casa admin" do
       it "allows" do
         is_expected.to permit(admin)

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "/volunteers", type: :request do
     end
   end
 
+  describe "GET /show" do
+    it "renders a successful response" do
+      sign_in admin
+
+      get volunteer_path(volunteer.id)
+      expect(response).to redirect_to(edit_volunteer_path(volunteer.id))
+    end
+  end
+
   describe "POST /datatable" do
     let(:data) { {recordsTotal: 51, recordsFiltered: 10, data: 10.times.map { {} }} }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3270

### What changed, and why?
A show action was added to the volunteers_controller which redirects to the edit action in the same controller.

### How will this affect user permissions?
The same level of authorization permissions for this new action are copied from the :index action in the same controller.

### How is this tested? (please write tests!) 💖💪
A new request spec was written which confirms that the :show action redirects to the :edit action on the volunteers_controller.
The volunteer_policy spec was updated to account for the new :show action.

### Screenshots please :)
n/a