### PR TITLE
3333 - Automatically Unassign Deactivated Volunteer From Supervisor

### DIFF
--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -78,6 +78,7 @@ class Volunteer < User
       updated = update(active: false)
       if updated
         case_assignments.update_all(active: false)
+        supervisor_volunteer&.update(is_active: false)
       end
 
       updated

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe Volunteer, type: :model do
       case_contacts.each { |c| c.reload }
       expect(case_contacts).to all(satisfy { |c| !c.active })
     end
+
+    context "when volunteer has previously been assigned a supervisor", runme: true do
+      let!(:supervisor_volunteer) { create(:supervisor_volunteer, volunteer: volunteer) }
+
+      it "deactivates the supervisor-volunteer relationship" do
+        volunteer.deactivate
+
+        expect { volunteer.reload }.to change(volunteer, :supervisor_volunteer)
+      end
+    end
+
+    context "when volunteer had no supervisor previously assigned" do
+      it "does not attempt to update a supervisor-volunteer table" do
+        volunteer.deactivate
+
+        expect { volunteer.reload }.not_to change(volunteer, :supervisor_volunteer)
+      end
+    end
   end
 
   describe "#display_name" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3333 

### What changed, and why?
Association between volunteer and supervisor is stored in supervisor_volunteer table, which contains a column named "is_active". When a volunteer is deactivated this column is now set to false in the appropriate row so that the inactive volunteer will no longer appear in the supervisor's listing.

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: not affected
- Admin permissions: not affected

### How is this tested? (please write tests!) 💖💪
Tested at the model level: when volunteer is deactivated table supervisor_volunteer is expected to reflect the change.

### Screenshots please :)
![volunteer_automatically_unassigned](https://user-images.githubusercontent.com/70590511/164771060-957a812f-73c9-44ce-9531-7d1b439b9fd7.gif)


### Feelings gif (optional)
:O :<

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9