### PR TITLE
[#3708] remove unused fields for editing case

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -150,8 +150,6 @@ class CasaCasesController < ApplicationController
       :case_number,
       :birth_month_year_youth,
       :court_report_due_date,
-      :hearing_type_id,
-      :judge_id,
       court_dates_attributes: [:date]
     )
   end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -2,7 +2,7 @@ class CasaCase < ApplicationRecord
   include ByOrganizationScope
   include DateHelper
 
-  self.ignored_columns = %w[court_date]
+  self.ignored_columns = %w[court_date hearing_type_id judge_id]
 
   attr_accessor :validate_contact_type
 

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -52,34 +52,6 @@
         </div>
       <% end %>
 
-      <% if policy(casa_case).update_hearing_type? %>
-        <div class="field form-group">
-          <%= form.label :hearing_type_id, "Hearing type" %>
-          <%= form.collection_select(
-                  :hearing_type_id,
-                  HearingType.active.for_organization(current_organization),
-                  :id, :name,
-                  {include_hidden: false, include_blank: "-Select Hearing Type-"},
-                  {class: "form-control"}
-              ) %>
-        </div>
-      <% end %>
-
-      <% if Judge.for_organization(current_organization).any? %>
-        <% if policy(casa_case).update_judge? %>
-          <div class="field form-group">
-            <%= form.label :judge_id, "Judge" %>
-            <%= form.collection_select(
-                    :judge_id,
-                    Judge.for_organization(current_organization),
-                    :id, :name,
-                    {include_hidden: false, include_blank: "-Select Judge-"},
-                    {class: "form-control"}
-                ) %>
-          </div>
-        <% end %>
-      <% end %>
-
       <% if policy(casa_case).update_court_date? && casa_case.new_record? %>
         <%= form.fields_for :court_dates, casa_case.court_dates.new do |cdf| %>
           <div class="field form-group">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -18,14 +18,10 @@ en:
           confirm_swal: Deactivating a CASA Case will unassign any volunteers currently assigned to this case.
           fail: No, go back
           success: Yes, deactivate
-        select_hearing_type: -Select Hearing Type-
-        select_judge: -Select Judge-
       youth_birth_month_year: "Youth's Birth Month & Year"
       youth_date_in_care: "Youth's Date in Care"
       case_number: Case number
       court_details: Court Details
-      hearing_type: Hearing type
-      judge: Judge
       transition_aged_youth: Transition Aged Youth
       court_report_status: Court Report Status
     index:
@@ -72,8 +68,6 @@ en:
         court_report_due_date: Court Report Due Date
         court_report_status: Court Report Status
         court_report_submitted_date: Court Report Submitted Date
-        hearing_type: Hearing Type
-        judge: Judge
         next_court_date: Next Court Date
         transition_aged_youth: Transition Aged Youth
         youth_date_in_care: "Youth's Date in Care"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -451,6 +451,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_022147) do
     t.datetime "reminder_sent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "case_contact_types", precision: nil
     t.index ["user_id"], name: "index_user_reminder_times_on_user_id"
   end
 

--- a/spec/factories/casa_cases.rb
+++ b/spec/factories/casa_cases.rb
@@ -7,14 +7,6 @@ FactoryBot.define do
     court_report_status { :not_submitted }
     case_court_orders { [] }
 
-    trait :with_hearing_type do
-      hearing_type
-    end
-
-    trait :with_judge do
-      judge
-    end
-
     trait :with_one_case_assignment do
       after(:create) do |casa_case, _|
         casa_org = casa_case.casa_org

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to have_many(:emancipation_categories).through(:casa_case_emancipation_categories) }
   it { is_expected.to have_many(:casa_cases_emancipation_options).dependent(:destroy) }
   it { is_expected.to have_many(:emancipation_options).through(:casa_cases_emancipation_options) }
-  it { is_expected.to belong_to(:hearing_type).optional }
-  it { is_expected.to belong_to(:judge).optional }
   it { is_expected.to validate_presence_of(:case_number) }
   it { is_expected.to validate_presence_of(:birth_month_year_youth) }
   it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id).case_insensitive }

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -2,15 +2,11 @@ require "rails_helper"
 
 RSpec.describe "/casa_cases", type: :request do
   let(:organization) { build(:casa_org) }
-  let(:hearing_type) { create(:hearing_type) }
-  let(:judge) { create(:judge) }
   let(:valid_attributes) do
     {
       case_number: "1234",
       birth_month_year_youth: pre_transition_aged_youth_age,
-      casa_org_id: organization.id,
-      hearing_type_id: hearing_type.id,
-      judge_id: judge.id
+      casa_org_id: organization.id
     }
   end
   let(:invalid_attributes) { {case_number: nil, birth_month_year_youth: nil} }
