### PR TITLE
3836 volunteers can view and edit their address

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   after_action :reset_custom_error_heading, only: [:update_password]
 
   def edit
+    set_initial_address
   end
 
   def update
@@ -38,6 +39,10 @@ class UsersController < ApplicationController
 
   private
 
+  def set_initial_address
+    Address.create(user_id: current_user.id, content: "") if !current_user.address
+  end
+
   def set_active_casa_admins
     @active_casa_admins = CasaAdmin.in_organization(current_organization).active
   end
@@ -60,9 +65,9 @@ class UsersController < ApplicationController
 
   def user_params
     if current_user.casa_admin?
-      params.require(:user).permit(:email, :display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [])
+      params.require(:user).permit(:email, :display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
     else
-      params.require(:user).permit(:display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [])
+      params.require(:user).permit(:display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   has_many :user_sms_notification_events
   has_many :sms_notification_events, through: :user_sms_notification_events
   has_many :notes, as: :notable
-  has_one :address
+  has_one :address, :dependent => :destroy
 
   accepts_nested_attributes_for :user_sms_notification_events, :address, allow_destroy: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   has_many :user_sms_notification_events
   has_many :sms_notification_events, through: :user_sms_notification_events
   has_many :notes, as: :notable
-  has_one :address, :dependent => :destroy
+  has_one :address, dependent: :destroy
 
   accepts_nested_attributes_for :user_sms_notification_events, :address, allow_destroy: true
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -18,6 +18,19 @@
         <%= form.text_field :phone_number, class: "form-control" %>
       </div>
 
+      <% if current_user.address %>
+        <% address = current_user.address %>
+      <% else %>
+        <% address = Address.new %>
+      <% end %>
+
+      <div class="field form-group">
+        <%= form.fields_for :address, address do |f| %>
+          <%= f.label :address, "Address" %>
+          <%= f.text_field :content, class: "form-control" %>
+        <% end %>
+      </div>
+
       <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
 
       <%= render "/shared/invite_login", resource: current_user %>

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    content { "" }
+  end
+end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,6 +1,0 @@
-FactoryBot.define do
-  factory :address do
-    content { "" }
-    association :user
-  end
-end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :address do
     content { "" }
+    association :user
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "/users", type: :request do
-
   before {
     sms_notification_event = SmsNotificationEvent.new(name: "test", user_type: Volunteer)
     sms_notification_event.save

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "/users", type: :request do
-  let(:address) { create(:address) }
 
   before {
     sms_notification_event = SmsNotificationEvent.new(name: "test", user_type: Volunteer)

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "/users", type: :request do
+  let(:address) { create(:address) }
+
   before {
     sms_notification_event = SmsNotificationEvent.new(name: "test", user_type: Volunteer)
     sms_notification_event.save
@@ -33,8 +35,9 @@ RSpec.describe "/users", type: :request do
       volunteer = build(:volunteer)
       sign_in volunteer
 
-      patch users_path, params: {user: {display_name: "New Name", phone_number: "+12223334444", sms_notification_event_ids: [SmsNotificationEvent.first.id]}}
+      patch users_path, params: {user: {display_name: "New Name", address_attributes: {content: "some address"}, phone_number: "+12223334444", sms_notification_event_ids: [SmsNotificationEvent.first.id]}}
 
+      expect(volunteer.address.content).to eq "some address"
       expect(volunteer.display_name).to eq "New Name"
       expect(volunteer.phone_number).to eq "+12223334444"
       expect(volunteer.sms_notification_event_ids).to include SmsNotificationEvent.first.id


### PR DESCRIPTION
Resolves #3836

### What changed, and why?

Volunteers and casa admins can edit their address from the edit profile page.

### How will this affect user permissions?

n/a

### How is this tested? (please write tests!) 💖💪

Visual confirmation and I updated an existing request test.

### Screenshots please :)

Before:
![Screenshot (539)](https://user-images.githubusercontent.com/42154066/185284007-adbfb5a0-e4dd-4ca1-aa21-dba082edc967.png)

After:
![Screenshot (540)](https://user-images.githubusercontent.com/42154066/185284060-a86e1b96-4be1-4fc6-a20f-871397f10f92.png)

![Screenshot (541)](https://user-images.githubusercontent.com/42154066/185284077-7e52c58b-7d92-4d91-9a13-56e3c51aa9f0.png)
