### PR TITLE
Case contacts save if additional expenses are blank - updated case contact controller

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -152,10 +152,10 @@ class CaseContactsController < ApplicationController
       if FeatureFlagService.is_enabled?(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG)
         new_cc = casa_case.case_contacts.new(create_case_contact_params)
         update_or_create_additional_expense(additional_expense_params, new_cc)
-        if @case_contact.valid?
+        if new_cc.valid?
           new_cc.save!
         else
-          @case_contact.errors
+          new_cc.errors
         end
       else
         new_cc = casa_case.case_contacts.create(create_case_contact_params.except(:casa_case_attributes))


### PR DESCRIPTION
…at case contact form will submit when additonal expenses input is left blank

### What github issue is this PR for, if any?
Resolves #3783 

### What changed, and why?
I dug around in pry a bit and realized something was glitching in a conditional statement of the create_case_contact_for_every_selected_casa_case method. It looks the the instance variable was not defined or accessible so I updated it to the local variable defined in the method and the form began to save regardless of if an additional expense was added. 

### How is this tested? (please write tests!) 💖💪
I tested this manually. All other tests that were previously in the case_contact_controller spec still pass though. 

<img width="584" alt="Screen Shot 2022-07-27 at 7 24 26 PM" src="https://user-images.githubusercontent.com/70597815/181389254-d9914e08-9062-4682-8909-f8b5c0cee505.png">

