### PR TITLE
contact_type_groups/edit: Just use string, instead of l18n file

### DIFF
--- a/app/views/contact_type_groups/edit.html.erb
+++ b/app/views/contact_type_groups/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "form", locals: {title: t(".title"), contact_type_group: @contact_type_group} %>
+<%= render partial: "form", locals: {title: "Edit Contact Type Groups", contact_type_group: @contact_type_group} %>


### PR DESCRIPTION
Found in config/locales/views.en.yaml:
```
  ...
  contact_type_groups:
    new:
      title: New Contact Type Group
    edit:
      title: Edit Contact Type Group
    form:
      active: Active
```

Closes: #3474

### What github issue is this PR for, if any?
Resolves #3474

### What changed, and why?
Nothing user facing for our users (non-international, only English). Should just show "Edit Contact Type Group" on contact_type_groups/edit.

### How will this affect user permissions?
It doesn't.

### How is this tested? (please write tests!) 💖💪
It's a view, it doesn't seem to be tested from the request tests, but I also think it'd be kinda overkill and can just be validated visually.

### Screenshots please :)
Internet is kind of janky, but will test and attach screenshot once I build the codebase

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

I am old and don't know how to use emojis

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9

Had fun :) 