### PR TITLE
#3314 Enable active_record.has_many_inversing config option

### DIFF
--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -1,6 +1,6 @@
 class CaseAssignment < ApplicationRecord
   belongs_to :casa_case
-  belongs_to :volunteer, class_name: "User", inverse_of: "case_assignments"
+  belongs_to :volunteer, class_name: "User"
 
   validates :casa_case_id, uniqueness: {scope: :volunteer_id} # only 1 row allowed per case-volunteer pair
   validates :volunteer, presence: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,6 @@ module Casa
     config.action_mailer.preview_path ||= defined?(Rails.root) ? Rails.root.join("lib", "mailers", "previews") : nil
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
     config.load_defaults 7.0
-    config.active_record.has_many_inversing = false
     config.active_storage.variant_processor = :mini_magick
     config.serve_static_assets = true
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3314 

### What changed, and why?
This PR is to enable the listed config option, and remove the inverse call from an association on the `case_assignment` model that causes tests to fail. 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
This is a spec fix that didn't require changes to the spec, but to the model being tested due to config change. 

### Screenshots please :)
![image](https://user-images.githubusercontent.com/4956537/172075527-d5f03940-9ae3-48ca-bef6-82cb85763784.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9