### PR TITLE
Add models for UserLanguages backfill values

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -36,10 +36,10 @@ class LanguagesController < ApplicationController
 
   def add_to_volunteer
     authorize @language
-    current_user.languages << @language
-    if current_user.save
+    begin
+      current_user.languages << @language
       redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
-    else
+    rescue ActiveRecord::RecordInvalid
       redirect_to edit_users_path, notice: "Error unable to add #{@language.name} to your languages list!"
     end
   end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,6 +1,7 @@
 class Language < ApplicationRecord
   belongs_to :casa_org
-  has_and_belongs_to_many :users
+  has_many :user_languages
+  has_many :users, through: :user_languages
 
   validates :name, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,8 @@ class User < ApplicationRecord
   has_many :sms_notification_events, through: :user_sms_notification_events
   has_many :notes, as: :notable
   has_one :address, dependent: :destroy
-  has_and_belongs_to_many :languages
+  has_many :user_languages
+  has_many :languages, through: :user_languages
 
   accepts_nested_attributes_for :user_sms_notification_events, :address, allow_destroy: true
 

--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -1,0 +1,23 @@
+class UserLanguage < ApplicationRecord
+  belongs_to :user
+  belongs_to :language
+
+  validates :language, uniqueness: {scope: :user}
+end
+
+# == Schema Information
+#
+# Table name: user_languages
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  language_id :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_user_languages_on_language_id              (language_id)
+#  index_user_languages_on_language_id_and_user_id  (language_id,user_id) UNIQUE
+#  index_user_languages_on_user_id                  (user_id)
+#

--- a/db/migrate/20221011044911_add_user_languages.rb
+++ b/db/migrate/20221011044911_add_user_languages.rb
@@ -1,0 +1,14 @@
+class AddUserLanguages < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    create_table :user_languages do |t|
+      t.references :user
+      t.references :language
+
+      t.timestamps
+    end
+
+    add_index :user_languages, [:language_id, :user_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20221012203806_populate_user_languages_from_languages_users.rb
+++ b/db/migrate/20221012203806_populate_user_languages_from_languages_users.rb
@@ -1,0 +1,10 @@
+class PopulateUserLanguagesFromLanguagesUsers < ActiveRecord::Migration[7.0]
+  def change
+    query = Arel.sql("select language_id, user_id from languages_users")
+    old_join_table_entries = ActiveRecord::Base.connection.execute(query).to_a
+
+    old_join_table_entries.each do |entry|
+      UserLanguage.create(user_id: entry["user_id"], language_id: entry["language_id"])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_03_202112) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_12_203806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -429,6 +429,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_03_202112) do
     t.index ["user_id"], name: "index_preference_sets_on_user_id"
   end
 
+  create_table "preferences", force: :cascade do |t|
+    t.bigint "user_id"
+    t.jsonb "case_volunteer_columns", default: "{}", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_preferences_on_user_id"
+  end
+
   create_table "sent_emails", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "casa_org_id", null: false
@@ -460,6 +468,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_03_202112) do
 
   create_table "task_records", id: false, force: :cascade do |t|
     t.string "version", null: false
+  end
+
+  create_table "user_languages", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "language_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id", "user_id"], name: "index_user_languages_on_language_id_and_user_id", unique: true
+    t.index ["language_id"], name: "index_user_languages_on_language_id"
+    t.index ["user_id"], name: "index_user_languages_on_user_id"
   end
 
   create_table "user_reminder_times", force: :cascade do |t|
@@ -514,6 +532,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_03_202112) do
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at", precision: nil
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/user_languages.rb
+++ b/spec/factories/user_languages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_language do
+    user
+    language
+  end
+end

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Language, type: :model do
   it { is_expected.to belong_to(:casa_org) }
-  it { is_expected.to have_and_belong_to_many(:users) }
+  it { is_expected.to have_many(:user_languages) }
+  it { is_expected.to have_many(:users).through(:user_languages) }
 
   it { is_expected.to validate_presence_of(:name) }
 end

--- a/spec/models/user_language_spec.rb
+++ b/spec/models/user_language_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe UserLanguage, type: :model do
+  it { is_expected.to belong_to(:language) }
+  it { is_expected.to belong_to(:user) }
+
+  it "validates uniqueness of language scoped to user" do
+    existing_record = create(:user_language)
+    new_record = build(:user_language, user: existing_record.user, language: existing_record.language)
+    expect(new_record).not_to be_valid
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_many(:casa_cases).through(:case_assignments) }
   it { is_expected.to have_many(:case_contacts) }
   it { is_expected.to have_many(:sent_emails) }
+  it { is_expected.to have_many(:user_languages) }
+  it { is_expected.to have_many(:languages).through(:user_languages) }
 
   it { is_expected.to have_many(:followups).with_foreign_key(:creator_id) }
 

--- a/spec/requests/languages_spec.rb
+++ b/spec/requests/languages_spec.rb
@@ -68,12 +68,28 @@ RSpec.describe LanguagesController, type: :request do
       end
 
       context "when request params are invalid" do
-        it "should raise error when Language do not exist" do
-          expect {
+        context "when the language does not exist" do
+          it "should raise error" do
+            expect {
+              patch add_to_volunteer_languages_path, params: {
+                language_id: 800
+              }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+
+        context "when the language is already present for the user" do
+          before { create(:user_language, user: volunteer, language: random_lang) }
+
+          it "should raise error" do
             patch add_to_volunteer_languages_path, params: {
-              language_id: 800
+              language_id: random_lang.id
             }
-          }.to raise_error(ActiveRecord::RecordNotFound)
+
+            expect(response.status).to eq 302
+            expect(response).to redirect_to(edit_users_path)
+            expect(flash[:notice]).to eq "Error unable to add #{random_lang.name} to your languages list!"
+          end
         end
       end
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3953

### What changed, and why?
Added a `UserLanguage` model and new database table. Added migration to backfill the values from the existing `languages_users` join table.

### How is this tested? (please write tests!) 💖💪
New rspec model and request specs for the affected code. Manual test for the backfill migration.