### PR TITLE
configure unassign bot

### DIFF
--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -9,7 +9,7 @@ jobs:
     name: Unassign issues
     steps:
       - name: Unassign issues
-        uses: rubyforgood/unassign-issues@v1.1
+        uses: rubyforgood/unassign-issues@1.2
         id: unassign_issues
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -16,6 +16,7 @@ jobs:
           unassign_inactive_in_hours: 360 # 15 days
           warning_inactive_in_hours: 240 # 10 days
           office_hours: 'Tuesdays 6-8 PM PST'
+          warning_inactive_message: 'If you are still working on this, comment here to tell the bot to give you more time'
       - name: Print the unassigned issues
         run: echo "Unassigned issues = ${{steps.unassign_issues.outputs.unassigned_issues}}"
       - name: Print the warned issues

--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -2,6 +2,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'
+  workflow_dispatch: # Enable manual runs of the bot
 
 jobs:
   unassign_issues:


### PR DESCRIPTION
Override warning_inactive_message from https://github.com/rubyforgood/unassign-issues to make the bot instructions more clear for contributors