### PR TITLE
Feature/1791 Users can view their SMS Terms & Conditions

### DIFF
--- a/app/javascript/src/stylesheets/shared/footer.scss
+++ b/app/javascript/src/stylesheets/shared/footer.scss
@@ -13,6 +13,9 @@ footer {
       max-height: 3em;
     }
   }
+  .terms-conditions-link {
+    color:#fff;
+  }
 
   .footer-logos{
     .rfglink {

--- a/app/views/layouts/footers/_not_logged_in.html.erb
+++ b/app/views/layouts/footers/_not_logged_in.html.erb
@@ -5,10 +5,11 @@
     <a href="https://rubyforgood.org/" class="rfglink" target="_blank">
       <%= image_pack_tag("media/src/images/rfglogo.png", class: "rfglogo") %>
     </a>
-    <%= link_to t(".link.report_site_issue"), "https://rubyforgood.typeform.com/to/iXY4BubB", class: "rfglink" %>
+    <%= link_to t(".link.report_site_issue"), "https://rubyforgood.typeform.com/to/iXY4BubB", class: "rfglink" %><br>
+    <%= link_to t(".link.sms_terms_and_conditions"), "/sms-terms-conditions.html", class: "terms-conditions-link" %>
   </span>
 
-  <div class="footer-logos">
+  <div class="footer-logos"><br>
     <%= image_pack_tag("media/src/images/default-logo.png") %>
   </div>
 </footer>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -360,6 +360,7 @@ en:
         built_by: Built by
         link:
           report_site_issue: Report a site issue
+          sms_terms_and_conditions: SMS Terms & Conditions
         ruby_for_good: Ruby For Good
     login_header:
       image:

--- a/public/sms-terms-conditions.html
+++ b/public/sms-terms-conditions.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <title>SMS Terms & Conditions</title>
+ <meta name="viewport" content="width=device-width,initial-scale=1">
+ <style>
+ .terms-conditions-page {
+   background-color: #325271;
+   color: #2E2F30;
+   font-family: arial, sans-serif;
+   margin: 0;
+ }
+ 
+ .terms-conditions-page div.dialog {
+   width: 95%;
+   max-width: 60em;
+   margin: 4em auto 0;
+ }
+ 
+ .terms-conditions-page div.dialog > div {
+   border: 1px solid #CCC;
+   border-right-color: #999;
+   border-left-color: #999;
+   border-bottom-color: #BBB;
+   border-top: #EF5652 solid 4px;
+   border-top-left-radius: 9px;
+   border-top-right-radius: 9px;
+   background-color: white;
+   padding: 7px 12% 0;
+   box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+ }
+ 
+ .terms-conditions-page h1 {
+   font-size: 100%;
+   color: #325271;
+   line-height: 1.5em;
+   text-align: center;
+  }
+ .terms-conditions-page h2 {
+   font-size: 85%;
+   color: #325271;
+   line-height: 1.5em;
+   text-align: center;
+  }
+ 
+ .terms-conditions-page div.dialog > p {
+   margin: 0 0 1em;
+   padding: 1em;
+   background-color: #F7F7F7;
+   color: #666;
+ }
+ 
+ .terms-conditions-page div.dialog > p.section {
+ 
+   text-indent: 5%;
+   margin: 0 0 0em;
+   padding: 1em;
+   background-color: #F7F7F7;
+   color: #666;
+ }
+ 
+ .center {
+   display: block;
+   margin-left: auto;
+   margin-right: auto;
+ }
+  </style>
+</head>
+ 
+<body class="terms-conditions-page">
+ <!-- This file lives in public/500.html -->
+ <div class="dialog">
+   <img src="apple-icon.png" style="width:150px;height:140px;" class="center">
+   <br>
+   <div>
+     <h1>SMS Terms & Conditions</h1>
+     <h2>Last updated: 05/21/2022</h2>
+   </div>
+   <p class="section">The CASA mobile message service (the "Service") is operated by "Court Appointed Special Advocate (CASA)/Prince George's County" ("CASA", "PGCasa", "we", or "us"). Your use of the Service constitutes your agreement to these terms and conditions ("Mobile Terms"). We may modify or cancel the Service or any of its features without notice. To the extent permitted by applicable law, we may also modify these Mobile Terms at any time and your continued use of the Service following the effective date of any such changes shall constitute your acceptance of such changes.</p>
+   <p class="section">By consenting to CASA's SMS/text messaging service, you agree to receive recurring SMS/text messages from and on behalf of CASA through your wireless provider to the mobile number you provided, even if your mobile number is registered on any state or federal Do Not Call list. Text messages may be sent using an automatic telephone dialing system or other technology. Service-related messages may include updates, alerts, and information (e.g., event reminders, account alerts, password resets, etc.).</p>
+   <p class="section">You understand that you do not have to sign up for this program, and your consent is not a condition of any purchase with CASA. Your participation in this program is completely voluntary. We do not charge for the Service, but you are responsible for all charges and fees associated with text messaging imposed by your wireless provider. Message frequency varies. Message and data rates may apply. Check your mobile plan and contact your wireless provider for details. You are solely responsible for all charges related to SMS/text messages, including charges from your wireless provider.</p>
+   <p class="section">You may opt-in/out of the Service at any time under your CASA profile page (https://casavolunteertracking.org/). No further messages will be sent to your mobile device unless initiated by you. If you have subscribed to other CASA mobile message programs and wish to cancel, except where applicable law requires otherwise, you will need to opt-out separately from those programs by following the instructions provided in their respective mobile terms. For Service support or assistance, email casa@rubyforgood.org.</p>
+   <p class="section">We may change any short-code or telephone number we use to operate the Service at any time and will notify you of these changes. You acknowledge that any messages you send to a short-code or telephone number we have changed may not be received and we will not be responsible for honoring requests made in such messages. The wireless carriers supported by the Service are not liable for delayed or undelivered messages. You agree to provide us with a valid mobile number. If you get a new mobile number, you will need to update your profile with the new number.</p>
+   <p class="section">To the extent permitted by applicable law, you agree that we will not be liable for failed, delayed, or misdirected delivery of any information sent through the Service, any errors in such information, and/or any action you may or may not take in reliance on the information or Service.</p>
+   <br>
+ </div>
+</body>
+</html>

--- a/public/sms-terms-conditions.html
+++ b/public/sms-terms-conditions.html
@@ -68,7 +68,7 @@
 </head>
  
 <body class="terms-conditions-page">
- <!-- This file lives in public/500.html -->
+ <!-- This file lives in public/sms-terms-conditions.html -->
  <div class="dialog">
    <img src="apple-icon.png" style="width:150px;height:140px;" class="center">
    <br>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1791

### What changed, and why?
Users can view their `SMS Terms & Conditions` in the site footer
- Made SMS terms of service link
- Created  `sms-terms-conditions.html` and added to `/public`

### How will this affect user permissions?
- Volunteer, Supervisor, Admin permissions: n/a

### Screenshots please :)

https://user-images.githubusercontent.com/58965520/169710205-f0d6570c-9278-4b42-91e5-6ea076cba47f.mov


### Feelings gif (optional)
![bird-law-i-know-a-lot-a-bout-the-law-and-various-other-lawyerings](https://user-images.githubusercontent.com/58965520/169710440-8e5cb7ba-557b-49af-b980-af4108e5c634.gif)