### PR TITLE
Logo linked to website root page

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,19 +1,22 @@
 <div id="sidebar-js" class="sidebar-wrapper">
   <div class="sidebar-heading text-center">
     <% if all_casa_admin_signed_in? || !current_organization.logo.attached? %>
-      <%= image_tag("default-logo.png",
+      <%= link_to image_tag("default-logo.png",
                          id: "casa-logo",
                          alt: t(".image.alt.logo"),
-                         class: "d-inline-block align-text-bottom") %>
+                         class: "d-inline-block align-text-bottom"),
+                         "https://casa-qa.herokuapp.com/" %>
     <% else %>
       <% if current_organization.logo.variable? %>
-        <%= image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
-                      alt: t(".image.alt.logo")) %>
+        <%= link_to image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
+                      alt: t(".image.alt.logo")),
+                      "https://casa-qa.herokuapp.com/" %>
       <% else %>
-        <%= image_tag(current_organization.logo,
+        <%= link_to image_tag(current_organization.logo,
                       width: 200,
                       height: 100,
-                      alt: t(".image.alt.logo")) %>
+                      alt: t(".image.alt.logo")),
+                      "https://casa-qa.herokuapp.com/" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -5,18 +5,18 @@
                          id: "casa-logo",
                          alt: t(".image.alt.logo"),
                          class: "d-inline-block align-text-bottom"),
-                         "https://casa-qa.herokuapp.com/" %>
+                         "/" %>
     <% else %>
       <% if current_organization.logo.variable? %>
         <%= link_to image_tag(current_organization.logo.variant(resize_to_limit: [200, 100]),
                       alt: t(".image.alt.logo")),
-                      "https://casa-qa.herokuapp.com/" %>
+                      "/" %>
       <% else %>
         <%= link_to image_tag(current_organization.logo,
                       width: 200,
                       height: 100,
                       alt: t(".image.alt.logo")),
-                      "https://casa-qa.herokuapp.com/" %>
+                      "/" %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
Resolves #3945

### What changed, and why?
Added link_to with the logo image with path "/" to redirect to root path as shown in example below
```diff
-<%= image_tag("default-logo.png"), %>
to
+<%= link_to image_tag("default-logo.png"), "/" %>
```
### How will this affect user permissions?
Should not have any impact on any permissions
- Volunteer permissions
- Supervisor permissions
- Admin permissions

### How is this tested? 💖💪
Since I'm on windows I haven't tested it yet, but its a very basic change and I hope a maintainer can help me with tests :)
I could install ruby on rails through other mediums if necessary.