### PR TITLE
Close #3449 Replace translation with literal

### DIFF
--- a/app/views/casa_cases/_inactive_case.html.erb
+++ b/app/views/casa_cases/_inactive_case.html.erb
@@ -1,7 +1,7 @@
 <div class="alert alert-danger">
-  <p><%= t(".notice") %>: <%= I18n.l(@casa_case.updated_at, format: :standard, default: nil) %>
+  <p>Case was deactivated on: <%= I18n.l(@casa_case.updated_at, format: :standard, default: nil) %>
     <%= link_to(
-            t("casa_cases.form.button.reactivate"),
+            "Reactivate CASA Case",
             reactivate_casa_case_path(@casa_case),
             method: :patch,
             class: "btn btn-primary pull-right"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -28,8 +28,6 @@ en:
       judge: Judge
       transition_aged_youth: Transition Aged Youth
       court_report_status: Court Report Status
-    inactive_case:
-      notice: Case was deactivated on
     index:
       button:
         new: New Case


### PR DESCRIPTION


### What github issue is this PR for, if any?

Resolves #3449

### What changed, and why?

When reading and modifying code it can be confusing to see a translation lookup. Instead this commit changes the inactive_case to use string literals instead. This makes modifying the view easier for developers, though comes at the cost of reduced ability to use localization features to switch language output. However, since there are only English locales, this commit represents no functional change to the application.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A 
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

Utilizes existing tests. No new tests written

### Screenshots please :)




### Feelings gif (optional)

![Hello from dog](https://media1.giphy.com/media/Wj7lNjMNDxSmc/giphy.gif?cid=790b761193d3a56c00c687f15f48bc49f259a3b066cc734c&rid=giphy.gif&ct=g)

### Feedback please? (optional)

I wrote https://www.codetriage.com I'm excited to be part of this workshop! 
