### PR TITLE
Fix: missing  button bug for adding court dates

### DIFF
--- a/app/views/casa_cases/_court_dates.html.erb
+++ b/app/views/casa_cases/_court_dates.html.erb
@@ -1,7 +1,7 @@
 <% court_dates = casa_case.court_dates.includes(:hearing_type).ordered_ascending.load %>
 
 <label>Court dates:</label>
-<% if court_dates.size == 0 %>
+<% if court_dates.empty? %>
   No Court Dates
 <% else %>
   <ul>
@@ -17,6 +17,7 @@
       </p>
     <% end %>
   </ul>
+<% end %>
   <ul>
     <div class="add-container past-court-dates">
       <a class="btn btn-primary" href="<%= new_casa_case_court_date_path(casa_case) %>">
@@ -24,4 +25,3 @@
       </a>
     </div>
   </ul>
-<% end %>

--- a/spec/views/casa_cases/show.html.erb_spec.rb
+++ b/spec/views/casa_cases/show.html.erb_spec.rb
@@ -2,10 +2,48 @@ require "rails_helper"
 
 RSpec.describe "casa_cases/show", type: :view do
   let(:organization) { create(:casa_org) }
+  let(:user) { create(:casa_admin, casa_org: organization) }
 
   before do
     enable_pundit(view, user)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
+  end
+
+  context "when there is court date" do
+    let!(:casa_case) { create(:casa_case, :with_upcoming_court_date, casa_org: organization, case_number: "111") }
+    let(:date) { casa_case.court_dates.map(&:date).first.to_date.strftime("%B %d, %Y") }
+
+    before { assign(:casa_case, casa_case) }
+    it "render casa case with court dates" do
+      render
+
+      expect(rendered).to match(casa_case.case_number)
+      expect(rendered).to match(date)
+    end
+
+    it "render button to add court date" do
+      render
+
+      expect(rendered).to have_content("Add a court date")
+    end
+  end
+
+  context "where there is no court date" do
+    let!(:casa_case) { create(:casa_case, casa_org: organization, case_number: "111") }
+
+    before { assign(:casa_case, casa_case) }
+    it "render casa case without court dates" do
+      render
+
+      expect(rendered).to match(casa_case.case_number)
+      expect(rendered).to have_content("No Court Dates")
+    end
+
+    it "render button to add court date" do
+      render
+
+      expect(rendered).to have_content("Add a court date")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4051

### What changed, and why?
Adjust partial logic to include button for adding court dates in order to fix bug.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
It was writen spec test with `type: :view` and test cases when there is court dates and when there isn't.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/92229784/195243104-4e64ce8e-44ab-4aaf-84b4-490296e19fb5.png)
