### PR TITLE
Ignore blank court orders when saving new/existing court date

### DIFF
--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -73,8 +73,16 @@ class CourtDatesController < ApplicationController
     @court_date = @casa_case.court_dates.find(params[:id])
   end
 
+  def sanitized_params
+    params.require(:court_date).tap do |p|
+      p[:case_court_orders_attributes]&.reject! do |k, _|
+        p[:case_court_orders_attributes][k][:text].blank? && p[:case_court_orders_attributes][k][:implementation_status].blank?
+      end
+    end
+  end
+
   def court_dates_params
-    params.require(:court_date).permit(
+    sanitized_params.permit(
       :date,
       :hearing_type_id,
       :judge_id,

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -326,10 +326,10 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
           orders_updated[:case_court_orders_attributes]["1"][:id] = court_date.case_court_orders[1].id
         end
 
-        it "does not update the first order" do
+        it "still updates the first order" do
           expect do
             patch casa_case_court_date_path(casa_case, court_date), params: {court_date: orders_updated}
-          end.not_to(
+          end.to(
             change { court_date.reload.case_court_orders[0].text }
           )
         end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2616

### What changed, and why?
- Remove blank court order params so they do not prevent the court date from being saved

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Updated `spec/requests/court_dates_spec.rb`

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9