### PR TITLE
3269 Add lines to weekly digest

### DIFF
--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -8,7 +8,7 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def case_contacts_latest
-    object.case_contacts.max_by(&:occurred_at)
+    object.case_contacts.order(occurred_at: :desc, created_at: :desc).first
   end
 
   def case_contacts_latest_before(date)

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -16,6 +16,11 @@
     </td>
   </tr>
   <% @supervisor.volunteers_ever_assigned.where("supervisor_volunteers.is_active = ?", true).active.each do |volunteer| %>
+    <tr>
+      <td class="content-block" style="font-size: 16px; padding: 0 0 10px">
+      <b>Summary for <%= link_to volunteer.display_name, edit_volunteer_url(volunteer) %></b>
+      </td>
+    </tr>
     <% volunteer.case_assignments_with_cases.each do |case_assignment| %>
       <% recently_unassigned = case_assignment.decorate.unassigned_in_past_week? %>
       <% if case_assignment.active || recently_unassigned %>
@@ -23,7 +28,6 @@
         <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
           <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
             <b>
-              Summary for <%= link_to volunteer.display_name, edit_volunteer_url(volunteer) %>
               Case <%= link_to casa_case.case_number, casa_case_url(casa_case) %>
             </b>
             <br>
@@ -70,6 +74,8 @@
         </tr>
       <% end %>
     <% end %>
+    <!-- If the table elements don't wrap this <hr> then the <hr> gets moved to the outside of the table by the HTML renderer -->
+    <tr><td style="padding: 0 0 10px"><hr></td></tr>
   <% end %>
 
   <% if @supervisor.recently_unassigned_volunteers.any? %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part 1 of Resolving #3269
Apologies this has taken me so long - and it is only partially complete

### What changed, and why?
This PR adds lines separating volunteers in the supervisor's weekly digest. The volunteer name is also updated to only appear once if there are multiple case contacts for the week. 
This PR also fixes the case studies displaying in an incorrect order if there were multiple case studies in one day

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
No tests - but please let me know if you prefer to have it for this.

### Screenshots please :)
Before on the left, after on the right
![Screen Shot 2022-10-11 at 6 10 05 PM](https://user-images.githubusercontent.com/70556962/195226070-bb9c7301-e7ee-464e-b7a2-4b9b6b278cb4.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9