### PR TITLE
Seed judges in development environment

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -55,7 +55,7 @@ class DbPopulator
   # Create 2 judges for each casa_org.
   def create_judges(casa_org)
     env = ENV["APP_ENVIRONMENT"] || Rails.env
-    if env == "qa" || env == "test"
+    if env == "qa" || env == "test" || env == "development"
       2.times { Judge.create(name: Faker::Name.name, casa_org: casa_org) }
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3423

### What changed, and why?
Add judges to development environment during DB Seed

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
During db seed check logs to see objects created
```
Records written to the DB:

Count  Class Name
-----  ----------

    3  CasaOrg
   14  CasaCase
*   8  Judge
   13  User
    8  Volunteer
    3  Supervisor
    2  CasaAdmin
    3  AllCasaAdmin
    6  SupervisorVolunteer
   14  CaseAssignment
   66  ContactType
   21  ContactTypeGroup
   39  CaseContact
   49  CaseCourtOrder
    0  PaperTrail::Version

Done.
```

### Screenshots please :)
See above ^
