### PR TITLE
always run bot script for debug

### DIFF
--- a/.github/workflows/after-deploy.yml
+++ b/.github/workflows/after-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     name: On Deploy
     steps:
       - name: After Deploy
-        uses: Firelemons/on-deploy@v2.1.1
+        uses: Firelemons/on-deploy@v2.1.2
         with:
           project_name: "CASA Volunteer Portal"
           done_column_card_limit: "16"


### PR DESCRIPTION
### What changed, and why?
Remove code to prevent bot script from being run if no recent deploy occurred for debug