### PR TITLE
2311 Limit volunteer mailer previews to only volunteers

### DIFF
--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -17,11 +17,11 @@ class VolunteerMailerPreview < ActionMailer::Preview
     VolunteerMailer.case_contacts_reminder(user, true)
   end
 
-private
+  private
 
   def get_user(user_id)
     user = User.find_by(id: user_id)
-    user && user.volunteer? ? user : Volunteer.last
+    user&.volunteer? ? user : Volunteer.last
   end
 end
 # :nocov:

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -2,19 +2,26 @@
 # :nocov:
 class VolunteerMailerPreview < ActionMailer::Preview
   def account_setup
-    user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
+    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
     VolunteerMailer.account_setup(user)
   end
 
   def court_report_reminder
-    user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
+    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
     VolunteerMailer.court_report_reminder(user, Date.today)
   end
 
   def case_contacts_reminder
-    user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
+    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
     user.supervisor = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.first
     VolunteerMailer.case_contacts_reminder(user, true)
+  end
+
+private
+
+  def get_user(user_id)
+    user = User.find_by(id: user_id)
+    user && user.volunteer? ? user : Volunteer.last
   end
 end
 # :nocov:

--- a/spec/mailers/previews/volunteer_mailer_preview_spec.rb
+++ b/spec/mailers/previews/volunteer_mailer_preview_spec.rb
@@ -3,23 +3,59 @@ require File.join(Rails.root, "lib", "mailers", "previews", "volunteer_mailer_pr
 
 RSpec.describe VolunteerMailerPreview do
   let(:subject) { described_class.new }
-  let!(:user) { create(:user) }
+  let!(:volunteer)  { create(:volunteer) }
+  let!(:supervisor) { create(:supervisor) }
+  let!(:admin)      { create(:casa_admin) }
 
   describe "#account_setup" do
     let(:message) { subject.account_setup }
 
-    it { expect(message.to).to eq [user.email] }
+    it { expect(message.to).to eq [volunteer.email] }
   end
 
   describe "#court_report_reminder" do
     let(:message) { subject.court_report_reminder }
 
-    it { expect(message.to).to eq [user.email] }
+    it { expect(message.to).to eq [volunteer.email] }
   end
 
   describe "#case_contacts_reminder" do
     let(:message) { subject.case_contacts_reminder }
 
-    it { expect(message.to).to eq [user.email] }
+    it { expect(message.to).to eq [volunteer.email] }
+  end
+
+  describe "#get_user" do
+    context "uses a volunteer record" do
+      context "when no id is provided" do
+        let(:message) { subject.account_setup }
+
+        it { expect(message.to).to eq [volunteer.email] }
+      end
+
+      context "when a volunteer id is provided" do
+        let(:params) { { id: volunteer.id } }
+        let(:subject) { described_class.new params }
+        let(:message) { subject.account_setup }
+
+        it { expect(message.to).to eq [volunteer.email] }
+      end
+
+      context "when a supervisor id is provided" do
+        let(:params) { { id: supervisor.id } }
+        let(:subject) { described_class.new params }
+        let(:message) { subject.account_setup }
+
+        it { expect(message.to).to eq [volunteer.email] }
+      end
+
+      context "when an admin id is provided" do
+        let(:params) { { id: admin.id } }
+        let(:subject) { described_class.new params }
+        let(:message) { subject.account_setup }
+
+        it { expect(message.to).to eq [volunteer.email] }
+      end
+    end
   end
 end

--- a/spec/mailers/previews/volunteer_mailer_preview_spec.rb
+++ b/spec/mailers/previews/volunteer_mailer_preview_spec.rb
@@ -3,9 +3,9 @@ require File.join(Rails.root, "lib", "mailers", "previews", "volunteer_mailer_pr
 
 RSpec.describe VolunteerMailerPreview do
   let(:subject) { described_class.new }
-  let!(:volunteer)  { create(:volunteer) }
+  let!(:volunteer) { create(:volunteer) }
   let!(:supervisor) { create(:supervisor) }
-  let!(:admin)      { create(:casa_admin) }
+  let!(:admin) { create(:casa_admin) }
 
   describe "#account_setup" do
     let(:message) { subject.account_setup }
@@ -34,7 +34,7 @@ RSpec.describe VolunteerMailerPreview do
       end
 
       context "when a volunteer id is provided" do
-        let(:params) { { id: volunteer.id } }
+        let(:params) { {id: volunteer.id} }
         let(:subject) { described_class.new params }
         let(:message) { subject.account_setup }
 
@@ -42,7 +42,7 @@ RSpec.describe VolunteerMailerPreview do
       end
 
       context "when a supervisor id is provided" do
-        let(:params) { { id: supervisor.id } }
+        let(:params) { {id: supervisor.id} }
         let(:subject) { described_class.new params }
         let(:message) { subject.account_setup }
 
@@ -50,7 +50,7 @@ RSpec.describe VolunteerMailerPreview do
       end
 
       context "when an admin id is provided" do
-        let(:params) { { id: admin.id } }
+        let(:params) { {id: admin.id} }
         let(:subject) { described_class.new params }
         let(:message) { subject.account_setup }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2311

### What changed, and why?
This PR is to limit the preview mailers to volunteers when an ID is provided. 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Spec added :)

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9