### PR TITLE
confirm before delete

### DIFF
--- a/app/assets/stylesheets/shared/async_notifier.scss
+++ b/app/assets/stylesheets/shared/async_notifier.scss
@@ -14,6 +14,7 @@
   font-weight: 900;
   position: fixed;
   right: 2em;
+  z-index: 100;
 
   div {
     border-radius: .25em;

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -294,11 +294,11 @@ patchNoteFunctions.onDeletePatchNote = function () {
     case 'Delete':
       pageNotifier.notify('Click 2 more times to delete', 'warn')
       deleteButton.text('2')
-      break;
+      break
     case '2':
       deleteButton.text('1')
-      break;
-    case '1': 
+      break
+    case '1':
       patchNoteFunctions.disablePatchNoteForm(formInputs)
 
       patchNoteFunctions.deletePatchNote(
@@ -310,7 +310,7 @@ patchNoteFunctions.onDeletePatchNote = function () {
         deleteButton.html('<i class="fa-solid fa-trash-can"></i> Delete')
       })
 
-      break;
+      break
   }
 }
 

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -284,18 +284,34 @@ patchNoteFunctions.onCancelEdit = function () {
 
 // Called when the delete button is pressed on a patch note form
 patchNoteFunctions.onDeletePatchNote = function () {
-  const patchNoteFormContainer = $(this).parent().parent()
+  const deleteButton = $(this)
+  const patchNoteFormContainer = deleteButton.parent().parent()
   const formInputs = patchNoteFunctions.getPatchNoteFormInputs(patchNoteFormContainer)
 
-  patchNoteFunctions.disablePatchNoteForm(formInputs)
+  console.log(deleteButton.text())
 
-  patchNoteFunctions.deletePatchNote(
-    patchNoteFunctions.getPatchNoteId(patchNoteFormContainer)
-  ).then(function () {
-    patchNoteFormContainer.parent().remove()
-  }).fail(function () {
-    patchNoteFunctions.enablePatchNoteForm(formInputs)
-  })
+  switch (deleteButton.text().trim()) {
+    case 'Delete':
+      pageNotifier.notify('Click 2 more times to delete', 'warn')
+      deleteButton.text('2')
+      break;
+    case '2':
+      deleteButton.text('1')
+      break;
+    case '1': 
+      patchNoteFunctions.disablePatchNoteForm(formInputs)
+
+      patchNoteFunctions.deletePatchNote(
+        patchNoteFunctions.getPatchNoteId(patchNoteFormContainer)
+      ).then(function () {
+        patchNoteFormContainer.parent().remove()
+      }).fail(function () {
+        patchNoteFunctions.enablePatchNoteForm(formInputs)
+        deleteButton.html('<i class="fa-solid fa-trash-can"></i> Delete')
+      })
+
+      break;
+  }
 }
 
 // Called when the delete button is pressed on a patch note form

--- a/app/javascript/src/async_notifier.js
+++ b/app/javascript/src/async_notifier.js
@@ -41,6 +41,7 @@ module.exports = class Notifier {
           .find('.async-failure-indicator button').click(function () {
             $(this).parent().remove()
           })
+
         break
       case 'info':
         this.notificationsElement.append(`


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #3651

### What changed, and why?
Required user to click several times to delete a patch note
Gave async notifier a higher z-index 

### How is this tested? (please write tests!) 💖💪
Not yet

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/193167659-f794af6b-7d5b-4699-a8ad-5ddfd9322a99.png)


### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9