### PR TITLE
Feature/1886 Volunteer receives SMS to notify of follow up generated by admin or supervisor

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -60,6 +60,7 @@ notifications/base_notification.rb
 notifications/followup_notification.rb
 notifications/followup_resolved_notification.rb
 notifications/youth_birthday_notification.rb
+notifications/delivery_methods/sms.rb
 policies/case_court_order_policy.rb
 policies/learning_hour_policy.rb
 presenters/base_presenter.rb

--- a/app/helpers/sms_body_helper.rb
+++ b/app/helpers/sms_body_helper.rb
@@ -25,4 +25,7 @@ module SmsBodyHelper
   def no_contact_made_msg(contact_type, short_link)
     "It's been two weeks since you've tried reaching '#{contact_type}'. Try again! #{short_link}"
   end
+  def case_contact_flagged_msg(display_name, short_link)
+    "-\n \n#{display_name} has flagged a Case Contact that needs follow up. Click to see more: #{short_link}"
+  end
 end

--- a/app/helpers/sms_body_helper.rb
+++ b/app/helpers/sms_body_helper.rb
@@ -25,6 +25,7 @@ module SmsBodyHelper
   def no_contact_made_msg(contact_type, short_link)
     "It's been two weeks since you've tried reaching '#{contact_type}'. Try again! #{short_link}"
   end
+
   def case_contact_flagged_msg(display_name, short_link)
     "-\n \n#{display_name} has flagged a Case Contact that needs follow up. Click to see more: #{short_link}"
   end

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,6 +1,6 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
   def deliver
-    # Logic for sending the notification
+    twilio = TwilioService.new(recipient.casa_org.twilio_api_key_sid, recipient.casa_org.twilio_api_key_secret, recipient.casa_org.twilio_account_sid)
   end
 
   # You may override this method to validate options for the delivery method

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,33 +1,25 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
   def deliver
-    twilio = TwilioService.new(recipient.casa_org.twilio_api_key_sid, recipient.casa_org.twilio_api_key_secret, recipient.casa_org.twilio_account_sid)
-
-    short_io_main = ShortUrlService.new
-    short_io_main.create_short_url(url)
-    shortened_url = short_io_main.short_url
-
-    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n#{supervisor_or_admin_display_name} has flagged a Case Contact that needs follow up. Click to see more: #{shortened_url}", To: recipient.phone_number}
-    twilio_res = twilio.send_sms(req_params)
+    if sender.casa_admin? || sender.supervisor?
+      short_io_api = ShortUrlService.new
+      short_io_api.create_short_url(case_contact_url)
+      shortened_url = short_io_api.short_url
+      twilio_api = TwilioService.new(sender.casa_org.twilio_api_key_sid, sender.casa_org.twilio_api_key_secret, sender.casa_org.twilio_account_sid)
+      twilio_api.send_sms({From: sender.casa_org.twilio_phone_number, Body: "-\n \n#{sender.display_name} has flagged a Case Contact that needs follow up. Click to see more: #{shortened_url}", To: recipient.phone_number})
+    end
   end
 
-  def url
-    Rails.application.credentials[:BASE_URL] + "/case_contacts/" + case_contact_id.to_s + "/edit"
+  def case_contact_url
+    Rails.application.credentials[:BASE_URL] + "/case_contacts/" + case_contact_id.to_s + "/edit?notification_id=" + record.id.to_s
   end
 
   private
 
-  def supervisor_or_admin_display_name
-    params[:created_by][:display_name]
+  def sender
+    User.find(params[:followup][:creator_id])
   end
 
   def case_contact_id
     params[:followup][:case_contact_id]
   end
-
-  # You may override this method to validate options for the delivery method
-  # Invalid options should raise a ValidationError
-  #
-  # def self.validate!(options)
-  #   raise ValidationError, "required_option missing" unless options[:required_option]
-  # end
 end

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,0 +1,12 @@
+class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
+  def deliver
+    # Logic for sending the notification
+  end
+
+  # You may override this method to validate options for the delivery method
+  # Invalid options should raise a ValidationError
+  #
+  # def self.validate!(options)
+  #   raise ValidationError, "required_option missing" unless options[:required_option]
+  # end
+end

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,6 +1,8 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
   def deliver
     twilio = TwilioService.new(recipient.casa_org.twilio_api_key_sid, recipient.casa_org.twilio_api_key_secret, recipient.casa_org.twilio_account_sid)
+    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n[supervisor/admin name] has flagged a Case Contact that needs follow up. Click to see more: [link]", To: recipient.phone_number}
+    twilio_res = twilio.send_sms(req_params)
   end
 
   # You may override this method to validate options for the delivery method

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,11 +1,12 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
+include SmsBodyHelper
   def deliver
     if sender.casa_admin? || sender.supervisor?
       short_io_api = ShortUrlService.new
       short_io_api.create_short_url(case_contact_url)
       shortened_url = short_io_api.short_url
       twilio_api = TwilioService.new(sender.casa_org.twilio_api_key_sid, sender.casa_org.twilio_api_key_secret, sender.casa_org.twilio_account_sid)
