### PR TITLE
Fix: other_duties visibility

### DIFF
--- a/app/controllers/other_duties_controller.rb
+++ b/app/controllers/other_duties_controller.rb
@@ -21,7 +21,7 @@ class OtherDutiesController < ApplicationController
 
   def index
     @volunteer_duties = if current_user.casa_admin?
-      generate_other_duty_list(Volunteer.where(casa_org_id: current_user.casa_org_id))
+      generate_other_duty_list(policy_scope(Volunteer))
     elsif current_user.supervisor?
       generate_other_duty_list(current_user.volunteers)
     else

--- a/app/controllers/other_duties_controller.rb
+++ b/app/controllers/other_duties_controller.rb
@@ -21,7 +21,7 @@ class OtherDutiesController < ApplicationController
 
   def index
     @volunteer_duties = if current_user.casa_admin?
-      generate_other_duty_list(Volunteer.all)
+      generate_other_duty_list(Volunteer.where(casa_org_id: current_user.casa_org_id))
     elsif current_user.supervisor?
       generate_other_duty_list(current_user.volunteers)
     else

--- a/app/policies/other_duty_policy.rb
+++ b/app/policies/other_duty_policy.rb
@@ -1,7 +1,7 @@
 class OtherDutyPolicy < UserPolicy
   class Scope
     attr_reader :user, :scope
-    
+
     def initialize(user, scope)
       @user = user
       @scope = scope

--- a/app/policies/other_duty_policy.rb
+++ b/app/policies/other_duty_policy.rb
@@ -1,4 +1,17 @@
 class OtherDutyPolicy < UserPolicy
+  class Scope
+    attr_reader :user, :scope
+    
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.where(casa_org_id: user.casa_org_id)
+    end
+  end
+
   def index?
     admin_or_supervisor?
   end

--- a/spec/policies/other_duty_case_policy/scope_spec.rb
+++ b/spec/policies/other_duty_case_policy/scope_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe OtherDutyPolicy::Scope do
+  describe "#resolve" do
+    let(:volunteer) { create(:volunteer) }
+    let!(:other_duty) { create(:other_duty, creator: volunteer) }
+    let(:org_admin) { create(:casa_admin, casa_org_id: volunteer.casa_org_id) }
+
+    it "returns volunteers in the same org as the admin" do
+      scope = described_class.new(org_admin, Volunteer)
+
+      expect(scope.resolve).to eq(Volunteer.where(casa_org_id: org_admin.casa_org_id))
+    end
+  end
+end

--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "/other_duties", type: :request do
         let(:another_volunteer) { create(:volunteer, casa_org_id: casa_org.id) }
         let!(:other_duty) { create(:other_duty, creator: volunteer) }
         let(:org_admin) { create(:casa_admin, casa_org_id: another_volunteer.casa_org_id) }
-        
+
         before { sign_in org_admin }
         it "other's duties" do
           get other_duties_path

--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe "/other_duties", type: :request do
     end
   end
 
-  context 'logged as admin' do
-    describe 'GET /INDEX' do
-      context 'when admin is on the same org as volunteer' do
+  context "logged as admin" do
+    describe "GET /INDEX" do
+      context "when admin is on the same org as volunteer" do
         let(:volunteer) { create(:volunteer) }
         let!(:other_duty) { create(:other_duty, creator: volunteer) }
         let(:org_admin) { create(:casa_admin, casa_org_id: volunteer.casa_org_id) }
-        
+
         before { sign_in org_admin }
         it "other's duties" do
           get other_duties_path
@@ -92,7 +92,7 @@ RSpec.describe "/other_duties", type: :request do
         end
       end
 
-      context 'when admin is on a different org than the volunteer' do
+      context "when admin is on a different org than the volunteer" do
         let(:volunteer) { create(:volunteer) }
         let(:casa_org) { create(:casa_org) }
         let(:another_volunteer) { create(:volunteer, casa_org_id: casa_org.id) }

--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -76,4 +76,36 @@ RSpec.describe "/other_duties", type: :request do
       end
     end
   end
+
+  context 'logged as admin' do
+    describe 'GET /INDEX' do
+      context 'when admin is on the same org as volunteer' do
+        let(:volunteer) { create(:volunteer) }
+        let!(:other_duty) { create(:other_duty, creator: volunteer) }
+        let(:org_admin) { create(:casa_admin, casa_org_id: volunteer.casa_org_id) }
+        
+        before { sign_in org_admin }
+        it "other's duties" do
+          get other_duties_path
+          expect(response.body).to include(volunteer.display_name)
+          expect(response.body).to include(other_duty.decorate.truncate_notes)
+        end
+      end
+
+      context 'when admin is on a different org than the volunteer' do
+        let(:volunteer) { create(:volunteer) }
+        let(:casa_org) { create(:casa_org) }
+        let(:another_volunteer) { create(:volunteer, casa_org_id: casa_org.id) }
+        let!(:other_duty) { create(:other_duty, creator: volunteer) }
+        let(:org_admin) { create(:casa_admin, casa_org_id: another_volunteer.casa_org_id) }
+        
+        before { sign_in org_admin }
+        it "other's duties" do
+          get other_duties_path
+          expect(response.body).not_to include(volunteer.display_name)
+          expect(response.body).not_to include(other_duty.decorate.truncate_notes)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3845

### What changed, and why?

Change query for volunteers to get only duties associated with admin.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: Prevent Admins from seeing other duties across orgs

### How is this tested? (please write tests!) 💖💪

Tests were written with tww different contexts. One when admin is on the same org as volunteer and the other is when admin is on a different org than the volunteer.

### Screenshots please :)
When admin is on the same org as volunteer
![image](https://user-images.githubusercontent.com/92229784/185240070-087a6a9c-3a53-4800-9d36-27f43b53799f.png)

When admin is on a different org than the volunteer
![image](https://user-images.githubusercontent.com/92229784/185240269-416d18b7-382a-4491-ac32-26f25ff52e51.png)