### PR TITLE
Change communication preference text

### DIFF
--- a/app/javascript/src/require_communication_preference.js
+++ b/app/javascript/src/require_communication_preference.js
@@ -17,8 +17,8 @@ function displayPopUpIfPreferencesIsInvalid () {
     disableBtn($(`.${SAVE_BUTTON_CLASS}`)[0])
     Swal.fire({
       icon: 'error',
-      title: 'Preference Error',
-      text: 'At least one communication preference required'
+      title: 'Contact Method Needed',
+      text: 'Please select at least one method of contact so we can communicate with you.'
     })
   } else {
     enableBtn($(`.${SAVE_BUTTON_CLASS}`)[0])


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3709

### What changed, and why?
Change communication preference popup error text per issue request.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Manual testing only.

### Screenshots please :)
#### Before
![Screen Shot 2022-07-08 at 11 23 13 AM](https://user-images.githubusercontent.com/49253356/178027466-292d7d7c-5410-4a26-a4e5-3b95be7b26b7.png)

#### After
![Screen Shot 2022-07-08 at 11 31 04 AM](https://user-images.githubusercontent.com/49253356/178027508-a5187867-ed09-4560-8309-57907f1f47f4.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9