### PR TITLE
3368 ContactType updates to Cases show ContactType names instead of ids

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -190,11 +190,11 @@ class CasaCasesController < ApplicationController
 
   def change_message_text(attribute, original_attribute, updated_attribute)
     if attribute == :contact_types
-      new_contact_type_ids = updated_attribute.map { |contact| contact["contact_type_id"] }
-      previous_contact_type_ids = original_attribute.map { |contact| contact["contact_type_id"] }
-      changed_count = new_contact_type_ids - previous_contact_type_ids
-      return if changed_count == 0
-      "#{changed_count} #{attribute.to_s.humanize.singularize.pluralize(changed_count)} added"
+      new_contact_types = updated_attribute.map { |contact| contact["name"] }
+      previous_contact_types = original_attribute.map { |contact| contact["name"] }
+      changed_contact_types = new_contact_types - previous_contact_types
+      return if changed_contact_types.empty?
+      "#{changed_contact_types} #{attribute.to_s.humanize.singularize.pluralize(changed_contact_types)} added"
     elsif attribute == :court_orders
       changed_count = (updated_attribute - original_attribute).count
       "#{changed_count} #{attribute.to_s.humanize.singularize.pluralize(changed_count)} added or updated"

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -200,7 +200,7 @@ class CasaCase < ApplicationRecord
   end
 
   def full_attributes_hash
-    attributes.symbolize_keys.merge({contact_types: casa_case_contact_types.map(&:attributes), court_orders: case_court_orders.map(&:attributes)})
+    attributes.symbolize_keys.merge({contact_types: contact_types.reload.map(&:attributes), court_orders: case_court_orders.map(&:attributes)})
   end
 
   # def to_param


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3368

### What changed, and why?
Previously IDs were displayed. Now I am displaying the names associated.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
In a seeded local, 
- navigate and edit a case details. 
- Add a few Contact Types in this screen 
- Click button to select update

### Screenshots please :)
<img width="619" alt="working_ui" src="https://user-images.githubusercontent.com/7889179/163661015-96572abe-414e-4303-847d-898100c36d9b.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9