### PR TITLE
Allow supervisor to delete case contact

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -111,7 +111,7 @@ class CaseContactsController < ApplicationController
   end
 
   def destroy
-    authorize CasaAdmin
+    authorize CaseContact
 
     @case_contact.destroy
     flash[:notice] = t("destroy", scope: "case_contact")

--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -264,13 +264,14 @@ RSpec.describe CaseContactsController, type: :controller do
       before do
         allow(controller).to receive(:authenticate_user!).and_return(true)
         allow(controller).to receive(:current_user).and_return(supervisor)
+        request.env["HTTP_REFERER"] = "/"
       end
 
       context ".destroy" do
         before { delete :destroy, params: {id: case_contact.id} }
         it { expect(response).to have_http_status(:redirect) }
-        it { expect(case_contact.reload.deleted?).to be_falsey }
-        it { expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.") }
+        it { expect(case_contact.reload.deleted?).to be_truthy }
+        it { expect(flash[:notice]).to eq("Contact is successfully deleted.") }
       end
 
       context ".restore" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3835

### What changed, and why?
Destroy method now uses controller policy.
A correct permission policy for this method was already implemented in:
app/policies/case_contact_policy.rb:14
But it wasn't being used.

### How will this affect user permissions?
- Volunteer permissions: Not changed
- Supervisor permissions: Now able to dele case contact 
- Admin permissions: Not changed

### How is this tested? (please write tests!) 💖💪
Updated endpoint existing tests. To run them:
`bundle exec rspec spec/controllers/case_contacts_controller_spec.rb:233`

### Screenshots please :)
[Screencast from 15-09-2022 14:14:30.webm](https://user-images.githubusercontent.com/36737050/190468962-a0701d95-0a4f-4ca5-b9f9-c6517ac1b25c.webm)