### PR TITLE
add test for phone number field in volunteers/edit view spec #1787

### DIFF
--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "volunteers/edit", type: :view do
-  let(:volunteer) { create :volunteer }
+  let(:org) { create :casa_org }
+  let(:volunteer) { create :volunteer, casa_org: org }
 
   it "allows an administrator to edit a volunteers email address" do
     administrator = build_stubbed :casa_admin
@@ -40,6 +41,32 @@ RSpec.describe "volunteers/edit", type: :view do
     render template: "volunteers/edit"
 
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
+  end
+
+  it "allows a supervisor in the same org to edit a volunteers phone number" do
+    supervisor = build_stubbed :supervisor, casa_org: org
+    enable_pundit(view, supervisor)
+    allow(view).to receive(:current_user).and_return(supervisor)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to have_field("volunteer_phone_number")
+  end
+
+  it "does not allow a supervisor from a different org to edit a volunteers phone number" do
+    different_supervisor = build_stubbed :supervisor
+    enable_pundit(view, different_supervisor)
+    allow(view).to receive(:current_user).and_return(different_supervisor)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).not_to have_field("volunteer_phone_number")
   end
 
   it "does not allow a supervisor to edit a volunteers email address" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1787 

### What changed, and why?
Nothing much changed lol. I just added tests to verify the supervisor can edit a volunteer's phone number within the same organization. All the code basically has already been written since #1785 

### How is this tested? (please write tests!) 💖💪
View specs are written to check the presence of the phone number field for the following situations:
1) Supervisor is within the same org as the volunteer
2) Supervisor is in a different org compared to the volunteer

### Screenshots please :)
![Screenshot from 2022-04-22 16-51-52](https://user-images.githubusercontent.com/86758440/164791827-dc5f471d-2b2e-4fb3-8ff7-a4b9b234ca0a.png)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9