### PR TITLE
Fix flaky reimbursement_datatable_spec.rb test

### DIFF
--- a/spec/datatables/reimbursement_datatable_spec.rb
+++ b/spec/datatables/reimbursement_datatable_spec.rb
@@ -140,17 +140,6 @@ RSpec.describe "ReimbursementDatatable" do
       it_behaves_like "a sorted results set"
     end
 
-    describe "order by case number" do
-      let(:order_by) { "case_number" }
-      let(:sorted_case_contacts) do
-        case_contacts
-          .sort_by { |case_contact| case_contact.casa_case.case_number }
-          .sort_by { |case_contact| case_contact.id }
-      end
-
-      it_behaves_like "a sorted results set"
-    end
-
     describe "order by created at" do
       let(:order_by) { "created_at" }
       let(:sorted_case_contacts) do
@@ -167,6 +156,34 @@ RSpec.describe "ReimbursementDatatable" do
       end
 
       it_behaves_like "a sorted results set"
+    end
+
+    describe "order by case number" do
+      let(:order_by) { "case_number" }
+      let(:sorted_case_contacts) { case_contacts.sort_by { |case_contact| case_contact.casa_case.case_number } }
+      let(:first_case_number) { first_result[:casa_case][:case_number] }
+      let(:lowest_case_number) { sorted_case_contacts.first.casa_case.case_number }
+
+      it "should order ascending by default" do
+        expect(first_case_number).to eq(lowest_case_number)
+      end
+
+      describe "explicit ascending order" do
+        let(:order_direction) { "ASC" }
+
+        it "should order correctly" do
+          expect(first_case_number).to eq(lowest_case_number)
+        end
+      end
+
+      describe "descending order" do
+        let(:order_direction) { "DESC" }
+        let(:highest_case_number) { sorted_case_contacts.last.casa_case.case_number }
+
+        it "should order correctly" do
+          expect(first_case_number).to eq(highest_case_number)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3326 

### What changed, and why?
The rspec test `spec/datatables/reimbursement_datatable_spec.rb` has been failing intermittently requiring multiple CI runs to get a passing build. The failing tests relate to ordering the reimbursement table by case number.

Example build failure: https://github.com/rubyforgood/casa/runs/5867140454?check_suite_focus=true

```
Failures:

  1) ReimbursementDatatable multiple record handling order by case number behaves like a sorted results set should order ascending by default
     Failure/Error: expect(first_result[:id]).to eq(sorted_case_contacts.first.id.to_s)

       expected: "193"
            got: "195"

       (compared using ==)
     Shared Example Group: "a sorted results set" called from ./spec/datatables/reimbursement_datatable_spec.rb:151
     # ./spec/datatables/reimbursement_datatable_spec.rb:26:in `block (3 levels) in <top (required)>'

  2) ReimbursementDatatable multiple record handling order by case number behaves like a sorted results set descending order should order correctly
     Failure/Error: expect(first_result[:id]).to eq(sorted_case_contacts.last.id.to_s)

       expected: "222"
            got: "220"

       (compared using ==)
     Shared Example Group: "a sorted results set" called from ./spec/datatables/reimbursement_datatable_spec.rb:151
     # ./spec/datatables/reimbursement_datatable_spec.rb:41:in `block (4 levels) in <top (required)>'

  3) ReimbursementDatatable multiple record handling order by case number behaves like a sorted results set explicit ascending order should order correctly
     Failure/Error: expect(first_result[:id]).to eq(sorted_case_contacts.first.id.to_s)

       expected: "223"
            got: "225"

       (compared using ==)
     Shared Example Group: "a sorted results set" called from ./spec/datatables/reimbursement_datatable_spec.rb:151
     # ./spec/datatables/reimbursement_datatable_spec.rb:33:in `block (4 levels) in <top (required)>'
```

The test data generates 15 reimbursement request records with each case number re-used 3 times. Grabbing the first id from the table when sorted by the case number resulted in flakiness.

For the purposes of the test, consider it sorted if the smallest case number is the first record when ordered ascending and the largest case number is the first record when ordered descending. This means it could be any one of 3 records but still proves that it's ordering by case number so should be sufficient to meet the purpose of these "ordered by case number"
tests.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Repeated the test 10x without failures.
`for _ in {1..10}; do rspec spec/datatables/reimbursement_datatable_spec.rb:161; done`

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9