### PR TITLE
Can delete new patch notes and the editing patch note UI works

### DIFF
--- a/app/assets/stylesheets/pages/patch_notes.scss
+++ b/app/assets/stylesheets/pages/patch_notes.scss
@@ -42,6 +42,10 @@
           &:nth-child(2) {
             margin-left: 0.5em
           };
+
+          &.button-cancel {
+            flex-grow: 3
+          }
         }
       }
     };

--- a/app/assets/stylesheets/pages/patch_notes.scss
+++ b/app/assets/stylesheets/pages/patch_notes.scss
@@ -9,6 +9,10 @@
     }
 
     .patch-note-list-item {
+      & .card-body>* {
+        margin: 0.25em 0;
+      }
+
       &.new {
         background-color: #ffecb3;
       }
@@ -33,7 +37,11 @@
         display: flex;
 
         button {
-          flex-grow: 1
+          flex-grow: 1;
+
+          &:nth-child(2) {
+            margin-left: 0.5em
+          };
         }
       }
     };

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,7 +1,7 @@
 const AsyncNotifier = require('../async_notifier')
 const TypeChecker = require('../type_checker')
 const patchNotePath = window.location.pathname
-//const patchNoteFormBeforeEditData = {}
+// const patchNoteFormBeforeEditData = {}
 const patchNoteFunctions = {} // A hack to be able to alphabetize functions
 
 let pageNotifier

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -53,7 +53,6 @@ patchNoteFunctions.addPatchNoteUI = function (patchNoteGroupId, patchNoteId, pat
   patchNoteFunctions.initPatchNoteForm(newPatchNoteUI)
 }
 
-
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
 //  @param    {string} patchNoteText     The text of the patch note
@@ -202,10 +201,9 @@ patchNoteFunctions.onToggleEditPatchNote = function () {
   switch ($(this).text()) {
     case 'Edit':
       patchNoteFunctions.togglePatchNoteFormEditMode(patchNoteFormInputs)
-      break;
+      break
     default:
       throw new RangeError('Unrecogniszed Form State')
-      break;
   }
 }
 

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -3,6 +3,12 @@ const TypeChecker = require('../type_checker')
 const patchNotePath = window.location.pathname
 let pageNotifier
 
+jQuery.ajaxSetup({
+  beforeSend: function() {
+    pageNotifier.startAsyncOperation()
+  }
+})
+
 // Inserts a patch note display after the create patch note form in the patch note list and styles it as new
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
 //  @param    {jQuery} patchNoteList     A jQuery object representing the patch note list
