### PR TITLE
3315 fix permission issues

### DIFF
--- a/app/policies/casa_admin_policy.rb
+++ b/app/policies/casa_admin_policy.rb
@@ -5,13 +5,16 @@ class CasaAdminPolicy < UserPolicy
 
   alias_method :new?, :index?
   alias_method :create?, :index?
-  alias_method :edit?, :index?
   alias_method :update?, :index?
   alias_method :activate?, :index?
   alias_method :resend_invitation?, :index?
   alias_method :restore?, :is_admin?
   alias_method :datatable?, :index?
   alias_method :change_to_supervisor?, :is_admin?
+
+  def edit?
+    is_admin_same_org?
+  end
 
   def deactivate?
     see_deactivate_option? && CasaAdmin.in_organization(current_organization).active.size > 1

--- a/app/policies/supervisor_policy.rb
+++ b/app/policies/supervisor_policy.rb
@@ -24,8 +24,11 @@ class SupervisorPolicy < UserPolicy
     is_admin?
   end
 
+  def edit?
+    admin_or_supervisor_same_org?
+  end
+
   alias_method :create?, :new?
-  alias_method :edit?, :index?
   alias_method :datatable?, :index?
   alias_method :change_to_admin?, :is_admin?
 end

--- a/spec/policies/casa_admin_policy_spec.rb
+++ b/spec/policies/casa_admin_policy_spec.rb
@@ -8,11 +8,28 @@ RSpec.describe CasaAdminPolicy do
   let(:volunteer) { build(:volunteer, casa_org: organization) }
   let(:supervisor) { build(:supervisor, casa_org: organization) }
 
-  permissions :index?, :new?, :create?, :edit?, :update?, :activate?, :resend_invitation?, :change_to_supervisor? do
+  permissions :edit? do
+    context "same org" do
+      let(:record) { build_stubbed(:casa_admin, casa_org: casa_admin.casa_org) }
+      it "allows editing admin" do
+        is_expected.to permit(casa_admin, record)
+      end
+    end
+    context "different org" do
+      let(:record) { build_stubbed(:casa_admin, casa_org: build_stubbed(:casa_org)) }
+      it "does not allow editing admin" do
+        is_expected.not_to permit(casa_admin, record)
+      end
+    end
+  end
+
+  permissions :index?, :new?, :create?, :update?, :activate?, :resend_invitation?, :change_to_supervisor? do
     it "allows casa_admins" do
       is_expected.to permit(casa_admin)
     end
+  end
 
+  permissions :index?, :edit?, :new?, :create?, :update?, :activate?, :resend_invitation?, :change_to_supervisor? do
     it "does not permit supervisor" do
       is_expected.to_not permit(supervisor)
     end

--- a/spec/policies/supervisor_policy_spec.rb
+++ b/spec/policies/supervisor_policy_spec.rb
@@ -47,7 +47,36 @@ RSpec.describe SupervisorPolicy do
     end
   end
 
-  permissions :index?, :edit?, :datatable? do
+  permissions :edit? do
+    context "same org" do
+      let(:record) { build_stubbed(:supervisor, casa_org: casa_admin.casa_org) }
+      context "when user is admin" do
+        it "can edit a supervisor" do
+          is_expected.to permit(casa_admin, record)
+        end
+      end
+      context "when user is supervisor" do
+        it "can edit a supervisor" do
+          is_expected.to permit(supervisor, record)
+        end
+      end
+    end
+    context "different org" do
+      let(:record) { build_stubbed(:supervisor, casa_org: build_stubbed(:casa_org)) }
+      context "when user is admin" do
+        it "cannot edit a supervisor" do
+          is_expected.not_to permit(casa_admin, record)
+        end
+      end
+      context "when user is a supervisor" do
+        it "cannot edit a supervisor" do
+          is_expected.not_to permit(supervisor, record)
+        end
+      end
+    end
+  end
+
+  permissions :index?, :datatable? do
     context "when user is an admin" do
       it "has access to the supervisors index action" do
         is_expected.to permit(casa_admin, Supervisor)
@@ -59,7 +88,9 @@ RSpec.describe SupervisorPolicy do
         is_expected.to permit(supervisor, Supervisor)
       end
     end
+  end
 
+  permissions :index?, :edit?, :datatable? do
     context "when user is a volunteer" do
       it "does not have access to the supervisors index action" do
         is_expected.to_not permit(volunteer, Supervisor)

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -3,12 +3,28 @@ require "rails_helper"
 RSpec.describe "/casa_admins", type: :request do
   describe "GET /casa_admins/:id/edit" do
     context "logged in as admin user" do
-      it "can successfully access a casa admin edit page" do
-        sign_in_as_admin
+      context "same org" do
+        let(:casa_one) { create(:casa_org) }
+        let(:casa_admin_one) { create(:casa_admin, casa_org: casa_one) }
+        it "can successfully access a casa admin edit page" do
+          sign_in(casa_admin_one)
 
