### PR TITLE
Fix flaky volunteer view test due to html-escaped supervisor name

### DIFF
--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "volunteers", type: :view do
       let(:supervisor) { build(:supervisor) }
 
       it "shows up in the supervisor dropdown" do
-        expect(subject).to include(ERB::Util.url_encode(supervisor.display_name).gsub("%20", " ")) # don't flake on names with ' like O'Hara
+        expect(subject).to include(CGI.escapeHTML(supervisor.display_name))
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3886

### What changed, and why?
The test `spec/views/volunteers/index.html.erb_spec.rb` was failing intermittently because it did not expect html-escaped characters in the supervisor name. 

For example, we expect the page to actually have `Keith O&#39;Reilly` behind-the-scenes for `Keith O'Reilly`. Previous work was done to handle this, but the html on the page is being html-escaped (`'` => `&#39;`) rather than url-encoded (`'` => `%27`). It's possible this changed and used to work (?) but html-escaping as it's doing is what we want.

Updated the test to expect the supervisor's name to have escaped html using [CGI.escapeHTML](https://www.rubydoc.info/stdlib/cgi/1.9.2/CGI.escapeHTML) from ruby's standard library.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Hard-coded `supervisor.displayname` in the [factory](https://github.com/rubyforgood/casa/blob/main/spec/factories/supervisors.rb#L3) to `Keith O'Reilly` temporarily.

Previously, the test failed with:
```
expected: "...Keith O%27Reilly"
got: "...Keith O&#39;Reilly"
```

Confirmed it now passes because it will be expecting `Keith O&#39;Reilly`, which is what the page view is generating (and is legit).

Then ran with the final code - the names from randomly generated faker names - confirming there were no intermittent failures:

`for i in {1..50}; do rspec spec/views/volunteers/index.html.erb_spec.rb >> temp_results.txt; done`

Verified that there were no test failures in the 50 test runs: `less temp_results.txt | grep "failures"` -> all `4 examples, 0 failures`.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

![bart-simpson-feeling-isolated-and-weird-quarentine](https://media.giphy.com/media/FX7A7ZBnOgz3W/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9