### PR TITLE
prevent null reference error when emailToggle not present

### DIFF
--- a/app/javascript/src/require_communication_preference.js
+++ b/app/javascript/src/require_communication_preference.js
@@ -29,7 +29,7 @@ $('document').ready(() => {
   const smsToggle = $(`.${SMS_TOGGLE_CLASS}`)[0]
   const emailToggle = $(`.${EMAIL_TOGGLE_CLASS}`)[0]
 
-  emailToggle.addEventListener('change', () => {
+  emailToggle?.addEventListener('change', () => {
     displayPopUpIfPreferencesIsInvalid()
   })
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4035 

### What changed, and why?
Used the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to stop throwing an error when `emailToggle` is `null` or `undefined`.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Not tested, as the functionality is part of the JavaScript language.

### Screenshots please :)
**Before - email toggle hidden**
<img width="1433" alt="Screenshot 2022-10-09 at 16 16 36" src="https://user-images.githubusercontent.com/22390758/194764872-7d893c68-0508-404e-a981-45a5dd5ecdf0.png">


**After - email toggle hidden**
<img width="1440" alt="Screenshot 2022-10-09 at 16 17 53" src="https://user-images.githubusercontent.com/22390758/194764881-d4a68945-4730-42c7-a050-d2a0eda30781.png">

### Feedback please? (optional)
Would've been useful to have reproduction steps, or the following details:
- which page it's happening on
- when is it happening?
- which user to log in with to see the error happen