### PR TITLE
Updated "common.email" translation with "Email"

### DIFF
--- a/app/views/all_casa_admins/new.html.erb
+++ b/app/views/all_casa_admins/new.html.erb
@@ -6,7 +6,7 @@
       <%= render "/shared/error_messages", resource: @all_casa_admin %>
 
       <div class="field form-group">
-        <%= form.label :email, t("common.email") %>
+        <%= form.label :email, "Email" %>
         <%= form.email_field :email, class: "form-control" %>
       </div>
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #3440

### What changed, and why?

Replaced `I18n.t` call for `common.email` with the actual text `Email`

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

<img width="284" alt="Screenshot 2022-05-18 at 11 47 14 AM" src="https://user-images.githubusercontent.com/56545288/169123487-43205c10-383f-4dee-999f-c60d95411f95.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9