### PR TITLE
[#3316] Allow for editing volunteer notes

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,11 +1,30 @@
 class NotesController < ApplicationController
+  before_action :find_note, only: %i[edit update]
+  before_action :find_volunteer
+
   def create
-    volunteer = Volunteer.find(params[:volunteer_id])
-    volunteer.notes.create(note_params)
-    redirect_to edit_volunteer_path(volunteer)
+    @volunteer.notes.create(note_params)
+    redirect_to edit_volunteer_path(@volunteer)
+  end
+
+  def edit
+  end
+
+  def update
+    @note.update(note_params)
+
+    redirect_to edit_volunteer_path(@volunteer)
   end
 
   private
+
+  def find_note
+    @note = Note.find(params[:id])
+  end
+
+  def find_volunteer
+    @volunteer = Volunteer.find(params[:volunteer_id])
+  end
 
   def note_params
     params.require(:note).permit(:content).merge({creator_id: current_user.id})

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,0 +1,12 @@
+<%= form_with(model: @note, local: true, url: volunteer_note_path(@volunteer, @note)) do |form| %>
+  <h3>Update Volunteer Note</h3>
+
+  <div class="form-group">
+    <%= form.text_area :content,
+      rows: 5,
+      placeholder: t("volunteers.edit.notes_placeholder"),
+      class: "form-control" %>
+  </div>
+
+  <%= form.submit t("notes.update"), class: "btn btn-primary", id: "note-submit" %>
+<% end %>

--- a/app/views/volunteers/_notes.html.erb
+++ b/app/views/volunteers/_notes.html.erb
@@ -11,6 +11,7 @@
               <th>Note</th>
               <th>Creator</th>
               <th>Date</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -19,6 +20,9 @@
                 <td><%= note.content %></td>
                 <td><%= note.creator.display_name %></td>
                 <td><%= note.created_at.strftime(t("time.formats.standard")) %></td>
+                <td>
+                  <%= link_to "Edit", edit_volunteer_note_path(@volunteer, note), class: "btn btn-primary" %>
+                </td>
               </tr>
             <% end %>
           </tbody>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -559,6 +559,9 @@ en:
       send_reminder: Send Reminder
       supervisor_checkbox_text: Send CC to Supervisor
       tooltip: Remind volunteer to input case contacts
+
+  notes:
+    update: Update Note
   mileage_rates:
     index:
       mileage_rates: Mileage Rates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,7 @@ Rails.application.routes.draw do
       patch :reminder
       get :impersonate
     end
-    resources :notes, only: %i[create]
+    resources :notes, only: %i[create edit update]
   end
   resources :case_assignments, only: %i[create destroy] do
     member do

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "/volunteers/notes", type: :request do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let(:volunteer) { create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id) }
+  let(:note) { volunteer.notes.create(creator: admin, content: "Good job.") }
+
+  describe "PATCH /update" do
+    subject(:request) { patch volunteer_note_path(volunteer, note), params: params }
+
+    context "when logged in as an admin" do
+      before do
+        sign_in admin
+        request
+      end
+
+      context "with valid params" do
+        let(:params) { {note: {content: "Very nice!"}} }
+
+        it "returns success response" do
+          expect(response).to redirect_to(edit_volunteer_path(volunteer))
+          expect(note.reload.content).to eq "Very nice!"
+        end
+      end
+    end
+  end
+end

--- a/spec/system/volunteers/notes/edit_spec.rb
+++ b/spec/system/volunteers/notes/edit_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "volunteers/notes/edit", type: :system do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let(:volunteer) { create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id) }
+  let(:note) { volunteer.notes.create(creator: admin, content: "Good job.") }
+
+  context "when logged in as an admin" do
+    before do
+      sign_in admin
+      visit edit_volunteer_note_path(volunteer, note)
+    end
+
+    scenario "editing an existing note" do
+      expect(page).to have_text("Good job.")
+
+      fill_in("note[content]", with: "Great job!")
+
+      click_on("Update Note")
+
+      expect(page.current_path).to eq edit_volunteer_path(volunteer)
+
+      expect(page).to have_text("Great job!")
+
+      expect(note.reload.content).to eq "Great job!"
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3316

### What changed, and why?
- Supervisors and admins are now able to edit existing notes in volunteers edit page

### How will this affect user permissions?
- Volunteer permissions: Nothing changed.
- Supervisor permissions: Supervisors can now change existing notes in volunteers edit page
- Admin permissions: Same as supervisors

### How is this tested? (please write tests!) 💖💪
- Unit tests
- Feature tests
- Manual testing
  - Log in as supervisor
  - Go to a volunteer edit page
  - Select a volunteer note and click on "Edit"
  - Edit the note
  - Click "Update note"
  - Check if the note has been updated

### Screenshots please :)
Before editing the note:
![image](https://user-images.githubusercontent.com/72531802/162020188-e8b3efa4-332f-4107-b52a-45d333c1c58e.png)

Note edit page:
![localhost_3000_volunteers_6_notes_1_edit](https://user-images.githubusercontent.com/72531802/162020224-08914fff-3742-4698-a210-c3b7ef4699f7.png)

Updated note:
![image](https://user-images.githubusercontent.com/72531802/162020266-80807f87-4073-43fe-9ade-d62ea54af387.png)
