### PR TITLE
Issue #3366 - Allow organization logos as .svg images

### DIFF
--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -3,6 +3,7 @@ class CasaOrg < ApplicationRecord
   CASA_DEFAULT_LOGO = Rails.root.join("public", "logo.jpeg")
 
   before_create :set_slug
+  before_update :sanitize_svg
 
   validates :name, presence: true, uniqueness: true
   validates_with CasaOrgValidator
@@ -64,6 +65,16 @@ class CasaOrg < ApplicationRecord
 
   def set_slug
     self.slug = name.parameterize
+  end
+
+  private
+
+  def sanitize_svg
+    if self.attachment_changes['logo']
+      file = self.attachment_changes['logo'].attachable
+      sanitized_file = SvgSanitizerService.sanitize(file)
+      self.logo.unfurl(sanitized_file)
+    end
   end
 
   # def to_param

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -70,10 +70,10 @@ class CasaOrg < ApplicationRecord
   private
 
   def sanitize_svg
-    if self.attachment_changes['logo']
-      file = self.attachment_changes['logo'].attachable
+    if attachment_changes["logo"]
+      file = attachment_changes["logo"].attachable
       sanitized_file = SvgSanitizerService.sanitize(file)
-      self.logo.unfurl(sanitized_file)
+      logo.unfurl(sanitized_file)
     end
   end
 

--- a/app/services/svg_sanitizer_service.rb
+++ b/app/services/svg_sanitizer_service.rb
@@ -1,0 +1,23 @@
+class SvgSanitizerService
+  class << self
+    def sanitize(file)
+      return file unless file&.content_type == "image/svg+xml"
+
+      content = file.read
+      content.force_encoding("UTF-8")
+      document = Loofah.xml_document(content)
+      safe_content = document.scrub!(scrubber).to_s
+      File.write(file.path, safe_content)
+      file.rewind
+      file
+    end
+
+    private
+
+    def scrubber
+      Loofah::Scrubber.new do |node|
+        node.remove if node.name == "script"
+      end
+    end
+  end
+end

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="custom-file mb-5">
         <%= form.label :logo, "Logo" %>
-        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp" %>
+        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp,.svg" %>
       </div>
       <div class="custom-file mb-5">
         <%= form.label :court_report_template, "Court report template" %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -6,8 +6,15 @@
                          alt: t(".image.alt.logo"),
                          class: "d-inline-block align-text-bottom") %>
     <% else %>
-      <%= image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
-                    alt: t(".image.alt.logo")) %>
+      <% if current_organization.logo.variable? %>
+        <%= image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
+                      alt: t(".image.alt.logo")) %>
+      <% else %>
+        <%= image_tag(current_organization.logo, 
+                      width: 200, 
+                      height: 100, 
+                      alt: t(".image.alt.logo")) %>
+      <% end %>
     <% end %>
   </div>
   <div class="sidebar-container">

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -10,9 +10,9 @@
         <%= image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
                       alt: t(".image.alt.logo")) %>
       <% else %>
-        <%= image_tag(current_organization.logo, 
-                      width: 200, 
-                      height: 100, 
+        <%= image_tag(current_organization.logo,
+                      width: 200,
+                      height: 100,
                       alt: t(".image.alt.logo")) %>
       <% end %>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module Casa
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
     config.load_defaults 7.0
     config.active_storage.variant_processor = :mini_magick
-    config.active_storage.content_types_to_serve_as_binary.delete('image/svg+xml')
+    config.active_storage.content_types_to_serve_as_binary.delete("image/svg+xml")
     config.serve_static_assets = true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Casa
     config.eager_load_paths << Rails.root.join("app", "lib", "importers")
     config.load_defaults 7.0
     config.active_storage.variant_processor = :mini_magick
+    config.active_storage.content_types_to_serve_as_binary.delete('image/svg+xml')
     config.serve_static_assets = true
   end
 end

--- a/spec/fixtures/files/unsafe_svg.svg
+++ b/spec/fixtures/files/unsafe_svg.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" baseProfile="full" xmlns="http://www.w3.org/2000/svg">
+   <polygon id="triangle" points="0,0 0,50 50,0" fill="#009900" stroke="#004400"/>
+   <script type="text/javascript">
+      alert("xss");
+   </script>
+</svg>

--- a/spec/services/svg_sanitizer_service_spec.rb
+++ b/spec/services/svg_sanitizer_service_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe SvgSanitizerService do
+  let(:result) { described_class.sanitize(file) }
+
+  describe "when receiving a svg file" do
+    let(:file) { fixture_file_upload("unsafe_svg.svg", "image/svg+xml") }
+
+    it "removes script tags" do
+      expect(result.read).not_to match("script")
+    end
+  end
+
+  describe "when not receiving a svg file" do
+    let(:file) { fixture_file_upload("../company_logo.png", "image/png") }
+
+    it "returns the file without changes" do
+      expect(result).to eq(file)
+    end
+  end
+
+  describe "when receiving nil" do
+    let(:file) { nil }
+
+    it "returns nil" do
+      expect(result).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3366

### What changed, and why?
Admins can now import organization logos, from the "editing CASA organization" page, as .svg files. As mentioned in the issue, .svg images can add vulnerabilities, more specifically, Cross-site scripting (XSS). I tried to execute scripts through it, but I couldn't. Even so, I wrote a svg sanitizer to make sure it won't happen at all.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Logo image importing was already being tested, nothing really changed here. However, I had to create a new test suite to validade the Svg Sanitizer Service, which is responsible for removing malicious entries from the svg files.

### Screenshots please :)
Replaced the default logo by this cute "tomato head" dude. https://freesvg.org/tomato-head
![image](https://user-images.githubusercontent.com/25598040/172948149-78fff3ec-3644-4744-8ff4-d24699262f3a.png)