### PR TITLE
Add arm64-darwin-21 platform back

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
@@ -468,6 +470,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux


### PR DESCRIPTION
As stated in
https://github.com/arzezak/casa/commit/c6fabd410012fdd69e3ab6fd2ddbd1db7df7b95f,
we're adding back the arm64 platform in order to bundle on M1 macs.