### PR TITLE
replace class with method in class << self to modules

### DIFF
--- a/app/services/court_report_due_sms_reminder_service.rb
+++ b/app/services/court_report_due_sms_reminder_service.rb
@@ -1,13 +1,13 @@
-class CourtReportDueSmsReminderService < SmsReminderService
+module CourtReportDueSmsReminderService
+  extend self
+  include SmsReminderService
+  include SmsBodyHelper
+
   GENERATE_CASE_COURT_REPORT_LINK = "/case_court_reports"
 
-  class << self
-    include SmsBodyHelper
-
-    def court_report_reminder(user, report_due_date)
-      short_link = create_short_link(GENERATE_CASE_COURT_REPORT_LINK)
-      message = court_report_due_msg(report_due_date, short_link)
-      send_reminder(user, message)
-    end
+  def court_report_reminder(user, report_due_date)
+    short_link = create_short_link(GENERATE_CASE_COURT_REPORT_LINK)
+    message = court_report_due_msg(report_due_date, short_link)
+    send_reminder(user, message)
   end
 end

--- a/app/services/no_contact_made_sms_reminder_service.rb
+++ b/app/services/no_contact_made_sms_reminder_service.rb
@@ -1,13 +1,13 @@
-class NoContactMadeSmsReminderService < SmsReminderService
+module NoContactMadeSmsReminderService
+  extend self
+  include SmsReminderService
+  include SmsBodyHelper
+
   NEW_CASE_CONTACT_LINK = "/case_contacts/new"
 
-  class << self
-    include SmsBodyHelper
-
-    def no_contact_made_reminder(user, contact_type)
-      short_link = create_short_link(NEW_CASE_CONTACT_LINK)
-      message = no_contact_made_msg(contact_type, short_link)
-      send_reminder(user, message)
-    end
+  def no_contact_made_reminder(user, contact_type)
+    short_link = create_short_link(NEW_CASE_CONTACT_LINK)
+    message = no_contact_made_msg(contact_type, short_link)
+    send_reminder(user, message)
   end
 end

--- a/app/services/sms_reminder_service.rb
+++ b/app/services/sms_reminder_service.rb
@@ -1,28 +1,27 @@
-class SmsReminderService
+module SmsReminderService
+  extend self
+
   BASE_URL = Rails.application.credentials[:BASE_URL]
+  def send_reminder(user, message)
+    return if !user[:receive_sms_notifications] || user[:phone_number].blank?
 
-  class << self
-    def send_reminder(user, message)
-      return if !user[:receive_sms_notifications] || user[:phone_number].blank?
+    user_casa_org = user.casa_org
+    twilio_service = TwilioService.new(user_casa_org.twilio_api_key_sid, user_casa_org.twilio_api_key_secret, user_casa_org.twilio_account_sid)
+    sms_params = {
+      From: user_casa_org.twilio_phone_number,
+      Body: message,
+      To: user.phone_number
+    }
+    twilio_service.send_sms(sms_params)
+  end
 
-      user_casa_org = user.casa_org
-      twilio_service = TwilioService.new(user_casa_org.twilio_api_key_sid, user_casa_org.twilio_api_key_secret, user_casa_org.twilio_account_sid)
-      sms_params = {
-        From: user_casa_org.twilio_phone_number,
-        Body: message,
-        To: user.phone_number
-      }
-      twilio_service.send_sms(sms_params)
+  def create_short_link(path)
+    if BASE_URL.blank?
+      raise "BASE_URL environment variable not defined"
     end
 
-    def create_short_link(path)
-      if BASE_URL.blank?
-        raise "BASE_URL environment variable not defined"
-      end
-
-      short_url_service = ShortUrlService.new
-      short_url_service.create_short_url(BASE_URL + path)
-      short_url_service.short_url
-    end
+    short_url_service = ShortUrlService.new
+    short_url_service.create_short_url(BASE_URL + path)
+    short_url_service.short_url
   end
 end


### PR DESCRIPTION
### What changed, and why?
Replace class with only class methods with module ``` extend self ```

"Reason is that Class is too heavy for creating only class methods. As we discussed earlier a class is supposed to have both data and behavior. If the only thing you care about is behavior then ruby suggests to implement it as a module."

more details: [https://www.bigbinary.com/blog/extend-self-in-ruby](https://www.bigbinary.com/blog/extend-self-in-ruby)