### PR TITLE
Capture selenium screenshot output so they are viewable in Github Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,3 +38,10 @@ jobs:
         run: docker-compose exec -T web bundle exec rails javascript:build
       - name: Test
         run: docker-compose exec -T web bundle exec rspec spec
+
+      - name: Archive selenium screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-screenshots
+          path: ${{ github.workspace }}/tmp/capybara/*.png

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -77,3 +77,10 @@ jobs:
           ./cc-test-reporter before-build
           RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
           ./cc-test-reporter after-build --exit-code $?
+
+      - name: Archive selenium screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-screenshots
+          path: ${{ github.workspace }}/tmp/capybara/*.png

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,6 +471,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-18
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux


### PR DESCRIPTION
### What changed, and why?

Added section to github actions for rspec and docker that will save the outputs on the Capybara screenshots so they can be viewed upon failure.


### Screenshots

<img width="1138" alt="Screen Shot 2022-06-26 at 1 40 47 PM" src="https://user-images.githubusercontent.com/1938665/175833070-4359aeaf-51d2-4a51-a1c9-d21db9196504.png">
<img width="1254" alt="Screen Shot 2022-06-26 at 1 38 55 PM" src="https://user-images.githubusercontent.com/1938665/175833072-c3cd9ca1-e4ef-48ee-b82e-11fcaed0c349.png">
