### PR TITLE
3928 remove footers logged in translations

### DIFF
--- a/app/views/layouts/footers/_logged_in.html.erb
+++ b/app/views/layouts/footers/_logged_in.html.erb
@@ -2,13 +2,13 @@
   <span class="copyright pull-left">© <%= default_page_header %></span>
   <span class="default-footer pull-right">
     <span class="col-12 col-sm-2">
-      <%= t(".built_by") %> <a href="https://rubyforgood.org/"><%= t(".ruby_for_good") %></a>
+      Built by <a href="https://rubyforgood.org/">Ruby For Good</a>
     </span>
     <span class="col-12 col-sm-2">
-      <%= link_to t(".link.report_site_issue"), "https://rubyforgood.typeform.com/to/iXY4BubB" %>
+      <%= link_to "Report a site issue", "https://rubyforgood.typeform.com/to/iXY4BubB" %>
     </span>
     <span class="col-12 col-sm-2">
-      <%= link_to t(".link.sms_terms_and_conditions"), "/sms-terms-conditions.html" %>
+      <%= link_to "SMS Terms & Conditions", "/sms-terms-conditions.html" %>
     </span>
   </span>
 </footer>

--- a/app/views/layouts/footers/_not_logged_in.html.erb
+++ b/app/views/layouts/footers/_not_logged_in.html.erb
@@ -1,12 +1,12 @@
 <footer>
   <p class="copyright">© <%= default_page_header %></p>
   <span class="default-footer">
-    <%= t(".built_by") %> <a href="https://rubyforgood.org/" class="rfglink"><%= t(".ruby_for_good") %></a>
+    Built by <a href="https://rubyforgood.org/" class="rfglink">Ruby For Good</a>
     <a href="https://rubyforgood.org/" class="rfglink" target="_blank">
       <%= image_tag("rfglogo.png", class: "rfglogo") %>
     </a>
-    <%= link_to t(".link.report_site_issue"), "https://rubyforgood.typeform.com/to/iXY4BubB", class: "rfglink" %><br>
-    <%= link_to t(".link.sms_terms_and_conditions"), "/sms-terms-conditions.html", class: "terms-conditions-link" %>
+    <%= link_to "Report a site issue", "https://rubyforgood.typeform.com/to/iXY4BubB", class: "rfglink" %><br>
+    <%= link_to "SMS Terms & Conditions", "/sms-terms-conditions.html", class: "terms-conditions-link" %>
   </span>
 
   <div class="footer-logos">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3928 

### What changed, and why?
Updated the following:
    footers:
      logged_in:
        built_by: Built by
        link:
          report_site_issue: Report a site issue
          sms_terms_and_conditions: SMS Terms & Conditions
        ruby_for_good: Ruby For Good


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
the footer when logged in: 
![image](https://user-images.githubusercontent.com/67713820/193938467-823242be-32e0-4fc9-9454-684bd8f8f64d.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9