### PR TITLE
update failing spec

### DIFF
--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "casa_cases/show", type: :system do
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
   let!(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
   let!(:emancipation_categories) { create_list(:emancipation_category, 3) }
-  let!(:future_court_date) { create(:court_date, date: 1.year.from_now, casa_case: casa_case) }
+  let!(:future_court_date) { create(:court_date, date: 21.days.from_now, casa_case: casa_case) }
 
   before do
     sign_in user
@@ -64,9 +64,9 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
     end
 
-    xit "can see next court date", js: true do # TODO fix and re-enable
+    it "can see next court date", js: true do
       expect(page).to have_content(
-        "Next Court Date: #{I18n.l(future_court_date.date, format: :day_and_date, default: "")}"
+        "Next Court Date: #{I18n.l(future_court_date.date, format: :day_and_date)}"
       )
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Fixes an ignored spec in the file mentioned in #2942. While the issue doesn't explicitly mention this spec, I was looking through the file and noticed we had one ignored spec that was failing.

### What changed, and why?
Changed the mocked date. For some reason, dates like `1.year.from_now` or `2.months.from_now` get formatted with an extra space, causing the spec to fail. The date rendered on the page appears to be formatted properly, without the extra space.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
- updated `next_court_date` for `casa_case`