### PR TITLE
Fix table overflow styling

### DIFF
--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -22,47 +22,49 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
-      <thead>
-      <tr>
-        <th><%= t(".heading.case_number") %></th>
-        <th><%= t(".heading.hearing_type") %></th>
-        <th><%= t(".heading.judge") %></th>
-        <th><%= t(".heading.status") %></th>
-        <th><%= t(".heading.transition_aged_youth") %></th>
-        <th><%= t(".heading.assigned_to") %></th>
-        <th><%= t(".heading.actions") %></th>
-        <th></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% @casa_cases.each do |casa_case| %>
-        <tr class="<%= casa_case.decorate.inactive_class %>">
-          <td><%= link_to(casa_case.case_number, casa_case) %></td>
-          <td><%= casa_case.hearing_type_name %></td>
-          <td><%= casa_case.judge_name %></td>
-          <td><%= casa_case.decorate.status %></td>
-          <td><%= casa_case.decorate.transition_aged_youth %></td>
-          <td>
-            <% if casa_case.active? %>
-              <% if current_user.volunteer? %>
-                <%= safe_join(casa_case.assigned_volunteers.map { |vol|
-                  vol.display_name }, ", ") %>
-              <% else %>
-                <%= safe_join(casa_case.assigned_volunteers.map { |vol|
-                  link_to(vol.display_name, edit_volunteer_path(vol)) },
-                              ", ") %>
-              <% end %>
-            <% else %>
-              Case was deactivated on: <%= I18n.l(casa_case.updated_at, format: :standard, default: nil) %>
-            <% end %>
-          </td>
-          <td><%= link_to t("button.detail_view"), casa_case_path(casa_case) %></td>
-          <td><%= link_to t("button.edit"), edit_casa_case_path(casa_case) %></td>
+    <div class="table-responsive">
+      <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
+        <thead>
+        <tr>
+          <th><%= t(".heading.case_number") %></th>
+          <th><%= t(".heading.hearing_type") %></th>
+          <th><%= t(".heading.judge") %></th>
+          <th><%= t(".heading.status") %></th>
+          <th><%= t(".heading.transition_aged_youth") %></th>
+          <th><%= t(".heading.assigned_to") %></th>
+          <th><%= t(".heading.actions") %></th>
+          <th></th>
         </tr>
-      <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+        <% @casa_cases.each do |casa_case| %>
+          <tr class="<%= casa_case.decorate.inactive_class %>">
+            <td><%= link_to(casa_case.case_number, casa_case) %></td>
+            <td><%= casa_case.hearing_type_name %></td>
+            <td><%= casa_case.judge_name %></td>
+            <td><%= casa_case.decorate.status %></td>
+            <td><%= casa_case.decorate.transition_aged_youth %></td>
+            <td>
+              <% if casa_case.active? %>
+                <% if current_user.volunteer? %>
+                  <%= safe_join(casa_case.assigned_volunteers.map { |vol|
+                    vol.display_name }, ", ") %>
+                <% else %>
+                  <%= safe_join(casa_case.assigned_volunteers.map { |vol|
+                    link_to(vol.display_name, edit_volunteer_path(vol)) },
+                                ", ") %>
+                <% end %>
+              <% else %>
+                Case was deactivated on: <%= I18n.l(casa_case.updated_at, format: :standard, default: nil) %>
+              <% end %>
+            </td>
+            <td><%= link_to t("button.detail_view"), casa_case_path(casa_case) %></td>
+            <td><%= link_to t("button.edit"), edit_casa_case_path(casa_case) %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/app/views/reimbursements/_table.html.erb
+++ b/app/views/reimbursements/_table.html.erb
@@ -1,60 +1,62 @@
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
-      <thead>
-      <tr>
-        <th><%= t(".heading.volunteer") %></th>
-        <th><%= t(".heading.case_number") %></th>
-        <th><%= t(".heading.contact_types") %></th>
-        <th><%= t(".heading.occurred_at") %></th>
-        <th><%= t(".heading.expense_type") %></th>
-        <th><%= t(".heading.description") %></th>
-        <th><%= t(".heading.amount") %></th>
-        <th><%= t(".heading.reimbursement_complete") %></th>
-      </tr>
-      </thead>
-      <tbody>
-      <% @reimbursements.each do |reimbursement| %>
+    <div class="table-responsive">
+      <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
+        <thead>
         <tr>
