### PR TITLE
fix non-volunteer-cant-save-address-new-case

### DIFF
--- a/spec/controllers/case_contacts_controller_spec.rb
+++ b/spec/controllers/case_contacts_controller_spec.rb
@@ -207,6 +207,40 @@ RSpec.describe CaseContactsController, type: :controller do
           expect(casa_case.case_contacts.last.miles_driven).to eq(123)
         end
       end
+
+      context "when volunteer address filled" do
+        let(:params) {
+          build(:case_contact, casa_case_id: case_id).attributes.merge(
+            casa_case_attributes: {
+              id: case_id, volunteers_attributes: {
+                "0" => {
+                  id: volunteer.id,
+                  address_attributes: {
+                    id: 0, content: "Volunteer address"
+                  }
+                }
+              }
+            }
+          )
+        }
+
+        context "when volunteer already has a address created" do
+          let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization, address: build(:address)) }
+
+          it "update volunteer address" do
+            expect { post :create, params: {case_contact: params}, format: :js }.to change(CaseContact, :count).by(1)
+            expect(casa_case.volunteers.first.address.content).to eq("Volunteer address")
+          end
+        end
+
+        context "when volunteer doesnt have a address created" do
+          let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: organization, address: nil) }
+          it "create new volunteer address" do
+            expect { post :create, params: {case_contact: params}, format: :js }.to change(CaseContact, :count).by(1)
+            expect(casa_case.volunteers.first.address.content).to eq("Volunteer address")
+          end
+        end
+      end
     end
 
     context "with invalid params" do

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :address do
     content { Faker::Address.full_address }
+    association :user
   end
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    content { Faker::Address.full_address }
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3971

### What changed, and why?
It was fixed a bug when try to create a new casa contact, and fill voluteers address.


### How will this affect user permissions?
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
- Log into staging as an admin or supervisor.
- Navigate to a casa case.
- Click the button to make a new case contact.
- Fill out all the required fields.
- Select Yes for driving reimbursement
- Fill out driving reimbursement with a volunteer address and a number of miles(now required)
