### PR TITLE
Remove has_transitioned? in favor of in_transition_age?

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -34,10 +34,10 @@ class CasaCaseDecorator < Draper::Decorator
     volunteer_names = object.assigned_volunteers.map(&:display_name).join(",")
 
     [
-      "#{object.case_number} - #{object.has_transitioned? ? "transition" : "non-transition"}(assigned to #{volunteer_names.length > 0 ? volunteer_names : "no one"})",
+      "#{object.case_number} - #{object.in_transition_age? ? "transition" : "non-transition"}(assigned to #{volunteer_names.length > 0 ? volunteer_names : "no one"})",
       object.case_number,
       {
-        "data-transitioned": object.has_transitioned?,
+        "data-transitioned": object.in_transition_age?,
         "data-lookup": volunteer_names
       }
     ]
@@ -109,11 +109,11 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def transition_aged_youth
-    object.in_transition_age? || object.has_transitioned? ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
+    object.in_transition_age? ? "Yes #{CasaCase::TRANSITION_AGE_YOUTH_ICON}" : "No #{CasaCase::NON_TRANSITION_AGE_YOUTH_ICON}"
   end
 
   def transition_aged_youth_icon
-    object.in_transition_age? || object.has_transitioned? ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
+    object.in_transition_age? ? CasaCase::TRANSITION_AGE_YOUTH_ICON : CasaCase::NON_TRANSITION_AGE_YOUTH_ICON
   end
 
   def unsuccessful_contacts_this_week

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -155,10 +155,6 @@ class CasaCase < ApplicationRecord
     judge_name
   end
 
-  def has_transitioned?
-    birth_month_year_youth && birth_month_year_youth < 14.years.ago
-  end
-
   def remove_emancipation_category(category_id)
     category = EmancipationCategory.find(category_id)
     raise ActiveRecord::RecordNotFound unless emancipation_categories.include?(category)

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -162,7 +162,7 @@ class CaseContact < ApplicationRecord
   end
 
   def has_casa_case_transitioned
-    casa_case.has_transitioned?
+    casa_case.in_transition_age?
   end
 
   def contact_groups_with_types

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "case_court_reports/index", type: :system do
   let(:volunteer) { create(:volunteer, :with_cases_and_contacts, :with_assigned_supervisor, display_name: "Name Last") }
   let(:supervisor) { volunteer.supervisor }
   let(:casa_cases) { CasaCase.actively_assigned_to(volunteer) }
-  let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:has_transitioned?).first }
-  let(:at_least_transition_age) { volunteer.casa_cases.find(&:has_transitioned?) }
+  let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:in_transition_age?).first }
+  let(:at_least_transition_age) { volunteer.casa_cases.find(&:in_transition_age?) }
 
   before do
     sign_in volunteer
@@ -83,9 +83,9 @@ RSpec.describe "case_court_reports/index", type: :system do
   end
 
   describe "'Case Number' dropdown list", js: true do
-    let(:transitioned_case_number) { casa_cases.find(&:has_transitioned?).case_number.to_s }
+    let(:transitioned_case_number) { casa_cases.find(&:in_transition_age?).case_number.to_s }
     let(:transitioned_option_text) { "#{transitioned_case_number} - transition(assigned to Name Last)" }
-    let(:non_transitioned_case_number) { casa_cases.reject(&:has_transitioned?).first.case_number.to_s }
+    let(:non_transitioned_case_number) { casa_cases.reject(&:in_transition_age?).first.case_number.to_s }
     let(:non_transitioned_option_text) { "#{non_transitioned_case_number} - non-transition(assigned to Name Last)" }
 
     it "has transition case option selected" do
@@ -106,7 +106,7 @@ RSpec.describe "case_court_reports/index", type: :system do
   end
 
   context "when generating a report, volunteer sees waiting page", js: true do
-    let(:casa_case) { casa_cases.find(&:has_transitioned?) }
+    let(:casa_case) { casa_cases.find(&:in_transition_age?) }
     let(:option_text) { "#{casa_case.case_number} - transition" }
 
     before do
@@ -134,7 +134,7 @@ RSpec.describe "case_court_reports/index", type: :system do
   end
 
   context "when selecting a case, volunteer can generate and download a report", js: true do
-    let(:casa_case) { casa_cases.find(&:has_transitioned?) }
+    let(:casa_case) { casa_cases.find(&:in_transition_age?) }
     let(:option_text) { "#{casa_case.case_number} - transition" }
 
     before do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3889

### What changed, and why?
Replace `has_transitioned?` transitioning method with more robust `in_transition_age?`.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Just automated checks passing. If there are other ways I can/should test this please let me know!

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9