### PR TITLE
fix import js to only run when import elements are present

### DIFF
--- a/app/javascript/src/import.js
+++ b/app/javascript/src/import.js
@@ -55,17 +55,21 @@ function populateFileInput (inputId) {
 $('document').ready(() => {
   ['volunteer', 'supervisor'].forEach((importType) => {
     const inputFileElementId = `${importType}-file`
+    const inputFileElement = $(`#${inputFileElementId}`)[0]
+    const importButtonElement = $(`#${importType}-import-button`)[0]
 
-    document.getElementById(inputFileElementId).addEventListener('change', function (event) {
-      document.getElementById(`${importType}-import-button`).disabled = event.target.value === ''
-      const file = document.getElementById(inputFileElementId).files[0]
-      storeCSVFile(file, inputFileElementId)
-    })
+    if (inputFileElement && importButtonElement) {
+      inputFileElement.addEventListener('change', function (event) {
+        importButtonElement.disabled = event.target.value === ''
+        const file = inputFileElement.files[0]
+        storeCSVFile(file, inputFileElementId)
+      })
 
-    if (document.getElementById('smsOptIn') == null) {
-      delete localStorage[inputFileElementId]
-    } else {
-      populateFileInput(inputFileElementId)
+      if ($('#smsOptIn') == null) {
+        delete localStorage[inputFileElementId]
+      } else {
+        populateFileInput(inputFileElementId)
+      }
     }
   })
 })


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #3547 

### What changed, and why?

* Changed `import.js` to only add event listeners when on import page to avoid undefined errors in console on other pages

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

* Tests for `import.js` were already written in #3380 

### Screenshots please :)

N/A

### Feelings gif (optional)
<img src="https://user-images.githubusercontent.com/47438886/169716629-83ab2c78-cb89-4c7b-b5d3-d86d8306f001.png" width="400" />