### PR TITLE
Removed unused css class case-list from codebase

### DIFF
--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -23,7 +23,7 @@
 <div class="card card-container">
   <div class="card-body">
     <div class="table-responsive">
-      <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
+      <table class="table table-striped table-bordered" id="<%= @casa_cases_filter_id %>">
         <thead>
         <tr>
           <th>Case Number</th>

--- a/app/views/case_assignments/index.html.erb
+++ b/app/views/case_assignments/index.html.erb
@@ -3,7 +3,7 @@
 <br>
 
 <% if @volunteer.casa_cases %>
-  <table class='table case-list' id='casa_cases'>
+  <table class='table' id='casa_cases'>
     <thead>
     <tr>
       <th>Case Number</th>

--- a/app/views/emancipation_checklists/index.html.erb
+++ b/app/views/emancipation_checklists/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered case-list" id="all-case-emancipations">
+    <table class="table table-striped table-bordered" id="all-case-emancipations">
       <thead>
       <tr>
         <th>Case Number</th>

--- a/app/views/reimbursements/_reimbursement_complete.html.erb
+++ b/app/views/reimbursements/_reimbursement_complete.html.erb
@@ -1,6 +1,6 @@
 <div class="card card-container">
   <div class="card-body">
-    <table class="table table-striped table-bordered case-list" id="<%= @casa_cases_filter_id %>">
+    <table class="table table-striped table-bordered" id="<%= @casa_cases_filter_id %>">
       <thead>
       <tr>
 

--- a/app/views/reimbursements/_table.html.erb
+++ b/app/views/reimbursements/_table.html.erb
@@ -1,7 +1,7 @@
 <div class="card card-container">
   <div class="card-body">
     <div class="table-responsive">
-      <table class="table table-striped table-bordered case-list" id="reimbursements">
+      <table class="table table-striped table-bordered" id="reimbursements">
         <thead>
         <tr>
           <th><%= "Volunteer" %></th>

--- a/app/views/shared/_manage_volunteers.html.erb
+++ b/app/views/shared/_manage_volunteers.html.erb
@@ -5,7 +5,7 @@
     <% if show_assigned_volunteers %>
       <%= yield :table_title %>
       <div class="table-responsive">
-        <table class='table case-list'>
+        <table class='table'>
           <thead>
             <tr>
               <th>Volunteer Name</th>

--- a/app/views/volunteers/_manage_cases.erb
+++ b/app/views/volunteers/_manage_cases.erb
@@ -6,7 +6,7 @@
       <% if @volunteer.case_assignments.any? %>
         <br>
         <h3>Assigned Cases</h3>
-        <table class='table case-list'>
+        <table class='table' id='manage_cases'>
           <thead>
           <tr>
             <th>Case Number</th>

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "volunteers/edit", type: :system do
     it "does not show any active assignment status in the Manage Cases section" do
       sign_in admin
       visit edit_volunteer_path(volunteer)
-      within ".table.case-list" do
+      within "#manage_cases" do
         expect(page).not_to have_content("Volunteer is Active")
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4006 

### What changed, and why?
Removes the unused `case-list` css class from views. 

There is one instance where `.case-list` is being used in a system test. Instead of deleting this test, I've chosen to keep it but change the selector from `.case-list` (which was mentioned multiple times) to a single `#manage_cases` to be more descriptive.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
