### PR TITLE
3973 - Make organization name required

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -6,7 +6,7 @@
       <%= render "/shared/error_messages", resource: current_organization %>
       <div class="field form-group">
         <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control" %>
+        <%= form.text_field :name, class: "form-control", required: true %>
       </div>
       <div class="field form-group">
         <%= form.label :display_name, "Display name" %>

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -122,4 +122,8 @@ RSpec.describe "casa_org/edit", type: :system do
     expect(page).to have_text("Twilio API Key Secret")
     expect(page).to have_text("Twilio Phone Number")
   end
+
+  it "requires name text field" do
+    expect(page).to have_selector("input[required=required]", id: "casa_org_name")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3973

### What changed, and why?
Make organization name required

### How will this affect user permissions?
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
- Go to Edit "Organization"
- remove name field value
- submit form
