### PR TITLE
Let Supervisors and Admins Hide Case Contacts Made by Previous Volunteers on a Case

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -61,11 +61,7 @@ class CaseAssignmentsController < ApplicationController
     casa_case = @case_assignment.casa_case
     volunteer = @case_assignment.volunteer
 
-    flash_message = if @case_assignment.hide_old_contacts?
-      "Old Case Contacts created by #{volunteer.display_name} are now visible."
-    else
-      "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
-    end
+    flash_message = "Old Case Contacts created by #{volunteer.display_name} #{@case_assignment.hide_old_contacts? ? "are now visible" : "were successfully hidden"}."
 
     if !@case_assignment.active && @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
       redirect_to after_action_path(casa_case), notice: flash_message

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -57,7 +57,7 @@ class CaseAssignmentsController < ApplicationController
   end
 
   def show_hide_contacts
-    authorize @case_assignment, :allowed_show_or_hide_contacts?
+    authorize @case_assignment, :show_or_hide_contacts?
     casa_case = @case_assignment.casa_case
     volunteer = @case_assignment.volunteer
 

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -58,14 +58,13 @@ class CaseAssignmentsController < ApplicationController
 
   def show_hide_contacts
     authorize @case_assignment, :allowed_show_or_hide_contacts?
-    casa_case = @case_assignment.casa_case
     volunteer = @case_assignment.volunteer
 
     flash_message = @case_assignment.hide_old_contacts? ? "Old Case Contacts created by #{volunteer.display_name} are now visible." : "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
 
     if !@case_assignment.active
       if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
-        redirect_to after_action_path(casa_case), notice: flash_message
+        redirect_to after_action_path(@case_assignment.casa_case), notice: flash_message
       end
     else
       render :edit

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -1,5 +1,5 @@
 class CaseAssignmentsController < ApplicationController
-  before_action :load_case_assignment, only: %i[destroy unassign]
+  before_action :load_case_assignment, only: %i[destroy unassign show_hide_contacts]
   after_action :verify_authorized
 
   def create
@@ -49,6 +49,22 @@ class CaseAssignmentsController < ApplicationController
       if params[:redirect_to_path] == "volunteer"
         redirect_to edit_volunteer_path(volunteer), notice: flash_message
       else
+        redirect_to after_action_path(casa_case), notice: flash_message
+      end
+    else
+      render :edit
+    end
+  end
+
+  def show_hide_contacts
+    authorize @case_assignment, :allowed_show_or_hide_contacts?
+    casa_case = @case_assignment.casa_case
+    volunteer = @case_assignment.volunteer
+
+    flash_message = @case_assignment.hide_old_contacts? ? "Old Case Contacts created by #{volunteer.display_name} are now visible." : "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
+
+    if !@case_assignment.active
+      if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)       
         redirect_to after_action_path(casa_case), notice: flash_message
       end
     else

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -64,7 +64,7 @@ class CaseAssignmentsController < ApplicationController
     flash_message = @case_assignment.hide_old_contacts? ? "Old Case Contacts created by #{volunteer.display_name} are now visible." : "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
 
     if !@case_assignment.active
-      if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)       
+      if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
         redirect_to after_action_path(casa_case), notice: flash_message
       end
     else

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -61,9 +61,11 @@ class CaseAssignmentsController < ApplicationController
     casa_case = @case_assignment.casa_case
     volunteer = @case_assignment.volunteer
 
-    flash_message = @case_assignment.hide_old_contacts? ?
-      "Old Case Contacts created by #{volunteer.display_name} are now visible." :
+    flash_message = if @case_assignment.hide_old_contacts?
+      "Old Case Contacts created by #{volunteer.display_name} are now visible."
+    else
       "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
+    end
 
     if !@case_assignment.active
       if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -67,10 +67,8 @@ class CaseAssignmentsController < ApplicationController
       "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
     end
 
