### PR TITLE
avoid error when trying to assign volunteer to non created casa case

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -178,7 +178,7 @@
     </div>
   </div>
 
-  <% if Pundit.policy(current_user, @casa_case).assign_volunteers? %>
+  <% if Pundit.policy(current_user, @casa_case).assign_volunteers? && casa_case.persisted? %>
     <%= render "volunteer_assignment" %>
   <% end %>
 </div>

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("Court Report Due Date")
       expect(page).to have_field("Court Report Due Date")
     end
+
+    context "when trying to assign a volunteer to a case" do
+      it "should be able to assign volunteers", js: true do
+        visit edit_casa_case_path(casa_case)
+  
+        expect(page).to have_content("Manage Volunteers")
+        expect(page).to have_css("#volunteer-assignment")
+      end
+    end
   end
 
   context "logged in as supervisor" do
@@ -467,6 +476,15 @@ of it unless it was included in a previous court report.")
       end
 
       expect(page).to have_text("At least one contact type must be selected")
+    end
+
+    context "when trying to assign a volunteer to a case" do
+      it "should be able to assign volunteers", js: true do
+        visit edit_casa_case_path(casa_case)
+  
+        expect(page).to have_content("Manage Volunteers")
+        expect(page).to have_css("#volunteer-assignment")
+      end
     end
   end
 

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Edit CASA Case", type: :system do
     context "when trying to assign a volunteer to a case" do
       it "should be able to assign volunteers", js: true do
         visit edit_casa_case_path(casa_case)
-  
+
         expect(page).to have_content("Manage Volunteers")
         expect(page).to have_css("#volunteer-assignment")
       end
@@ -481,7 +481,7 @@ of it unless it was included in a previous court report.")
     context "when trying to assign a volunteer to a case" do
       it "should be able to assign volunteers", js: true do
         visit edit_casa_case_path(casa_case)
-  
+
         expect(page).to have_content("Manage Volunteers")
         expect(page).to have_css("#volunteer-assignment")
       end

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -116,4 +116,13 @@ RSpec.describe "casa_cases/new", type: :system do
       expect(page).to have_content(contact_type_group.name)
     end
   end
+
+  context "when trying to assign a volunteer to a case" do
+    it "should not be able to assign volunteers" do
+      visit new_casa_case_path
+
+      expect(page).not_to have_content("Manage Volunteers")
+      expect(page).not_to have_css("#volunteer-assignment")
+    end
+  end
 end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe "case_contacts/new", type: :system do
 
         find("body").click
 
-        # page.accept_alert
+        page.accept_alert
 
         field_value = page.find_field("case_contact_occurred_at").value
 

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe "case_contacts/new", type: :system do
 
         find("body").click
 
-        page.accept_alert
+        # page.accept_alert
 
         field_value = page.find_field("case_contact_occurred_at").value
 

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "casa_cases/edit", type: :view do
     let(:user) { build_stubbed(:casa_admin, casa_org: organization) }
 
     it "does not have an option to select a volunteer that is already assigned to the casa case" do
-      casa_case = build(:casa_case, casa_org: organization)
+      casa_case = create(:casa_case, casa_org: organization)
       assign :casa_case, casa_case
       assigned_volunteer = build_stubbed(:volunteer)
       build_stubbed(:case_assignment, volunteer: assigned_volunteer, casa_case: casa_case)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3611 

### What changed, and why?
The system was showing the option to assign a volunteer to a case on its creation, this would always return an error since the case id was not found in the database. This behavior was changed and the option to assign volunteers to cases is only shown when we open the edit case page.

### How is this tested? (please write tests!) 💖💪
Rspec tests were written to ensure that the option to assign volunteers appears on the edit case page and does not appear on the create page.
