### PR TITLE
convert volunteers dropdown to searchable select

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,5 +34,6 @@
 @use "pages/login";
 @use "pages/password";
 @use "pages/patch_notes";
+@use "pages/reimbursements";
 @use "pages/supervisors";
 @use "pages/volunteers";

--- a/app/assets/stylesheets/pages/reimbursements.scss
+++ b/app/assets/stylesheets/pages/reimbursements.scss
@@ -1,0 +1,8 @@
+.reimbursements-index {
+  .select2-container {
+    .select2-selection {
+      max-height: 60px;
+      overflow: scroll;
+    }
+  }
+}

--- a/app/javascript/src/reimbursements.js
+++ b/app/javascript/src/reimbursements.js
@@ -75,7 +75,7 @@ $('document').ready(() => {
       .on('change', onMarkAsCompleteChange)
   })
 
-  $('[data-filter="volunteer"] input[type="checkbox"]').on('change', () => reimbursementsTable.draw())
+  $('[data-filter="volunteer"] .select2').on('select2:select select2:unselect', () => reimbursementsTable.draw())
   $('[data-filter="occurred_at"] input').on('change', () => reimbursementsTable.draw())
 
   const handleAjaxError = e => {
@@ -98,12 +98,20 @@ $('document').ready(() => {
 
   const getDatatableFilterParams = () => {
     return {
-      volunteers: map($('[data-filter="volunteer"] input:checked'), 'value'),
+      volunteers: selectedVolunteerIdsOrAll(),
       occurred_at: {
         start: $('input[name="occurred_at_starting"]').val(),
         end: $('input[name="occurred_at_ending"]').val()
       }
     }
+  }
+
+  const selectedVolunteerIdsOrAll = () => {
+    let selectedVols = $('[data-filter="volunteer"] .creator_ids').val()
+    if (selectedVols.length === 0) {
+      selectedVols = map($('[data-filter="volunteer"] .creator_ids option'), 'value')
+    }
+    return selectedVols
   }
 
   const reimbursementsTableCols = [

--- a/app/views/reimbursements/index.html.erb
+++ b/app/views/reimbursements/index.html.erb
@@ -20,16 +20,12 @@
       <%= t("reimbursements.filters.title") %>
     </h4>
     <!-- Volunteer filter -->
-    <div class="dropdown pull-left mr-2" data-filter="volunteer">
-      <%= render partial: "filter_trigger", locals: { title: t("reimbursements.filters.volunteer_filter_title") } %>
-      <div class="dropdown-menu">
-        <% @volunteers_for_filter.each do |key, value| %>
-          <div class="dropdown-item form-check">
-            <%= check_box_tag(nil, key, true, class: "form-check-input", data: { value: key }) %>
-            <%= label_tag '', value, class: "form-check-label" %>
-          </div>
+    <div class="pull-left mr-2 w-25" data-filter="volunteer">
+      <select class="form-control select2 creator_ids" multiple="true" data-placeholder="Volunteer">
+        <% @volunteers_for_filter.each do |volunteer| %>
+          <option value="<%= volunteer[0] %>"><%= volunteer[1] %></option>
         <% end %>
-      </div>
+      </select>
     </div>
     <!-- Occurred at filter -->
     <div class="dropdown pull-left mr-2" data-filter="occurred_at">

--- a/spec/system/reimbursements/reimbursements_spec.rb
+++ b/spec/system/reimbursements/reimbursements_spec.rb
@@ -4,14 +4,15 @@ require "rails_helper"
 
 RSpec.describe "reimbursements", type: :system do
   let(:admin) { create(:casa_admin) }
+  let!(:contact1) { create(:case_contact, :wants_reimbursement) }
+  let!(:contact2) { create(:case_contact, :wants_reimbursement) }
+
+  before do
+    sign_in admin
+    visit reimbursements_path
+  end
 
   it "shows reimbursements", js: true do
-    sign_in admin
-
-    contact1 = create(:case_contact, :wants_reimbursement)
-    contact2 = create(:case_contact, :wants_reimbursement)
-
-    visit reimbursements_path
     expect(page).to have_content("Needs Review")
     expect(page).to have_content("Reimbursement Complete")
     expect(page).to have_content("Occurred At")
@@ -20,10 +21,22 @@ RSpec.describe "reimbursements", type: :system do
   end
 
   it "shows pagination", js: true do
-    sign_in admin
-
-    visit reimbursements_path
     expect(page).to have_content("Previous")
     expect(page).to have_content("Next")
+  end
+
+  it "filters by volunteers", js: true do
+    expect(page).to have_selector("#reimbursements-datatable tbody tr", count: 2)
+
+    page.find(".select2-search__field").click
+    send_keys(contact1.creator.display_name)
+    send_keys(:enter)
+
+    expect(page).to have_selector("#reimbursements-datatable tbody tr", count: 1)
+    expect(page).to have_content contact1.creator.display_name
+
+    page.find(".select2-selection__choice__remove").click
+
+    expect(page).to have_selector("#reimbursements-datatable tbody tr", count: 2)
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4017

### What changed, and why?
- Changed the filter by Volunteers dropdown on the reimbursements page to be a searchable select box instead.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
New system test

### Screenshots please :)
No volunteers selected so page shows all

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/4965672/194154354-fcc72bbc-3589-4c00-a8a9-c89220d26a05.png">

When volunteers are selected, box has fixed height and overflow scroll

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/4965672/194154557-f07ce711-ea4b-4dd4-b3f1-3dcdb4b3b3c6.png">



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9