### PR TITLE
Create patch notes and fill in initial patch note group data

### DIFF
--- a/app/models/patch_note.rb
+++ b/app/models/patch_note.rb
@@ -1,0 +1,33 @@
+class PatchNote < ApplicationRecord
+  validates :note, presence: true
+
+  belongs_to :patch_note_type
+  belongs_to :patch_note_group
+
+  scope :notes_available_for_user, ->(user) {
+    joins(:patch_note_group)
+      .where("POSITION(? IN value)>0", user.type)
+  }
+end
+
+# == Schema Information
+#
+# Table name: patch_notes
+#
+#  id                  :bigint           not null, primary key
+#  note                :text             not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  patch_note_group_id :bigint           not null
+#  patch_note_type_id  :bigint           not null
+#
+# Indexes
+#
+#  index_patch_notes_on_patch_note_group_id  (patch_note_group_id)
+#  index_patch_notes_on_patch_note_type_id   (patch_note_type_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patch_note_group_id => patch_note_groups.id)
+#  fk_rails_...  (patch_note_type_id => patch_note_types.id)
+#

--- a/app/policies/patch_note_policy.rb
+++ b/app/policies/patch_note_policy.rb
@@ -1,0 +1,12 @@
+class PatchNotePolicy < ApplicationPolicy
+  class Scope < Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.notes_available_for_user(@user)
+    end
+  end
+end

--- a/db/migrate/20220622022147_create_patch_notes.rb
+++ b/db/migrate/20220622022147_create_patch_notes.rb
@@ -1,0 +1,11 @@
+class CreatePatchNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :patch_notes do |t|
+      t.text :note, null: false
+      t.references :patch_note_type, null: false, foreign_key: true
+      t.references :patch_note_group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_18_042137) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_22_022147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -395,6 +395,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_18_042137) do
     t.index ["name"], name: "index_patch_note_types_on_name", unique: true
   end
 
+  create_table "patch_notes", force: :cascade do |t|
+    t.text "note", null: false
+    t.bigint "patch_note_type_id", null: false
+    t.bigint "patch_note_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["patch_note_group_id"], name: "index_patch_notes_on_patch_note_group_id"
+    t.index ["patch_note_type_id"], name: "index_patch_notes_on_patch_note_type_id"
+  end
+
   create_table "preference_sets", force: :cascade do |t|
     t.bigint "user_id"
     t.jsonb "case_volunteer_columns", default: "{}", null: false
@@ -519,6 +529,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_18_042137) do
   add_foreign_key "judges", "casa_orgs"
   add_foreign_key "learning_hours", "users"
   add_foreign_key "mileage_rates", "users"
+  add_foreign_key "patch_notes", "patch_note_groups"
+  add_foreign_key "patch_notes", "patch_note_types"
   add_foreign_key "preference_sets", "users"
   add_foreign_key "sent_emails", "casa_orgs"
   add_foreign_key "sent_emails", "users"

--- a/db/seeds/patch_note_group_data.rb
+++ b/db/seeds/patch_note_group_data.rb
@@ -1,0 +1,4 @@
+# PatchNote Section Headers
+
+PatchNoteGroup.where(value: "Admin+Supervisor").first_or_create
+PatchNoteGroup.where(value: "Admin+Supervisor+Volunteer").first_or_create

--- a/lib/tasks/deployment/20220702005957_create_initial_patch_note_groups.rake
+++ b/lib/tasks/deployment/20220702005957_create_initial_patch_note_groups.rake
@@ -1,5 +1,5 @@
 namespace :after_party do
-  desc 'Deployment task: create_initial_patch_note_groups'
+  desc "Deployment task: create_initial_patch_note_groups"
   task create_initial_patch_note_groups: :environment do
     puts "Running deploy task 'create_initial_patch_note_groups'"
 

--- a/lib/tasks/deployment/20220702005957_create_initial_patch_note_groups.rake
+++ b/lib/tasks/deployment/20220702005957_create_initial_patch_note_groups.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: create_initial_patch_note_groups'
+  task create_initial_patch_note_groups: :environment do
+    puts "Running deploy task 'create_initial_patch_note_groups'"
+
+    load(Rails.root.join("db", "seeds", "patch_note_group_data.rb"))
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/patch_notes.rb
+++ b/spec/factories/patch_notes.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :patch_note do
+    sequence :note do |n|
+      n.to_s
+    end
+
+    patch_note_type { create(:patch_note_type) }
+    patch_note_group { create(:patch_note_group) }
+  end
+end

--- a/spec/models/patch_note_spec.rb
+++ b/spec/models/patch_note_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe PatchNote, type: :model do
+  let!(:patch_note) { create(:patch_note) }
+
+  it { is_expected.to belong_to(:patch_note_group) }
+  it { is_expected.to belong_to(:patch_note_type) }
+  it { is_expected.to validate_presence_of(:note) }
+end

--- a/spec/models/patch_note_spec.rb
+++ b/spec/models/patch_note_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PatchNote, type: :model do
   let!(:patch_note) { create(:patch_note) }

--- a/spec/policies/patch_note_policy_spec.rb
+++ b/spec/policies/patch_note_policy_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PatchNotePolicy, type: :policy do
   let(:user) { User.new }

--- a/spec/policies/patch_note_policy_spec.rb
+++ b/spec/policies/patch_note_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe PatchNotePolicy, type: :policy do
+  let(:user) { User.new }
+
+  subject { described_class }
+
+  permissions ".scope" do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :create? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :update? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :destroy? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Created patch notes model, database table, and policy,
Created afterparty task to create initial patch note groups

### How will this affect user permissions?
- Volunteer Supervisor, Admin permissions:
Can access patch notes if of the correct group

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)