### PR TITLE
Replace locale strings in casa admin edit view

### DIFF
--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -6,7 +6,7 @@
       <%= render "/shared/error_messages", resource: @casa_admin %>
 
       <div class="field form-group">
-        <%= form.label :email, t("common.email") %>
+        <%= form.label :email, "Email" %>
         <%= form.email_field :email, class: "form-control" %>
       </div>
       <% if @casa_admin.persisted? %>
@@ -21,7 +21,7 @@
                           deactivate_all_casa_admins_casa_org_casa_admin_path,
                           method: :patch,
                           class: "btn btn-outline-danger",
-                          data: {confirm: t("forms.casa_admin.mark_inactive_warning")} %>
+                          data: {confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"} %>
               <%= form.submit "Update Profile", class: "btn btn-primary" %>
             </div>
           <% else %>

--- a/app/views/all_casa_admins/casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/casa_admins/edit.html.erb
@@ -21,7 +21,8 @@
                           deactivate_all_casa_admins_casa_org_casa_admin_path,
                           method: :patch,
                           class: "btn btn-outline-danger",
-                          data: {confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure you want to do this?"} %>
+                          data: { confirm: "WARNING: Marking an admin inactive will make them unable to login. " \
+                                           "Are you sure you want to do this?"} %>
               <%= form.submit "Update Profile", class: "btn btn-primary" %>
             </div>
           <% else %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3436 

### What changed, and why?
Replaced locale strings in the casa admin edit view to make the code more understandable and maintainable

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Loaded page on main, located email and warning text. Made changes and reloaded the page, and verified that the text appeared the same.

### Screenshots please :)
<img width="348" alt="Screen Shot 2022-05-18 at 11 56 07 AM" src="https://user-images.githubusercontent.com/6710249/169132403-9e117914-37b2-4de5-b394-2485a535747e.png">
<img width="471" alt="Screen Shot 2022-05-18 at 11 56 27 AM" src="https://user-images.githubusercontent.com/6710249/169132427-b87e9dda-130e-40d5-aa4b-0a062309f7f3.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? 
![alt text](https://media.giphy.com/media/MtWJ2pJx7CbJe/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9