@@ -156,8 +152,6 @@ RSpec.describe "/casa_cases", type: :request do
           casa_case = CasaCase.last
           expect(casa_case.casa_org).to eq organization
           expect(casa_case.transition_aged_youth).to be true
-          expect(casa_case.hearing_type).to eq hearing_type
-          expect(casa_case.judge).to eq judge
         end
 
         it "also responds as json", :aggregate_failures do
@@ -175,9 +169,7 @@ RSpec.describe "/casa_cases", type: :request do
           case_number: "1234",
           transition_aged_youth: true,
           birth_month_year_youth: pre_transition_aged_youth_age,
-          casa_org_id: other_org.id,
-          hearing_type_id: hearing_type.id,
-          judge_id: judge.id
+          casa_org_id: other_org.id
         }
 
         expect { post casa_cases_url, params: {casa_case: attributes} }.to(
@@ -241,16 +233,12 @@ RSpec.describe "/casa_cases", type: :request do
       let(:new_attributes) do
         {
           case_number: "12345",
-          hearing_type_id: hearing_type.id,
-          judge_id: judge.id,
           case_court_orders_attributes: orders_attributes
         }
       end
       let(:new_attributes2) do
         {
           case_number: "12345",
-          hearing_type_id: hearing_type.id,
-          judge_id: judge.id,
           case_court_orders_attributes: orders_attributes,
           casa_case_contact_types_attributes: [{contact_type_id: type1.id}]
         }
@@ -261,8 +249,6 @@ RSpec.describe "/casa_cases", type: :request do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes2}
           casa_case.reload
           expect(casa_case.case_number).to eq "12345"
-          expect(casa_case.hearing_type).to eq hearing_type
-          expect(casa_case.judge).to eq judge
           expect(casa_case.case_court_orders[0].text).to eq texts[0]
           expect(casa_case.case_court_orders[0].implementation_status).to eq implementation_statuses[0]
           expect(casa_case.case_court_orders[1].text).to eq texts[1]
@@ -277,7 +263,7 @@ RSpec.describe "/casa_cases", type: :request do
 
         it "displays changed attributes" do
           patch casa_case_url(casa_case), params: {casa_case: new_attributes2}
-          expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>Changed Hearing type</li><li>Changed Judge</li><li>[\"#{type1.name}\"] Contact types added</li><li>2 Court orders added or updated</li></ul>")
+          expect(flash[:notice]).to eq("CASA case was successfully updated.<ul><li>Changed Case number</li><li>[\"#{type1.name}\"] Contact types added</li><li>2 Court orders added or updated</li></ul>")
         end
 
         it "also responds as json", :aggregate_failures do
@@ -502,8 +488,6 @@ RSpec.describe "/casa_cases", type: :request do
         {
           case_number: "12345",
           court_report_status: :submitted,
-          hearing_type_id: hearing_type.id,
-          judge_id: judge.id,
           case_court_orders_attributes: orders_attributes
         }
       }
@@ -517,8 +501,6 @@ RSpec.describe "/casa_cases", type: :request do
 
           # Not permitted
           expect(casa_case.case_number).to eq "111"
-          expect(casa_case.hearing_type).to eq hearing_type
-          expect(casa_case.judge).to eq judge
           expect(casa_case.case_court_orders.size).to be 2
         end
 

--- a/spec/services/casa_case_change_service_spec.rb
+++ b/spec/services/casa_case_change_service_spec.rb
@@ -13,15 +13,13 @@ RSpec.describe CasaCaseChangeService do
 
   context "with different original and changed" do
     let(:original) { create(:casa_case).full_attributes_hash }
