### PR TITLE
case contact occurred date suggestion correction

### DIFF
--- a/app/javascript/__tests__/case_contact.test.js
+++ b/app/javascript/__tests__/case_contact.test.js
@@ -36,6 +36,6 @@ test("occured date field won't allow future dates and it will be set back to the
   expect(caseOccurredAt.value).toEqual(todayString)
 })
 
-test("utc date is correctly converted to system date", () => {
-  expect(convertDateToSystemTimeZone("2022-06-22 17:14:50 UTC")).toEqual(new Date("2022-06-22 17:14:50 UTC"))
+test('utc date is correctly converted to system date', () => {
+  expect(convertDateToSystemTimeZone('2022-06-22 17:14:50 UTC')).toEqual(new Date('2022-06-22 17:14:50 UTC'))
 })

--- a/app/javascript/__tests__/case_contact.test.js
+++ b/app/javascript/__tests__/case_contact.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { validateOccurredAt } from '../src/case_contact'
+import { validateOccurredAt, convertDateToSystemTimeZone } from '../src/case_contact'
 
 require('jest')
 
@@ -34,4 +34,8 @@ test("occured date field won't allow future dates and it will be set back to the
   validateOccurredAt(caseOccurredAt, 'focusout')
 
   expect(caseOccurredAt.value).toEqual(todayString)
+})
+
+test("utc date is correctly converted to system date", () => {
+  expect(convertDateToSystemTimeZone("2022-06-22 17:14:50 UTC")).toEqual(new Date("2022-06-22 17:14:50 UTC"))
 })

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -15,8 +15,8 @@ window.onload = function () {
 
   const timeZoneConvertedDate = enGBDateString(new Date())
 
-  if (enGBDateString(convertDateToSystemTimeZone(caseOccurredAt.value)) == timeZoneConvertedDate) {
-    caseOccurredAt.value = timeZoneConvertedDate;
+  if (enGBDateString(convertDateToSystemTimeZone(caseOccurredAt.value)) === timeZoneConvertedDate) {
+    caseOccurredAt.value = timeZoneConvertedDate
   }
 
   milesDriven.onchange = function () {
@@ -115,12 +115,12 @@ function validateOccurredAt (caseOccurredAt, eventType = '') {
   }
 }
 
-function enGBDateString(date) {
+function enGBDateString (date) {
   return date.toLocaleDateString('en-GB').split('/').reverse().join('-')
 }
 
-function convertDateToSystemTimeZone(date) {
-  return new Date((typeof date === "string" ? new Date(date) : date))   
+function convertDateToSystemTimeZone (date) {
+  return new Date((typeof date === 'string' ? new Date(date) : date))
 }
 
 async function displayFollowupAlert () {

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -13,6 +13,12 @@ window.onload = function () {
   const caseOccurredAt = document.getElementById('case_contact_occurred_at')
   const caseContactSubmit = document.getElementById('case-contact-submit')
 
+  const timeZoneConvertedDate = enGBDateString(new Date())
+
+  if (enGBDateString(convertDateToSystemTimeZone(caseOccurredAt.value)) == timeZoneConvertedDate) {
+    caseOccurredAt.value = timeZoneConvertedDate;
+  }
+
   milesDriven.onchange = function () {
     const contactMedium = document.getElementById('case_contact_medium_type').value || '(contact medium not set)'
     const contactMediumInPerson = `${contactMedium}` === 'in-person'
@@ -105,8 +111,16 @@ function validateOccurredAt (caseOccurredAt, eventType = '') {
     if (eventType !== 'focusout') {
       alert(msg)
     }
-    caseOccurredAt.value = today.toLocaleDateString('en-GB').split('/').reverse().join('-')
+    caseOccurredAt.value = enGBDateString(today)
   }
+}
+
+function enGBDateString(date) {
+  return date.toLocaleDateString('en-GB').split('/').reverse().join('-')
+}
+
+function convertDateToSystemTimeZone(date) {
+  return new Date((typeof date === "string" ? new Date(date) : date))   
 }
 
 async function displayFollowupAlert () {
@@ -151,5 +165,6 @@ $('document').ready(() => {
 })
 
 export {
-  validateOccurredAt
+  validateOccurredAt,
+  convertDateToSystemTimeZone
 }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3174

### What changed, and why?
This bug was happening because of different time zones. The default time zone in Rails is UTC. When
the user tried registering a new case contact after 5 pm in the Pacific time zone, it was already the next day in UTC. The modification I did was to set the input field date to the user system date in order to avoid that behaviour.

### How will this affect user permissions?
- Volunteer permissions: No impacts
- Supervisor permissions: No impacts
- Admin permissions: No impacts

### How is this tested? (please write tests!) 💖💪
There was written a Jest test, just run Jest.

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![alt text](https://camo.githubusercontent.com/158c0bc1146cc4fccfb76f4056b17a949474afeded6f879cc8561557afa0beb9/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f575251425853436e45464a4975786b746e772f67697068792e676966)