### PR TITLE
Feat/add export volunteers emails button

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,4 +4,15 @@ class ReportsController < ApplicationController
   def index
     authorize :application, :see_reports_page?
   end
+
+  def export_emails
+    authorize :application, :see_reports_page?
+
+    respond_to do |format|
+      format.csv do
+        send_data VolunteersEmailsExportCsvService.new.perform,
+          filename: "volunteers-emails-#{Time.current.strftime("%Y-%m-%d")}.csv"
+      end
+    end
+  end
 end

--- a/app/services/volunteers_emails_export_csv_service.rb
+++ b/app/services/volunteers_emails_export_csv_service.rb
@@ -1,0 +1,27 @@
+require "csv"
+
+class VolunteersEmailsExportCsvService
+  attr_reader :volunteers
+
+  def initialize()
+    @volunteers = Volunteer.active
+  end
+
+  def perform
+    CSV.generate(headers: true) do |csv|
+      csv << full_data.keys.map(&:to_s).map(&:titleize)
+      @volunteers.each do |volunteer|
+        csv << full_data(volunteer).values
+      end
+    end
+  end
+
+  private
+
+  def full_data(volunteer = nil)
+    {
+      email: volunteer&.email,
+      case_number: volunteer&.casa_cases&.active&.pluck(:case_number).to_s,
+    }
+  end
+end

--- a/app/services/volunteers_emails_export_csv_service.rb
+++ b/app/services/volunteers_emails_export_csv_service.rb
@@ -3,7 +3,7 @@ require "csv"
 class VolunteersEmailsExportCsvService
   attr_reader :volunteers
 
-  def initialize()
+  def initialize
     @volunteers = Volunteer.active
   end
 
@@ -21,7 +21,7 @@ class VolunteersEmailsExportCsvService
   def full_data(volunteer = nil)
     {
       email: volunteer&.email,
-      case_number: volunteer&.casa_cases&.active&.pluck(:case_number).to_s,
+      case_number: volunteer&.casa_cases&.active&.pluck(:case_number).to_a.join(", ")
     }
   end
 end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -20,6 +20,12 @@
         <%= f.submit "Learning Hours Report", class: "btn btn-primary report-form-submit" %>
       <% end %>
     </div>
+
+    <div class="btn-group">
+      <%= form_with url: export_emails_path(format: :csv), method: :get do |f| %>
+        <%= f.submit "Export Volunteers Emails", class: "btn btn-primary report-form-submit" %>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,10 @@ Rails.application.routes.draw do
       patch :resolve, on: :member
     end
   end
+
   resources :reports, only: %i[index]
+  get :export_emails, to: "reports#export_emails"
+
   resources :case_court_reports, only: %i[index show] do
     collection do
       post :generate

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -31,4 +31,19 @@ RSpec.describe "/reports", type: :request do
       it { is_expected.not_to be_successful }
     end
   end
+
+  describe "GET #export_emails" do
+    before do
+      sign_in build(:casa_admin)
+    end
+
+    it "renders a csv file to download" do
+      get export_emails_url(format: :csv)
+
+      expect(response).to be_successful
+      expect(
+        response.headers["Content-Disposition"]
+      ).to include "attachment; filename=\"volunteers-emails-#{Time.current.strftime("%Y-%m-%d")}.csv"
+    end
+  end
 end

--- a/spec/services/volunteers_emails_export_csv_service_spec.rb
+++ b/spec/services/volunteers_emails_export_csv_service_spec.rb
@@ -1,20 +1,25 @@
 require "rails_helper"
 
 RSpec.describe VolunteersEmailsExportCsvService do
-  subject { described_class.new().perform }
+  subject { described_class.new.perform }
+  let!(:active_volunteer) { create(:volunteer, :with_casa_cases) }
+  let!(:inactive_volunteer) { create(:volunteer, :inactive) }
+  let(:active_volunteer_cases) { active_volunteer.casa_cases.active.pluck(:case_number).to_a.join(", ") }
 
-  before do
-    create(:volunteer)
-  end
+  describe "#perform" do
+    it "Exports correct data from volunteers" do
+      results = subject.split("\n")
+      expect(results.count).to eq(2)
+      expect(results[0].split(",")).to eq(["Email", "Case Number"])
+      expect(results[1]).to eq("#{active_volunteer.email},\"#{active_volunteer_cases}\"")
+    end
 
-  it "creates CSV" do
-    binding.pry
-    results = subject.split("\n")
-    expect(results.count).to eq(2)
-    expect(results[0].split(",")).to eq([
-      "Email",
-      "Case Number",
-    ])
-    expect(results[1].split(",").count).to eq(2)
+    it "includes active volunteers" do
+      expect(subject).to match(/#{active_volunteer.email}/)
+    end
+
+    it "does not include inactive volunteers" do
+      expect(subject).not_to match(/#{inactive_volunteer.email}/)
+    end
   end
 end

--- a/spec/services/volunteers_emails_export_csv_service_spec.rb
+++ b/spec/services/volunteers_emails_export_csv_service_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe VolunteersEmailsExportCsvService do
+  subject { described_class.new().perform }
+
+  before do
+    create(:volunteer)
+  end
+
+  it "creates CSV" do
+    binding.pry
+    results = subject.split("\n")
+    expect(results.count).to eq(2)
+    expect(results[0].split(",")).to eq([
+      "Email",
+      "Case Number",
+    ])
+    expect(results[1].split(",").count).to eq(2)
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4022

### What changed, and why?
Created "export volunteers emails" service and button

### How will this affect user permissions?
- Volunteer permissions: won't change
- Supervisor permissions: won't change
- Admin permissions: will be able to export emails

### How is this tested? (please write tests!) 💖💪
to run tests:
`rspec spec/services/volunteers_emails_export_csv_service_spec.rb`
and
`rspec spec/requests/reports_spec.rb:35`

### Screenshots please :)
[Screencast from 07-10-2022 19:36:55.webm](https://user-images.githubusercontent.com/36737050/194671814-1d30276d-3d38-4657-a3c2-72bd2a2f4325.webm)