### PR TITLE
Replace translations in app/views/contact_types/_form.html.erb partial

### DIFF
--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -9,13 +9,13 @@
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.label :contact_type_group, t(".contact_type_group") %>
+        <%= form.label :contact_type_group, "Contact type group" %>
         <%= form.select :contact_type_group_id, set_group_options, class: "form-control" %>
       </div>
       <div class="field form-group">
         <div class="form-check">
           <%= form.check_box :active, class: 'form-check-input' %>
-          <%= form.label :active, t(".active"), class: 'form-check-label' %>
+          <%= form.label :active, "Active", class: 'form-check-label' %>
         </div>
       </div>
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -283,9 +283,6 @@ en:
       title: New Contact Type
     edit:
       title: Edit Contact Type
-    form:
-      contact_type_group: Contact type group
-      active: Active
   emancipation:
     index:
       heading:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3476

### What changed, and why?
Replaced translations with their strings from the English locale config. 
Deleted the views/contact_types/form subsection of the locale YAML.

### How will this affect user permissions?
This change doesn't have an impact in permissions

### How is this tested? (please write tests!) 💖💪
This is just a localization removal, no need to include tests.

### Screenshots please :)
This is just a localization removal, I don't think its worth including screenshots.