### PR TITLE
3112 Manage volunteer assignments partial

### DIFF
--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -1,96 +1,72 @@
-<h1 class="pt-5">Manage Volunteers</h1>
+<% content_for :table_title do %>
+  <h3>Assigned Volunteers</h3>
+<% end %>
 
-<div id="volunteer-assignment" class="card card-container">
-  <div class="card-body">
-    <% if @casa_case.volunteers.present? %>
-      <br>
-      <h3>Assigned Volunteers</h3>
-      <div class="table-responsive">
-        <table class='table case-list'>
-          <thead>
-            <tr>
-              <th>Volunteer Name</th>
-              <th>Volunteer Email</th>
-              <th>Status</th>
-              <th>Start Date</th>
-              <th>End Date</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-          <% @casa_case.case_assignments.each do |assignment| %>
-            <tr>
-              <td data-test="volunteer-name">
-                <%= link_to assignment.volunteer.display_name, edit_volunteer_path(assignment.volunteer) %>
-              </td>
-              <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
-              <td data-test="assigned">
-                <% if assignment.active? %>
-                  <span class='badge badge-success text-uppercase'>Assigned</span>
-                <% else %>
-                    <span class="badge badge-danger text-uppercase">
-                      <%= assignment.volunteer.active? ? "Unassigned" : "Deactivated volunteer" %>
-                    </span>
-                <% end %>
-              </td>
-              <td data-test="assignment-start"><%= I18n.l(assignment.created_at, format: :full, default: nil) %></td>
-              <td data-test="assignment-end">
-                <% unless assignment.active? %>
-                  <%= I18n.l(assignment.updated_at, format: :full, default: nil) %>
-                <% end %>
-              </td>
-              <td data-test="action">
-                <% if policy(assignment).unassign? %>
-                  <%= button_to("Unassign Volunteer",
-                                unassign_case_assignment_path(assignment),
-                                method: :patch,
-                                class: "btn btn-outline-danger text-wrap") %>
-                <% else %>
-                  <% if !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
-                    <%= link_to "Activate Volunteer",
-                                activate_volunteer_path(assignment.volunteer,
-                                                        redirect_to_path: 'casa_case',
-                                                        casa_case_id: @casa_case.id
-                                ),
-                                method: :patch,
-                                class: "btn btn-outline-success" %>
-                  <% end %>
-                  <% if (policy(assignment).hide_contacts?) %>
-                    <%= button_to("Hide Old Contacts",
-                                show_hide_contacts_case_assignment_path(assignment),
-                                method: :patch,
-                                class: "btn btn-outline-secondary text-wrap") %>
-                  <% else %>
-                    <%= button_to("Show Old Contacts",
-                                show_hide_contacts_case_assignment_path(assignment),
-                                method: :patch,
-                                class: "btn btn-outline-warning text-wrap") %>
-                  <% end %>
-                <% end %>
-              </td>
-            </tr>
+<% content_for :table_body do %>
+  <tbody>
+  <% @casa_case.case_assignments.each do |assignment| %>
+    <tr>
+      <td data-test="volunteer-name">
+        <%= link_to assignment.volunteer.display_name, edit_volunteer_path(assignment.volunteer) %>
+      </td>
+      <td data-test="volunteer-email"><%= assignment&.volunteer&.email %></td>
+      <td data-test="assigned">
+        <% if assignment.active? %>
+          <span class='badge badge-success text-uppercase'>Assigned</span>
+        <% else %>
+            <span class="badge badge-danger text-uppercase">
+              <%= assignment.volunteer.active? ? "Unassigned" : "Deactivated volunteer" %>
+            </span>
+        <% end %>
+      </td>
+      <td data-test="assignment-start"><%= I18n.l(assignment.created_at, format: :full, default: nil) %></td>
+      <td data-test="assignment-end">
+        <% unless assignment.active? %>
+          <%= I18n.l(assignment.updated_at, format: :full, default: nil) %>
+        <% end %>
+      </td>
+      <td data-test="action">
+        <% if policy(assignment).unassign? %>
+          <%= button_to("Unassign Volunteer",
+                        unassign_case_assignment_path(assignment),
+                        method: :patch,
+                        class: "btn btn-outline-danger text-wrap") %>
+        <% else %>
+          <% if !assignment.volunteer.active? && policy(assignment.volunteer).activate? %>
+            <%= link_to "Activate Volunteer",
+                        activate_volunteer_path(assignment.volunteer,
+                                                redirect_to_path: 'casa_case',
+                                                casa_case_id: @casa_case.id
+                        ),
+                        method: :patch,
+                        class: "btn btn-outline-success" %>
           <% end %>
