### PR TITLE
Address flaky system specs by disabling Rack::Attack in the test environment

### DIFF
--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Rack::Attack do
   let(:cache) { Rails.cache }
 
   before do
+    Rack::Attack.enabled = true
     ActionController::Base.perform_caching = true
     allow(Rails).to receive(:cache).and_return(memory_store)
     Rails.cache.clear

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    Rack::Attack.enabled = false
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

### What changed, and why?

This commit disables Rack::Attack in the test environment except for a single spec that needs it.

The problem we noticed was that system specs occasionally fail in the CI and the resulting screenshot at the failure is a blank page that just says "Retry later". This seems similar to an issue posted at https://github.com/thoughtbot/capybara-webkit/issues/628 and the fix for that issue was to disable Rack::Attack in the test environment.

It's difficult to be certain that this will fix the specs since we aren't able to reproduce locally but this seems like a reasonable thing to try.

See more conversation in the Ruby for Good Slack https://rubyforgood.slack.com/archives/C04PM108S/p1658887094904429

### How will this affect user permissions?
- Volunteer permissions: No changes
- Supervisor permissions: No changes
- Admin permissions: No changes

### How is this tested? (please write tests!) 💖💪

No new tests since its a change to existing test

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9