### PR TITLE
Make court date field required when creating a new casa case

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -71,7 +71,8 @@
             <div class="field form-group">
               <%= cdf.text_field :date,
                               data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
-                              class: "form-control" %>
+                              class: "form-control",
+                              :required=> 'required' %>
           </div>
         <% end %>
       <% end %>

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe "casa_cases/new", type: :system do
     end
   end
 
+  context "when the court date field is not filled" do
+    it "does not create a new case" do
+      fill_in "Case number", with: case_number
+      five_years = (Date.today.year - 5).to_s
+      select "March", from: "casa_case_birth_month_year_youth_2i"
+      select five_years, from: "casa_case_birth_month_year_youth_1i"
+
+      within ".actions" do
+        click_on "Create CASA Case"
+      end
+
+      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
+      expect(page).to have_content("Court dates date can't be blank")
+      expect(page.find_field("Next Court Date")[:required]).to eq("required")
+    end
+  end
+
   context "when the case number already exists in the organization" do
     let!(:casa_case) { create(:casa_case, case_number: case_number, casa_org: casa_org) }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3277

### What changed, and why?
The court date field didn't need to be filled in, now it is.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
It is tested through an integration test that checks the validation of the model and the presence of the `required` in the form field.

### Feedback please?
Happy to contribute and for the reception!