### PR TITLE
require hearing type name

### DIFF
--- a/app/views/hearing_types/_form.html.erb
+++ b/app/views/hearing_types/_form.html.erb
@@ -6,7 +6,7 @@
       <%= render "/shared/error_messages", resource: hearing_type %>
       <div class="field form-group">
         <%= form.label :name, t("common.name") %>
-        <%= form.text_field :name, class: "form-control" %>
+        <%= form.text_field :name, class: "form-control", required: true %>
       </div>
       <div class="field form-group">
         <div class="form-check">

--- a/spec/views/hearing_types/edit.html.erb_spec.rb
+++ b/spec/views/hearing_types/edit.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "hearing_types/edit", type: :view do
+  let(:admin) { build_stubbed(:casa_admin) }
+
+  before do
+    assign :hearing_type, HearingType.new
+    sign_in admin
+
+    render template: "hearing_types/edit"
+  end
+
+  it "shows edit hearing type form" do
+    expect(rendered).to have_text("Edit")
+    expect(rendered).to have_selector("input", id: "hearing_type_name")
+    expect(rendered).to have_selector("input", id: "hearing_type_active")
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "requires name text_field" do
+    expect(rendered).to have_selector("input[required=required]", id: "hearing_type_name")
+  end
+end

--- a/spec/views/hearing_types/new.html.erb_spec.rb
+++ b/spec/views/hearing_types/new.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "hearing_types/new", type: :view do
+  let(:admin) { build_stubbed(:casa_admin) }
+
+  before do
+    assign :hearing_type, HearingType.new
+    sign_in admin
+
+    render template: "hearing_types/new"
+  end
+
+  it "shows new hearing type form" do
+    expect(rendered).to have_text("New Hearing Type")
+    expect(rendered).to have_selector("input", id: "hearing_type_name")
+    expect(rendered).to have_selector("input", id: "hearing_type_active")
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "requires name text_field" do
+    expect(rendered).to have_selector("input[required=required]", id: "hearing_type_name")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3714 

### What changed, and why?
Name is now required on the hearing type form.

### How will this affect user permissions?
- It won't.

### How is this tested? (please write tests!) 💖💪
- To test run:
`rspec spec/views/hearing_types/new.html.erb_spec.rb`
`rspec spec/views/hearing_types/edit.html.erb_spec.rb`

### Screenshots please :)
![image](https://user-images.githubusercontent.com/36737050/176545971-c75bd119-35af-4c49-b574-38da79e3fe95.png)