### PR TITLE
tests for update notes all casa admin display

### DIFF
--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -1,23 +1,31 @@
 <div class="patch-note-list-item card">
-  <div id="patch-note-<%= dom_id patch_note %>" class="card-body">
+  <div id="patch-note-<%= patch_note.id %>" class="card-body">
     <textarea disabled="true"><%= patch_note.note %></textarea>
     <div class="label-and-select">
-      <label for="patch-note-<%= dom_id patch_note %>-type">Patch Note Type:</label>
-      <select id="patch-note-<%= dom_id patch_note %>-type" disabled="true">
+      <label for="patch-note-<%= patch_note.id %>-type">Patch Note Type:</label>
+      <select id="patch-note-<%= patch_note.id %>-type" disabled="true">
         <% @patch_note_types&.each do |patch_note_type| %>
-          <option value="<%= patch_note_type.id %>" <%= patch_note_type.id === patch_note.patch_note_type_id ? "selected" : nil %>>
-            <%= patch_note_type.name %>
-          </option>
+          <% if patch_note_type.id === patch_note.patch_note_type_id %>
+            <option value="<%= patch_note_type.id %>" selected="selected">
+          <% else%>
+            <option value="<%= patch_note_type.id %>">
+          <% end %>
+              <%= patch_note_type.name %>
+            </option>
         <% end %>
       </select>
     </div>
     <div class="label-and-select">
-      <label for="patch-note-<%= dom_id patch_note %>-group">User Group:</label>
-      <select id="patch-note-<%= dom_id patch_note %>-group" disabled="true">
+      <label for="patch-note-<%= patch_note.id %>-group">User Group:</label>
+      <select id="patch-note-<%= patch_note.id %>-group" disabled="true">
         <% @patch_note_groups&.each do |patch_note_group| %>
-          <option value="<%= patch_note_group.id %>" <%= patch_note_group.id === patch_note.patch_note_group_id ? "selected" : nil %>>
-            <%= patch_note_group.value %>
-          </option>
+          <% if patch_note_group.id === patch_note.patch_note_group_id %>
+            <option value="<%= patch_note_group.id %>" selected="selected">
+          <% else%>
+            <option value="<%= patch_note_group.id %>">
+          <% end %>
+              <%= patch_note_group.value %>
+            </option>
         <% end %>
       </select>
     </div>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -7,7 +7,7 @@
         <% @patch_note_types&.each do |patch_note_type| %>
           <% if patch_note_type.id === patch_note.patch_note_type_id %>
             <option value="<%= patch_note_type.id %>" selected="selected">
-          <% else%>
+          <% else %>
             <option value="<%= patch_note_type.id %>">
           <% end %>
               <%= patch_note_type.name %>
@@ -21,7 +21,7 @@
         <% @patch_note_groups&.each do |patch_note_group| %>
           <% if patch_note_group.id === patch_note.patch_note_group_id %>
             <option value="<%= patch_note_group.id %>" selected="selected">
-          <% else%>
+          <% else %>
             <option value="<%= patch_note_group.id %>">
           <% end %>
               <%= patch_note_group.value %>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -5,7 +5,7 @@
       <label for="patch-note-<%= dom_id patch_note %>-type">Patch Note Type:</label>
       <select id="patch-note-<%= dom_id patch_note %>-type" disabled="true">
         <% @patch_note_types&.each do |patch_note_type| %>
-          <option value="<%= patch_note_type.id %>"><%= patch_note_type.name %></option>
+          <option value="<%= patch_note_type.id %>" <%= patch_note_type.id === patch_note.patch_note_type_id ? "selected" : nil %>><%= patch_note_type.name %></option>
         <% end %>
       </select>
     </div>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -5,7 +5,9 @@
       <label for="patch-note-<%= dom_id patch_note %>-type">Patch Note Type:</label>
       <select id="patch-note-<%= dom_id patch_note %>-type" disabled="true">
         <% @patch_note_types&.each do |patch_note_type| %>
-          <option value="<%= patch_note_type.id %>" <%= patch_note_type.id === patch_note.patch_note_type_id ? "selected" : nil %>><%= patch_note_type.name %></option>
+          <option value="<%= patch_note_type.id %>" <%= patch_note_type.id === patch_note.patch_note_type_id ? "selected" : nil %>>
+            <%= patch_note_type.name %>
+          </option>
         <% end %>
       </select>
     </div>
@@ -13,7 +15,9 @@
       <label for="patch-note-<%= dom_id patch_note %>-group">User Group:</label>
       <select id="patch-note-<%= dom_id patch_note %>-group" disabled="true">
         <% @patch_note_groups&.each do |patch_note_group| %>
-          <option value="<%= patch_note_group.id %>"><%= patch_note_group.value %></option>
+          <option value="<%= patch_note_group.id %>" <%= patch_note_group.id === patch_note.patch_note_group_id ? "selected" : nil %>>
+            <%= patch_note_group.value %>
+          </option>
         <% end %>
       </select>
     </div>

