### PR TITLE
Update new CASA organization name field to be required

### DIFF
--- a/app/views/all_casa_admins/casa_orgs/new.html.erb
+++ b/app/views/all_casa_admins/casa_orgs/new.html.erb
@@ -7,7 +7,7 @@
 
       <div class="field form-group">
         <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control" %>
+        <%= form.text_field :name, class: "form-control", required: true %>
       </div>
 
       <div class="field form-group">

--- a/spec/views/all_casa_admins/casa_orgs/new.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/casa_orgs/new.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "all_casa_admins/casa_orgs/new", type: :view do
+  let(:organization) { create :casa_org }
+  let(:admin) { build_stubbed(:all_casa_admin) }
+
+  before do
+    allow(view).to receive(:selected_organization).and_return(organization)
+    sign_in admin
+
+    render template: "all_casa_admins/casa_orgs/new"
+  end
+
+  it "shows new CASA Organization page title" do
+    expect(rendered).to have_text("Create a new CASA Organization")
+  end
+
+  it "shows new CASA Organization form" do
+    expect(rendered).to have_selector("input", id: "casa_org_name")
+    expect(rendered).to have_selector("input", id: "casa_org_display_name")
+    expect(rendered).to have_selector("input", id: "casa_org_address")
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "requires name text field" do
+    expect(rendered).to have_selector("input[required=required]", id: "casa_org_name")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3716

### What changed, and why?
Name field of new CASA organization form is now required.

### How will this affect user permissions?
It won't.

### How is this tested? (please write tests!) 💖💪
New CASA Organization
`docker-compose exec web rspec spec/views/all_casa_admins/casa_orgs/new.html.erb_spec.rb`
or
`rspec spec/views/all_casa_admins/casa_orgs/new.html.erb_spec.rb`

### Screenshots please :)
![3](https://user-images.githubusercontent.com/30778707/179015534-b6450ec8-af8b-4a05-98f1-2ad21af953ed.png)