@@ -57,8 +63,6 @@ function createPatchNote (patchNoteGroupId, patchNoteText, patchNoteTypeId) {
   TypeChecker.checkPositiveInteger(patchNoteTypeId, 'patchNoteTypeId')
   TypeChecker.checkString(patchNoteText, 'patchNoteText')
 
-  pageNotifier.startAsyncOperation()
-
   // Post request
   return $.post(patchNotePath, {
     note: patchNoteText,
@@ -88,8 +92,6 @@ function createPatchNote (patchNoteGroupId, patchNoteText, patchNoteTypeId) {
 //  @throws   {RangeError} if optionId is negative
 function deletePatchNote (patchNoteId) {
   TypeChecker.checkPositiveInteger(patchNoteId, 'patchNoteId')
-
-  pageNotifier.startAsyncOperation()
 
   // Post request
   return $.ajax({

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -4,7 +4,7 @@ const patchNotePath = window.location.pathname
 let pageNotifier
 
 jQuery.ajaxSetup({
-  beforeSend: function() {
+  beforeSend: function () {
     pageNotifier.startAsyncOperation()
   }
 })

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,7 +1,7 @@
 const AsyncNotifier = require('../async_notifier')
 const TypeChecker = require('../type_checker')
 const patchNotePath = window.location.pathname
-const patchNoteFormBeforeEditData = {}
+//const patchNoteFormBeforeEditData = {}
 const patchNoteFunctions = {} // A hack to be able to alphabetize functions
 
 let pageNotifier
@@ -230,8 +230,6 @@ patchNoteFunctions.resolveAsyncOperation = function (error) {
 //  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) {
-  const isInEditMode = patchNoteFormInputs.noteTextArea.attr('disabled')
-
   patchNoteFunctions.enablePatchNoteForm(patchNoteFormInputs)
 
   // Change button controls

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -9,47 +9,6 @@ jQuery.ajaxSetup({
   }
 })
 
-// Inserts a patch note display after the create patch note form in the patch note list and styles it as new
-//  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
-//  @param    {jQuery} patchNoteList     A jQuery object representing the patch note list
-//  @param    {string} patchNoteText     The text of the patch note
-//  @param    {number} patchNoteTypeId   The id of the patch note type
-//  @throws   {TypeError}  for a parameter of the incorrect type
-//  @throws   {RangeError} if an id parameter is negative
-function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
-  TypeChecker.checkPositiveInteger(patchNoteGroupId, 'patchNoteGroupId')
-  TypeChecker.checkPositiveInteger(patchNoteId, 'patchNoteId')
-  TypeChecker.checkPositiveInteger(patchNoteTypeId, 'patchNoteTypeId')
-  TypeChecker.checkNonEmptyJQueryObject(patchNoteList, 'patchNoteList')
-  TypeChecker.checkString(patchNoteText, 'patchNoteText')
-
-  const newPatchNoteForm = patchNoteList.children().eq(1)
-
-  if (!(newPatchNoteForm.length)) {
-    throw new ReferenceError('Could not find new patch note form')
-  }
-
-  const newPatchNoteUI = newPatchNoteForm.clone()
-  const newPatchNoteUIFormInputs = getPatchNoteFormInputs(newPatchNoteUI.children())
-
-  newPatchNoteUI.addClass('new')
-  newPatchNoteUIFormInputs.noteTextArea.val(patchNoteText)
-  newPatchNoteUIFormInputs.dropdownGroup.children().removeAttr('selected')
-  newPatchNoteUIFormInputs.dropdownGroup.children(`option[value="${patchNoteGroupId}"]`).attr('selected', true)
-  newPatchNoteUIFormInputs.dropdownType.children().removeAttr('selected')
-  newPatchNoteUIFormInputs.dropdownType.children(`option[value="${patchNoteTypeId}"]`).attr('selected', true)
-  newPatchNoteUIFormInputs.buttonControls.parent().html(`
-    <button type="button" class="btn btn-primary button-edit">
-      <i class="fa-solid fa-pen-to-square"></i>Edit
-    </button>
-    <button type="button" class="btn btn-danger button-delete">
-      <i class="fa-solid fa-trash-can"></i>Delete
-    </button>
-  `)
-
-  newPatchNoteForm.after(newPatchNoteUI)
-}
-
 // Creates a patch note
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
 //  @param    {string} patchNoteText     The text of the patch note
@@ -178,6 +137,73 @@ function resolveAsyncOperation (error) {
   pageNotifier.stopAsyncOperation(error)
 }
 
+function onDeletePatchNote () {
+  const patchNoteFormContainer = $(this).parent().parent()
+  const formInputs = getPatchNoteFormInputs(patchNoteFormContainer)
+
+  disablePatchNoteForm(formInputs)
+
+  deletePatchNote(
+    Number.parseInt(patchNoteFormContainer.attr('id').match(/patch-note-(\d+)/)[1])
+  ).then(function () {
+    patchNoteFormContainer.parent().remove()
+  }).fail(function () {
+    enablePatchNoteForm(formInputs)
+  })
+}
+
+// Add event listeners to a patch note form
+//  @param {object} patchNoteForm An jQuery object representing the patch note form
+//  @throws   {TypeError}  for a parameter of the incorrect type
+function initPatchNoteForm (patchNoteForm) {
+  TypeChecker.checkNonEmptyJQueryObject(patchNoteForm)
+
+  patchNoteForm.find('.button-delete').click(onDeletePatchNote)
+}
+
+// Inserts a patch note display after the create patch note form in the patch note list and styles it as new
+//  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
+//  @param    {jQuery} patchNoteList     A jQuery object representing the patch note list
+//  @param    {string} patchNoteText     The text of the patch note
+//  @param    {number} patchNoteTypeId   The id of the patch note type
+//  @throws   {TypeError}  for a parameter of the incorrect type
+//  @throws   {RangeError} if an id parameter is negative
+function addPatchNoteUI (patchNoteGroupId, patchNoteId, patchNoteList, patchNoteText, patchNoteTypeId) {
+  TypeChecker.checkPositiveInteger(patchNoteGroupId, 'patchNoteGroupId')
+  TypeChecker.checkPositiveInteger(patchNoteId, 'patchNoteId')
+  TypeChecker.checkPositiveInteger(patchNoteTypeId, 'patchNoteTypeId')
+  TypeChecker.checkNonEmptyJQueryObject(patchNoteList, 'patchNoteList')
+  TypeChecker.checkString(patchNoteText, 'patchNoteText')
+
+  const newPatchNoteForm = patchNoteList.children().eq(1)
+
+  if (!(newPatchNoteForm.length)) {
+    throw new ReferenceError('Could not find new patch note form')
+  }
+
+  const newPatchNoteUI = newPatchNoteForm.clone()
+  const newPatchNoteUIFormInputs = getPatchNoteFormInputs(newPatchNoteUI.children())
+
+  newPatchNoteUI.addClass('new')
+  newPatchNoteUI.children().attr('id', `patch-note-${patchNoteId}`)
+  newPatchNoteUIFormInputs.noteTextArea.val(patchNoteText)
+  newPatchNoteUIFormInputs.dropdownGroup.children().removeAttr('selected')
+  newPatchNoteUIFormInputs.dropdownGroup.children(`option[value="${patchNoteGroupId}"]`).attr('selected', true)
+  newPatchNoteUIFormInputs.dropdownType.children().removeAttr('selected')
+  newPatchNoteUIFormInputs.dropdownType.children(`option[value="${patchNoteTypeId}"]`).attr('selected', true)
+  newPatchNoteUIFormInputs.buttonControls.parent().html(`
+    <button type="button" class="btn btn-primary button-edit">
+      <i class="fa-solid fa-pen-to-square"></i>Edit
+    </button>
+    <button type="button" class="btn btn-danger button-delete">
+      <i class="fa-solid fa-trash-can"></i>Delete
+    </button>
+  `)
+
+  newPatchNoteForm.after(newPatchNoteUI)
+  initPatchNoteForm(newPatchNoteUI)
+}
+
 $('document').ready(() => {
   if (!(window.location.pathname.includes('patch_notes'))) {
     return
@@ -218,20 +244,7 @@ $('document').ready(() => {
       })
     })
 
-    $('#patch-note-list .button-delete').click(function () {
-      const patchNoteFormContainer = $(this).parent().parent()
-      const formInputs = getPatchNoteFormInputs(patchNoteFormContainer)
-
-      disablePatchNoteForm(formInputs)
-
-      deletePatchNote(
-        Number.parseInt(patchNoteFormContainer.attr('id').match(/patch-note-(\d+)/)[1])
-      ).then(function () {
-        patchNoteFormContainer.parent().remove()
-      }).fail(function () {
-        enablePatchNoteForm(formInputs)
-      })
-    })
+    $('#patch-note-list .button-delete').click(onDeletePatchNote)
   } catch (err) {
     pageNotifier.notify('Could not intialize app', 'error')
     pageNotifier.notify(err.message, 'error')

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -234,7 +234,7 @@ patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) 
     patchNoteFormBeforeEditData[patchNoteFunctions.getPatchNoteId(patchNoteFormInputs.noteTextArea.parent())] = {
       note: patchNoteFormInputs.noteTextArea.val(),
       groupId: Number.parseInt(patchNoteFormInputs.dropdownGroup.val()),
-      typeId:  Number.parseInt(patchNoteFormInputs.dropdownType.val())
+      typeId: Number.parseInt(patchNoteFormInputs.dropdownType.val())
     }
 
     console.log(patchNoteFormBeforeEditData)

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -128,6 +128,49 @@ patchNoteFunctions.disablePatchNoteForm = function (patchNoteFormElements) {
   }
 }
 
+// Change a patch note form out of edit mode
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @throws {TypeError} for a parameter of the incorrect type
+patchNoteFunctions.disablePatchNoteFormEditMode = function (patchNoteFormInputs) {
+  TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
+
+  let patchNoteDataBeforeEditing
+
+  try {
+    patchNoteDataBeforeEditing = patchNoteFormBeforeEditData[patchNoteFunctions.getPatchNoteId(patchNoteFormInputs.noteTextArea.parent())]
+
+    patchNoteFormInputs.noteTextArea.val(patchNoteDataBeforeEditing.note)
+    patchNoteFormInputs.dropdownGroup.val(patchNoteDataBeforeEditing.groupId)
+    patchNoteFormInputs.dropdownType.val(patchNoteDataBeforeEditing.typeId)
+  } catch (e) {
+    pageNotifier.notify('Failed to load patch note data from before editing', 'error')
+    throw e
+  }
+
+  patchNoteFormInputs.noteTextArea.prop('disabled', true)
+  patchNoteFormInputs.dropdownGroup.prop('disabled', true)
+  patchNoteFormInputs.dropdownType.prop('disabled', true)
+
+  // Change button controls
+  //   Clear click listeners
+  patchNoteFormInputs.buttonControls.off()
+
+  const buttonLeft = patchNoteFormInputs.buttonControls.siblings('.button-save')
+  const buttonRight = patchNoteFormInputs.buttonControls.siblings('.button-cancel')
+
+  buttonLeft.html('<i class="fa-solid fa-pen-to-square"></i> Edit')
+  buttonLeft.removeClass('button-save')
+  buttonLeft.addClass('button-edit')
+
+  buttonRight.html('<i class="fa-solid fa-trash-can"></i> Delete')
+  buttonRight.removeClass('btn-secondary')
+  buttonRight.removeClass('button-cancel')
+  buttonRight.addClass('btn-danger')
+  buttonRight.addClass('button-delete')
+
+  patchNoteFunctions.initPatchNoteForm(patchNoteFormInputs.noteTextArea.parent())
+}
+
 // Enables all form elements of a patch note form
 //  @param    {object} patchNoteFormElements An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
 //  @throws   {TypeError} for a parameter of the incorrect type
@@ -135,6 +178,45 @@ patchNoteFunctions.enablePatchNoteForm = function (patchNoteFormElements) {
   for (const formElement of Object.values(patchNoteFormElements)) {
     formElement.removeAttr('disabled')
   }
+}
+
+// Change a patch note form into edit mode
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @throws {TypeError} for a parameter of the incorrect type
+patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) {
+  TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
+
+  try {
+    patchNoteFormBeforeEditData[patchNoteFunctions.getPatchNoteId(patchNoteFormInputs.noteTextArea.parent())] = {
+      note: patchNoteFormInputs.noteTextArea.val(),
+      groupId: Number.parseInt(patchNoteFormInputs.dropdownGroup.val()),
+      typeId: Number.parseInt(patchNoteFormInputs.dropdownType.val())
+    }
+  } catch (e) {
+    pageNotifier.notify('Failed to save patch note form data before editing', 'error')
+    throw e
+  }
+
+  patchNoteFunctions.enablePatchNoteForm(patchNoteFormInputs)
+
+  // Change button controls
+  //   Clear click listeners
+  patchNoteFormInputs.buttonControls.off()
+
+  const buttonLeft = patchNoteFormInputs.buttonControls.siblings('.button-edit')
+  const buttonRight = patchNoteFormInputs.buttonControls.siblings('.button-delete')
+
+  buttonLeft.html('<i class="fas fa-save"></i> Save')
+  buttonLeft.removeClass('button-edit')
+  buttonLeft.addClass('button-save')
+
+  buttonRight.html('<i class="fa-solid fa-xmark"></i> Cancel')
+  buttonRight.removeClass('button-delete')
+  buttonRight.removeClass('btn-danger')
+  buttonRight.addClass('button-cancel')
+  buttonRight.addClass('btn-secondary')
+
+  patchNoteFunctions.initPatchNoteForm(patchNoteFormInputs.noteTextArea.parent())
 }
 
 // Get all form elements of a patch note in edit mode
@@ -176,7 +258,7 @@ patchNoteFunctions.getPatchNoteFormInputs = function (patchNoteElement) {
 //  @returns {number} The id of the patch note as a number
 //  @throws  {TypeError}  for a parameter of the incorrect type
 patchNoteFunctions.getPatchNoteId = function (patchNoteForm) {
-  TypeChecker.checkNonEmptyJQueryObject(patchNoteForm)
+  TypeChecker.checkNonEmptyJQueryObject(patchNoteForm, 'patchNoteForm')
 
   return Number.parseInt(patchNoteForm.attr('id').match(/patch-note-(\d+)/)[1])
 }
@@ -185,10 +267,19 @@ patchNoteFunctions.getPatchNoteId = function (patchNoteForm) {
 //  @param {object} patchNoteForm A jQuery object representing the patch note form
 //  @throws   {TypeError}  for a parameter of the incorrect type
 patchNoteFunctions.initPatchNoteForm = function (patchNoteForm) {
-  TypeChecker.checkNonEmptyJQueryObject(patchNoteForm)
+  TypeChecker.checkNonEmptyJQueryObject(patchNoteForm, 'patchNoteForm')
 
+  patchNoteForm.find('.button-cancel').click(patchNoteFunctions.onCancelEdit)
   patchNoteForm.find('.button-delete').click(patchNoteFunctions.onDeletePatchNote)
   patchNoteForm.find('.button-edit').click(patchNoteFunctions.onEditPatchNote)
+}
+
+// Called when the cancel button is pressed on a patch note form
+patchNoteFunctions.onCancelEdit = function () {
+  const patchNoteFormContainer = $(this).parent().parent()
+  const formInputs = patchNoteFunctions.getPatchNoteFormInputs(patchNoteFormContainer)
+
+  patchNoteFunctions.disablePatchNoteFormEditMode(formInputs)
 }
 
 // Called when the delete button is pressed on a patch note form
@@ -224,43 +315,6 @@ patchNoteFunctions.resolveAsyncOperation = function (error) {
   }
 
   pageNotifier.stopAsyncOperation(error)
-}
-
-// Change a patch note form into edit mode
-//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
-//  @throws {TypeError} for a parameter of the incorrect type
-patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) {
-  try {
-    patchNoteFormBeforeEditData[patchNoteFunctions.getPatchNoteId(patchNoteFormInputs.noteTextArea.parent())] = {
-      note: patchNoteFormInputs.noteTextArea.val(),
-      groupId: Number.parseInt(patchNoteFormInputs.dropdownGroup.val()),
-      typeId: Number.parseInt(patchNoteFormInputs.dropdownType.val())
-    }
-
-    console.log(patchNoteFormBeforeEditData)
-  } catch (e) {
-    pageNotifier.notify('Failed to save patch note form data before editing', 'error')
-    throw e
-  }
-
-  patchNoteFunctions.enablePatchNoteForm(patchNoteFormInputs)
-
-  // Change button controls
-  //   Clear click listeners
-  patchNoteFormInputs.buttonControls.off()
-
-  const buttonLeft = patchNoteFormInputs.buttonControls.siblings('.button-edit')
-  const buttonRight = patchNoteFormInputs.buttonControls.siblings('.button-delete')
-
-  buttonLeft.html('<i class="fas fa-save"></i> Save')
-  buttonLeft.removeClass('button-edit')
-  buttonLeft.addClass('button-save')
-
-  buttonRight.html('<i class="fa-solid fa-xmark"></i> Cancel')
-  buttonRight.removeClass('button-delete')
-  buttonRight.removeClass('btn-danger')
-  buttonRight.addClass('button-cancel')
-  buttonRight.addClass('btn-secondary')
 }
 
 $('document').ready(() => {

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -1,7 +1,7 @@
 const AsyncNotifier = require('../async_notifier')
 const TypeChecker = require('../type_checker')
 const patchNotePath = window.location.pathname
-// const patchNoteFormBeforeEditData = {}
+const patchNoteFormBeforeEditData = {}
 const patchNoteFunctions = {} // A hack to be able to alphabetize functions
 
 let pageNotifier
@@ -230,6 +230,19 @@ patchNoteFunctions.resolveAsyncOperation = function (error) {
 //  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) {
+  try {
+    patchNoteFormBeforeEditData[patchNoteFunctions.getPatchNoteId(patchNoteFormInputs.noteTextArea.parent())] = {
+      note: patchNoteFormInputs.noteTextArea.val(),
+      groupId: Number.parseInt(patchNoteFormInputs.dropdownGroup.val()),
+      typeId:  Number.parseInt(patchNoteFormInputs.dropdownType.val())
+    }
+
+    console.log(patchNoteFormBeforeEditData)
+  } catch (e) {
+    pageNotifier.notify('Failed to save patch note form data before editing', 'error')
+    throw e
+  }
+
   patchNoteFunctions.enablePatchNoteForm(patchNoteFormInputs)
 
   // Change button controls

--- a/app/javascript/src/type_checker.js
+++ b/app/javascript/src/type_checker.js
@@ -29,6 +29,16 @@ module.exports = {
     }
   },
 
+  // Checks if a variable is an object
+  //  @param  {any}    variable The variable to be checked
+  //  @param  {string} varName  The name of the variable to be checked
+  //  @throws {TypeError}  If variable is not an object
+  checkObject (variable, varName) {
+    if (typeof variable !== 'object' || Array.isArray(variable) || variable === null) {
+      throw new TypeError(`Param ${varName} is not an object`)
+    }
+  },
+
   // Checks if a variable is a positive integer
   //  @param  {any}    variable The variable to be checked
   //  @param  {string} varName  The name of the variable to be checked

--- a/bin/asset_bundling_scripts/build_js.js
+++ b/bin/asset_bundling_scripts/build_js.js
@@ -6,17 +6,19 @@ const isWatching = CLIArgs.includes('--watch')
 const esbuild = require('esbuild')
 const logger = require('./logger.js')
 
-const watchValue = isWatching ? {
-  onRebuild(error, result) {
-    if (error) {
-      logger.error('watch build failed:')
-      logger.error(error.stack)
-    } else {
-      logger.info('watch build succeeded:')
-      logger.info(JSON.stringify(result, null, 2))
+const watchValue = isWatching
+  ? {
+      onRebuild (error, result) {
+        if (error) {
+          logger.error('watch build failed:')
+          logger.error(error.stack)
+        } else {
+          logger.info('watch build succeeded:')
+          logger.info(JSON.stringify(result, null, 2))
+        }
+      }
     }
-  }
-} : false
+  : false
 
 esbuild.build({
   entryPoints: ['app/javascript/application.js', 'app/javascript/all_casa_admin.js'],

--- a/bin/asset_bundling_scripts/build_js.js
+++ b/bin/asset_bundling_scripts/build_js.js
@@ -31,5 +31,5 @@ esbuild.build({
   }
 }).catch((err) => {
   logger.error('failed to build application.js')
-  logger.error(err)
+  logger.error(err.stack)
 })

--- a/bin/asset_bundling_scripts/build_js.js
+++ b/bin/asset_bundling_scripts/build_js.js
@@ -13,7 +13,7 @@ const watchValue = isWatching ? {
       logger.error(error.stack)
     } else {
       logger.info('watch build succeeded:')
-      logger.info(JSON.stringify(result))
+      logger.info(JSON.stringify(result, null, 2))
     }
   }
 } : false

--- a/bin/asset_bundling_scripts/build_js.js
+++ b/bin/asset_bundling_scripts/build_js.js
@@ -6,11 +6,23 @@ const isWatching = CLIArgs.includes('--watch')
 const esbuild = require('esbuild')
 const logger = require('./logger.js')
 
+const watchValue = isWatching ? {
+  onRebuild(error, result) {
+    if (error) {
+      logger.error('watch build failed:')
+      logger.error(error.stack)
+    } else {
+      logger.info('watch build succeeded:')
+      logger.info(JSON.stringify(result))
+    }
+  }
+} : false
+
 esbuild.build({
   entryPoints: ['app/javascript/application.js', 'app/javascript/all_casa_admin.js'],
   outdir: 'app/assets/builds',
   bundle: true,
-  watch: isWatching
+  watch: watchValue
 }).then(result => {
   logger.info('application.js, all_casa_admin.js built successfully')
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #3651

### What changed, and why?
 - New patch notes can be deleted(the yellow ones)
 - Can enter into edit mode
 - Can cancel out of edit mode

### Screenshots please :)  
Edit Before
![image](https://user-images.githubusercontent.com/8918762/191873049-04725e6a-35ee-42f1-bcb0-2d8ed0f40404.png)
Edit Mode
![image](https://user-images.githubusercontent.com/8918762/191873170-36b55928-523e-4022-aec3-c80d50e45c27.png)
Edit Changes
![image](https://user-images.githubusercontent.com/8918762/191873192-4e91a76f-f611-4adf-8ccd-132f6b884612.png)
Edit Cancel
![image](https://user-images.githubusercontent.com/8918762/191873213-3c3a28a5-6a3d-4305-8428-7e23c5a2eeac.png)

### How is this tested? (please write tests!) 💖💪
Not yet

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9