### PR TITLE
3969 - include CsvExporterHelper in rails_helper

### DIFF
--- a/spec/models/learning_hours_report_spec.rb
+++ b/spec/models/learning_hours_report_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe LearningHoursReport, type: :model do
-  let!(:casa_org) { create(:casa_org) }
+  let!(:casa_org) { build(:casa_org) }
   let!(:users) { create_list(:user, 3, casa_org: casa_org) }
 
   describe "#to_csv" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
   config.include PunditHelper, type: :view
   config.include SessionHelper, type: :view
   config.include SessionHelper, type: :request
+  config.include CsvExporterHelper, type: :model
   config.include TemplateHelper
   config.include Warden::Test::Helpers
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3969

### What changed, and why?
I included CsvExporterHelper in rails_helper.rb, because the method ```wait_for_csv_parse``` is locate in this file.


### How is this tested? (please write tests!) 💖💪

```ruby
bin/rspec spec/models/learning_hours_report_spec.rb
```
