### PR TITLE
#2638 Add office hours to unassign warning message

### DIFF
--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -9,12 +9,13 @@ jobs:
     name: Unassign issues
     steps:
       - name: Unassign issues
-        uses: rubyforgood/unassign-issues@v1
+        uses: rubyforgood/unassign-issues@v1.1
         id: unassign_issues
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           unassign_inactive_in_hours: 360 # 15 days
           warning_inactive_in_hours: 240 # 10 days
+          office_hours: 'Tuesdays 6-8 PM PST'
       - name: Print the unassigned issues
         run: echo "Unassigned issues = ${{steps.unassign_issues.outputs.unassigned_issues}}"
       - name: Print the warned issues


### PR DESCRIPTION
Resolves #2638 
This is the second of two pull requests necessary for this issue.
First PR: https://github.com/rubyforgood/unassign-issues/pull/2

### What changed, and why?
The issue unassign warning message now suggests coming to office hours for help.
The message is also now more friendly.

### How will this affect user permissions?
not affected

### How is this tested? (please write tests!) 💖💪
I created and ran a workflow using the new release.

### Screenshots please :)
![unassign-warning-message2](https://user-images.githubusercontent.com/26423484/179453630-30defc85-b99a-452c-9269-e691ab691c3a.png)
