### PR TITLE
Show when last contact was made of each type in contact_type partial

### DIFF
--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -3,4 +3,21 @@ module ContactTypesHelper
   def set_group_options
     @group_options = ContactTypeGroup.for_organization(current_organization).collect { |group| [group.name, group.id] }
   end
+
+  def time_ago_of_last_contact_made_of(contact_type_name, casa_case)
+    contact = last_contact_made_of(contact_type_name, casa_case)
+
+    return "never" if contact.nil?
+
+    "#{time_ago_in_words(contact.created_at)} ago"
+  end
+
+  def last_contact_made_of(contact_type_name, casa_case)
+    casa_case
+      .case_contacts
+      .joins(:contact_types)
+      .where(contact_types: {name: contact_type_name})
+      .order(created_at: :desc)
+      .first
+  end
 end

--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -13,6 +13,8 @@ module ContactTypesHelper
   end
 
   def last_contact_made_of(contact_type_name, casa_case)
+    return unless casa_case
+
     casa_case
       .case_contacts
       .joins(:contact_types)

--- a/app/views/case_contacts/_contact_types.html.erb
+++ b/app/views/case_contacts/_contact_types.html.erb
@@ -20,6 +20,12 @@
               <label class="form-check-label" for="<%= dom_id(contact_type, :case_contact) %>">
                 <%= contact_type.name %>
               </label>
+              <span style="color: #93903C;">
+                <%= time_ago_of_last_contact_made_of(
+                  contact_type.name,
+                  @casa_cases.order(created_at: :desc).first
+                ) %>
+              </span>
             </div>
           <% end %>
         </td>

--- a/app/views/case_contacts/_contact_types.html.erb
+++ b/app/views/case_contacts/_contact_types.html.erb
@@ -20,12 +20,14 @@
               <label class="form-check-label" for="<%= dom_id(contact_type, :case_contact) %>">
                 <%= contact_type.name %>
               </label>
-              <span style="color: #93903C;">
-                <%= time_ago_of_last_contact_made_of(
-                  contact_type.name,
-                  @casa_cases.order(created_at: :desc).first
-                ) %>
-              </span>
+              <% if @casa_cases %>
+                <span style="color: #93903C;">
+                  <%= time_ago_of_last_contact_made_of(
+                    contact_type.name,
+                    @casa_cases.sort_by(&:created_at).last
+                  ) %>
+                </span>
+              <% end %>
             </div>
           <% end %>
         </td>

--- a/spec/helpers/contact_types_helper_spec.rb
+++ b/spec/helpers/contact_types_helper_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe ContactTypesHelper, type: :helper do
       before do
         contact = build_stubbed(:case_contact, casa_case: casa_case, created_at: 1.day.ago)
         allow(helper).to receive(:last_contact_made_of).and_return(contact)
-
-        it { is_expected.to eq("1 day ago") }
       end
+
+      it { is_expected.to eq("1 day ago") }
     end
   end
 
@@ -38,6 +38,12 @@ RSpec.describe ContactTypesHelper, type: :helper do
 
     it "returns the last contact made of the given type" do
       expect(subject).to eq(contact_1)
+    end
+
+    context "when casa_case is nil" do
+      subject { helper.last_contact_made_of(contact_type.name, nil) }
+
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/helpers/contact_types_helper_spec.rb
+++ b/spec/helpers/contact_types_helper_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe ContactTypesHelper, type: :helper do
+  describe "#time_ago_of_last_contact_made_of" do
+    subject { helper.time_ago_of_last_contact_made_of(contact_type_name, casa_case) }
+
+    let(:casa_case) { build_stubbed(:casa_case) }
+    let(:contact_type_name) { "School" }
+
+    context "when contact never made" do
+      before { allow(helper).to receive(:last_contact_made_of).and_return(nil) }
+
+      it { is_expected.to eq("never") }
+    end
+
+    context "when contact was made" do
+      before do
+        contact = build_stubbed(:case_contact, casa_case: casa_case, created_at: 1.day.ago)
+        allow(helper).to receive(:last_contact_made_of).and_return(contact)
+
+        it { is_expected.to eq("1 day ago") }
+      end
+    end
+  end
+
+  describe "#last_contact_made_of" do
+    subject { helper.last_contact_made_of(contact_type.name, casa_case) }
+
+    let(:casa_case) { create(:casa_case) }
+    let(:contact_type) { create(:contact_type) }
+
+    let!(:contact_1) { create(:case_contact, casa_case: casa_case, contact_types: [contact_type]) }
+
+    let!(:contact_2) do
+      create(:case_contact, casa_case: casa_case, contact_types: [contact_type],
+             created_at: 1.day.ago)
+    end
+
+    it "returns the last contact made of the given type" do
+      expect(subject).to eq(contact_1)
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/casa/issues/3171

### What changed, and why?

Show when the last contact was made for each type, in `new case_contact form`

### How is this tested? (please write tests!) 💖💪

Browse to a casa_case and click on the `New case contact` link 

### Screenshots please :)

![image](https://user-images.githubusercontent.com/47258878/160286526-57e9995d-c637-4f24-b6c1-ea1526baa63c.png)

![image](https://user-images.githubusercontent.com/47258878/160286593-5328d17c-becc-42de-90eb-90f5a655a485.png)
