### PR TITLE
Fix court order flaky test

### DIFF
--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -322,15 +322,18 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
           patch casa_case_court_date_path(casa_case, court_date), params: {court_date: new_attributes}
           court_date.reload
 
-          orders_updated[:case_court_orders_attributes]["0"][:id] = court_date.case_court_orders[0].id
-          orders_updated[:case_court_orders_attributes]["1"][:id] = court_date.case_court_orders[1].id
+          @first_order_id = court_date.case_court_orders[0].id
+          @second_order_id = court_date.case_court_orders[1].id
+
+          orders_updated[:case_court_orders_attributes]["0"][:id] = @first_order_id
+          orders_updated[:case_court_orders_attributes]["1"][:id] = @second_order_id
         end
 
         it "still updates the first order" do
           expect do
             patch casa_case_court_date_path(casa_case, court_date), params: {court_date: orders_updated}
           end.to(
-            change { court_date.reload.case_court_orders[0].text }
+            change { court_date.reload.case_court_orders.find(@first_order_id).text }
           )
         end
 
@@ -338,7 +341,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
           expect do
             patch casa_case_court_date_path(casa_case, court_date), params: {court_date: orders_updated}
           end.not_to(
-            change { court_date.reload.case_court_orders[1].text }
+            change { court_date.reload.case_court_orders.find(@second_order_id).text }
           )
         end
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3970

### What changed, and why?
When updating a court_order, the order of the array changes, creating inconsistencies when using index to find them,
so case_court_order is now found by ID. 

### How will this affect user permissions?
It won't
