### PR TITLE
Update checklist item category and description fields to be required

### DIFF
--- a/app/views/checklist_items/_form.html.erb
+++ b/app/views/checklist_items/_form.html.erb
@@ -6,11 +6,11 @@
       <%= render "/shared/error_messages", resource: checklist_item %>
       <div class="field form-group">
         <%= form.label :category %>
-        <%= form.text_field :category, class: "form-control" %>
+        <%= form.text_field :category, class: "form-control", required: true %>
       </div>
       <div class="field form-group">
         <%= form.label :description %>
-        <%= form.text_field :description, class: "form-control" %>
+        <%= form.text_field :description, class: "form-control", required: true %>
       </div>
       <div class="field form-group">
         <div class="form-check">

--- a/spec/views/checklist_items/edit.html.erb_spec.rb
+++ b/spec/views/checklist_items/edit.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "checklist_items/edit", type: :view do
+  let(:admin) { build_stubbed(:casa_admin) }
+
+  before do
+    assign :hearing_type, HearingType.new(id: 1)
+    assign :checklist_item, ChecklistItem.new
+    sign_in admin
+
+    render template: "checklist_items/edit"
+  end
+
+  it "shows edit checklist item page title" do
+    expect(rendered).to have_text("Edit this checklist item")
+  end
+
+  it "shows edit checklist item form" do
+    expect(rendered).to have_selector("input", id: "checklist_item_category")
+    expect(rendered).to have_selector("input", id: "checklist_item_description")
+    expect(rendered).to have_selector("input", id: "checklist_item_mandatory")
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "requires category text field" do
+    expect(rendered).to have_selector("input[required=required]", id: "checklist_item_category")
+  end
+
+  it "requires description text field" do
+    expect(rendered).to have_selector("input[required=required]", id: "checklist_item_description")
+  end
+end

--- a/spec/views/checklist_items/new.html.erb_spec.rb
+++ b/spec/views/checklist_items/new.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "checklist_items/new", type: :view do
+  let(:admin) { build_stubbed(:casa_admin) }
+
+  before do
+    assign :hearing_type, HearingType.new(id: 1)
+    assign :checklist_item, ChecklistItem.new
+    sign_in admin
+
+    render template: "checklist_items/new"
+  end
+
+  it "shows new checklist item page title" do
+    expect(rendered).to have_text("Add a new checklist item")
+  end
+
+  it "shows new checklist item form" do
+    expect(rendered).to have_selector("input", id: "checklist_item_category")
+    expect(rendered).to have_selector("input", id: "checklist_item_description")
+    expect(rendered).to have_selector("input", id: "checklist_item_mandatory")
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "requires category text field" do
+    expect(rendered).to have_selector("input[required=required]", id: "checklist_item_category")
+  end
+
+  it "requires description text field" do
+    expect(rendered).to have_selector("input[required=required]", id: "checklist_item_description")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3715

### What changed, and why?

Category and description fields of new and edit checklist item form are now required.

### How will this affect user permissions?
It won't.

### How is this tested? (please write tests!) 💖💪
New checklist item
`docker-compose exec web rspec spec/views/checklist_items/new.html.erb_spec.rb`
or
`rspec spec/views/checklist_items/new.html.erb_spec.rb`

Edit checklist item
`docker-compose exec web rspec spec/views/checklist_items/edit.html.erb_spec.rb`
or
`rspec spec/views/checklist_items/edit.html.erb_spec.rb`


### Screenshots please :)
Category field
![1](https://user-images.githubusercontent.com/30778707/178756988-2169d299-8fb5-46c6-acb0-083d6cb11394.png)

Description field
![2](https://user-images.githubusercontent.com/30778707/178757017-ec262405-e7f3-40bf-abae-dfd95ca91c48.png)