-    if !@case_assignment.active
-      if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
-        redirect_to after_action_path(casa_case), notice: flash_message
-      end
+    if !@case_assignment.active && @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
+      redirect_to after_action_path(casa_case), notice: flash_message
     else
       render :edit
     end

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -58,13 +58,16 @@ class CaseAssignmentsController < ApplicationController
 
   def show_hide_contacts
     authorize @case_assignment, :allowed_show_or_hide_contacts?
+    casa_case = @case_assignment.casa_case
     volunteer = @case_assignment.volunteer
 
-    flash_message = @case_assignment.hide_old_contacts? ? "Old Case Contacts created by #{volunteer.display_name} are now visible." : "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
+    flash_message = @case_assignment.hide_old_contacts? ?
+      "Old Case Contacts created by #{volunteer.display_name} are now visible." :
+      "Old Case Contacts created by #{volunteer.display_name} were successfully hidden."
 
     if !@case_assignment.active
       if @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
-        redirect_to after_action_path(@case_assignment.casa_case), notice: flash_message
+        redirect_to after_action_path(casa_case), notice: flash_message
       end
     else
       render :edit

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -15,6 +15,13 @@ class CasaCaseDecorator < Draper::Decorator
     object.case_contacts.where("occurred_at < ?", date).max_by(&:occurred_at)
   end
 
+  def case_contacts_filtered_by_active_assignment_ordered_by_occurred_at
+    object.case_contacts
+      .joins("INNER JOIN case_assignments on case_assignments.casa_case_id = case_contacts.casa_case_id and case_assignments.volunteer_id = case_contacts.creator_id")
+      .where("case_assignments.hide_old_contacts = false")
+      .order(occurred_at: :desc)
+  end
+
   def court_report_submission
     object.court_report_status.humanize
   end

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -31,12 +31,13 @@ end
 #
 # Table name: case_assignments
 #
-#  id           :bigint           not null, primary key
-#  active       :boolean          default(TRUE), not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  casa_case_id :bigint           not null
-#  volunteer_id :bigint           not null
+#  id                :bigint           not null, primary key
+#  active            :boolean          default(TRUE), not null
+#  hide_old_contacts :boolean          default(FALSE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  casa_case_id      :bigint           not null
+#  volunteer_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -23,4 +23,12 @@ class CaseAssignmentPolicy < ApplicationPolicy
   def unassign?
     record.active? && admin_or_supervisor?
   end
+
+  def hide_contacts?
+    !record.active? && !record.hide_old_contacts? && admin_or_supervisor?
+  end
+
+  def allowed_show_or_hide_contacts?
+    hide_contacts? || !hide_contacts?
+  end
 end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -28,7 +28,7 @@ class CaseAssignmentPolicy < ApplicationPolicy
     !record.active? && !record.hide_old_contacts? && admin_or_supervisor?
   end
 
-  def allowed_show_or_hide_contacts?
+  def show_or_hide_contacts?
     hide_contacts? || !hide_contacts?
   end
 end

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -45,16 +45,27 @@
                                 unassign_case_assignment_path(assignment),
                                 method: :patch,
                                 class: "btn btn-outline-danger text-wrap") %>
-                <% elsif !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
-                  <%= link_to "Activate Volunteer",
-                              activate_volunteer_path(assignment.volunteer,
-                                                      redirect_to_path: 'casa_case',
-                                                      casa_case_id: @casa_case.id
-                              ),
-                              method: :patch,
-                              class: "btn btn-outline-success" %>
                 <% else %>
