### PR TITLE
3332: Add Case Number to Filename When Downloading Emancipation Checklist

### DIFF
--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -22,7 +22,7 @@ class EmancipationsController < ApplicationController
         html_body = EmancipationChecklistDownloadHtml.new(@current_case, @emancipation_form_data).call
 
         context = {
-          case_number: Sablon.content(:html, @current_case.case_number),
+          case_number: @current_case.case_number,
           emancipation_checklist: Sablon.content(:html, html_body)
         }
 

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -26,7 +26,7 @@ class EmancipationsController < ApplicationController
           emancipation_checklist: Sablon.content(:html, html_body)
         }
 
-        send_data((@template.render_to_string context), filename: "#{@current_case.case_number} Emancipation Checklist.docx", type: :docx)
+        send_data((@template.render_to_string context, type: :docx), filename: "#{@current_case.case_number} Emancipation Checklist.docx")
       }
     end
   end

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -12,7 +12,7 @@ class EmancipationsController < ApplicationController
     @current_case = CasaCase.find(params[:casa_case_id])
     authorize @current_case
     @emancipation_form_data = EmancipationCategory.all
-    
+
     respond_to do |format|
       format.html
       format.docx {

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -12,7 +12,7 @@ class EmancipationsController < ApplicationController
     @current_case = CasaCase.find(params[:casa_case_id])
     authorize @current_case
     @emancipation_form_data = EmancipationCategory.all
-
+    
     respond_to do |format|
       format.html
       format.docx {
@@ -22,11 +22,11 @@ class EmancipationsController < ApplicationController
         html_body = EmancipationChecklistDownloadHtml.new(@current_case, @emancipation_form_data).call
 
         context = {
-          case_number: @current_case.case_number,
+          case_number: Sablon.content(:html, @current_case.case_number),
           emancipation_checklist: Sablon.content(:html, html_body)
         }
 
-        send_data @template.render_to_string context, type: :docx
+        send_data((@template.render_to_string context), filename: "#{@current_case.case_number} Emancipation Checklist.docx", type: :docx)
       }
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3332

### What changed, and why?
The filename was not set to reflect the case number. This was a requested feature. 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Tested functionally. 
**Note: I did not add tests because this is a rails method with an additional parameter, and that seems unnecessary.**

### Screenshots please :)
![image](https://user-images.githubusercontent.com/4956537/172060103-a6d95a28-69e5-4105-a230-8ff1c5d8bc6e.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9