### PR TITLE
Site update notes

### DIFF
--- a/app/assets/stylesheets/pages/patch_notes.scss
+++ b/app/assets/stylesheets/pages/patch_notes.scss
@@ -29,8 +29,12 @@
         }
       }
 
-      button {
-        width: 100%;
+      .patch-note-button-controls {
+        display: flex;
+
+        button {
+          flex-grow: 1
+        }
       }
     };
   };

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,4 +1,5 @@
 const AsyncNotifier = require('../async_notifier')
+const TypeChecker = require('./type_checker.js')
 const patchNotePath = window.location.pathname
 let pageNotifier
 
@@ -9,8 +10,8 @@ let pageNotifier
 //  @param    {number} patchNoteTypeId   The id of the patch note type
 //  @throws   {TypeError}  for a parameter of the incorrect type
 //  @throws   {RangeError} if an id parameter is negative
-//function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
-//}
+// function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
+// }
 
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
@@ -33,9 +34,7 @@ function createPatchNote (patchNoteGroupId, patchNoteText, patchNoteTypeId) {
     throw new RangeError('Param patchNoteTypeId cannot be negative')
   }
 
-  if (typeof patchNoteText !== 'string') {
-    throw new TypeError('Param patchNoteText must be a string')
-  }
+  TypeChecker.checkString(patchNoteText, 'patchNoteText')
 
   pageNotifier.startAsyncOperation()
 

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -9,8 +9,8 @@ let pageNotifier
 //  @param    {number} patchNoteTypeId   The id of the patch note type
 //  @throws   {TypeError}  for a parameter of the incorrect type
 //  @throws   {RangeError} if an id parameter is negative
-function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
-}
+//function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
+//}
 
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -2,13 +2,23 @@ const AsyncNotifier = require('../async_notifier')
 const patchNotePath = window.location.pathname
 let pageNotifier
 
+// Inserts a patch note display after the create patch note form in the patch note list and styles it as new
+//  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
+//  @param    {jQuery} patchNoteList     A jQuery object representing the patch note list
+//  @param    {string} patchNoteText     The text of the patch note
+//  @param    {number} patchNoteTypeId   The id of the patch note type
+//  @throws   {TypeError}  for a parameter of the incorrect type
+//  @throws   {RangeError} if an id parameter is negative
+function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
+}
+
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
 //  @param    {string} patchNoteText     The text of the patch note
 //  @param    {number} patchNoteTypeId   The id of the patch note type
 //  @returns  {array} a jQuery jqXHR object. See https://api.jquery.com/jQuery.ajax/#jqXHR
 //  @throws   {TypeError}  for a parameter of the incorrect type
