### PR TITLE
Rename enum value not_implemented

### DIFF
--- a/app/javascript/__tests__/court_order_list.test.js
+++ b/app/javascript/__tests__/court_order_list.test.js
@@ -146,7 +146,7 @@ describe('removeCourtOrder', () => {
           <textarea name="casa_case[case_court_orders_attributes][0][text]" id="casa_case_case_court_orders_attributes_0_text">${courtOrdersText[0]}</textarea>\
           <select class="implementation-status" name="casa_case[case_court_orders_attributes][0][implementation_status]" id="casa_case_case_court_orders_attributes_0_implementation_status">\
             <option value="">Set Implementation Status</option>\
-            <option value="not_implemented">Not implemented</option>
+            <option value="unimplemented">Not implemented</option>
             <option value="partially_implemented">Partially implemented</option>\
             <option value="implemented">Implemented</option>
           </select>\
@@ -157,7 +157,7 @@ describe('removeCourtOrder', () => {
           <textarea name="casa_case[case_court_orders_attributes][1][text]" id="casa_case_case_court_orders_attributes_1_text">${courtOrdersText[1]}</textarea>\
           <select class="implementation-status" name="casa_case[case_court_orders_attributes][1][implementation_status]" id="casa_case_case_court_orders_attributes_1_implementation_status">\
             <option value="">Set Implementation Status</option>\
-            <option value="not_implemented">Not implemented</option>\
+            <option value="unimplemented">Not implemented</option>\
             <option value="partially_implemented">Partially implemented</option>\
             <option value="implemented">Implemented</option></select>\
           <button type="button" class="remove-mandate-button btn btn-danger">Delete</button>\
@@ -167,7 +167,7 @@ describe('removeCourtOrder', () => {
           <textarea name="casa_case[case_court_orders_attributes][2][text]" id="casa_case_case_court_orders_attributes_2_text">${courtOrdersText[2]}</textarea>\
           <select class="implementation-status" name="casa_case[case_court_orders_attributes][2][implementation_status]" id="casa_case_case_court_orders_attributes_2_implementation_status">\
             <option value="">Set Implementation Status</option>\
-            <option value="not_implemented">Not implemented</option>\
+            <option value="unimplemented">Not implemented</option>\
             <option value="partially_implemented">Partially implemented</option>\
             <option value="implemented">Implemented</option>\
           </select>\
@@ -178,7 +178,7 @@ describe('removeCourtOrder', () => {
           <textarea name="casa_case[case_court_orders_attributes][3][text]" id="casa_case_case_court_orders_attributes_3_text">${courtOrdersText[3]}</textarea>\
           <select class="implementation-status" name="casa_case[case_court_orders_attributes][3][implementation_status]" id="casa_case_case_court_orders_attributes_3_implementation_status">\
             <option value="">Set Implementation Status</option>\
-            <option value="not_implemented">Not implemented</option>\
+            <option value="unimplemented">Not implemented</option>\
             <option value="partially_implemented">Partially implemented</option>\
             <option value="implemented">Implemented</option>\
           </select>\
@@ -189,7 +189,7 @@ describe('removeCourtOrder', () => {
           <textarea name="casa_case[case_court_orders_attributes][4][text]" id="casa_case_case_court_orders_attributes_4_text">${courtOrdersText[4]}</textarea>\
           <select class="implementation-status" name="casa_case[case_court_orders_attributes][4][implementation_status]" id="casa_case_case_court_orders_attributes_4_implementation_status">\
             <option value="">Set Implementation Status</option>\
-            <option value="not_implemented">Not implemented</option>\
+            <option value="unimplemented">Not implemented</option>\
             <option value="partially_implemented">Partially implemented</option>\
             <option value="implemented">Implemented</option>\
           </select>\

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -34,7 +34,7 @@ module.exports = class CourtOrderList {
     name="${resourceName}[case_court_orders_attributes][${index}][implementation_status]"\
     id="${resourceName}_case_court_orders_attributes_${index}_implementation_status">\
         <option value="">Set Implementation Status</option>
-        <option value="not_implemented">Not implemented</option>
+        <option value="unimplemented">Not implemented</option>
         <option value="partially_implemented">Partially implemented</option>
         <option value="implemented">Implemented</option>
       </select>

--- a/app/models/case_court_order.rb
+++ b/app/models/case_court_order.rb
@@ -1,5 +1,5 @@
 class CaseCourtOrder < ApplicationRecord
-  IMPLEMENTATION_STATUSES = {not_implemented: 1, partially_implemented: 2, implemented: 3}
+  IMPLEMENTATION_STATUSES = {unimplemented: 1, partially_implemented: 2, implemented: 3}
 
   belongs_to :casa_case
   belongs_to :court_date, optional: true

--- a/spec/factories/case_court_orders.rb
+++ b/spec/factories/case_court_orders.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :case_court_order do
     casa_case
     text { Faker::Lorem.paragraph(sentence_count: 5, supplemental: true, random_sentences_to_add: 20) }
-    implementation_status { [:not_implemented, :partially_implemented, :implemented].sample }
+    implementation_status { [:unimplemented, :partially_implemented, :implemented].sample }
   end
 end

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -208,13 +208,13 @@ RSpec.describe CaseCourtReport, type: :model do
   describe "when court orders has different implementation statuses" do
     let(:casa_case) { create(:casa_case, case_number: "Sample-Case-12345") }
     let(:court_order_implemented) { create(:case_court_order, casa_case: casa_case, text: "K6N-ce8|NuXnht(", implementation_status: :implemented) }
-    let(:court_order_not_implemented) { create(:case_court_order, casa_case: casa_case, text: "'q\"tE1LP-9W>,2)", implementation_status: :not_implemented) }
+    let(:court_order_unimplemented) { create(:case_court_order, casa_case: casa_case, text: "'q\"tE1LP-9W>,2)", implementation_status: :unimplemented) }
     let(:court_order_partially_implemented) { create(:case_court_order, casa_case: casa_case, text: "ZmCw@w@\d`&roct", implementation_status: :partially_implemented) }
     let(:court_order_not_specified) { create(:case_court_order, casa_case: casa_case, text: "(4WqOL7e'FRYd@%", implementation_status: nil) }
 
     before(:each) do
       casa_case.case_court_orders << court_order_implemented
-      casa_case.case_court_orders << court_order_not_implemented
+      casa_case.case_court_orders << court_order_unimplemented
       casa_case.case_court_orders << court_order_partially_implemented
       casa_case.case_court_orders << court_order_not_specified
     end
@@ -233,8 +233,8 @@ RSpec.describe CaseCourtReport, type: :model do
       expect(document_inspector.word_list_document_contains?(court_order_implemented.text)).to eq(true)
       expect(document_inspector.word_list_document_contains?("Implemented")).to eq(true)
 
-      expect(document_inspector.word_list_document_contains?(court_order_not_implemented.text)).to eq(true)
-      expect(document_inspector.word_list_document_contains?("Not implemented")).to eq(true)
+      expect(document_inspector.word_list_document_contains?(court_order_unimplemented.text)).to eq(true)
+      expect(document_inspector.word_list_document_contains?("Unimplemented")).to eq(true)
 
       expect(document_inspector.word_list_document_contains?(court_order_partially_implemented.text)).to eq(true)
       expect(document_inspector.word_list_document_contains?("Partially implemented")).to eq(true)

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "/casa_cases", type: :request do
   let(:invalid_attributes) { {case_number: nil, birth_month_year_youth: nil} }
   let(:casa_case) { create(:casa_case, casa_org: organization, case_number: "111") }
   let(:texts) { ["1-New Mandate Text One", "0-New Mandate Text Two"] }
-  let(:implementation_statuses) { ["not_implemented", nil] }
+  let(:implementation_statuses) { ["unimplemented", nil] }
   let(:orders_attributes) do
     {
       "0" => {text: texts[0], implementation_status: implementation_statuses[0]},
@@ -297,7 +297,7 @@ RSpec.describe "/casa_cases", type: :request do
               case_court_orders_attributes: {
                 "0" => {
                   text: "New Mandate Text One Updated",
-                  implementation_status: :not_implemented
+                  implementation_status: :unimplemented
                 },
                 "1" => {
                   text: ""

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
     }
   end
   let(:texts) { ["1-New Order Text One", "0-New Order Text Two"] }
-  let(:implementation_statuses) { ["not_implemented", nil] }
+  let(:implementation_statuses) { ["unimplemented", nil] }
   let(:orders_attributes) do
     {
       "0" => {text: texts[0], implementation_status: implementation_statuses[0], casa_case_id: casa_case.id},
@@ -309,7 +309,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
             case_court_orders_attributes: {
               "0" => {
                 text: "New Order Text One Updated",
-                implementation_status: :not_implemented
+                implementation_status: :unimplemented
               },
               "1" => {
                 text: ""

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     it "when not implemented" do
-      casa_case.case_court_orders[0].update(implementation_status: :not_implemented)
+      casa_case.case_court_orders[0].update(implementation_status: :unimplemented)
 
       visit casa_case_path(casa_case)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2625

### What changed, and why?
- Renamed the CaseCourtOrder enum value `not_implemented` to `unimplemented`
- I don't think any backfilling is required here because psql saves the integer value of the enum which has not changed so when I make this change locally, a CaseCourtOrder that previously had a `not_implemented` status, automagically changes to `unimplemented`

Before the change:
```
> CaseCourtOrder.find(141)
Enum element 'not_implemented' in CaseCourtOrder uses the prefix 'not_'. This has caused a conflict with auto generated negative scopes. Avoid using enum elements starting with 'not' where the positive form is also an element.
  CaseCourtOrder Load (0.3ms)  SELECT "case_court_orders".* FROM "case_court_orders" WHERE "case_court_orders"."id" = $1 LIMIT $2  [["id", 141], ["LIMIT", 1]]
 =>
#<CaseCourtOrder:0x000000010edae580
 id: 141,
 casa_case_id: 70,
 created_at: Fri, 07 Oct 2022 16:16:44.350347000 UTC +00:00,
 updated_at: Fri, 07 Oct 2022 16:16:44.350347000 UTC +00:00,
 implementation_status: "not_implemented",
 court_date_id: nil,
 text:
  "The youth shall maintain appropriate housing while working towards obtaining housing that can accommodate all of the children being reunified, and make home available for inspection, under the direction of the department;">
```
After the change:
```
> CaseCourtOrder.find(141)
  CaseCourtOrder Load (0.4ms)  SELECT "case_court_orders".* FROM "case_court_orders" WHERE "case_court_orders"."id" = $1 LIMIT $2  [["id", 141], ["LIMIT", 1]]
 =>
#<CaseCourtOrder:0x000000010dc40b40
 id: 141,
 casa_case_id: 70,
 created_at: Fri, 07 Oct 2022 16:16:44.350347000 UTC +00:00,
 updated_at: Fri, 07 Oct 2022 16:16:44.350347000 UTC +00:00,
 implementation_status: "unimplemented",
 court_date_id: nil,
 text:
  "The youth shall maintain appropriate housing while working towards obtaining housing that can accommodate all of the children being reunified, and make home available for inspection, under the direction of the department;">
```

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Verified manually that the warning message is no longer displayed (see output above)

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9