-                  None
+                  <% if !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
+                    <%= link_to "Activate Volunteer",
+                                activate_volunteer_path(assignment.volunteer,
+                                                        redirect_to_path: 'casa_case',
+                                                        casa_case_id: @casa_case.id
+                                ),
+                                method: :patch,
+                                class: "btn btn-outline-success" %>
+                  <% end %>
+                  <% if (policy(assignment).hide_contacts?) %>
+                    <%= button_to("Hide Old Contacts",
+                                show_hide_contacts_case_assignment_path(assignment),
+                                method: :patch,
+                                class: "btn btn-outline-secondary text-wrap") %>
+                  <% else %>
+                    <%= button_to("Show Old Contacts",
+                                show_hide_contacts_case_assignment_path(assignment),
+                                method: :patch,
+                                class: "btn btn-outline-warning text-wrap") %>
+                  <% end %>
                 <% end %>
               </td>
             </tr>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -141,13 +141,22 @@
         </div>
       <% end %>
 
-      <div>
-        <%= render(partial: "case_contacts/case_contact",
-                   collection: @casa_case.decorate
-                    .case_contacts_ordered_by_occurred_at
-                    .includes(contact_types: [:contact_type_group])
-                    .grab_all(current_user),
-                   as: :contact) %>
+      <div id="case_contacts_list" >
+        <% if current_user.supervisor? || current_user.casa_admin? %>
+          <%= render(partial: "case_contacts/case_contact",
+                    collection: @casa_case.decorate
+                      .case_contacts_ordered_by_occurred_at
+                      .includes(contact_types: [:contact_type_group])
+                      .grab_all(current_user),
+                    as: :contact) %>
+        <% else %>
+          <%= render(partial: "case_contacts/case_contact",
+                    collection: @casa_case.decorate
+                      .case_contacts_filtered_by_active_assignment_ordered_by_occurred_at
+                      .includes(contact_types: [:contact_type_group])
+                      .grab_all(current_user),
+                    as: :contact) %>
+        <%end%>
       </div>
     </div>
   </div>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -141,7 +141,7 @@
         </div>
       <% end %>
 
-      <div id="case_contacts_list" >
+      <div id="case_contacts_list">
         <% if current_user.supervisor? || current_user.casa_admin? %>
           <%= render(partial: "case_contacts/case_contact",
                     collection: @casa_case.decorate
@@ -156,7 +156,7 @@
                       .includes(contact_types: [:contact_type_group])
                       .grab_all(current_user),
                     as: :contact) %>
-        <%end%>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
     member do
       get :unassign
       patch :unassign
+      patch :show_hide_contacts
     end
   end
   resources :case_court_orders, only: %i[destroy]

--- a/db/migrate/20220607184910_add_hide_old_contacts_to_case_assignment.rb
+++ b/db/migrate/20220607184910_add_hide_old_contacts_to_case_assignment.rb
@@ -1,5 +1,5 @@
 class AddHideOldContactsToCaseAssignment < ActiveRecord::Migration[7.0]
   def change
-    add_column :case_assignments, :hide_old_contacts, :boolean, :default => false
+    add_column :case_assignments, :hide_old_contacts, :boolean, default: false
   end
 end

--- a/db/migrate/20220607184910_add_hide_old_contacts_to_case_assignment.rb
+++ b/db/migrate/20220607184910_add_hide_old_contacts_to_case_assignment.rb
@@ -1,0 +1,5 @@
+class AddHideOldContactsToCaseAssignment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :case_assignments, :hide_old_contacts, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_19_233803) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_07_184910) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -104,6 +104,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_19_233803) do
     t.integer "court_report_status", default: 0
     t.string "slug"
     t.datetime "date_in_care"
+    t.boolean "hide_old_contacts", default: false
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number", "casa_org_id"], name: "index_casa_cases_on_case_number_and_casa_org_id", unique: true
     t.index ["hearing_type_id"], name: "index_casa_cases_on_hearing_type_id"
@@ -141,6 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_19_233803) do
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "hide_old_contacts", default: false
     t.index ["casa_case_id"], name: "index_case_assignments_on_casa_case_id"
     t.index ["volunteer_id"], name: "index_case_assignments_on_volunteer_id"
   end
@@ -432,6 +434,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_19_233803) do
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type"
+    t.string "{:null=>false}"
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at", precision: nil
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -164,4 +164,20 @@ RSpec.describe "/case_assignments", type: :request do
       end
     end
   end
