### PR TITLE
Load case_contacts/new when the case has no volunteers

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -136,7 +136,7 @@
               " for both of them. This is not currently possible."
             else
               volunteer = casa_cases[0].volunteers.first
-              address = volunteer.address.nil? ? Address.new : volunteer.address
+              address = volunteer&.address.nil? ? Address.new : volunteer.address
             end
           end
         %>

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "case_contacts/new", type: :view do
   subject { render template: "case_contacts/new" }
+  let(:casa_org) { CasaOrg.first }
+  let(:current_time) { Time.zone.now.strftime("%Y-%m-%d") }
 
   before do
     case_contact = build_stubbed(:case_contact)
@@ -10,20 +12,32 @@ RSpec.describe "case_contacts/new", type: :view do
     assign :selected_cases, [case_contact.casa_case]
     assign :contact_types, []
     assign :current_organization_groups, []
+
+    allow(view).to receive(:current_organization).and_return(casa_org)
+    allow(view).to receive(:current_role).and_return(role)
   end
 
   context "while signed-in as a volunteer" do
-    let(:casa_org) { CasaOrg.first }
     let(:role) { "Volunteer" }
+
     before do
       sign_in_as_volunteer
-      allow(view).to receive(:current_organization).and_return(casa_org)
-      allow(view).to receive(:current_role).and_return(role)
     end
-
-    let(:current_time) { Time.zone.now.strftime("%Y-%m-%d") }
 
     it { is_expected.to have_field("c. Occurred On", with: current_time) }
     it { is_expected.to have_selector("textarea", id: "case_contact_notes") }
+  end
+
+  context "while signed-in as an admin" do
+    let(:role) { "Casa Admin" }
+
+    before do
+      sign_in_as_admin
+    end
+
+    context "when the case has no volunteers" do
+      it { is_expected.to have_field("c. Occurred On", with: current_time) }
+      it { is_expected.to have_selector("textarea", id: "case_contact_notes") }
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4018

### What changed, and why?
- Add a `&` so the check for a volunteer's address does not explode if the volunteer is nil

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Created a new view test that failed before I fixed the problem

### Screenshots please :)
If the case has no volunteers and you select "Yes" under "Want Driving Reimbursement" on the `/case_contacts/new` page, the "Volunteer Address" section shows but there is no information underneath it. Perhaps this should be reworked in another ticket.

<img width="528" alt="image" src="https://user-images.githubusercontent.com/4965672/194115228-e293c1d4-c460-4e69-94ba-d475bdd01faf.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9