### PR TITLE
update learning_hour model validations

### DIFF
--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -10,12 +10,17 @@ class LearningHour < ApplicationRecord
   }
 
   validates :learning_type, presence: true
-  validates :duration_minutes, presence: true, numericality: {greater_than: 0}
+  validates :duration_minutes, presence: true
+  validates :duration_minutes, numericality: {greater_than: 0}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future
 
   private
+
+  def zero_duration_hours?
+    duration_hours == 0
+  end
 
   def occurred_at_not_in_future
     return false if !occurred_at

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -13,10 +13,20 @@ RSpec.describe LearningHour, type: :model do
     expect(learning_hour.errors[:learning_type]).to eq(["can't be blank"])
   end
 
-  it "has a duration in minutes that is greater than 0" do
-    learning_hour = build_stubbed(:learning_hour, duration_minutes: 0)
-    expect(learning_hour).to_not be_valid
-    expect(learning_hour.errors[:duration_minutes]).to eq(["must be greater than 0"])
+  context "duration_hours is zero" do
+    it "has a duration in minutes that is greater than 0" do
+      learning_hour = build_stubbed(:learning_hour, duration_hours: 0, duration_minutes: 0)
+      expect(learning_hour).to_not be_valid
+      expect(learning_hour.errors[:duration_minutes]).to eq(["must be greater than 0"])
+    end
+  end
+
+  context "duration_hours is greater than zero" do
+    it "has a duration in minutes that is greater than 0" do
+      learning_hour = build_stubbed(:learning_hour, duration_hours: 1, duration_minutes: 0)
+      expect(learning_hour).to be_valid
+      expect(learning_hour.errors[:duration_minutes]).to eq([])
+    end
   end
 
   it "has an occurred_at date" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Fixes #3711

### What changed, and why?
Learning hour now only requires duration_minutes > 0 if duration_hours == 0 

### How will this affect user permissions?
I don't know what could affect permissions, could you explain?

### How is this tested? (please write tests!) 💖💪
To test, please run:
`bundle exec rspec spec/models/learning_hour_spec.rb`

### Screenshots please :)
![image](https://user-images.githubusercontent.com/36737050/176745309-ae621f2d-3a74-4b98-a4ad-8d8bdc9c167f.png)

![image](https://user-images.githubusercontent.com/36737050/176745418-a9dee25f-aa9b-40aa-b16c-6d45b0f18b86.png)