### PR TITLE
Updated case_contact_flagged_msg body

### DIFF
--- a/app/helpers/sms_body_helper.rb
+++ b/app/helpers/sms_body_helper.rb
@@ -27,6 +27,6 @@ module SmsBodyHelper
   end
 
   def case_contact_flagged_msg(display_name, short_link)
-    "-\n \n#{display_name} has flagged a Case Contact that needs follow up. Click to see more: #{short_link}"
+    "#{display_name} has flagged a Case Contact that needs follow up. Click to see more: #{short_link}"
   end
 end


### PR DESCRIPTION
### What changed, and why?
Removed line `breaks and dash` from case_contact_flagged_msg body. Added during development so the text message displays nicely on a Twilio trial account, but this will cause odd line breaks and a dash in the message body outside of using a trial account. 

### How will this affect user permissions?
- Volunteer, Supervisor, Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
n/a