-//  @throws   {RangeError} if optionId is negative
+//  @throws   {RangeError} if an id parameter is negative
 function createPatchNote (patchNoteGroupId, patchNoteText, patchNoteTypeId) {
   // Input check
   if (!Number.isInteger(patchNoteGroupId)) {
@@ -89,7 +99,7 @@ function deletePatchNote (patchNoteId) {
 
 // Disables all form elements of a patch note form
 //  @param    {object} patchNoteFormElements An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
-//  @throws   {TypeError}      for a parameter of the incorrect type
+//  @throws   {TypeError} for a parameter of the incorrect type
 function disablePatchNoteForm (patchNoteFormElements) {
   for (const formElement of Object.values(patchNoteFormElements)) {
     formElement.prop('disabled', true)
@@ -98,7 +108,7 @@ function disablePatchNoteForm (patchNoteFormElements) {
 
 // Enables all form elements of a patch note form
 //  @param    {object} patchNoteFormElements An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
-//  @throws   {TypeError}      for a parameter of the incorrect type
+//  @throws   {TypeError} for a parameter of the incorrect type
 function enablePatchNoteForm (patchNoteFormElements) {
   for (const formElement of Object.values(patchNoteFormElements)) {
     formElement.removeAttr('disabled')

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -107,6 +107,13 @@ function enablePatchNoteForm (patchNoteFormElements) {
 
 // Get all form elements of a patch note in edit mode
 //  @param    {number} patchNoteId The id of the patch note form
+//  @returns  {object} An object containing jQuery objects in this form
+//    {
+//      dropdownGroup:  The select for the patch note's user visibility group
+//      dropdownType:   The select for the patch note's type
+//      noteTextArea:   The textarea containing the patch note
+//      buttonControls: A list of all the buttons at the bottom of the form
+//    }
 //  @throws   {TypeError}      for a parameter of the incorrect type
 //  @throws   {ReferenceError} if an element could not be found
 function getPatchNoteFormInputs (patchNoteElement) {

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,5 +1,5 @@
 const AsyncNotifier = require('../async_notifier')
-const TypeChecker = require('./type_checker.js')
+const TypeChecker = require('../type_checker')
 const patchNotePath = window.location.pathname
 let pageNotifier
 
@@ -209,5 +209,6 @@ $('document').ready(() => {
   } catch (err) {
     pageNotifier.notify('Could not intialize app', 'error')
     pageNotifier.notify(err.message, 'error')
+    console.error(err)
   }
 })

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -68,9 +68,8 @@ function deletePatchNote (patchNoteId) {
 
   // Post request
   return $.ajax({
-    url: patchNotePath,
+    url: `${patchNotePath}/${patchNoteId}`,
     type: 'DELETE',
-    data: { patch_note_id: patchNoteId }
   })
     .then(function (response, textStatus, jqXHR) {
       if (response.errors) {
@@ -178,7 +177,18 @@ $('document').ready(() => {
     })
 
     $('#patch-note-list .button-delete').click(function () {
-      disablePatchNoteForm(getPatchNoteFormInputs($(this).parent().parent()))
+      const patchNoteFormContainer = $(this).parent().parent()
+      const formInputs = getPatchNoteFormInputs(patchNoteFormContainer)
+
+      disablePatchNoteForm(formInputs)
+
+      deletePatchNote(
+        Number.parseInt(patchNoteFormContainer.attr('id').match(/patch-note-(\d+)/)[1])
+      ).then(function () {
+        patchNoteFormContainer.parent().remove()
+      }).fail(function () {
+        enablePatchNoteForm(formInputs)
+      })
     })
   } catch (err) {
     pageNotifier.notify('Could not intialize app', 'error')

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -69,7 +69,7 @@ function deletePatchNote (patchNoteId) {
   // Post request
   return $.ajax({
     url: `${patchNotePath}/${patchNoteId}`,
-    type: 'DELETE',
+    type: 'DELETE'
   })
     .then(function (response, textStatus, jqXHR) {
       if (response.errors) {

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -1,4 +1,5 @@
 /* global $ */
+const TypeChecker = require('./type_checker.js')
 
 module.exports = class Notifier {
   //  @param {object} notificationsElement The notification DOM element as a jQuery object
@@ -20,9 +21,7 @@ module.exports = class Notifier {
   //  @throws {RangeError} for unsupported logging levels
 
   notify (message, level) {
-    if (typeof message !== 'string') {
-      throw new TypeError('Param message must be a string')
-    }
+    TypeChecker.checkString(message, 'message')
 
     const escapedMessage = message.replace(/&/g, '&amp;')
       .replace(/>/g, '&gt;')

--- a/app/javascript/src/type_checker.js
+++ b/app/javascript/src/type_checker.js
@@ -1,0 +1,14 @@
+// Object.keys({variable})[0]
+
+module.exports = {
+
+  // Checks if a variable is a string or not
+  //  @param    {any}    variable The variable to be checked
+  //  @param    {string} varName  The name of the variable to be checked
+  //  @throws   {TypeError} If variable is not a string
+  checkString (variable, varName) {
+    if (typeof variable !== 'string') {
+      throw new TypeError(`Param ${varName} must be a string`)
+    }
+  }
+}

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -31,6 +31,7 @@
     </div>
     <div class="patch-note-button-controls">
       <button type="button" class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
+      <button type="button" class="btn btn-danger"><i class="fa-solid fa-trash-can"></i>Delete</button>
     </div>
   </div>
 </div>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -29,6 +29,8 @@
         <% end %>
       </select>
     </div>
-    <button type="button" class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
+    <div class="patch-note-button-controls">
+      <button type="button" class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
+    </div>
   </div>
 </div>

--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -30,8 +30,8 @@
       </select>
     </div>
     <div class="patch-note-button-controls">
-      <button type="button" class="btn btn-primary"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
-      <button type="button" class="btn btn-danger"><i class="fa-solid fa-trash-can"></i>Delete</button>
+      <button type="button" class="btn btn-primary button-edit"><i class="fa-solid fa-pen-to-square"></i>Edit</button>
+      <button type="button" class="btn btn-danger button-delete"><i class="fa-solid fa-trash-can"></i>Delete</button>
     </div>
   </div>
 </div>

--- a/app/views/all_casa_admins/patch_notes/index.html.erb
+++ b/app/views/all_casa_admins/patch_notes/index.html.erb
@@ -22,7 +22,9 @@
             <% end %>
           </select>
         </div>
-        <button type="button" class="btn btn-primary">Create</button>
+        <div class="patch-note-button-controls">
+          <button type="button" class="btn btn-primary">Create</button>
+        </div>
       </div>
     </div>
     <% # Paginate this %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
 - Patch notes can be deleted
 - fixed a key reference error for json responses
 - Created a module for parameter type checking
 - Errors that crash patch note page js are printed to the console

### How will this affect user permissions?
No

### How is this tested? (please write tests!) 💖💪
Not yet

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/187017456-554850ec-7a4b-48cd-b668-5a6a1adff6a8.png)
