### PR TITLE
Change court report select text transitioning to be calculated from birthdate

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -6,7 +6,7 @@ class CaseCourtReportsController < ApplicationController
 
   def index
     authorize CaseCourtReport
-    assigned_cases.select(:id, :case_number, :transition_aged_youth)
+    assigned_cases.select(:id, :case_number, :birth_month_year_youth)
   end
 
   def show

--- a/app/controllers/emancipation_checklists_controller.rb
+++ b/app/controllers/emancipation_checklists_controller.rb
@@ -6,7 +6,7 @@ class EmancipationChecklistsController < ApplicationController
   def index
     authorize :application, :see_emancipation_checklist?
     org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers)
-    @casa_transitioning_cases = policy_scope(org_cases).where("birth_month_year_youth < ?", 14.years.ago).includes([:hearing_type, :judge])
+    @casa_transitioning_cases = policy_scope(org_cases).is_transitioned.includes([:hearing_type, :judge])
 
     if @casa_transitioning_cases.count == 1
       redirect_to casa_case_emancipation_path(@casa_transitioning_cases[0])

--- a/app/controllers/emancipation_checklists_controller.rb
+++ b/app/controllers/emancipation_checklists_controller.rb
@@ -1,11 +1,12 @@
 class EmancipationChecklistsController < ApplicationController
+  include DateHelper
   before_action :require_organization!
   after_action :verify_authorized
 
   def index
     authorize :application, :see_emancipation_checklist?
     org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers)
-    @casa_transitioning_cases = policy_scope(org_cases).where(transition_aged_youth: true).includes([:hearing_type, :judge])
+    @casa_transitioning_cases = policy_scope(org_cases).where("birth_month_year_youth < ?", 14.years.ago).includes([:hearing_type, :judge])
 
     if @casa_transitioning_cases.count == 1
       redirect_to casa_case_emancipation_path(@casa_transitioning_cases[0])

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -109,11 +109,11 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def transition_aged_youth
-    object.in_transition_age? || object.transition_aged_youth ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    object.in_transition_age? || object.has_transitioned? ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
   def transition_aged_youth_icon
-    object.in_transition_age? || object.transition_aged_youth ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    object.in_transition_age? || object.has_transitioned? ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def unsuccessful_contacts_this_week

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -83,6 +83,10 @@ class CasaCase < ApplicationRecord
     where.not(id: CourtDate.where("date >= ?", Date.today).pluck(:casa_case_id))
   }
 
+  scope :is_transitioned, -> {
+    where("birth_month_year_youth < ?", 14.years.ago)
+  }
+
   scope :active, -> {
     where(active: true)
   }

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -12,6 +12,7 @@ class CasaCase < ApplicationRecord
     judge_name
     status
     transition_aged_youth
+    birth_month_year_youth
     assigned_to
     actions
   ].freeze
@@ -70,8 +71,7 @@ class CasaCase < ApplicationRecord
       .order(:case_number)
   }
   scope :should_transition, -> {
-    where(transition_aged_youth: false)
-      .where("birth_month_year_youth <= ?", 14.years.ago)
+    where("birth_month_year_youth <= ?", 14.years.ago)
   }
 
   scope :birthday_next_month, -> {
@@ -152,7 +152,7 @@ class CasaCase < ApplicationRecord
   end
 
   def has_transitioned?
-    transition_aged_youth
+    birth_month_year_youth && birth_month_year_youth < 14.years.ago  
   end
 
   def remove_emancipation_category(category_id)

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -152,7 +152,7 @@ class CasaCase < ApplicationRecord
   end
 
   def has_transitioned?
-    birth_month_year_youth && birth_month_year_youth < 14.years.ago  
+    birth_month_year_youth && birth_month_year_youth < 14.years.ago
   end
 
   def remove_emancipation_category(category_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@
 class User < ApplicationRecord
   include Roles
   include ByOrganizationScope
+  include DateHelper
+
 
   validates_with UserValidator
 
@@ -131,10 +133,9 @@ class User < ApplicationRecord
   end
 
   def serving_transition_aged_youth?
-    actively_assigned_and_active_cases.where(transition_aged_youth: true).any?
+    actively_assigned_and_active_cases.where("birth_month_year_youth <= ?", 14.years.ago).any?
   end
 end
-
 # == Schema Information
 #
 # Table name: users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
   include ByOrganizationScope
   include DateHelper
 
-
   validates_with UserValidator
 
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, :trackable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,7 +132,7 @@ class User < ApplicationRecord
   end
 
   def serving_transition_aged_youth?
-    actively_assigned_and_active_cases.where("birth_month_year_youth <= ?", 14.years.ago).any?
+    actively_assigned_and_active_cases.is_transitioned.any?
   end
 end
 # == Schema Information

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe CasaCaseDecorator do
   end
 
   describe "#transition_age_youth" do
-    it "returns transition age youth status with icon if transition age youth && birthday is nil" do
-      casa_case = build(:casa_case, transition_aged_youth: true, birth_month_year_youth: nil)
-      expect(casa_case.decorate.transition_aged_youth)
-        .to eq "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}"
-    end
-
     it "returns transition age youth status with icon if not transition age youth && birthday is nil" do
       casa_case = build(:casa_case, transition_aged_youth: false, birth_month_year_youth: nil)
       expect(casa_case.decorate.transition_aged_youth)
@@ -79,12 +73,6 @@ RSpec.describe CasaCaseDecorator do
   end
 
   describe "#transition_age_youth_icon" do
-    it "returns transition age youth status with icon if transition age youth && birthday is nil" do
-      casa_case = build(:casa_case, transition_aged_youth: true, birth_month_year_youth: nil)
-      expect(casa_case.decorate.transition_aged_youth_icon)
-        .to eq CasaCase::TRANSITION_AGE_YOUTH_ICON
-    end
-
     it "returns transition age youth status with icon if not transition age youth && birthday is nil" do
       casa_case = build(:casa_case, transition_aged_youth: false, birth_month_year_youth: nil)
       expect(casa_case.decorate.transition_aged_youth_icon)

--- a/spec/factories/volunteers.rb
+++ b/spec/factories/volunteers.rb
@@ -14,7 +14,8 @@ FactoryBot.define do
     trait :with_cases_and_contacts do
       after(:create) do |user, _|
         assignment1 = create :case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: false), volunteer: user
-        create :case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, transition_aged_youth: true, birth_month_year_youth: 10.years.ago), volunteer: user
+        create :case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, birth_month_year_youth: 10.years.ago), volunteer: user
+        create :case_assignment, casa_case: create(:casa_case, casa_org: user.casa_org, birth_month_year_youth: 15.years.ago), volunteer: user
         contact = create :case_contact, creator: user, casa_case: assignment1.casa_case
         contact_types = create_list :contact_type, 3, contact_type_group: create(:contact_type_group, casa_org: user.casa_org)
         3.times do

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "case_court_reports/index", type: :system do
   let(:supervisor) { volunteer.supervisor }
   let(:casa_cases) { CasaCase.actively_assigned_to(volunteer) }
   let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:has_transitioned?).first }