--- a/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "patch_notes/index", type: :view do
   end
 
   describe "the patch note list" do
-    it "renders a list of patch_notes" do
+    it "displays the patch_notes" do
       patch_notes[0].update(note: "?UvV*Z~v\"`P]4ol")
       patch_notes[1].update(note: "#tjJ/+o\"3s@osjV")
 
@@ -97,6 +97,18 @@ RSpec.describe "patch_notes/index", type: :view do
 
       expect(parsed_html.css(".patch-note-list-item textarea").text).to include(patch_notes[0].note)
       expect(parsed_html.css(".patch-note-list-item textarea").text).to include(patch_notes[1].note)
+    end
+
+    it "displays the latest patch notes first" do
+      patch_notes[0].update(note: "#'hQ+`dGC(qc=}wu")
+      patch_notes[1].update(note: "k2cz&c'xYLr|&)B)")
+
+      render template: "all_casa_admins/patch_notes/index"
+      parsed_html = Nokogiri.HTML5(rendered)
+
+      expect(parsed_html.css(".patch-note-list-item textarea")[1].text).to include(patch_notes[0].note)
+      expect(parsed_html.css(".patch-note-list-item textarea")[2].text).to include(patch_notes[1].note)
+      expect(patch_notes[0].created_at < patch_notes[1].created_at).to eq(true)
     end
   end
 end

--- a/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
@@ -123,12 +123,10 @@ RSpec.describe "patch_notes/index", type: :view do
       expect(patch_note_element.css("textarea").text).to include(patch_notes[0].note)
       expect(patch_note_element
         .css("#patch-note-#{patch_notes[0].id}-group option[@selected=\"selected\"]")
-        .attr("value").value
-      ).to eq("#{patch_notes[0].patch_note_group_id}")
+        .attr("value").value).to eq(patch_notes[0].patch_note_group_id.to_s)
       expect(patch_note_element
         .css("#patch-note-#{patch_notes[0].id}-type option[@selected=\"selected\"]")
-        .attr("value").value
-      ).to eq("#{patch_notes[0].patch_note_type_id}")
+        .attr("value").value).to eq(patch_notes[0].patch_note_type_id.to_s)
     end
   end
 end

--- a/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
@@ -110,5 +110,25 @@ RSpec.describe "patch_notes/index", type: :view do
       expect(parsed_html.css(".patch-note-list-item textarea")[2].text).to include(patch_notes[1].note)
       expect(patch_notes[0].created_at < patch_notes[1].created_at).to eq(true)
     end
+
+    it "displays the correct patch note group and patch note type with the patch note" do
+      patch_notes[0].update(note: "#'hQ+`dGC(qc=}wu")
+      patch_notes[1].update(note: "k2cz&c'xYLr|&)B)")
+
+      render template: "all_casa_admins/patch_notes/index"
+      parsed_html = Nokogiri.HTML5(rendered)
+
+      patch_note_element = parsed_html.css(".patch-note-list-item")[1]
+
+      expect(patch_note_element.css("textarea").text).to include(patch_notes[0].note)
+      expect(patch_note_element
+        .css("#patch-note-#{patch_notes[0].id}-group option[@selected=\"selected\"]")
+        .attr("value").value
+      ).to eq("#{patch_notes[0].patch_note_group_id}")
+      expect(patch_note_element
+        .css("#patch-note-#{patch_notes[0].id}-type option[@selected=\"selected\"]")
+        .attr("value").value
+      ).to eq("#{patch_notes[0].patch_note_type_id}")
+    end
   end
 end

--- a/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe "patch_notes/index", type: :view do
     sign_in all_casa_admin
   end
 
-  it "renders a list of patch_notes" do
-    render template: "all_casa_admins/patch_notes/index"
-  end
-
   describe "the new patch note form" do
     it "is present on the page" do
       render template: "all_casa_admins/patch_notes/index"
@@ -88,6 +84,19 @@ RSpec.describe "patch_notes/index", type: :view do
 
         expect(option_text).to include(patch_note_type_1.name)
       end
+    end
+  end
+
+  describe "the patch note list" do
+    it "renders a list of patch_notes" do
+      patch_notes[0].update(note: "?UvV*Z~v\"`P]4ol")
+      patch_notes[1].update(note: "#tjJ/+o\"3s@osjV")
+
+      render template: "all_casa_admins/patch_notes/index"
+      parsed_html = Nokogiri.HTML5(rendered)
+
+      expect(parsed_html.css(".patch-note-list-item textarea").text).to include(patch_notes[0].note)
+      expect(parsed_html.css(".patch-note-list-item textarea").text).to include(patch_notes[1].note)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
 - Added tests for patch notes display
 - Updated patch notes to display correct patch note type and group