### PR TITLE
move pick displayed columns button

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -4,9 +4,6 @@
     <% if policy(current_organization.volunteers.new).new? %>
       <%= link_to t(".button.new"), new_volunteer_path, class: "btn btn-primary mb-2 mb-md-0" %>
     <% end %>
-    <button type="button" class="btn btn-primary mb-2 mb-md-0" data-toggle="modal" data-target="#visibleColumns">
-      <%= t(".pick_displayed_columns") %>
-    </button>
   </div>
 </div>
 <hr>
@@ -97,6 +94,11 @@
         </div>
       </div>
     </div>
+  </div>
+  <div class="ml-3">
+    <button type="button" class="btn btn-primary mb-2 mb-md-0" data-toggle="modal" data-target="#visibleColumns">
+      <%= t(".pick_displayed_columns") %>
+    </button>
   </div>
 </div>
 <br>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4021

### What changed, and why?
Moved the "pick displayed columns" button.

### How will this affect user permissions?
It won't

### Screenshots please :)
Is it ok like that?

![image](https://user-images.githubusercontent.com/36737050/194645643-47f66788-b5fa-42e4-841e-fc2c23718ac0.png)
