### PR TITLE
[RailsConf] Update View to replace t() with english text

### DIFF
--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -12,18 +12,18 @@
       <% if casa_admin.persisted? %>
         <div class="field form-group">
           <% if casa_admin.active? %>
-            <%= t(".active_text") %> <span class="badge badge-success text-uppercase display-1"><%= t(".active") %></span>
-            <%= link_to t(".button.deactivate"),
+            Admin is <span class="badge badge-success text-uppercase display-1">Active</span>
+            <%= link_to "Deactivate",
                         deactivate_casa_admin_path(casa_admin),
                         method: :patch,
                         class: "btn btn-outline-danger",
-                        data: {confirm: t(".prompt.mark_inactive_warning")} %>
+                        data: {confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"} %>
           <% else %>
             <div class="alert alert-danger">
-              <%= t(".deactive_text") %>: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
+              Admin was deactivated on: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
             </div>
             <% if policy(casa_admin).activate? %>
-              <%= link_to t(".button.activate"),
+              <%= link_to "Activate Admin",
                           activate_casa_admin_path(casa_admin),
                           method: :patch,
                           class: "btn btn-outline-success" %>
@@ -47,7 +47,7 @@
       <% end %>
 
       <div class="actions">
-        <%= form.submit t("button.submit"), class: "btn btn-primary" %>
+        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3441

### What changed, and why?

Updating `t()` to English text in `app/views/casa_admins/_form.html.erb`


### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: None
- Admin permissions: None

### How is this tested? (please write tests!) 💖💪
Checked the site in development & passed existing tests

### Screenshots please :)
<img width="1408" alt="image" src="https://user-images.githubusercontent.com/53536373/169130911-e98009c5-dd2f-4a36-960c-58d505c7a2ec.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9