### PR TITLE
Fix delete button wrapping on some case contacts on a casa case page

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -35,22 +35,23 @@
           </div>
         </div>
       </div>
-      <div class="row justify-content-between">
+      <div class="d-flex justify-content-between">
         <% if Pundit.policy(current_user, contact).update? %>
           <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
-          <div class="col-sm-5">
+          <div class="mr-2">
             <%= link_to edit_case_contact_path(contact), class: "btn btn-outline-primary" do %>
               <strong><%= t("button.edit") %></strong>
             <% end %>
           </div>
         <% end %>
-      </div>
-      <div class="row pl-3">
-        <div class="col">
+        <div class="">
+        <div class="">
           <%= link_to(t("button.delete"), case_contact_path(contact.id), method: :delete,
                 class: "btn btn-danger") if policy(current_user).destroy? && !contact.deleted? %>
         </div>
       </div>
+      </div>
+
     </div>
   </div>
   <div>

--- a/app/views/case_contacts/_followup.html.erb
+++ b/app/views/case_contacts/_followup.html.erb
@@ -1,11 +1,11 @@
 <% if followup %>
-  <div class="col-sm-5">
+  <div class="mr-2">
     <%= button_to resolve_followup_path(followup), method: :patch, class: "btn btn-success" do %>
       <%= t("button.resolve") %>
     <% end %>
   </div>
 <% else %>
-  <div class="col-sm-4">
+  <div class="mr-2">
     <button type="button"
             class="btn btn-outline-primary followup-button"
             id="followup-button-<%= contact.id %>">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3369

### What changed, and why?
The delete button didn't belong to the same wrapping context of the buttons to its left. I just moved the delete button to the same wrapping div and made sure they were equally spaced.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Test's not applicable

### Screenshots please :)
![delete wrapp](https://user-images.githubusercontent.com/44203348/165152856-bac5d22b-18cf-4571-b2da-8518490b624b.gif)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9