### PR TITLE
Fix assignment status on Edit Volunteer page

### DIFF
--- a/app/views/volunteers/_manage_cases.erb
+++ b/app/views/volunteers/_manage_cases.erb
@@ -3,7 +3,7 @@
 
   <div class="card card-container">
     <div class="card-body">
-      <% if @volunteer.casa_cases.count > 0 %>
+      <% if @volunteer.case_assignments.any? %>
         <br>
         <h3>Assigned Cases</h3>
         <table class='table case-list'>
@@ -21,8 +21,10 @@
               <td><%= link_to assignment.casa_case.case_number, casa_case_path(assignment.casa_case) %></td>
               <td><%= assignment.casa_case.decorate.transition_aged_youth %></td>
               <td>
-                <% if @volunteer.active? && assignment.casa_case.active? %>
+                <% if @volunteer.active? && assignment.casa_case.active? && assignment.active? %>
                   Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
+                <% elsif @volunteer.active? && assignment.casa_case.active? && !assignment.active? %>
+                  Volunteer is <span class="badge badge-danger text-uppercase">Unassigned</span>
                 <% elsif @volunteer.active? %>
                   Case was deactivated
                   on: <%= I18n.l(assignment.casa_case.updated_at, format: :standard, default: nil) %>


### PR DESCRIPTION
### What GitHub issue is this PR for, if any?
Resolves #3665 

### What changed, and why?
- Changed the logic for showing case history even when the volunteer is not currently assigned to a case.
- Update the assignment status to Unassigned when the volunteer has been unassigned from a particular case.

### How will this affect user permissions?
It will not affect user permissions.

### How is this tested? (please write tests!) 💖💪
Added system tests, ran `bin/rails spec` and all tests passed.

Tested manually by:
1. Log in as admin and/or supervisor
2. Pick a volunteer with active case assignments and go to their edit volunteer page.
3. Unassign them from all cases.
4. Go back to their edit volunteer page and observe that assignment statuses are displayed correctly.

### Screenshots please :)
Cases can be listed as unassigned:
![casa pr 1](https://user-images.githubusercontent.com/88938117/179479118-23a439a1-c8d4-4ac9-9d51-1e7ff59be7b8.png)

Case history does not disappear when all cases are unassigned:
![casa pr 2](https://user-images.githubusercontent.com/88938117/179479197-6bcb9926-29fa-4d96-b089-9da3c8e61381.png)

Of note, the Assigned Cases subsection does not appear if a volunteer has never been assigned to a case:
![casa pr 3](https://user-images.githubusercontent.com/88938117/179480395-bd5ed840-44a6-4e2e-852c-6bd6ef78acb9.png)
