### PR TITLE
Issue #3039 - Casa Cases Missing Data Report

### DIFF
--- a/app/controllers/missing_data_reports_controller.rb
+++ b/app/controllers/missing_data_reports_controller.rb
@@ -1,0 +1,15 @@
+class MissingDataReportsController < ApplicationController
+  after_action :verify_authorized
+
+  def index
+    authorize :application, :see_reports_page?
+    missing_data_report = MissingDataReport.new(current_organization.id)
+
+    respond_to do |format|
+      format.csv do
+        send_data missing_data_report.to_csv,
+          filename: "missing-data-report-#{Time.current.strftime("%Y-%m-%d")}.csv"
+      end
+    end
+  end
+end

--- a/app/models/missing_data_report.rb
+++ b/app/models/missing_data_report.rb
@@ -1,0 +1,12 @@
+class MissingDataReport
+  attr_reader :casa_cases
+
+  def initialize(org_id)
+    @casa_cases = CasaCase.where(casa_org_id: org_id)
+      .includes(:court_dates, :case_court_orders)
+  end
+
+  def to_csv
+    MissingDataExportCsvService.new(@casa_cases).perform
+  end
+end

--- a/app/services/missing_data_export_csv_service.rb
+++ b/app/services/missing_data_export_csv_service.rb
@@ -24,8 +24,8 @@ class MissingDataExportCsvService
 
   def has_missing_values?(casa_case)
     !casa_case.birth_month_year_youth? ||
-    casa_case.next_court_date.nil? ||
-    casa_case.case_court_orders.empty?
+      casa_case.next_court_date.nil? ||
+      casa_case.case_court_orders.empty?
   end
 
   def get_status(missing)

--- a/app/services/missing_data_export_csv_service.rb
+++ b/app/services/missing_data_export_csv_service.rb
@@ -1,0 +1,43 @@
+require "csv"
+
+class MissingDataExportCsvService
+  attr_reader :casa_cases
+
+  def initialize(casa_cases)
+    @casa_cases = casa_cases
+  end
+
+  def perform
+    CSV.generate(headers: true) do |csv|
+      csv << full_data.keys.map(&:to_s).map(&:titleize)
+      if casa_cases.present?
+        casa_cases.decorate.each do |casa_case|
+          if has_missing_values?(casa_case)
+            csv << full_data(casa_case).values
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def has_missing_values?(casa_case)
+    !casa_case.birth_month_year_youth? ||
+    casa_case.next_court_date.nil? ||
+    casa_case.case_court_orders.empty?
+  end
+
+  def get_status(missing)
+    missing ? "MISSING" : "OK"
+  end
+
+  def full_data(casa_case = nil)
+    {
+      casa_case_number: casa_case&.case_number,
+      youth_birth_month_and_year: get_status(!casa_case&.birth_month_year_youth?),
+      upcoming_hearing_date: get_status(casa_case&.next_court_date.nil?),
+      court_orders: get_status(casa_case&.case_court_orders&.empty?)
+    }
+  end
+end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,10 +2,18 @@
 
 <div class="card card-container my-4">
   <div class="card-body">
-    <%= form_with url: mileage_reports_path(format: :csv), method: :get do |f| %>
-        <%= f.submit t(".download_mileage_report_button.enabled"), class: "btn btn-primary report-form-submit",
-         data: {disable_with: t(".download_mileage_report_button.disabled")} %>
-    <% end %>
+    <div class="btn-group">
+      <%= form_with url: mileage_reports_path(format: :csv), method: :get do |f| %>
+          <%= f.submit t(".download_mileage_report_button.enabled"), class: "btn btn-primary report-form-submit",
+          data: {disable_with: t(".download_mileage_report_button.disabled")} %>
+      <% end %>
+    </div>
+
+    <div class="btn-group">
+      <%= form_with url: missing_data_reports_path(format: :csv), method: :get do |f| %>
+        <%= f.submit t(".download_missing_data_report_button"), class: "btn btn-primary report-form-submit" %>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -471,6 +471,7 @@ en:
       download_mileage_report_button:
         enabled: Mileage Report
         disabled: Downloading Mileage Report
+      download_missing_data_report_button: "Missing Data Report"
       download_report_button: Download Report
       driving_reimbursement_label: "Want Driving Reimbursement:"
       end_date_label: "Ending At:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
   resources :judges, only: %i[new create edit update]
   resources :notifications, only: :index
   resources :other_duties, only: %i[new create edit index update]
+  resources :missing_data_reports, only: %i[index]
 
   resources :supervisors, except: %i[destroy show], concerns: %i[with_datatable] do
     member do