-          <td id="volunteer-<%= reimbursement.id %>">
-            <span class="mobile-label">Volunteer</span>
-            <%= link_to(reimbursement.creator.display_name, volunteer_path(reimbursement.creator)) %>
-          </td>
-
-          <td id="case-number-<%= reimbursement.id %>">
-            <span class="mobile-label">Case Number</span>
-            <%= link_to(reimbursement.casa_case.case_number, casa_case_path(reimbursement.casa_case)) %>
-          </td>
-
-          <td id="contact-types-<%= reimbursement.id %>">
-          <%= contact_types_list(reimbursement) %>
-          </td>
-
-          <td id="date-attempted-<%= reimbursement.id %>">
-            <%= reimbursement.occurred_at.strftime("%B %d %Y") %>
-          </td>
-
-          <td id="expense-type-<%= reimbursement.id %>">
-          </td>
-
-          <td id="description-<%= reimbursement.id %>">
-          </td>
-
-          <td id="amount-<%= reimbursement.id %>">
-            <%= reimbursement.miles_driven %>
-          </td>
-
-          <td>
-            <%= form_with(model: reimbursement, url: reimbursement_mark_as_complete_path(reimbursement),
-method: "patch") do |form| %>
-              <%= form.label :reimbursement_complete, t("common.yes_text") %>
-              <%= form.check_box(:reimbursement_complete, value: reimbursement.reimbursement_complete,
-onchange: 'this.form.submit();') %>
-            <% end %>
-          </td>
+          <th><%= t(".heading.volunteer") %></th>
+          <th><%= t(".heading.case_number") %></th>
+          <th><%= t(".heading.contact_types") %></th>
+          <th><%= t(".heading.occurred_at") %></th>
+          <th><%= t(".heading.expense_type") %></th>
+          <th><%= t(".heading.description") %></th>
+          <th><%= t(".heading.amount") %></th>
+          <th><%= t(".heading.reimbursement_complete") %></th>
         </tr>
