### PR TITLE
Issue #3558: Make other duties' notes field required

### DIFF
--- a/app/views/other_duties/_form.html.erb
+++ b/app/views/other_duties/_form.html.erb
@@ -35,10 +35,10 @@
       </div>
 
       <div class="field notes form-group field-card">
-        <h2><%= form.label :notes, t(".enter_notes") %></h2>
+        <h2><%= form.label :notes, t(".enter_notes") %><span class="red-letter"> *</span></h2>
 
-        <%= form.text_area :notes, :rows => 5, placeholder: t(".enter_notes_placeholder"),
-class: "cc-italic form-control" %>
+        <%= form.text_area :notes, rows: 5, placeholder: t(".enter_notes_placeholder"),
+class: "cc-italic form-control", required: true %>
       </div>
 
       <div class="actions">

--- a/spec/system/other_duties/new_spec.rb
+++ b/spec/system/other_duties/new_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "other_duties/new", type: :system do
+  let(:casa_org) { build(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: casa_org) }
+  let(:case_number) { "12345" }
+  let!(:next_year) { (Date.today.year + 1).to_s }
+  let(:court_date) { 21.days.from_now }
+
+  let(:organization) { build(:casa_org) }
+  let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization) }
+
+  before do
+    sign_in volunteer
+    visit root_path
+  end
+
+  context "as a volunteer", js: true do
+    it "should have an error if a new duty is attempted to be created without any notes" do
+      click_on "My Cases"
+      click_on "New Duty"
+
+      click_on "Submit"
+
+      message = page.find("#other_duty_notes").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3558 

### What changed, and why?
We made other duties' notes field required on front side, so that the user can see the error without any call to the backend.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
- The use case is tested through a new system test, checking the error message on the page

### Screenshots please :)
![image](https://user-images.githubusercontent.com/25673850/170615360-62f24ed2-9592-41f3-9640-dce5573cee59.png)