### PR TITLE
All casa admin can enter and view patch notes

### DIFF
--- a/app/assets/stylesheets/pages/patch_notes.scss
+++ b/app/assets/stylesheets/pages/patch_notes.scss
@@ -4,6 +4,10 @@
   #patch-note-list {
     width: 50%;
 
+    h1 {
+      text-align: center
+    }
+
     .patch-note-list-item {
       textarea {
         width: 100%;
@@ -21,10 +25,8 @@
         }
       }
 
-      #new-patch-note {
-        button {
-          width: 100%;
-        }
+      button {
+        width: 100%;
       }
     };
   };

--- a/app/assets/stylesheets/pages/patch_notes.scss
+++ b/app/assets/stylesheets/pages/patch_notes.scss
@@ -9,6 +9,10 @@
     }
 
     .patch-note-list-item {
+      &.new {
+        background-color: #ffecb3;
+      }
+
       textarea {
         width: 100%;
       }

--- a/app/controllers/all_casa_admins/patch_notes_controller.rb
+++ b/app/controllers/all_casa_admins/patch_notes_controller.rb
@@ -47,6 +47,6 @@ class AllCasaAdmins::PatchNotesController < AllCasaAdminsController
 
   # Only allow a list of trusted parameters through.
   def patch_note_params
-    params.require(:patch_note).permit(:note, :patch_note_group_id, :patch_note_type_id)
+    params.permit(:note, :patch_note_group_id, :patch_note_type_id)
   end
 end

--- a/app/controllers/all_casa_admins/patch_notes_controller.rb
+++ b/app/controllers/all_casa_admins/patch_notes_controller.rb
@@ -3,7 +3,7 @@ class AllCasaAdmins::PatchNotesController < AllCasaAdminsController
   def index
     @patch_note_groups = PatchNoteGroup.all
     @patch_note_types = PatchNoteType.all
-    @patch_notes = PatchNote.all
+    @patch_notes = PatchNote.order(created_at: :desc)
   end
 
   # POST /patch_notes or /patch_notes.json

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,6 +1,6 @@
 const AsyncNotifier = require('../async_notifier')
 const patchNotePath = window.location.pathname
-let pageNotifier;
+let pageNotifier
 
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -132,11 +132,7 @@ $('document').ready(() => {
       Number.parseInt(newPatchNoteFormElements.dropdownGroup.val()),
       newPatchNoteFormElements.noteTextArea.val(),
       Number.parseInt(newPatchNoteFormElements.dropdownType.val())
-    ).then(function (response, textStatus, jqXHR) {
-      resolveAsyncOperation()
-
-      return response
-    }).always(function () {
+    ).always(function () {
       enablePatchNoteForm(newPatchNoteFormElements)
     })
   })

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -48,6 +48,11 @@ $('document').ready(() => {
   }
 
   newPatchNoteFormElements.submitButton.click(() => {
+    if (!(newPatchNoteFormElements.noteTextArea.val())) {
+      patchNotePage.notifier.notify('Cannot save an empty patch note', 'warn')
+      return
+    }
+
     console.log(`Patch Note: ${newPatchNoteFormElements.noteTextArea.val()}`)
     console.log(`Patch Note Group ID: ${newPatchNoteFormElements.dropdownGroup.val()}`)
     console.log(`Patch Note Type ID: ${newPatchNoteFormElements.dropdownType.val()}`)
@@ -55,6 +60,4 @@ $('document').ready(() => {
     disableNewPatchNoteForm()
     patchNotePage.notifier.startAsyncOperation()
   })
-
-  patchNotePage.notifier.notify('test', 'warn')
 })

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -39,20 +39,18 @@ $('document').ready(() => {
   const asyncNotificationsElement = $('#async-notifications')
   patchNotePage.notifier = new Notifier(asyncNotificationsElement)
 
-  const newPatchNoteElement = $('#new-patch-note')
-  const newPatchNoteGroupDropdown = $('#new-patch-note-group')
-  const newPatchNoteTypeDropdown = $('#new-patch-note-type')
+  const newPatchNoteFormElements = getPatchNoteFormInputs('new-patch-note')
 
   const disableNewPatchNoteForm = () => {
-    for (const formElement of Object.values(getPatchNoteFormInputs('new-patch-note'))) {
+    for (const formElement of Object.values(newPatchNoteFormElements)) {
       formElement.prop('disabled', true)
     }
   }
 
-  newPatchNoteElement.children('button').click(() => {
-    console.log(`Patch Note: ${newPatchNoteElement.children('textarea').val()}`)
-    console.log(`Patch Note Group ID: ${newPatchNoteGroupDropdown.val()}`)
-    console.log(`Patch Note Type ID: ${newPatchNoteTypeDropdown.val()}`)
+  newPatchNoteFormElements.submitButton.click(() => {
+    console.log(`Patch Note: ${newPatchNoteFormElements.noteTextArea.val()}`)
+    console.log(`Patch Note Group ID: ${newPatchNoteFormElements.dropdownGroup.val()}`)
+    console.log(`Patch Note Type ID: ${newPatchNoteFormElements.dropdownType.val()}`)
 
     disableNewPatchNoteForm()
     patchNotePage.notifier.startAsyncOperation()

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -1,2 +1,24 @@
-<div id="<%= dom_id patch_note %>">
+<div class="patch-note-list-item card">
+  <div id="patch-note-<%= dom_id patch_note %>" class="card-body">
+    <textarea disabled="true">
+      <%= patch_note.note %>
+    </textarea>
+    <div class="label-and-select">
+      <label for="patch-note-<%= dom_id patch_note %>-type">Patch Note Type:</label>
+      <select id="patch-note-<%= dom_id patch_note %>-type" disabled="true">
+        <% @patch_note_types&.each do |patch_note_type| %>
+          <option value="<%= patch_note_type.id %>"><%= patch_note_type.name %></option>
+        <% end %>
+      </select>
+    </div>
+    <div class="label-and-select">
+      <label for="patch-note-<%= dom_id patch_note %>-group">User Group:</label>
+      <select id="patch-note-<%= dom_id patch_note %>-group" disabled="true">
+        <% @patch_note_groups&.each do |patch_note_group| %>
+          <option value="<%= patch_note_group.id %>"><%= patch_note_group.value %></option>
+        <% end %>
+      </select>
+    </div>
+    <button type="button" class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
+  </div>
 </div>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -1,8 +1,6 @@
 <div class="patch-note-list-item card">
   <div id="patch-note-<%= dom_id patch_note %>" class="card-body">
-    <textarea disabled="true">
-      <%= patch_note.note %>
-    </textarea>
+    <textarea disabled="true"><%= patch_note.note %></textarea>
     <div class="label-and-select">
       <label for="patch-note-<%= dom_id patch_note %>-type">Patch Note Type:</label>
       <select id="patch-note-<%= dom_id patch_note %>-type" disabled="true">

--- a/app/views/all_casa_admins/patch_notes/index.html.erb
+++ b/app/views/all_casa_admins/patch_notes/index.html.erb
@@ -1,9 +1,8 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Patch Notes</h1>
-
 <div id="patch-notes">
   <div id="patch-note-list">
+    <h1>Patch Notes</h1>
     <div class="patch-note-list-item card">
       <div id="new-patch-note" class="card-body">
         <textarea placeholder="New Patch Note"></textarea>
@@ -26,13 +25,11 @@
         <button type="button" class="btn btn-primary">Create</button>
       </div>
     </div>
+    <% # Paginate this %>
+    <% @patch_notes&.each do |patch_note| %>
+      <%= render "all_casa_admins/patch_notes/patch_note", patch_note: patch_note %>
+    <% end %>
   </div>
-  <% # Paginate this %>
-  <% @patch_notes&.each do |patch_note| %>
-    <%= render "all_casa_admins/patch_notes/patch_note", patch_note: patch_note %>
-    <p>
-    </p>
-  <% end %>
 </div>
 
 <%= render "shared/async_notifier" %>

--- a/spec/requests/all_casa_admins/patch_notes_spec.rb
+++ b/spec/requests/all_casa_admins/patch_notes_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
     context "with valid parameters" do
       it "creates a new PatchNote" do
         expect {
-          post all_casa_admins_patch_notes_path, params: {patch_note: valid_attributes}
+          post all_casa_admins_patch_notes_path, params: valid_attributes
         }.to change(PatchNote, :count).by(1)
       end
 
       it "shows json indicating the patch note was created" do
-        post all_casa_admins_patch_notes_path, params: {patch_note: valid_attributes}
+        post all_casa_admins_patch_notes_path, params: valid_attributes
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(response.body).to_not be_nil
         expect(response).to have_http_status(:created)
@@ -65,12 +65,12 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
     context "with invalid parameters" do
       it "does not create a new PatchNote" do
         expect {
-          post all_casa_admins_patch_notes_path, params: {patch_note: invalid_attributes}
+          post all_casa_admins_patch_notes_path, params: invalid_attributes
         }.to change(PatchNote, :count).by(0)
       end
 
       it "shows json indicating the patch note could not be created" do
-        post all_casa_admins_patch_notes_path, params: {patch_note: invalid_attributes}
+        post all_casa_admins_patch_notes_path, params: invalid_attributes
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(response.body).to_not be_nil
         expect(response).to have_http_status(:unprocessable_entity)
@@ -94,7 +94,7 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
 
       it "updates the requested patch_note" do
         patch_note = PatchNote.create! valid_attributes
-        patch all_casa_admins_patch_note_path(patch_note), params: {patch_note: new_attributes}
+        patch all_casa_admins_patch_note_path(patch_note), params: new_attributes
         patch_note.reload
         expect(patch_note.note).to eq(new_attributes[:note])
         expect(patch_note.patch_note_group_id).to eq(patch_note_group_2.id)
@@ -103,7 +103,7 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
 
       it "renders a successful response (a json with an ok status)" do
         patch_note = PatchNote.create! valid_attributes
-        patch all_casa_admins_patch_note_path(patch_note), params: {patch_note: new_attributes}
+        patch all_casa_admins_patch_note_path(patch_note), params: new_attributes
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(response.body).to_not be_nil
         expect(response).to have_http_status(:ok)
@@ -113,7 +113,7 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
     context "with invalid parameters" do
       it "renders a successful response (a json with a list of errors)" do
         patch_note = PatchNote.create! valid_attributes
-        patch all_casa_admins_patch_note_path(patch_note), params: {patch_note: invalid_attributes}
+        patch all_casa_admins_patch_note_path(patch_note), params: invalid_attributes
         expect(response.body).to_not be_nil
         expect(response).to have_http_status(:unprocessable_entity)
         expect(JSON.parse(response.body)).to have_key("errors")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Can enter patch notes and view them

### How will this affect user permissions?

### How is this tested? (please write tests!) 💖💪
Not yet

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/186792676-b5d224bd-d583-46bd-af4a-be2a35def3de.png)
