### PR TITLE
fix additional expense params

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -150,7 +150,7 @@ class CaseContactsController < ApplicationController
   def create_case_contact_for_every_selected_casa_case(selected_cases)
     selected_cases.map do |casa_case|
       if FeatureFlagService.is_enabled?(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG)
-        new_cc = casa_case.case_contacts.new(create_case_contact_params)
+        new_cc = casa_case.case_contacts.new(create_case_contact_params.except(:casa_case_attributes))
         update_or_create_additional_expense(additional_expense_params, new_cc)
         if new_cc.valid?
           new_cc.save!

--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -190,9 +190,9 @@ RSpec.describe CaseContactsController, type: :controller do
 
         let(:additional_expense) { build(:additional_expense) }
         let(:case_contact) { build(:case_contact, casa_case_id: case_id) }
-        let(:params) { case_contact.attributes.merge("additional_expenses" => [additional_expense.attributes]) }
+        let(:params) { case_contact.attributes.merge(additional_expenses_attributes: {"0" => additional_expense.attributes}) }
 
-        xit "creates additional expense" do # TODO DrewAPeterson7671
+        it "creates additional expense" do
           expect(organization.casa_cases).to include(casa_case)
           expect { post :create, params: {case_contact: params}, format: :js }.to change(AdditionalExpense, :count).by(1)
           expect(casa_case.case_contacts.last.additional_expenses.count).to eq(1)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3895

### What changed, and why?
When creating case contacts params, "casa_case_attributes" are now ignored. This was already happening when additional expenses were disabled.
They are later used to update volunteer addresses.

I believe updating this address while creating case contacts will be impossible because the reference needed is:
CaseContact -> CasaCase -> Volunteer
But during CaseContact creation, this reference doesn't exist. So the current behavior is correct: Creating the contact and then updating volunteers.

I would suggest removing casa_case_attributes from the CaseContactParameters service, if you agree, I can make this change in this PR.

### How will this affect user permissions?
It won't affect any permissions

### How is this tested? (please write tests!) 💖💪
to run tests:
`bundle exec rspec spec/controllers/case_contacts_controller_spec.rb:195`

### Screenshots please :)
[Screencast from 06-09-2022 16:10:45.webm](https://user-images.githubusercontent.com/36737050/188725259-ec97b4e4-9153-4ed5-9249-eca56ea0f1aa.webm)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`