### PR TITLE
Nicer UI validation for requiring name for judge so we don't have to …

### DIFF
--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -5,8 +5,8 @@
     <%= form_with(model: judge, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: judge %>
       <div class="field form-group">
-        <%= form.label :name, t("common.name") %>
-        <%= form.text_field :name, class: "form-control" %>
+        <%= form.label :name, "Name" %>
+        <%= form.text_field :name, class: "form-control", required: true %>
       </div>
       <div class="field form-group">
         <div class="form-check">


### PR DESCRIPTION

### What github issue is this PR for, if any?
Resolves #3712

### What changed, and why?
Nicer UI validation for requiring name for judge so we don't have to call the server just to hear that a judge needs a name

### How will this affect user permissions?
no

### How is this tested? (please write tests!) 💖💪
no :(

### Screenshots please :)
<img width="371" alt="Screen Shot 2022-06-28 at 6 33 59 PM" src="https://user-images.githubusercontent.com/578159/176332069-c87d1091-3285-4f38-88d4-2e345ed46ab8.png">
<img width="723" alt="Screen Shot 2022-06-28 at 6 33 48 PM" src="https://user-images.githubusercontent.com/578159/176332072-184c2c88-9b5f-496c-a9af-05e4201b8843.png">
