### PR TITLE
Create Patch Note Types

### DIFF
--- a/app/models/patch_note_type.rb
+++ b/app/models/patch_note_type.rb
@@ -1,0 +1,18 @@
+class PatchNoteType < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true, presence: true
+end
+
+# == Schema Information
+#
+# Table name: patch_note_types
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_patch_note_types_on_name  (name) UNIQUE
+#

--- a/db/migrate/20220615015056_create_patch_note_types.rb
+++ b/db/migrate/20220615015056_create_patch_note_types.rb
@@ -1,0 +1,9 @@
+class CreatePatchNoteTypes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :patch_note_types do |t|
+      t.string :name, null: false
+      t.index  :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220615015056_create_patch_note_types.rb
+++ b/db/migrate/20220615015056_create_patch_note_types.rb
@@ -2,7 +2,7 @@ class CreatePatchNoteTypes < ActiveRecord::Migration[7.0]
   def change
     create_table :patch_note_types do |t|
       t.string :name, null: false
-      t.index  :name, unique: true
+      t.index :name, unique: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_07_184910) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_15_015056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -360,6 +360,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_184910) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "patch_note_types", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_patch_note_types_on_name", unique: true
   end
 
   create_table "preference_sets", force: :cascade do |t|

--- a/db/seeds/patch_note_type_data.rb
+++ b/db/seeds/patch_note_type_data.rb
@@ -1,0 +1,5 @@
+# PatchNote Section Headers
+
+PatchNoteType.where(name: "Coming Up").first_or_create()
+PatchNoteType.where(name: "Fixes").first_or_create()
+PatchNoteType.where(name: "What's New").first_or_create()

--- a/db/seeds/patch_note_type_data.rb
+++ b/db/seeds/patch_note_type_data.rb
@@ -1,5 +1,5 @@
 # PatchNote Section Headers
 
-PatchNoteType.where(name: "Coming Up").first_or_create()
-PatchNoteType.where(name: "Fixes").first_or_create()
-PatchNoteType.where(name: "What's New").first_or_create()
+PatchNoteType.where(name: "Coming Up").first_or_create
+PatchNoteType.where(name: "Fixes").first_or_create
+PatchNoteType.where(name: "What's New").first_or_create

--- a/db/seeds/patch_note_type_data.rb
+++ b/db/seeds/patch_note_type_data.rb
@@ -2,4 +2,4 @@
 
 PatchNoteType.where(name: "Coming Up").first_or_create
 PatchNoteType.where(name: "Fixes").first_or_create
-PatchNoteType.where(name: "What's New").first_or_create
+PatchNoteType.where(name: "What's New?").first_or_create

--- a/lib/tasks/deployment/20220615020226_create_initial_patch_note_types.rake
+++ b/lib/tasks/deployment/20220615020226_create_initial_patch_note_types.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: create_initial_patch_note_types'
+  desc "Deployment task: create_initial_patch_note_types"
   task create_initial_patch_note_types: :environment do
     puts "Running deploy task 'create_initial_patch_note_types'"
 

--- a/lib/tasks/deployment/20220615020226_create_initial_patch_note_types.rake
+++ b/lib/tasks/deployment/20220615020226_create_initial_patch_note_types.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: create_initial_patch_note_types'
+  task create_initial_patch_note_types: :environment do
+    puts "Running deploy task 'create_initial_patch_note_types'"
+
+    load(Rails.root.join("db", "seeds", "patch_note_type_data.rb"))
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/patch_note_types.rb
+++ b/spec/factories/patch_note_types.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :patch_note_type do
+    sequence(:name) { |n| "Patch Note Type #{n}" }
+  end
+end

--- a/spec/models/patch_note_type_spec.rb
+++ b/spec/models/patch_note_type_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PatchNoteType, type: :model do
   it "does not have duplicate names" do

--- a/spec/models/patch_note_type_spec.rb
+++ b/spec/models/patch_note_type_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe PatchNoteType, type: :model do
+  it "does not have duplicate names" do
+    create_patch_note_type = -> { create(:contact_type_group, {name: "Test1"}) }
+    create_patch_note_type.call
+    expect { create_patch_note_type.call }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name has already been taken")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Added Patch Note Types table and populated it with defaults via afterparty
Patch Note Types are headers for groups of patch notes

### How will this affect user permissions?
shouldn't