-          </tbody>
-        </table>
-      </div>
-    <% end %>
-
-    <br>
-
-    <h3>Assign a New Volunteer</h3>
-
-    <%= form_for CaseAssignment.new, url: case_assignments_path(casa_case_id: @casa_case.id) do |form| %>
-
-      <div class='form-group'>
-        <label for='case_assignment_casa_case_id'>Select a Volunteer</label>
-        <select id='case_assignment_casa_case_id' name='case_assignment[volunteer_id]' class='form-control select2'>
-          <% @casa_case.unassigned_volunteers.each do |volunteer| %>
-            <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+          <% if (policy(assignment).hide_contacts?) %>
+            <%= button_to("Hide Old Contacts",
+                        show_hide_contacts_case_assignment_path(assignment),
+                        method: :patch,
+                        class: "btn btn-outline-secondary text-wrap") %>
+          <% else %>
+            <%= button_to("Show Old Contacts",
+                        show_hide_contacts_case_assignment_path(assignment),
+                        method: :patch,
+                        class: "btn btn-outline-warning text-wrap") %>
           <% end %>
-        </select>
-      </div>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+<% end %>
 
-      <%= form.submit "Assign Volunteer", class: 'btn btn-secondary' %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+  "shared/manage_volunteers",
+  assignable_obj: CaseAssignment,
+  assign_action: case_assignments_path(casa_case_id: @casa_case.id),
+  available_volunteers: @casa_case.unassigned_volunteers,
+  select_id: 'case_assignment_casa_case_id',
+  select_name: 'case_assignment[volunteer_id]',
+  show_assigned_volunteers: @casa_case.volunteers.present?
+  )
+%>

--- a/app/views/shared/_manage_volunteers.html.erb
+++ b/app/views/shared/_manage_volunteers.html.erb
@@ -1,0 +1,54 @@
+<h1 class="pt-5">Manage Volunteers</h1>
+
+<div id="volunteer-assignment" class="card card-container">
+  <div class="card-body">
+    <% if show_assigned_volunteers %>
+      <%= yield :table_title %>
+      <div class="table-responsive">
+        <table class='table case-list'>
+          <thead>
+            <tr>
+              <th>Volunteer Name</th>
+              <th>Volunteer Email</th>
+              <% if @casa_case %>
+                <th>Status</th>
+                <th>Start Date</th>
+                <th>End Date</th>
+              <% end %>
+              <% if local_assigns[:button_text] == "Hide unassigned" %>
+                <th>Currently Assigned To</th>
+              <% end %>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <%= yield :table_body %>
+        </table>
+      </div>
+    <% end %>
+
+    <br>
+
+    <h3>Assign a New Volunteer</h3>
+
+    <fieldset class="border-0" <%= 'disabled' unless available_volunteers.any? %>>
+      <%= form_for assignable_obj.new, url: assign_action do |form| %>
+        <div class='form-group'>
+          <label for="<%= select_id %>">Select a Volunteer</label>
+          <select id="<%= select_id %>" name="<%= select_name %>" class='form-control select2'>
+            <% available_volunteers.each do |volunteer| %>
+              <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+            <% end %>
+          </select>
+        </div>
+        <% if @supervisor %>
+          <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
+        <% end %>
+
+        <%= form.submit "Assign Volunteer", class: 'btn btn-secondary' %>
+      <% end %>
+    </fieldset>
+    <% unless available_volunteers.any? %>
+      <p class="text-danger">There are no active, unassigned volunteers available.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/supervisors/edit.html.erb
+++ b/app/views/supervisors/edit.html.erb
@@ -24,76 +24,54 @@
   </div>
 </div>
 
-<h1 class="pt-5"><%= t(".manage_volunteers") %></h1>
+<% button_text = @all_volunteers_ever_assigned.nil? ? t(".include_unassigned") : t(".hide_unassigned") %>
 