-      <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+        <% @reimbursements.each do |reimbursement| %>
+          <tr>
+            <td id="volunteer-<%= reimbursement.id %>">
+              <span class="mobile-label">Volunteer</span>
+              <%= link_to(reimbursement.creator.display_name, volunteer_path(reimbursement.creator)) %>
+            </td>
+
+            <td id="case-number-<%= reimbursement.id %>">
+              <span class="mobile-label">Case Number</span>
+              <%= link_to(reimbursement.casa_case.case_number, casa_case_path(reimbursement.casa_case)) %>
+            </td>
+
+            <td id="contact-types-<%= reimbursement.id %>">
+            <%= contact_types_list(reimbursement) %>
+            </td>
+
+            <td id="date-attempted-<%= reimbursement.id %>">
+              <%= reimbursement.occurred_at.strftime("%B %d %Y") %>
+            </td>
+
+            <td id="expense-type-<%= reimbursement.id %>">
+            </td>
+
+            <td id="description-<%= reimbursement.id %>">
+            </td>
+
+            <td id="amount-<%= reimbursement.id %>">
+              <%= reimbursement.miles_driven %>
+            </td>
+
+            <td>
+              <%= form_with(model: reimbursement, url: reimbursement_mark_as_complete_path(reimbursement),
+  method: "patch") do |form| %>
+                <%= form.label :reimbursement_complete, t("common.yes_text") %>
+                <%= form.check_box(:reimbursement_complete, value: reimbursement.reimbursement_complete,
+  onchange: 'this.form.submit();') %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -119,27 +119,29 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <table
-      class="table table-striped table-bordered"
-      id="volunteers"
-      data-source="<%= datatable_volunteers_path format: :json %>">
-      <thead>
-      <tr>
-        <th><%= t(".heading.name") %></th>
-        <th><%= t(".heading.e_mail") %></th>
-        <th><%= t(".heading.supervisor") %></th>
-        <th><%= t(".heading.status") %></th>
-        <th><%= t(".heading.assigned_transition_aged_youth") %></th>
-        <th><%= t(".heading.case_number") %></th>
-        <th><%= t(".heading.last_attempted_contact") %></th>
-        <th><%= t(".heading.contacts") %></th>
-        <th><%= t(".heading.hours_spent_in") %></th>
-        <th><%= t(".heading.actions") %></th>
-      </tr>
-      </thead>
+    <div class="table-responsive">
+      <table
+        class="table table-striped table-bordered"
+        id="volunteers"
+        data-source="<%= datatable_volunteers_path format: :json %>">
+        <thead>
+          <tr>
+            <th><%= t(".heading.name") %></th>
+            <th><%= t(".heading.e_mail") %></th>
+            <th><%= t(".heading.supervisor") %></th>
+            <th><%= t(".heading.status") %></th>
+            <th><%= t(".heading.assigned_transition_aged_youth") %></th>
+            <th><%= t(".heading.case_number") %></th>
+            <th><%= t(".heading.last_attempted_contact") %></th>
+            <th><%= t(".heading.contacts") %></th>
+            <th><%= t(".heading.hours_spent_in") %></th>
+            <th><%= t(".heading.actions") %></th>
+          </tr>
+        </thead>
 
-      <tbody>
-      </tbody>
-    </table>
+        <tbody>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3323

### What changed, and why?
Fix table overflow sizing for the casa_cases, reimbursements, and volunteers tables.

When the window was not wide enough, some larger tables were overflowing past their parent card div. The simple fix implemented here is to wrap the table in a div with bootstrap's table-responsive class which makes it automatically scroll horizontally as needed: https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Manual testing in UI only.

### Screenshots please :)
<details>
<summary>Before - Volunteers Table...</summary>
<br>
<img width="862" alt="Screen Shot 2022-04-06 at 9 59 52 PM" src="https://user-images.githubusercontent.com/49253356/162248733-ad9790d3-a7e1-4673-8547-7e4c926e9132.png">
</details>

#### After - Volunteers table
<img width="858" alt="Screen Shot 2022-04-06 at 10 00 48 PM" src="https://user-images.githubusercontent.com/49253356/162249051-23a0b686-46c3-46ff-a6d5-018145e0ae39.png">

<details>
<summary>Before - Cases...</summary>
<br>
<img width="664" alt="Screen Shot 2022-04-06 at 10 12 00 PM" src="https://user-images.githubusercontent.com/49253356/162250777-7a9cb12d-967d-487e-8151-3db7ffd97c25.png">
</details>

#### After - Cases
<img width="669" alt="Screen Shot 2022-04-06 at 10 12 35 PM" src="https://user-images.githubusercontent.com/49253356/162250812-fd6ea942-be33-4e5b-aba5-84eac646cbfc.png">

<details>
<summary>Before - Reimbursement Queue...</summary>
<br>
<img width="810" alt="Screen Shot 2022-04-06 at 10 20 35 PM" src="https://user-images.githubusercontent.com/49253356/162249944-3a4ff816-6cdb-4641-baf7-34d2e69e33ba.png">
</details>

#### After - Reimbursement Queue
<img width="799" alt="Screen Shot 2022-04-06 at 10 21 14 PM" src="https://user-images.githubusercontent.com/49253356/162250302-0e6de8a1-2e12-4297-ac0f-c42532df80a1.png">

<img width="704" alt="Screen Shot 2022-04-06 at 10 21 32 PM" src="https://user-images.githubusercontent.com/49253356/162250323-c74cd8ce-1830-4a23-9fa8-4e23fdb3deb9.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9