-    let(:changed) { create(:casa_case, :with_hearing_type, :with_judge, :with_case_assignments, :with_one_court_order, :active, :with_case_contacts).full_attributes_hash }
+    let(:changed) { create(:casa_case, :with_case_assignments, :with_one_court_order, :active, :with_case_contacts).full_attributes_hash }
     it "shows useful diff" do
       expect(subject).to match_array([
         "Changed Id",
         "Changed Case number",
         "Changed Created at",
         "Changed Birth month year youth",
-        "Changed Hearing type",
-        "Changed Judge",
         "Changed Slug",
         "1 Court order added or updated"
       ])

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Edit CASA Case", type: :system do
   context "logged in as admin" do
     let(:organization) { build(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
-    let(:casa_case) { create(:casa_case, :with_judge, :with_one_court_order, casa_org: organization) }
+    let(:casa_case) { create(:casa_case, :with_one_court_order, casa_org: organization) }
     let(:contact_type_group) { create(:contact_type_group, casa_org: organization) }
     let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
 
@@ -25,8 +25,6 @@ RSpec.describe "Edit CASA Case", type: :system do
     it "edits case", js: true do
       visit casa_case_path(casa_case.id)
       click_on "Edit Case Details"
-      expect(page).to have_select("Hearing type")
-      expect(page).to have_select("Judge")
       select "Submitted", from: "casa_case_court_report_status"
       check contact_type.name
 
@@ -87,7 +85,7 @@ RSpec.describe "Edit CASA Case", type: :system do
   context "logged in as supervisor" do
     let(:casa_org) { build(:casa_org) }
     let(:supervisor) { create(:supervisor, casa_org: casa_org) }
-    let(:casa_case) { create(:casa_case, :with_judge, :with_hearing_type, :with_one_court_order, casa_org: casa_org) }
+    let(:casa_case) { create(:casa_case, :with_one_court_order, casa_org: casa_org) }
     let!(:contact_type_group) { build(:contact_type_group, casa_org: casa_org) }
     let!(:contact_type_1) { create(:contact_type, name: "Youth", contact_type_group: contact_type_group) }
     let!(:contact_type_2) { build(:contact_type, name: "Supervisor", contact_type_group: contact_type_group) }
@@ -134,6 +132,7 @@ RSpec.describe "Edit CASA Case", type: :system do
     end
 
     context "with an available judge" do
+      before { skip }
       let!(:judge) { create(:judge, casa_org: casa_org) }
 
       it "is able to assign a judge to the case when there is no assigned judge", js: true do
@@ -207,6 +206,7 @@ RSpec.describe "Edit CASA Case", type: :system do
 
     context "When a Casa instance has no judge names added" do
       it "does not display judge names details" do
+        skip
         casa_case = create(:casa_case, casa_org: casa_org, judge: nil)
 
         visit edit_casa_case_path(casa_case)
@@ -217,6 +217,7 @@ RSpec.describe "Edit CASA Case", type: :system do
 
     context "When an admin has added judge names to a Casa instance" do
       it "displays judge details as select option" do
+        skip
         create :judge, casa_org: casa_org
 
         visit edit_casa_case_path(casa_case)
@@ -365,6 +366,7 @@ of it unless it was included in a previous court report.")
     end
 
     context "with an available hearing type", js: true do
+      before { skip }
       let!(:hearing_type) { create(:hearing_type, casa_org: casa_org) }
 
       it "is able to assign a hearing type when there is none assigned" do

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -131,55 +131,6 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text("8-SEP-#{next_year}")
     end
 
-    context "with an available judge" do
-      before { skip }
-      let!(:judge) { create(:judge, casa_org: casa_org) }
-
-      it "is able to assign a judge to the case when there is no assigned judge", js: true do
-        casa_case.update(judge: nil)
-
-        visit edit_casa_case_path(casa_case)
-
-        expect(page).to have_select("Judge", selected: "-Select Judge-")
-        select judge.name, from: "casa_case_judge_id"
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Judge", selected: judge.name)
-        expect(casa_case.reload.judge).to eq judge
-      end
-
-      it "is able to assign another judge to the case", js: true do
-        visit edit_casa_case_path(casa_case)
-
-        expect(page).to have_select("Judge", selected: casa_case.judge.name)
-        select judge.name, from: "casa_case_judge_id"
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Judge", selected: judge.name)
-        expect(casa_case.reload.judge).to eq judge
-      end
-
-      it "is able to unassign a judge from the case", js: true do
-        visit edit_casa_case_path(casa_case)
-
-        expect(page).to have_select("Judge", selected: casa_case.judge.name)
-        select "-Select Judge-", from: "casa_case_judge_id"
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Judge", selected: "-Select Judge-")
-        expect(casa_case.reload.judge).to be_nil
-      end
-    end
-
     it "views deactivated case" do
       casa_case.deactivate
       visit edit_casa_case_path(casa_case)
@@ -202,28 +153,6 @@ RSpec.describe "Edit CASA Case", type: :system do
 
       expect(page).to have_text(court_order.text)
       expect(page).to have_text(court_order.implementation_status.humanize)
-    end
-
-    context "When a Casa instance has no judge names added" do
-      it "does not display judge names details" do
-        skip
-        casa_case = create(:casa_case, casa_org: casa_org, judge: nil)
-
-        visit edit_casa_case_path(casa_case)
-
-        expect(page).not_to have_select("Judge")
-      end
-    end
-
-    context "When an admin has added judge names to a Casa instance" do
-      it "displays judge details as select option" do
-        skip
-        create :judge, casa_org: casa_org
-
-        visit edit_casa_case_path(casa_case)
-
-        expect(page).to have_select("Judge")
-      end
     end
 
     describe "assign and unassign a volunteer to a case" do
@@ -362,61 +291,6 @@ of it unless it was included in a previous court report.")
           click_on "Update CASA Case"
         end
         expect(page).to_not have_text(text)
-      end
-    end
-
-    context "with an available hearing type", js: true do
-      before { skip }
-      let!(:hearing_type) { create(:hearing_type, casa_org: casa_org) }
-
-      it "is able to assign a hearing type when there is none assigned" do
-        casa_case.update(hearing_type: nil)
-
-        visit edit_casa_case_path(casa_case.id)
-
-        expect(page).to have_select("Hearing type",
-          selected: I18n.t("casa_cases.form.prompt.select_hearing_type"))
-        select hearing_type.name, from: "casa_case_hearing_type_id"
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Hearing type", selected: hearing_type.name)
-        expect(casa_case.reload.hearing_type).to eq hearing_type
-      end
-
-      it "is able to assign another hearing type to the case" do
-        visit edit_casa_case_path(casa_case.id)
-
-        expect(page).to have_select("Hearing type", selected: casa_case.hearing_type.name)
-        select hearing_type.name, from: "casa_case_hearing_type_id"
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Hearing type", selected: hearing_type.name)
-        expect(casa_case.reload.hearing_type).to eq hearing_type
-      end
-
-      it "is able to unassign a hearing type from the case" do
-        expect(casa_case.hearing_type).not_to be_nil
-
-        visit edit_casa_case_path(casa_case.id)
-
-        expect(page).to have_select("Hearing type",
-          selected: casa_case.hearing_type.name)
-        select(I18n.t("casa_cases.form.prompt.select_hearing_type"),
-          from: "casa_case_hearing_type_id")
-
-        within ".actions" do
-          click_on "Update CASA Case"
-        end
-
-        expect(page).to have_select("Hearing type",
-          selected: I18n.t("casa_cases.form.prompt.select_hearing_type"))
-        expect(casa_case.reload.hearing_type).to be_nil
       end
     end
 

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "view all volunteers", type: :system do
     context "when no logo_url" do
       it "can see volunteers and navigate to their cases", js: true do
         volunteer = create(:volunteer, :with_assigned_supervisor, display_name: "User 1", email: "casa@example.com", casa_org: organization)
-        volunteer.casa_cases << create(:casa_case, :with_judge, :with_hearing_type, casa_org: organization, birth_month_year_youth: 14.years.ago)
-        volunteer.casa_cases << create(:casa_case, :with_judge, :with_hearing_type, casa_org: organization, birth_month_year_youth: 14.years.ago)
+        volunteer.casa_cases << create(:casa_case, casa_org: organization, birth_month_year_youth: 14.years.ago)
+        volunteer.casa_cases << create(:casa_case, casa_org: organization, birth_month_year_youth: 14.years.ago)
         casa_case = volunteer.casa_cases[0]
 
         sign_in admin
@@ -25,8 +25,6 @@ RSpec.describe "view all volunteers", type: :system do
 
         expect(page).to have_text("CASA Case Details")
         expect(page).to have_text("Case number: #{casa_case.case_number}")
-        expect(page).to have_text("Hearing Type:")
-        expect(page).to have_text("Judge:")
         expect(page).to have_text("Transition Aged Youth: Yes")
         expect(page).to have_text("Next Court Date:")
         expect(page).to have_text("Court Report Due Date:")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3708

### What changed, and why?

- Removed Judge and Hearing association fields on the Edit Case UI because this is not set until day of court
- Also, there was a field that was causing test to fail on `user_reminder_times` so added and regenerated `schema.rb`.

### How will this affect user permissions?
- Volunteer permissions: N / A
- Supervisor permissions: N/A
- Admin permissions: N / A

### How is this tested? (please write tests!) 💖💪
Due to the removal of the two fields, traits and specific tests related to judge and hearing in casa cases were removed. I am happy to add back in and either `before { skip }` or `skip`, but I didn't want to keep dead code cause ya know.

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![I just kept crawling through the first PR](https://media3.giphy.com/media/RmfzOLuCJTApa/giphy.gif?cid=790b76117337e5c5faad7461ee4b4cfa7f3f0d0065a03d17&rid=giphy.gif&ct=g)