-      twilio_api.send_sms({From: sender.casa_org.twilio_phone_number, Body: "-\n \n#{sender.display_name} has flagged a Case Contact that needs follow up. Click to see more: #{shortened_url}", To: recipient.phone_number})
+      twilio_api.send_sms({From: sender.casa_org.twilio_phone_number, Body: case_contact_flagged_msg(sender.display_name, shortened_url), To: recipient.phone_number})
     end
   end
 

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,7 +1,12 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
   def deliver
     twilio = TwilioService.new(recipient.casa_org.twilio_api_key_sid, recipient.casa_org.twilio_api_key_secret, recipient.casa_org.twilio_account_sid)
-    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n#{supervisor_or_admin_display_name} has flagged a Case Contact that needs follow up. Click to see more: #{url}", To: recipient.phone_number}
+
+    short_io_main = ShortUrlService.new
+    short_io_main.create_short_url(url)
+    shortened_url = short_io_main.short_url
+
+    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n#{supervisor_or_admin_display_name} has flagged a Case Contact that needs follow up. Click to see more: #{shortened_url}", To: recipient.phone_number}
     twilio_res = twilio.send_sms(req_params)
   end
 

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,8 +1,22 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
   def deliver
     twilio = TwilioService.new(recipient.casa_org.twilio_api_key_sid, recipient.casa_org.twilio_api_key_secret, recipient.casa_org.twilio_account_sid)
-    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n[supervisor/admin name] has flagged a Case Contact that needs follow up. Click to see more: [link]", To: recipient.phone_number}
+    req_params = {From: recipient.casa_org.twilio_phone_number, Body: "-\n \n#{supervisor_or_admin_display_name} has flagged a Case Contact that needs follow up. Click to see more: #{url}", To: recipient.phone_number}
     twilio_res = twilio.send_sms(req_params)
+  end
+
+  def url
+    Rails.application.credentials[:BASE_URL] + "/case_contacts/" + case_contact_id.to_s + "/edit"
+  end
+
+  private
+
+  def supervisor_or_admin_display_name
+    params[:created_by][:display_name]
+  end
+
+  def case_contact_id
+    params[:followup][:case_contact_id]
   end
 
   # You may override this method to validate options for the delivery method

--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -1,5 +1,5 @@
 class DeliveryMethods::Sms < Noticed::DeliveryMethods::Base
-include SmsBodyHelper
+  include SmsBodyHelper
   def deliver
     if sender.casa_admin? || sender.supervisor?
       short_io_api = ShortUrlService.new

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -7,10 +7,10 @@ class FollowupNotification < BaseNotification
   # Add your delivery methods
   #
   deliver_by :database
-  # deliver_by :email, mailer: "UserMailer", if: email_notifications?
+  # deliver_by :email, mailer: "UserMailer", if: :email_notifications?
   # deliver_by :slack
   # deliver_by :custom, class: "MyDeliveryMethod"
-  deliver_by :sms, class: "DeliveryMethods:Sms", if: sms_notifications? # Reminder: Validate that when 'receive_sms_notifications' == true 'phone_number' is not nil (UserValidator)
+  deliver_by :sms, class: "DeliveryMethods::Sms", if: :sms_notifications? # Reminder: Validate that when 'receive_sms_notifications' == true 'phone_number' is not nil (UserValidator)
 
   # Add required params
   #

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -8,9 +8,9 @@ class FollowupNotification < BaseNotification
   #
   deliver_by :database
   # deliver_by :email, mailer: "UserMailer", if: :email_notifications?
+  # deliver_by :sms, class: "DeliveryMethods::Sms", if: :sms_notifications?
   # deliver_by :slack
   # deliver_by :custom, class: "MyDeliveryMethod"
-  deliver_by :sms, class: "DeliveryMethods::Sms", if: :sms_notifications? # Reminder: Validate that when 'receive_sms_notifications' == true 'phone_number' is not nil (UserValidator)
 
   # Add required params
   #

--- a/app/notifications/followup_notification.rb
+++ b/app/notifications/followup_notification.rb
@@ -7,9 +7,10 @@ class FollowupNotification < BaseNotification
   # Add your delivery methods
   #
   deliver_by :database
-  # deliver_by :email, mailer: "UserMailer"
+  # deliver_by :email, mailer: "UserMailer", if: email_notifications?
   # deliver_by :slack
   # deliver_by :custom, class: "MyDeliveryMethod"
+  deliver_by :sms, class: "DeliveryMethods:Sms", if: sms_notifications? # Reminder: Validate that when 'receive_sms_notifications' == true 'phone_number' is not nil (UserValidator)
 
   # Add required params
   #
@@ -28,6 +29,14 @@ class FollowupNotification < BaseNotification
   end
 
   private
