### PR TITLE
Remove hidden field on new volunteer form 

### DIFF
--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -11,8 +11,6 @@
     <%= form.text_field :display_name, class: "form-control" %>
   </div>
 
-  <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
-
   <div class="actions">
     <%= form.submit "Create User", class: "btn btn-primary" %>
   </div>

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe "/volunteers", type: :request do
         {
           volunteer: {
             display_name: "Example",
-            email: "volunteer1@example.com",
-            casa_org_id: admin.casa_org_id
+            email: "volunteer1@example.com"
           }
         }
       end
@@ -96,6 +95,10 @@ RSpec.describe "/volunteers", type: :request do
         expect(volunteer.email).to eq("volunteer1@example.com")
         expect(volunteer.display_name).to eq("Example")
         expect(response).to redirect_to edit_volunteer_path(volunteer)
+      end
+
+      it "assigns new volunteer to creator's organization" do
+        expect(volunteer.casa_org_id).to eq(admin.casa_org_id)
       end
 
       it "sends an account_setup email" do
@@ -110,8 +113,7 @@ RSpec.describe "/volunteers", type: :request do
         {
           volunteer: {
             display_name: "",
-            email: "volunteer1@example.com",
-            casa_org_id: admin.casa_org_id
+            email: "volunteer1@example.com"
           }
         }
       end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "/volunteers", type: :request do
   let(:organization) { create(:casa_org) }
   let(:admin) { build(:casa_admin, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
   let(:volunteer) { create(:volunteer, casa_org: organization) }
 
   describe "GET /index" do
@@ -55,11 +56,25 @@ RSpec.describe "/volunteers", type: :request do
   end
 
   describe "GET /new" do
-    it "renders a successful response only for admin user" do
+    it "renders a successful response for admin user" do
       sign_in admin
 
       get new_volunteer_path
       expect(response).to be_successful
+    end
+
+    it "renders a successful response for supervisor user" do
+      sign_in supervisor
+
+      get new_volunteer_path
+      expect(response).to be_successful
+    end
+
+    it "does not render for volunteers" do
+      sign_in volunteer
+
+      get new_volunteer_path
+      expect(response).to_not be_successful
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3297

### What changed, and why?
Removes hidden `casa_org_id` field on new volunteer form and `casa_org_id` from the volunteer params accordingly. While unlikely to be a problem, this is a security no-no because a tech-savvy user could edit the hidden form field and assign the volunteer to a different organization. The new volunteer is already being created for the current organization ([code reference](https://github.com/rubyforgood/casa/blob/main/app/controllers/volunteers_controller.rb#L28)) so the information is already available in the volunteer controller. 

### How will this affect user permissions?
- Volunteer permissions: No change.
- Supervisor permissions: No change.
- Admin permissions: No change.

### How is this tested? (please write tests!) 💖💪
Added a test to verify that the logged in admin's `casa_org_id` matches the new volunteer's `casa_org_id` to ensure that the new volunteer is assigned to the same organization as the user who created the volunteer. 

### Screenshots please :)
Changes are just behind the scenes. Verified manually:
- hidden field gone
- edited form is only used by the new volunteer page
- new volunteer created by authorized user (admin/supervisor) is successfully created and assigned to the same casa org

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9