-        get edit_casa_admin_path(create(:casa_admin))
+          get edit_casa_admin_path(create(:casa_admin, casa_org: casa_one))
 
-        expect(response).to be_successful
+          expect(response).to be_successful
+        end
+      end
+
+      context "different org" do
+        let(:diff_org) { create(:casa_org) }
+        it "cannot access a casa admin edit page" do
+          sign_in_as_admin
+
+          get edit_casa_admin_path(create(:casa_admin, casa_org: diff_org))
+
+          expect(response).to redirect_to root_path
+          expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+        end
       end
     end
 

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -29,46 +29,69 @@ RSpec.describe "/supervisors", type: :request do
   end
 
   describe "GET /edit" do
-    it "admin can view the edit supervisor page" do
-      sign_in admin
+    context "same org" do
+      it "admin can view the edit supervisor page" do
+        sign_in admin
 
-      get edit_supervisor_url(supervisor)
+        get edit_supervisor_url(supervisor)
 
-      expect(response).to be_successful
+        expect(response).to be_successful
+      end
+
+      it "supervisor can view the edit supervisor page" do
+        sign_in supervisor
+
+        get edit_supervisor_url(supervisor)
+
+        expect(response).to be_successful
+      end
+
+      it "other supervisor can view the edit supervisor page" do
+        sign_in build(:supervisor)
+
+        get edit_supervisor_url(supervisor)
+
+        expect(response).to be_successful
+      end
+
+      it "returns volunteers ever assigned if include_unassigned param is present" do
+        sign_in admin
+
+        get edit_supervisor_url(supervisor), params: {include_unassigned: true}
+
+        expect(response).to be_successful
+        expect(assigns(:all_volunteers_ever_assigned)).to_not be_nil
+      end
+
+      it "returns no volunteers ever assigned if include_unassigned param is false" do
+        sign_in admin
+
+        get edit_supervisor_url(supervisor), params: {include_unassigned: false}
+
+        expect(response).to be_successful
+        expect(assigns(:all_volunteers_ever_assigned)).to be_nil
+      end
     end
 
-    it "supervisor can view the edit supervisor page" do
-      sign_in supervisor
+    context "different org" do
+      let(:diff_org) { create(:casa_org) }
+      let(:supervisor_diff_org) { create(:supervisor, casa_org: diff_org) }
+      it "admin cannot view the edit supervisor page" do
+        sign_in_as_admin
 
-      get edit_supervisor_url(supervisor)
+        get edit_supervisor_url(supervisor_diff_org)
 
-      expect(response).to be_successful
-    end
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+      it "supervisor cannot view the edit supervisor page" do
+        sign_in_as_supervisor
 
-    it "other supervisor can view the edit supervisor page" do
-      sign_in build(:supervisor)
+        get edit_supervisor_url(supervisor_diff_org)
 
-      get edit_supervisor_url(supervisor)
-
-      expect(response).to be_successful
-    end
-
-    it "returns volunteers ever assigned if include_unassigned param is present" do
-      sign_in admin
-
-      get edit_supervisor_url(supervisor), params: {include_unassigned: true}
-
-      expect(response).to be_successful
-      expect(assigns(:all_volunteers_ever_assigned)).to_not be_nil
-    end
-
-    it "returns no volunteers ever assigned if include_unassigned param is false" do
-      sign_in admin
-
-      get edit_supervisor_url(supervisor), params: {include_unassigned: false}
-
-      expect(response).to be_successful
-      expect(assigns(:all_volunteers_ever_assigned)).to be_nil
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
     end
   end
 

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "supervisors/edit", type: :system do
     end
 
     context "when the email exists already" do
-      let!(:existing_supervisor) { create(:supervisor) }
+      let!(:existing_supervisor) { create(:supervisor, casa_org_id: organization.id) }
 
       it "responds with a notice" do
         sign_in user


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3315 

### What changed, and why?
CasaAdmins and Supervisors were able to edit others at their own hierarchical level or below even if they belonged to different organizations. Now the organization is checked to make sure it matches before the :edit endpoint can be accessed.

From what I understood this is necessary because different organizations should have independent staffs and consequently members of one should not be accessible at the edit level to members of another.


### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: limited to supervisors and volunteers from the same organization
- Admin permissions: limited to admins, supervisors, and volunteers from the same organization

### How is this tested? (please write tests!) 💖💪
Tested at the policy level: check edit permissions
Tested at the controller level (request): check redirect endpoint to root

### Screenshots please :)
![admin_permissions](https://user-images.githubusercontent.com/70590511/164297141-2e6c463c-c6a3-4061-8266-377eb754dc07.gif)
![supervisor_permissions](https://user-images.githubusercontent.com/70590511/164297164-38e7ed99-fc90-4b72-88d9-1422b462aa69.gif)

### Feelings gif (optional)
:D

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9