### PR TITLE
Remove i18n lookups and replace them with strings in casa_org edit page

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -1,60 +1,60 @@
-<h1><%= t(".title") %></h1>
+<h1>Editing CASA Organization</h1>
 
 <div class="card card-container">
   <div class="card-body">
     <%= form_with(model: current_organization, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: current_organization %>
       <div class="field form-group">
-        <%= form.label :name, t("common.name") %>
+        <%= form.label :name, "Name" %>
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.label :display_name, t("common.display_name") %>
+        <%= form.label :display_name, "Display name" %>
         <%= form.text_field :display_name, class: "form-control" %>
       </div>
       <div class="field form-group">
-        <%= form.label :address, t("common.address") %>
+        <%= form.label :address, "Address" %>
         <%= form.text_field :address, class: "form-control" %>
       </div>
       <div class="custom-file mb-5">
-        <%= form.label :logo, t(".logo") %>
+        <%= form.label :logo, "Logo" %>
         <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp" %>
       </div>
       <div class="custom-file mb-5">
-        <%= form.label :court_report_template, t(".court_report_template") %>
+        <%= form.label :court_report_template, "Court report template" %>
         <%= form.file_field :court_report_template, class: "form-control" %>
       </div>
       <div class="field form-group">
         <div class="form-check">
           <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
-          <%= form.label :show_driving_reimbursement, t(".show_driving_reimbursement"), class: 'form-check-label' %>
+          <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label' %>
         </div>
       </div>
       <hr>
       <div class="field form-group">
-          <%= form.label :twilio_phone_number, t(".twilio_phone_number") %>
+          <%= form.label :twilio_phone_number, "Twilio Phone Number" %>
           <%= form.text_field :twilio_phone_number, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_account_sid, t(".twilio_account_sid") %>
+          <%= form.label :twilio_account_sid, "Twilio Account SID" %>
           <%= form.text_field :twilio_account_sid, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_api_key_sid, t(".twilio_api_key_sid") %>
+          <%= form.label :twilio_api_key_sid, "Twilio API Key SID" %>
           <%= form.text_field :twilio_api_key_sid, class: "form-control" %>
       </div>
       <div class="field form-group">
-          <%= form.label :twilio_api_key_secret, t(".twilio_api_key_secret") %>
+          <%= form.label :twilio_api_key_secret, "Twilio API Key Secret" %>
           <%= form.text_field :twilio_api_key_secret, class: "form-control" %>
       </div>
       <div class="actions">
-        <%= form.submit t("button.submit"), class: "btn btn-primary" %>
+        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>
 </div>
 
-<h1 class="pt-5"><%= t(".manage_contact_types_title") %></h1>
+<h1 class="pt-5">Manage Contact Types</h1>
 
 <div class="card card-container">
   <div class="card-body">
@@ -63,7 +63,7 @@
   </div>
 </div>
 
-<h1 class="pt-5"><%= t(".manage_court_details_title") %></h1>
+<h1 class="pt-5">Manage Court Details</h1>
 
 <div class="card card-container">
   <div class="card-body">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3483 

### What changed, and why?
Remove all the i18n lookups in the casa_org edit page and replace them with simple strings.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
![image](https://user-images.githubusercontent.com/22888178/169131079-06a82b29-7d72-4ac6-a8cf-3e60be78be5e.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue?
![image](https://user-images.githubusercontent.com/22888178/169132953-9f2bb582-988c-4da4-95a4-b0d56180fea1.png)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9