### PR TITLE
Display message when no other duties are found for volunteers

### DIFF
--- a/app/controllers/other_duties_controller.rb
+++ b/app/controllers/other_duties_controller.rb
@@ -63,7 +63,7 @@ class OtherDutiesController < ApplicationController
         no_duties_found = false
       end
     end
-    no_duties_found 
+    no_duties_found
   end
 
   def other_duty_params

--- a/app/controllers/other_duties_controller.rb
+++ b/app/controllers/other_duties_controller.rb
@@ -47,12 +47,23 @@ class OtherDutiesController < ApplicationController
   end
 
   def generate_other_duty_list(volunteers)
+    return [] if no_other_duties_for(volunteers)
     volunteers.map do |volunteer|
       {
         volunteer: volunteer,
         other_duties: volunteer.other_duties
       }
     end
+  end
+
+  def no_other_duties_for(volunteers)
+    no_duties_found = true
+    volunteers.each do |volunteer|
+      if volunteer.other_duties.present?
+        no_duties_found = false
+      end
+    end
+    no_duties_found 
   end
 
   def other_duty_params


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3785

### What changed, and why?
<img width="1618" alt="Screen Shot 2022-08-26 at 11 26 07 AM" src="https://user-images.githubusercontent.com/64810661/186939655-1a2ee4c1-8477-4623-81a0-5672f52a55d3.png">
> We wrote [PR 3800](https://github.com/rubyforgood/casa/pull/3800) to display a message when no other duties were present. The view was checking a condition that was previously not set. This PR moves the logic into the controller and sets that variable. 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
> We are working on controller tests but wanted to get this fix ready since it was a bug in production.

### Screenshots please :)
See Above

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9