-  let(:at_least_transition_age) { volunteer.casa_cases.select(&:has_transitioned?).first }
+  let(:at_least_transition_age) { volunteer.casa_cases.find(&:has_transitioned?).first }
 
   before do
     sign_in volunteer

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "case_court_reports/index", type: :system do
   let(:supervisor) { volunteer.supervisor }
   let(:casa_cases) { CasaCase.actively_assigned_to(volunteer) }
   let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:has_transitioned?).first }
-  let(:at_least_transition_age) { volunteer.casa_cases.find(&:has_transitioned?).first }
+  let(:at_least_transition_age) { volunteer.casa_cases.find(&:has_transitioned?) }
 
   before do
     sign_in volunteer

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe "case_court_reports/index", type: :system do
   let(:volunteer) { create(:volunteer, :with_cases_and_contacts, :with_assigned_supervisor, display_name: "Name Last") }
   let(:supervisor) { volunteer.supervisor }
   let(:casa_cases) { CasaCase.actively_assigned_to(volunteer) }
+  let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:has_transitioned?).first }
+  let(:at_least_transition_age) { volunteer.casa_cases.select(&:has_transitioned?).first }
 
   before do
     sign_in volunteer
     visit case_court_reports_path
   end
 
-  context "when first arriving to 'Generate Court Report' page, by default" do
+  context "when first arriving to 'Generate Court Report' page" do
     it "sees 'Generate Report' button" do
       options = {text: "Generate Report", visible: true}
 
@@ -34,13 +36,13 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     it "shows transition stamp for transitioned case" do
-      expected_text = "#{casa_cases.second.case_number} - transition"
+      expected_text = "#{at_least_transition_age.case_number} - transition"
 
       expect(page).to have_selector "#case-selection option", text: expected_text
     end
 
     it "shows non-transition stamp for non-transitioned case" do
-      expected_text = "#{casa_cases.first.case_number} - non-transition"
+      expected_text = "#{younger_than_transition_age.case_number} - non-transition"
 
       expect(page).to have_selector "#case-selection option", text: expected_text
     end


### PR DESCRIPTION
Updated files to use birthday rather than transition_aged_youth boolean to calculate whether casa case is transition aged youth

### What github issue is this PR for, if any?
Resolves #2343 

### What changed, and why?
Updated certain instances of the transitioned_aged_youth attribute to calculate if the casa case is under 14 years old from birthday instead. 


### How is this tested? (please write tests!) 💖💪

These tests are still passing. A few tests are now failing since they are still using the boolean value. I am working on cleaning those test/everything else still using or defaulting to that boolean up still though! It is only being referenced in a few more places - mainly specs. 

it "returns transition age youth status with icon if over 14 years old" do
      casa_case = build(:casa_case, birth_month_year_youth: 14.years.ago)
      expect(casa_case.decorate.transition_aged_youth)
        .to eq "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}"
    end

    it "returns non-transition age youth status with icon if not over 14 years old" do
      casa_case = build(:casa_case, birth_month_year_youth: 13.years.ago)
      expect(casa_case.decorate.transition_aged_youth)
        .to eq "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
    end
  end


### Screenshots please :)
<img width="919" alt="Screen Shot 2022-08-19 at 6 43 31 PM" src="https://user-images.githubusercontent.com/70597815/185722750-e5d3d330-a06f-46f7-a251-5fe7ddb751ee.png

<img width="950" alt="Screen Shot 2022-08-19 at 6 47 43 PM" src="https://user-images.githubusercontent.com/70597815/185725947-8fd8e207-be14-4463-aae7-cdda51932957.png">

Im happy to keep working on this and create a new pull request once the transition_aged_youth column in the db is deleted if easier! 


