### PR TITLE
Add x86_64-darwin-21 platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
It looks like https://github.com/rubyforgood/casa/commit/1c9d571c4efb012fcae12d600894936bd83691f4 removed some platforms. We'll probably need to add `arm64-darwin-21` as well.