### PR TITLE
add validate presence to name of languages

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,6 +1,8 @@
 class Language < ApplicationRecord
   belongs_to :casa_org
   has_and_belongs_to_many :users
+
+  validates :name, presence: true
 end
 
 # == Schema Information

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -7,7 +7,7 @@
 
       <div class="field form-group">
         <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control" %>
+        <%= form.text_field :name, class: "form-control", required: true %>
       </div>
 
       <div class="actions">

--- a/db/migrate/20220924181447_remove_all_empty_languages.rb
+++ b/db/migrate/20220924181447_remove_all_empty_languages.rb
@@ -1,0 +1,5 @@
+class RemoveAllEmptyLanguages < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured { execute "DELETE from languages WHERE name IS NULL or trim(name) = ''" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_26_130829) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_24_181447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -3,4 +3,6 @@ require "rails_helper"
 RSpec.describe Language, type: :model do
   it { is_expected.to belong_to(:casa_org) }
   it { is_expected.to have_and_belong_to_many(:users) }
+
+  it { is_expected.to validate_presence_of(:name) }
 end

--- a/spec/system/languages/languages_spec.rb
+++ b/spec/system/languages/languages_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "languages/new", type: :system do
+  let(:admin) { create(:casa_admin) }
+  let(:organization) { admin.casa_org }
+
+  before do
+    sign_in admin
+
+    visit new_language_path
+  end
+
+  it "requires name text field" do
+    expect(page).to have_selector("input[required=required]", id: "language_name")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3972

### What changed, and why?
it was added a presence validation to name field of language model, because no make sense to create language without name 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
- Go to admin
- Edit organization
- new language

### Screenshots please :)
![image](https://user-images.githubusercontent.com/836472/192112990-adf277cb-2b7a-4bd8-876b-77bce123e8c8.png)


