### PR TITLE
Don't allow editing volunteers from other organizations

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -51,8 +51,22 @@ class ApplicationPolicy
     user.casa_admin?
   end
 
+  def same_org?
+    user.casa_org == record.casa_org
+  end
+
+  def is_admin_same_org?
+    # eventually everything should use this
+    user.casa_admin? && same_org?
+  end
+
   def is_supervisor?
     user.supervisor?
+  end
+
+  def is_supervisor_same_org?
+    # eventually everything should use this
+    user.supervisor? && same_org?
   end
 
   def is_volunteer?
@@ -61,6 +75,11 @@ class ApplicationPolicy
 
   def admin_or_supervisor?
     is_admin? || is_supervisor?
+  end
+
+  def admin_or_supervisor_same_org?
+    # eventually everything should use this
+    is_admin_same_org? || is_supervisor_same_org?
   end
 
   def admin_or_supervisor_or_volunteer?

--- a/app/policies/volunteer_policy.rb
+++ b/app/policies/volunteer_policy.rb
@@ -21,6 +21,10 @@ class VolunteerPolicy < UserPolicy
     admin_or_supervisor?
   end
 
+  def edit?
+    admin_or_supervisor_same_org?
+  end
+
   def impersonate?
     admin_or_supervisor?
   end
@@ -32,7 +36,6 @@ class VolunteerPolicy < UserPolicy
   alias_method :datatable?, :index?
   alias_method :new?, :index?
   alias_method :create?, :index?
-  alias_method :edit?, :index?
   alias_method :show?, :index?
   alias_method :update?, :index?
   alias_method :activate?, :index?

--- a/spec/controllers/volunteers_controller_spec.rb
+++ b/spec/controllers/volunteers_controller_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe VolunteersController, type: :controller do
         expect(assigns(:supervisors)).to eq([supervisor])
         expect(assigns(:volunteer)).to eq(volunteer_east)
       end
+
+      it "cannot edit volunteer for a different casa org" do
+        east = create :casa_org, name: "East"
+        west = create :casa_org, name: "West"
+        supervisor = create :supervisor, casa_org: east
+        allow(controller).to receive(:authenticate_user!).and_return(:supervisor)
+        allow(controller).to receive(:current_user).and_return(supervisor)
+        volunteer_west = create :volunteer, casa_org: west
+        get :edit, params: {id: volunteer_west.id}
+        expect(response).to redirect_to("/")
+      end
     end
   end
 end

--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -7,7 +7,51 @@ RSpec.describe VolunteerPolicy do
   let(:supervisor) { build_stubbed(:supervisor) }
   let(:volunteer) { build_stubbed(:volunteer) }
 
-  permissions :index?, :show?, :datatable?, :edit?, :update?, :activate?, :deactivate?, :create?, :new? do
+  permissions :edit? do
+    context "same org" do
+      let(:record) { build_stubbed(:volunteer, casa_org: admin.casa_org) }
+      context "when user is a casa admin" do
+        it "allows for same org" do
+          is_expected.to permit(admin, record)
+        end
+      end
+
+      context "when user is a supervisor" do
+        it "allows" do
+          is_expected.to permit(supervisor, record)
+        end
+      end
+
+      context "when user is a volunteer" do
+        it "does not permit" do
+          is_expected.not_to permit(volunteer)
+        end
+      end
+    end
+
+    context "different org" do
+      let(:record) { build_stubbed(:volunteer, casa_org: build_stubbed(:casa_org)) }
+      context "when user is a casa admin" do
+        it "does not allow for different org" do
+          is_expected.not_to permit(admin, record)
+        end
+      end
+
+      context "when user is a supervisor" do
+        it "does not allow" do
+          is_expected.not_to permit(supervisor, record)
+        end
+      end
+
+      context "when user is a volunteer" do
+        it "does not permit" do
+          is_expected.not_to permit(volunteer)
+        end
+      end
+    end
+  end
+
+  permissions :index?, :show?, :datatable?, :update?, :activate?, :deactivate?, :create?, :new? do
     context "when user is a casa admin" do
       it "allows" do
         is_expected.to permit(admin)

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe "volunteers/edit", type: :system do
   end
 
   it "allows the admin to unassign a volunteer from a supervisor" do
-    supervisor = build(:supervisor, display_name: "Haka Haka")
-    volunteer = create(:volunteer, display_name: "Bolu Bolu", supervisor: supervisor)
+    supervisor = build(:supervisor, display_name: "Haka Haka", casa_org: organization)
+    volunteer = create(:volunteer, display_name: "Bolu Bolu", supervisor: supervisor, casa_org: organization)
 
     sign_in admin
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3286

### What changed, and why?
Don't allow editing volunteers from other organizations
Made new helper methods for policy files but they don't work with index calls, only with calls that have a record
There are other places that should convert to use these new methods (all of them??) but we are starting with fixing this one bug for now. 

### How will this affect user permissions?
- Volunteer permissions: no
- Supervisor permissions: no longer be able to visit the edit page for a volunteer from another organization 😱
- Admin permissions: no longer be able to visit the edit page for a volunteer from another organization 😱

### How is this tested? (please write tests!) 💖💪
rspec (see also issue #3295 to convert controller specs to request specs, sorry)
