### PR TITLE
[#3822] Fix ambiguous CaseContact column reference

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -102,7 +102,7 @@ class CaseContact < ApplicationRecord
     when /^occurred_at/
       order(occurred_at: direction)
     when /^contact_type/
-      joins(:contact_types).order(name: direction)
+      joins(:contact_types).merge(ContactType.order(name: direction))
     when /^medium_type/
       order(medium_type: direction)
     when /^want_driving_reimbursement/


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3822

### What changed, and why?
Previously, when sorting `CaseContact`s by their `ContactType`, the `order(:name)` query created an ambiguous reference. This change ensures the `order` specifically targets the `contact_types` table, removing ambiguity and making sure we can filter when we'd like.

### How will this affect user permissions?
- Volunteer permissions: *N/A*
- Supervisor permissions: *N/A*
- Admin permissions: *N/A*

### How is this tested? (please write tests!) 💖💪
Controller tests are extended to verify the failing filter requests are now fixed.

### Screenshots please :)
_Not much to show here, but this is verification that the example failing URL from #3822 is now loading as expected! 🙌_
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/4934682/184064741-c539710e-ff22-42d5-a6bc-974ce0b8cdb1.png">

### Feelings gif (optional)
![Person in bright colors exclaiming "Boy, how the tables have turned"](https://media.giphy.com/media/erMxGf7f3SeTKghkjX/giphy.gif)