### PR TITLE
Issue Rails Conf 19: Removing translation function in favor of stringliterals in contact type groups

### DIFF
--- a/app/views/casa_org/_contact_type_groups.html.erb
+++ b/app/views/casa_org/_contact_type_groups.html.erb
@@ -1,16 +1,16 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3><%= t(".title") %></h3>
-    <%= link_to t(".button.new"), new_contact_type_group_path, class: "btn btn-primary" %>
+    <h3>Contact Type Groups</h3>
+    <%= link_to "New Group", new_contact_type_group_path, class: "btn btn-primary" %>
   </div>
 </div>
 
 <table class="table table-striped table-bordered" id="contact-type-groups">
   <thead>
   <tr>
-    <th><%= t(".heading.name") %></th>
-    <th><%= t(".heading.active") %></th>
-    <th><%= t(".heading.actions") %></th>
+    <th>Name</th>
+    <th>Active?</th>
+    <th>Actions</th>
   </tr>
   </thead>
 
@@ -21,10 +21,10 @@
         <%= group.name %>
       </td>
       <td scope="row">
-        <%= group.active? ? t("common.yes_text") : t("common.no_text") %>
+        <%= group.active? ? "Yes" : "No" %>
       </td>
       <td>
-        <%= link_to t(".button.edit"), edit_contact_type_group_path(group) %>
+        <%= link_to "Edit", edit_contact_type_group_path(group) %>
       </td>
     </tr>
   <% end %>


### PR DESCRIPTION
… 
### What GitHub issue is this PR for if any?

Resolves [#3457](https://github.com/rubyforgood/casa/issues/3457)

### What changed, and why?

Removing translation functions in favor of string literals in the contact type groups partial. This partial is rendered in the edit view of casa orgs.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A


### Screenshots please :)

<img width="1340" alt="Screen Shot 2022-05-18 at 12 25 11" src="https://user-images.githubusercontent.com/5366444/169141229-026bc27c-4685-41e4-a8d5-b34f0278eb41.png">
