### PR TITLE
Add foreign key on the other_duties table's creator_id

### DIFF
--- a/app/models/other_duty.rb
+++ b/app/models/other_duty.rb
@@ -18,3 +18,7 @@ end
 #  updated_at       :datetime         not null
 #  creator_id       :bigint           not null
 #
+# Foreign Keys
+#
+#  fk_rails_...  (creator_id => users.id)
+#

--- a/db/migrate/20221002103627_add_user_foreign_key_to_other_duties.rb
+++ b/db/migrate/20221002103627_add_user_foreign_key_to_other_duties.rb
@@ -1,0 +1,5 @@
+class AddUserForeignKeyToOtherDuties < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :other_duties, :users, column: :creator_id, validate: false
+  end
+end

--- a/db/migrate/20221002103754_validate_add_user_foreign_key_to_other_duties.rb
+++ b/db/migrate/20221002103754_validate_add_user_foreign_key_to_other_duties.rb
@@ -1,0 +1,5 @@
+class ValidateAddUserForeignKeyToOtherDuties < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :other_duties, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_24_181447) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_02_103754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -536,6 +536,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_24_181447) do
   add_foreign_key "languages", "casa_orgs"
   add_foreign_key "learning_hours", "users"
   add_foreign_key "mileage_rates", "users"
+  add_foreign_key "other_duties", "users", column: "creator_id"
   add_foreign_key "patch_notes", "patch_note_groups"
   add_foreign_key "patch_notes", "patch_note_types"
   add_foreign_key "preference_sets", "users"

--- a/spec/models/other_duty_spec.rb
+++ b/spec/models/other_duty_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe OtherDuty, type: :model do
     expect(duty).to_not be_valid
     expect(duty.errors[:notes]).to eq(["can't be blank"])
   end
+
+  it "cannot be saved without a user" do
+    other_duty = OtherDuty.new
+    other_duty.creator = nil
+    expect { other_duty.save!(validate: false) }.to raise_error ActiveRecord::NotNullViolation
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -241,4 +241,13 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  context "when there is an associated Other Duty record" do
+    let(:user) { create(:supervisor) }
+    let!(:duty) { create(:other_duty, creator: user) }
+
+    it "cannot be destroyed without destroying the associated Other Duty record" do
+      expect { user.delete }.to raise_error ActiveRecord::InvalidForeignKey
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3976 

### What changed, and why?
Added two reversible migrations; one to add the foreign key on creator_id, the other to validate it.

### How will this affect user permissions?
It is not expected to affect user permissions.

### How is this tested? (please write tests!) 💖💪
1. Login as a supervisor.
2. Create a duty under "Other Duties"
3. Open up the rails console.
4. Attempt to delete (not destroy) the supervisor associated with the duty.
5. A foreign key violation error should be raised. See the screenshots below.

In addition, new tests on OtherDuty and User models are written.

### Screenshots please :)
![casa issue 1](https://user-images.githubusercontent.com/88938117/193456117-c7b4bcf7-0a05-4b67-86a8-2212fea7b23e.png)
![casa issue 2](https://user-images.githubusercontent.com/88938117/193456124-cb6d0568-ca83-4b77-8151-2471d4b4bde3.png)
