### PR TITLE
Replace localization method calls with string literals in app/views/contact_type_groups/_form.html.erb

### DIFF
--- a/app/views/contact_type_groups/_form.html.erb
+++ b/app/views/contact_type_groups/_form.html.erb
@@ -6,7 +6,7 @@
       <%= render "/shared/error_messages", resource: contact_type_group %>
 
       <div class="field form-group">
-        <%= form.label :name, t("common.name") %>
+        <%= form.label :name, "Name" %>
         <%= form.text_field :name, class: "form-control" %>
       </div>
 
@@ -18,7 +18,7 @@
       </div>
 
       <div class="actions">
-        <%= form.submit t("button.submit"), class: "btn btn-primary" %>
+        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3494

### What changed, and why?
Replace localization method calls with string literals in app/views/contact_type_groups/_form.html.erb

### How will this affect user permissions?
N/A