### PR TITLE
update WSL docs for installing chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,14 @@ The complete [role description of a CASA volunteer](https://pgcasa.org/volunteer
 
 1. The Spec tests uses Chrome Browser and Chromedriver for some of the tests. A current version of chromedriver will be installed when `bundle install` is run. TO install Chrome, see [Chrome Install](https://support.google.com/chrome/answer/95346?hl=en&ref_topic=7439538).
 
-Another option is to install the Chromium browser for your operating system so the browser-based Ruby feature/integration tests can run. Installing `chromium-browser` is enough, even in WSL (Windows subsystem for Linux)
+Another option is to install the Chromium browser for your operating system so the browser-based Ruby feature/integration tests can run. Installing `chromium-browser` is enough, including for many WSL (Windows subsystem for Linux) distributions.
+
+If you are using Ubuntu on WSL and receive the following message when trying to run the test suite...
+
+> Command '/usr/bin/chromium-browser' requires the chromium snap to be installed. Please install it with:
+> `snap install chromium`
+
+...check out the instructions on [installing google-chrome and chromedriver for WSL Ubuntu](https://github.com/rubyforgood/casa/blob/main/doc/WSL_SETUP.md#google-chrome).
 
 **Installing Packages**
 1. `cd casa/`
@@ -130,15 +137,22 @@ Another option is to install the Chromium browser for your operating system so t
 
 #### Ubuntu and WSL
 
-1. If you are on Ubuntu in Windows Subsystem for Linux (WSL) and `rbenv install` indicates that the Ruby version is unavailable, you might be using Ubuntu's default install of `ruby-build`, which only comes with old installs of Ruby (ending before 2.6.) You should uninstall rvm and ruby-build's apt packages (`apt remove rvm ruby-build`) and install them with Git like this:
+1. Rbenv
 
-- `git clone https://github.com/rbenv/rbenv.git ~/.rbenv`
-- `echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc`
-- `echo 'eval "$(rbenv init -)"' >> ~/.bashrc`
-- `exec $SHELL`
-- `git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build`
+    If you are on Ubuntu in Windows Subsystem for Linux (WSL) and `rbenv install` indicates that the Ruby version is unavailable, you might be using Ubuntu's default install of `ruby-build`, which only comes with old installs of Ruby (ending before 2.6.) You should uninstall rvm and ruby-build's apt packages (`apt remove rvm ruby-build`) and install them with Git like this:
 
-You'll probably hit a problem where ruby-version reads `ruby-2.7.2` but the install available to you is called `2.7.2`. If you do, install [rbenv-alias](https://github.com/tpope/rbenv-aliases) and create an alias between the two.
+    - `git clone https://github.com/rbenv/rbenv.git ~/.rbenv`
+    - `echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc`
+    - `echo 'eval "$(rbenv init -)"' >> ~/.bashrc`
+    - `exec $SHELL`
+    - `git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build`
+
+    You'll probably hit a problem where ruby-version reads `ruby-2.7.2` but the install available to you is called `2.7.2`. If you do, install [rbenv-alias](https://github.com/tpope/rbenv-aliases) and create an alias between the two.
+
+2. Chrome / Chromium
+
+    If you are on Ubuntu in Windows Subsystem for Linux (WSL) you may need to install google-chrome and chromedriver if your version of Ubuntu requires the chromium snap to be installed.
+    For instructions how to do this, check out our [WSL Setup docs](https://github.com/rubyforgood/casa/blob/main/doc/WSL_SETUP.md#google-chrome).
 
 ### Common issues
 

--- a/doc/WSL_SETUP.md
+++ b/doc/WSL_SETUP.md
@@ -98,7 +98,54 @@ The Casa package frontend leverages several javascript packages managed through 
 
 ### Google Chrome
 
-Many of the frontend tests are run using Google Chrome, so if you don't already have that installed you may wish to [install it](https://www.google.com/chrome/downloads/).
+Many of the frontend tests are run using Google Chrome, so if you don't already have that installed you may wish to install it.
+
+For some linux distributions, installing `chromium-browser` may be enough on WSL. However, some versions of Ubuntu may require the chromium snap to be installed in order to use chromium.
+If you receive errors about needing the chromium snap while running the test suite, you can install Chrome and chromedriver instead:
+
+1. Download and Install Chrome on WSL Ubuntu
+  - Update your packages:
+
+    `sudo apt update`
+
+  - Download Chrome:
+
+    `wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
+
+  - Install chrome from the downloaded file
+
+    `sudo dpkg -i google-chrome-stable_current_amd64.deb`
+
+    `sudo apt-get install -f`
+
+  - Check that Chrome is installed correctly
+
+    `google-chrome --version`
+
+2. Install the appropriate Chromedriver
+  - Depending on the version of google-chrome you installed, you will need a specific chromedriver. You can see which version you need on the [chromedriver dowload page](https://chromedriver.chromium.org/downloads).
+    - For example, if `google-chrome --version` returns 105.x.xxxx.xxx you will want to download the version of chromedriver recommended on the page for version 105.
+    - As of this writing, the download page says the following for Chrome version 105:
+      > If you are using Chrome version 105, please download ChromeDriver 105.0.5195.52
+  - To download chromedriver, run the following command, replacing `{CHROMEDRIVER-VERSION}` with the version of chromedriver you need (e.g., 105.0.5195.52)
+
+    `wget https://chromedriver.storage.googleapis.com/{CHROMEDRIVER-VERSION}/chromedriver_linux64.zip`
+
+  - Next, unzip the file you downloaded
+
+    `unzip chromedriver_linux64.zip`
+
+  - Finally, move chromedriver to the correct location and enable it for use:
+
+    `sudo mv chromedriver /usr/bin/chromedriver`
+
+    `sudo chown root:root /usr/bin/chromedriver`
+
+    `sudo chmod +x /usr/bin/chromedriver`
+
+3. Run the test suite
+  - Assuming the rest of the application is already set up, you can run the test suite to verify that you no longer receive error regarding chromium snap:
+    `bin/rails spec`
 
 ### Casa & Rails
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
No official issue.

### What changed, and why?
Newer versions of Ubuntu require the chromium snap when trying to run chromium. 
This presents an issue for anyone running Ubuntu on WSL because snap requires Systemd to be running as the main process, but WSL has a different main process to provide for interoperability with Windows (see [this SO answer](https://stackoverflow.com/a/71722804)).

This PR adds instructions for how to download and install Google Chrome and the appropriate chromedriver for WSL Ubuntu users who need to do it entirely via the linux command line.

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Manual testing. 
The test suite failed and returned a bunch of errors regarding the chromium snap prior to running through these steps. 
After these steps, test suite passed and errors were gone.

### Screenshots please :)
N/A

### Feelings gif (optional)
![Hacking](https://media.giphy.com/media/rMS1sUPhv95f2/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9