+
+  describe "PATCH /show_hide_contacts" do
+    context "when the 'case_assignment' is not active" do
+      it "hides case contacts" do
+        assignment = create(:case_assignment, casa_case: casa_case, active: false)
+
+        sign_in admin
+
+        expect {
+          patch show_hide_contacts_case_assignment_path(assignment)
+        }.to change { assignment.reload.hide_old_contacts? }
+
+        expect(response).to redirect_to  edit_casa_case_path(casa_case)
+      end
+    end
+  end
 end

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "/case_assignments", type: :request do
           patch show_hide_contacts_case_assignment_path(assignment)
         }.to change { assignment.reload.hide_old_contacts? }
 
-        expect(response).to redirect_to  edit_casa_case_path(casa_case)
+        expect(response).to redirect_to edit_casa_case_path(casa_case)
       end
     end
   end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe "casa_cases/show", type: :system do
         expect(page).not_to have_content("Add to Calendar")
       end
     end
+
+    context "when old case contacts are hidden" do
+      it "should display all case contacts to admin", js: true do
+        casa_case = create(:casa_case, casa_org: organization)
+        volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+       
+        visit casa_case_path(casa_case.id)
+
+        expect(page).to have_css("#case_contacts_list .card", count: 2)
+      end
+    end
   end
 
   context "supervisor user" do
@@ -141,6 +157,22 @@ RSpec.describe "casa_cases/show", type: :system do
         end
       end
     end
+
+    context "when old case contacts are hidden" do
+      it "should display all case contacts to supervisor", js: true do
+        casa_case = create(:casa_case, casa_org: organization)
+        volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+       
+        visit casa_case_path(casa_case.id)
+
+        expect(page).to have_css("#case_contacts_list .card", count: 2)
+      end
+    end
   end
 
   context "volunteer user" do
@@ -152,6 +184,25 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
+    end
+
+    context "when old case contacts are hidden" do
+      it "should display only visible cases to volunteer", js: true do
+        casa_case = create(:casa_case, casa_org: organization)
+        volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
+
+        sign_in volunteer_1
+
+        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+       
+        visit casa_case_path(casa_case.id)
+
+        expect(page).to have_css("#case_contacts_list .card", count: 1)
+      end
     end
   end
 

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe "casa_cases/show", type: :system do
         casa_case = create(:casa_case, casa_org: organization)
         volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
         volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
-        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
-        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
-        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
-       
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+
         visit casa_case_path(casa_case.id)
 
         expect(page).to have_css("#case_contacts_list .card", count: 2)
@@ -163,11 +163,11 @@ RSpec.describe "casa_cases/show", type: :system do
         casa_case = create(:casa_case, casa_org: organization)
         volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
         volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
-        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
-        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
-        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
-       
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+
         visit casa_case_path(casa_case.id)
 
         expect(page).to have_css("#case_contacts_list .card", count: 2)
@@ -194,11 +194,11 @@ RSpec.describe "casa_cases/show", type: :system do
         sign_in volunteer_1
 
         volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
-        case_assignment_1 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
-        case_assignment_2 = create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        case_contact_1 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
-        case_contact_2 = create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
-       
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
+        create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+
         visit casa_case_path(casa_case.id)
 
         expect(page).to have_css("#case_contacts_list .card", count: 1)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3338

### What changed, and why?
Supervisors and Admins are now able to choose whether new volunteers see old volunteers' case contacts on a casa case.

### How will this affect user permissions?
- Volunteer permissions: Will only be able to see old case contacts if an admin or supervisor allows it.
- Supervisor permissions: Can define whether volunteers can see old case_contacts or not.
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
There were added system and request tests. Just run rspec.

### Screenshots please :)
![Screenshot 2022-06-10 11:57:06](https://user-images.githubusercontent.com/42497300/173093627-07d13534-bf48-4e17-a96f-f812decdcd45.png)