### PR TITLE
Replace localization method calls with string literals in app/views/contact_types/_form.html.erb

### DIFF
--- a/app/views/contact_types/_form.html.erb
+++ b/app/views/contact_types/_form.html.erb
@@ -5,7 +5,7 @@
     <%= form_with(model: contact_type, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: contact_type %>
       <div class="field form-group">
-        <%= form.label :name, t("common.name") %>
+        <%= form.label :name, "Name" %>
         <%= form.text_field :name, class: "form-control" %>
       </div>
       <div class="field form-group">
@@ -20,7 +20,7 @@
       </div>
 
       <div class="actions">
-        <%= form.submit t("button.submit"), class: "btn btn-primary" %>
+        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3497

### What changed, and why?
Replace localization method calls with string literals in app/views/contact_types/_form.html.erb

### How will this affect user permissions?
N/A