--- a/spec/controllers/missing_data_reports_controller_spec.rb
+++ b/spec/controllers/missing_data_reports_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe MissingDataReportsController, type: :controller do
+  let(:admin) { create(:casa_admin) }
+
+  context "as an admin user" do
+    before do
+      allow(controller).to receive(:authenticate_user!).and_return(true)
+      allow(controller).to receive(:current_user).and_return(admin)
+    end
+
+    describe "#index" do
+      before { get :index, as: :csv }
+
+      it "returns a successful response" do
+        expect(response).to be_successful
+        expect(response.header['Content-Type']).to eq("text/csv")
+      end
+    end
+  end
+
+  context "without authenctication" do
+    describe "#index" do
+      before { get :index, as: :csv }
+
+      it "return unauthorized" do
+        expect(response).to_not be_successful
+      end
+    end
+  end
+end

--- a/spec/controllers/missing_data_reports_controller_spec.rb
+++ b/spec/controllers/missing_data_reports_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MissingDataReportsController, type: :controller do
 
       it "returns a successful response" do
         expect(response).to be_successful
-        expect(response.header['Content-Type']).to eq("text/csv")
+        expect(response.header["Content-Type"]).to eq("text/csv")
       end
     end
   end

--- a/spec/factories/casa_case.rb
+++ b/spec/factories/casa_case.rb
@@ -59,4 +59,10 @@ FactoryBot.define do
       end
     end
   end
+
+  trait :with_upcoming_court_date do
+    after(:create) do |casa_case|
+      create(:court_date, casa_case: casa_case, date: Date.tomorrow)
+    end
+  end
 end

--- a/spec/models/missing_data_report_spec.rb
+++ b/spec/models/missing_data_report_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe MissingDataReport, type: :model do
+  describe "#to_csv" do
+    let!(:casa_org) { create(:casa_org) }
+    let(:result) { CSV.parse(described_class.new(casa_org.id).to_csv) }
+
+    shared_examples "report_with_header" do
+      it "contains header" do
+        expect(result[0]).to eq([
+          "Casa Case Number",
+          "Youth Birth Month And Year",
+          "Upcoming Hearing Date",
+          "Court Orders"
+        ])
+      end
+    end
+
+    context "when there are casa cases" do
+      let!(:incomplete_casa_cases) do
+        [
+          create(:casa_case),
+          create(:casa_case, :with_one_court_order),
+          create(:casa_case, :with_upcoming_court_date)
+        ]
+      end
+
+      let!(:incomplete_casa_cases_from_other_org) { create_list(:casa_case, 3, casa_org: create(:casa_org)) }
+      let!(:complete_casa_cases) { create_list(:casa_case, 3, :with_upcoming_court_date, :with_one_court_order) }
+
+      it "includes only cases with missing data" do
+        expect(result.length).to eq(4)
+        expect(result[1]).to eq([incomplete_casa_cases[0].case_number, "OK", "MISSING", "MISSING"])
+        expect(result[2]).to eq([incomplete_casa_cases[1].case_number, "OK", "MISSING", "OK"])
+        expect(result[3]).to eq([incomplete_casa_cases[2].case_number, "OK", "OK", "MISSING"])
+      end
+
+      it_behaves_like "report_with_header"
+    end
+
+    context "when there are no casa cases" do
+      it "includes only the header" do
+        expect(result.length).to eq(1)
+      end
+
+      it_behaves_like "report_with_header"
+    end
+  end
+end

--- a/spec/services/missing_data_export_csv_service_spec.rb
+++ b/spec/services/missing_data_export_csv_service_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe MissingDataExportCsvService do
+  let!(:casa_cases) { create_list(:casa_case, 3) }
+  let(:result) { described_class.new(CasaCase.all).perform }
+
+  describe "#perform" do
+    it "returns a string formatted as csv" do
+      expect(result).to eq("Casa Case Number,Youth Birth Month And Year,Upcoming Hearing Date,Court Orders\n"\
+        "#{casa_cases[0].case_number},OK,MISSING,MISSING\n"\
+        "#{casa_cases[1].case_number},OK,MISSING,MISSING\n"\
+        "#{casa_cases[2].case_number},OK,MISSING,MISSING\n")
+    end
+  end
+end

--- a/spec/system/reports/export_data_spec.rb
+++ b/spec/system/reports/export_data_spec.rb
@@ -68,4 +68,14 @@ RSpec.describe "case_contact_reports/index", type: :system do
     expect(download_content).to include(case_contact_with_mileage.creator.display_name)
     expect(download_content).not_to include(case_contact_without_mileage.creator.display_name)
   end
+
+  it "downloads missing data report", js: true do
+    sign_in admin
+
+    visit reports_path
+    click_button "Missing Data Report"
+    wait_for_download
+
+    expect(download_file_name).to match(/missing-data-report-\d{4}-\d{2}-\d{2}.csv/)
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3039

### What changed, and why?
I've added a feature to download a report of cases with all missing data describe in #3039. The reports path `/reports` now have a button to perform this action and download the report as a `.csv` file.

### How is this tested? (please write tests!) 💖💪
It's tested by validating if the `.csv` file is being properly generated, with the correct columns, and rows corresponding to only the cases, from a fiven casa org, that have missing data. I'm also checking if the cvs is being downloaded with the correct name when the button from the reports page was pressed.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/25598040/173672618-a90b1889-a1f6-4041-99ba-5ff734c08ec5.png)