+
+  def sms_notifications?
+    recipient.receive_sms_notifications == true
+  end
+
+  def email_notifications?
+    recipient.receive_email_notifications == true
+  end
 
   def message_with_note(note)
     [

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -5,6 +5,7 @@ class UserValidator < ActiveModel::Validator
     valid_phone_number_contents(record.phone_number, record)
     validate_presence(:display_name, record)
     at_least_one_communication_preference_selected(record)
+    valid_phone_number_if_receive_sms_notifications(record)
   end
 
   private
@@ -28,5 +29,11 @@ class UserValidator < ActiveModel::Validator
 
   def at_least_one_communication_preference_selected(record)
     record.errors.add(:base, " At least one communication preference must be selected.") unless record.receive_email_notifications || record.receive_sms_notifications
+  end
+
+  def valid_phone_number_if_receive_sms_notifications(record)
+    if record.receive_sms_notifications && record.phone_number.blank?
+      record.errors.add(:base, " Must add a valid phone number to receive SMS notifications.")
+    end
   end
 end

--- a/spec/lib/tasks/case_contact_types_reminder_spec.rb
+++ b/spec/lib/tasks/case_contact_types_reminder_spec.rb
@@ -85,13 +85,4 @@ RSpec.describe CaseContactTypesReminder do
       expect(responses[0][:messages][2].body).to match CaseContactTypesReminder::THIRD_MESSAGE + "https://42ni.short.gy/jzTwdF"
     end
   end
-
-  context "volunteer with uncontacted contact types, sms notifications on, no reminder in last quarter, no phone number" do
-    it "should not send sms reminder" do
-      UserReminderTime.destroy_all
-      Volunteer.update_all(phone_number: nil)
-      responses = CaseContactTypesReminder.new.send!
-      expect(responses.count).to match 0
-    end
-  end
 end

--- a/spec/lib/tasks/no_contact_made_reminder_spec.rb
+++ b/spec/lib/tasks/no_contact_made_reminder_spec.rb
@@ -125,20 +125,4 @@ RSpec.describe NoContactMadeReminder do
       expect(responses.count).to eq 0
     end
   end
-
-  context "volunteer with no phone number" do
-    let(:volunteer) {
-      create(
-        :volunteer,
-        casa_org_id: casa_org.id,
-        phone_number: nil,
-        receive_sms_notifications: true
-      )
-    }
-
-    it "should send not sms reminder" do
-      responses = NoContactMadeReminder.new.send!
-      expect(responses.count).to eq 0
-    end
-  end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe "users/edit", type: :system do
       expect(page).to have_text("At least one communication preference must be selected.")
     end
 
+    it "displays Volunteer error message if SMS communication preference is selected without adding a valid phone number" do
+      uncheck "user_receive_email_notifications"
+      check "user_receive_sms_notifications"
+      click_on "Save Preferences"
+      expect(page).to have_content "1 error prohibited this Volunteer from being saved:"
+      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
+    end
+
     it "displays notification events selection as enabled if sms notification preference is selected", js: true do
       check "user_receive_sms_notifications"
       expect(page).to have_field("toggle-sms-notification-event", type: "checkbox", disabled: false)
@@ -149,6 +157,14 @@ RSpec.describe "users/edit", type: :system do
       click_on "Save Preferences"
       expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
       expect(page).to have_text("At least one communication preference must be selected.")
+    end
+
+    it "displays Supervisor error message if SMS communication preference is selected without adding a valid phone number" do
+      uncheck "user_receive_email_notifications"
+      check "user_receive_sms_notifications"
+      click_on "Save Preferences"
+      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
+      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
     end
   end
 
@@ -229,6 +245,14 @@ RSpec.describe "users/edit", type: :system do
       click_on "Save Preferences"
       expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
       expect(page).to have_text("At least one communication preference must be selected.")
+    end
+
+    it "displays admin error message if SMS communication preference is selected without adding a valid phone number" do
+      uncheck "user_receive_email_notifications"
+      check "user_receive_sms_notifications"
+      click_on "Save Preferences"
+      expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
+      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #1886 
### What changed, and why?
Admins and Supervisors can send SMS messages to notify volunteers about case contact follow-ups
- Added `delivery_methods/sms.rb` to `followup_notification.rb`
- Required preferences `sms_notifications?` and `email_notifications?` before corresponding deliveries
- Created `valid_phone_number_if_receive_sms_notifications` to ensure users add a `phone number` that will receive SMSs
- Used `SmsBodyHelper` to store message bodies

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: Can now send follow-up SMS notifications
- Admin permissions: Can now send follow-up SMS notifications

### How is this tested? (please write tests!) 💖💪
Previous tests: 

`Follow-up tests` &rarr; spec/system/users/edit_spec.rb
`Twilio delivery tests` &rarr; spec/services/twilio_service_spec.rb
`Short.io tests` &rarr; spec/services/short_url_service_spec.rb


New test:
Ensure a valid phone number is required before users select the receive SMS preference &rarr;   `edit_spec.rb`

Removed tests in:

&rarr;  spec/lib/tasks/case_contact_types_reminder_spec.rb 
&rarr; spec/lib/tasks/no_contact_made_reminder_spec.rb  

They were removed because Volunteers can no longer have the SMS preference without `first` adding a phone number
### Screenshots please :)
https://user-images.githubusercontent.com/58965520/177439075-ef1b6aac-866a-4ed9-87c7-51239a8a9b9b.mov