### PR TITLE
Create Patch Note Groups

### DIFF
--- a/app/models/patch_note_group.rb
+++ b/app/models/patch_note_group.rb
@@ -1,0 +1,17 @@
+class PatchNoteGroup < ApplicationRecord
+  validates :value, uniqueness: true, presence: true
+end
+
+# == Schema Information
+#
+# Table name: patch_note_groups
+#
+#  id         :bigint           not null, primary key
+#  value      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_patch_note_groups_on_value  (value) UNIQUE
+#

--- a/db/migrate/20220618042137_create_patch_note_groups.rb
+++ b/db/migrate/20220618042137_create_patch_note_groups.rb
@@ -1,0 +1,10 @@
+class CreatePatchNoteGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :patch_note_groups do |t|
+      t.string :value, null: false
+      t.index :value, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_16_021404) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_18_042137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,11 +136,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_021404) do
     t.string "footer_links", default: [], array: true
     t.string "slug"
     t.boolean "show_driving_reimbursement", default: true
+    t.boolean "show_fund_request", default: false
     t.string "twilio_phone_number"
     t.string "twilio_account_sid"
     t.string "twilio_api_key_sid"
     t.string "twilio_api_key_secret"
-    t.boolean "show_fund_request", default: false
     t.index ["slug"], name: "index_casa_orgs_on_slug", unique: true
   end
 
@@ -379,6 +379,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_16_021404) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "patch_note_groups", force: :cascade do |t|
+    t.string "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["value"], name: "index_patch_note_groups_on_value", unique: true
   end
 
   create_table "patch_note_types", force: :cascade do |t|

--- a/spec/factories/patch_note_groups.rb
+++ b/spec/factories/patch_note_groups.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :patch_note_group do
     sequence :value do |n| # Factory with default value includes no users
-      "#{n}"
+      n.to_s
     end
 
     trait :all_users do

--- a/spec/factories/patch_note_groups.rb
+++ b/spec/factories/patch_note_groups.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :patch_note_group do
+    sequence :value do |n| # Factory with default value includes no users
+      "#{n}"
+    end
+
+    trait :all_users do
+      value { "Admin+Supervisor+Volunteer" }
+    end
+
+    trait :only_supervisors_and_admins do
+      value { "Admin+Supervisor" }
+    end
+  end
+end

--- a/spec/models/patch_note_group_spec.rb
+++ b/spec/models/patch_note_group_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe PatchNoteGroup, type: :model do
+  it { is_expected.to validate_uniqueness_of(:value) }
+  it { is_expected.to validate_presence_of(:value) }
+end

--- a/spec/models/patch_note_group_spec.rb
+++ b/spec/models/patch_note_group_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe PatchNoteGroup, type: :model do
+  let!(:patch_note_group) { create(:patch_note_group) }
+
   it { is_expected.to validate_uniqueness_of(:value) }
   it { is_expected.to validate_presence_of(:value) }
 end

--- a/spec/models/patch_note_group_spec.rb
+++ b/spec/models/patch_note_group_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PatchNoteGroup, type: :model do
   it { is_expected.to validate_uniqueness_of(:value) }

--- a/spec/models/patch_note_group_spec.rb
+++ b/spec/models/patch_note_group_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PatchNoteGroup, type: :model do
-  let!(:patch_note_group) { create(:patch_note_group) }
+  let!(:patch_note_group) { create(:patch_note_group, value: "test") }
 
   it { is_expected.to validate_uniqueness_of(:value) }
   it { is_expected.to validate_presence_of(:value) }

--- a/spec/models/patch_note_type_spec.rb
+++ b/spec/models/patch_note_type_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe PatchNoteType, type: :model do
+  let!(:patch_note_type) { create(:patch_note_type) }
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
 end

--- a/spec/models/patch_note_type_spec.rb
+++ b/spec/models/patch_note_type_spec.rb
@@ -1,9 +1,6 @@
 require "rails_helper"
 
 RSpec.describe PatchNoteType, type: :model do
-  it "does not have duplicate names" do
-    create_patch_note_type = -> { create(:contact_type_group, {name: "Test1"}) }
-    create_patch_note_type.call
-    expect { create_patch_note_type.call }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Name has already been taken")
-  end
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Added Patch Note Groups Table to contain information about who is allowed to receive a patch note

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
Model tests