-<div class="card card-container">
-  <div class="card-body">
-    <% if @supervisor_has_unassigned_volunteers || @supervisor.volunteers.any? %>
-      <h3 class="pull-left"><%= t(".volunteer_title", count: @unassigned_volunteer_count) %></h3>
-      <% if @supervisor_has_unassigned_volunteers %>
-        <% button_text = @all_volunteers_ever_assigned.nil? ? t(".include_unassigned") : t(".hide_unassigned") %>
-        <%= button_to button_text,
-                      edit_supervisor_path(@supervisor),
-                      params: { include_unassigned: @all_volunteers_ever_assigned.nil? },
-                      method: :get,
-                      class: "btn btn-outline-primary pull-right" %>
+<% content_for :table_title do %>
+  <h3 class="pull-left"><%= t(".volunteer_title", count: @unassigned_volunteer_count) %></h3>
+  <% if @supervisor_has_unassigned_volunteers %>
+    <%= button_to button_text,
+                  edit_supervisor_path(@supervisor),
+                  params: { include_unassigned: @all_volunteers_ever_assigned.nil? },
+                  method: :get,
+                  class: "btn btn-outline-primary pull-right" %>
+  <% end %>
+<% end %>
+
+<% content_for :table_body do %>
+  <tbody>
+  <% (@all_volunteers_ever_assigned || @supervisor.volunteers).each do |volunteer| %>
+    <tr>
+      <td><%= link_to volunteer.display_name, edit_volunteer_path(volunteer) %></td>
+      <td><%= volunteer.email %></td>
+      <% if button_text == t(".hide_unassigned") %>
+        <td>
+          <%= volunteer.has_supervisor? ? volunteer.supervisor.display_name : "No One" %>
+        </td>
       <% end %>
-      <table class='table volunteer-list'>
-        <thead>
-        <tr>
-          <th><%= t(".volunteer_name") %></th>
-          <th><%= t(".volunteer_email") %></th>
-          <% if button_text == t(".hide_unassigned") %>
-            <th><%= t(".currently_assigned_to") %></th>
-          <% end %>
-          <th><%= t(".unassign") %></th>
-        </tr>
-        </thead>
-        <tbody>
-        <% (@all_volunteers_ever_assigned || @supervisor.volunteers).each do |volunteer| %>
-          <tr>
-            <td><%= link_to volunteer.display_name, edit_volunteer_path(volunteer) %></td>
-            <td><%= volunteer.email %></td>
-            <% if button_text == t(".hide_unassigned") %>
-              <td>
-                <%= volunteer.has_supervisor? ? volunteer.supervisor.display_name : "No One" %>
-              </td>
-            <% end %>
-            <td>
-              <% if volunteer.supervised_by?(@supervisor) %>
-                <%= button_to t(".unassign"),
-                              unassign_supervisor_volunteer_path(volunteer),
-                              method: :patch,
-                              class: "btn btn-danger" %>
-              <% else %>
-                <%= t(".unassigned") %>
-              <% end %>
-            </td>
-          </tr>
+      <td>
+        <% if volunteer.supervised_by?(@supervisor) %>
+          <%= button_to t(".unassign"),
+                        unassign_supervisor_volunteer_path(volunteer),
+                        method: :patch,
+                        class: "btn btn-danger" %>
+        <% else %>
+          <%= t(".unassigned") %>
         <% end %>
-        </tbody>
-      </table>
-    <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+<% end %>
 
-    <h3><%= t(".assign_a_volunteer") %></h3>
-
-   <fieldset class="border-0" <%= 'disabled' unless @available_volunteers.any? %>>
-      <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(supervisor_id: @supervisor.id) do |form| %>
-
-        <div class='form-group'>
-          <label for='supervisor_volunteer_volunteer_id'><%= t(".select_a_volunteer") %></label>
-          <select name='supervisor_volunteer[volunteer_id]' class='form-control select2'>
-            <% @available_volunteers.each do |volunteer| %>
-              <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
-            <% end %>
-          </select>
-        </div>
-        <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>
-        <%= form.submit t(".assign_volunteer"), class: 'btn btn-primary' %>
-      <% end %>
-   </fieldset>
-    <% unless @available_volunteers.any? %>
-      <p class="text-danger"><%= t(".no_volunteers_available") %></p>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+  "shared/manage_volunteers",
+  assignable_obj: SupervisorVolunteer,
+  assign_action: supervisor_volunteers_path(supervisor_id: @supervisor.id),
+  available_volunteers: @available_volunteers,
+  select_id: 'supervisor_volunteer_volunteer_id',
+  select_name: 'supervisor_volunteer[volunteer_id]',
+  show_assigned_volunteers: @supervisor_has_unassigned_volunteers || @supervisor.volunteers.any?,
+  button_text: button_text
+  )
+%>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3112

### What changed, and why?
Refactored out the common elements of the "Manage Volunteers" section for the Casa Case and Supervisor edit pages into a shared partial. DRYs up the code a little bit. 

Unfortunately, not as much of the table code was reusable as I'd hoped since one page was a table of case assignments, while the other was a table of the supervisor's volunteers. There might be another way to refactor this even more, but it would likely be a much more invasive change.

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Existing tests all pass.

### Screenshots please :)
Looks exactly the same 🙂 

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9