### PR TITLE
Remove i18n references in casa_org edit page

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -1,60 +1,60 @@
-<h1><%= t(".title") %></h1>
+<h1>Editing CASA Organization</h1>
 
 <div class="card card-container">
   <div class="card-body">
     <%= form_with(model: current_organization, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: current_organization %>
       <div class="field form-group">
-        <%= form.label :name, t("common.name") %>
+        <%= form.label :name, "Name" %>
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.label :display_name, t("common.display_name") %>
+        <%= form.label :display_name, "Display name" %>
         <%= form.text_field :display_name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.label :address, t("common.address") %>
+        <%= form.label :address, "Address" %>
         <%= form.text_field :address, class: "form-control" %>
       </div>
       <div class="custom-file mb-5">
-        <%= form.label :logo, t(".logo") %>
+        <%= form.label :logo, "Logo" %>
         <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp" %>
       </div>
       <div class="custom-file mb-5">
-        <%= form.label :court_report_template, t(".court_report_template") %>
+        <%= form.label :court_report_template, "Court report template" %>
         <%= form.file_field :court_report_template, class: "form-control" %>
       </div>
       <div class="field form-group">
         <div class="form-check">
           <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
-          <%= form.label :show_driving_reimbursement, t(".show_driving_reimbursement"), class: 'form-check-label' %>
+          <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label' %>
         </div>
       </div>
       <hr>
       <div class="field form-group">
-          <%= form.label :twilio_phone_number, t(".twilio_phone_number") %>
+          <%= form.label :twilio_phone_number, "Twilio Phone Number" %>
           <%= form.text_field :twilio_phone_number, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_account_sid, t(".twilio_account_sid") %>
+          <%= form.label :twilio_account_sid, "Twilio Account SID" %>
           <%= form.text_field :twilio_account_sid, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_api_key_sid, t(".twilio_api_key_sid") %>
+          <%= form.label :twilio_api_key_sid, "Twilio API Key SID" %>
           <%= form.text_field :twilio_api_key_sid, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_api_key_secret, t(".twilio_api_key_secret") %>
+          <%= form.label :twilio_api_key_secret, "Twilio API Key Secret" %>
           <%= form.text_field :twilio_api_key_secret, class: "form-control" %>
       </div>
       <div class="actions">
-        <%= form.submit t("button.submit"), class: "btn btn-primary" %>
+        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>
 </div>
 
-<h1 class="pt-5"><%= t(".manage_contact_types_title") %></h1>
+<h1 class="pt-5">Manage Contact Types</h1>
 
 <div class="card card-container">
   <div class="card-body">
@@ -63,7 +63,7 @@
   </div>
 </div>
 
-<h1 class="pt-5"><%= t(".manage_court_details_title") %></h1>
+<h1 class="pt-5">Manage Court Details</h1>
 
 <div class="card card-container">
   <div class="card-body">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -246,17 +246,6 @@ en:
         mailer_type: Mailer Type
         sent_address: Recipient
       title: Sent Emails
-    edit:
-      manage_court_details_title: Manage Court Details
-      manage_contact_types_title: Manage Contact Types
-      title: Editing CASA Organization
-      logo: Logo
-      court_report_template: Court report template
-      show_driving_reimbursement: Show driving reimbursement
-      twilio_account_sid: Twilio Account SID
-      twilio_api_key_sid: Twilio API Key SID
-      twilio_api_key_secret: Twilio API Key Secret
-      twilio_phone_number: Twilio Phone Number
   case_court_reports:
     index:
       button:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3462 

### What changed, and why?
As per the issue description, all the calls to `translate` within the casa org edit screen have been replaced with hardcoded strings.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
[Existing tests](https://github.com/rubyforgood/casa/blob/d35bd5469322f657b52841f86e8784c4ef1080b3/spec/system/casa_org/edit_spec.rb) cover the translations!

### Screenshots please :)
<details>
<summary> Before 📷   </summary>
<p>

![Screenshot 2022-05-18 at 11-50-58 CASA Volunteer Tracking](https://user-images.githubusercontent.com/12506356/169127147-7a470a5f-7ddf-45db-9035-9c57ace217ef.png)

</p>
</details>

<details>
<summary> After 📸  </summary>
<p>

![Screenshot 2022-05-18 at 11-40-21 CASA Volunteer Tracking](https://user-images.githubusercontent.com/12506356/169125474-e2bdfc45-fd2e-4b98-adba-ec9e5308f171.png)

</p>
</details>


### Feelings gif (optional)
![](https://media.giphy.com/media/kYsBThMhhalLG/giphy.gif)
