### PR TITLE
Improve volunteer search

### DIFF
--- a/app/datatables/volunteer_datatable.rb
+++ b/app/datatables/volunteer_datatable.rb
@@ -193,7 +193,7 @@ class VolunteerDatatable < ApplicationDatatable
         CaseAssignment
           .select(:volunteer_id)
           .joins(:casa_case)
-          .where("casa_cases.case_number ILIKE ?", "%#{search_term}%")
+          .where("casa_cases.case_number ILIKE ? AND case_assignments.active = true", "%#{search_term}%")
           .group(:volunteer_id)
           .to_sql
       }.call


### PR DESCRIPTION
Exclude matching rows that are matching on unassigned casa cases.

### What github issue is this PR for, if any?
Resolves #3337 

### What changed, and why?
Previous SQL query was matching case numbers regardless of if the case assignment was still active.
New query only returns matching case numbers where case assignment is active.

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Rspec test for the volunteer data table

### Screenshots please :)
Bottom row volunteer had previous case assignments, but has no active ones now:


![image](https://user-images.githubusercontent.com/44326005/170437884-c85b3288-75e9-43b2-9d93-16880e59e620.png)

When searching "CINA" that row is no longer shown:

![image](https://user-images.githubusercontent.com/44326005/170437998-c688e045-8234-49b5-af1e-eaf6d67991a5.png)



### Feelings gif (optional)

![walking database](https://media.giphy.com/media/dIBLtolI6axTGIGopo/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9