### PR TITLE
Allow supervisors to "delete" notes like admins currently can

### DIFF
--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -11,7 +11,7 @@ class CaseContactPolicy < ApplicationPolicy
   alias_method :new?, :admin_or_supervisor_or_volunteer?
   alias_method :show?, :is_creator_or_casa_admin?
   alias_method :create?, :is_creator_or_casa_admin?
-  alias_method :destroy?, :is_admin?
+  alias_method :destroy?, :admin_or_supervisor?
   alias_method :update?, :is_creator_or_supervisor_or_casa_admin?
   alias_method :edit?, :is_creator_or_supervisor_or_casa_admin?
   alias_method :restore?, :is_admin?

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -47,7 +47,7 @@
         <div class="">
         <div class="">
           <%= link_to("Delete", case_contact_path(contact.id), method: :delete,
-                class: "btn btn-danger") if policy(current_user).destroy? && !contact.deleted? %>
+                class: "btn btn-danger") if policy(contact).destroy? && !contact.deleted? %>
         </div>
       </div>
       </div>

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -89,12 +89,12 @@ RSpec.describe "case_contacts/case_contact", type: :view do
         allow(view).to receive(:current_user).and_return(supervisor)
       end
 
-      it "should not show delete button" do
+      it "shows delete button" do
         assign :case_contact, case_contact
         assign :casa_cases, [case_contact.casa_case]
 
         render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-        expect(rendered).not_to have_link("Delete", href: "/case_contacts/#{case_contact.id}")
+        expect(rendered).to have_link("Delete", href: "/case_contacts/#{case_contact.id}")
       end
 
       it "should not show undelete button" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3835

### What changed, and why?
Supervisors can delete case contacts now like admins can.

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: can delete case contacts.
- Admin permissions: not affected

### How is this tested? (please write tests!) 💖💪
Test adapted in [spec/views/case_contacts/case_contact.html.erb_spec.rb](https://github.com/rubyforgood/casa/compare/main...Salanoid:casa:main#diff-344a87062e8641584b0fde53c8a95016dd483a2150075aa7c4466e2e750dc6a7)

### Screenshots please :)
The same screenshot used in issue #3835:
![](https://user-images.githubusercontent.com/578159/184420599-38f15b4e-30dd-468d-9e63-79f4cb974a29.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9