### PR TITLE
Use friendly_id to have slugs CasaCase URLs instead of ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "twilio-ruby" # twilio helper functions
 gem "draper" # adds decorators for cleaner presentation logic
 gem "faker" # creates realistic seed data, valuable for staging and demos
 gem "filterrific" # filtering and sorting of models
+gem 'friendly_id', '~> 5.4.0' # allows us to use a slug instead of casa case ids in their URLs
 gem "image_processing", "~> 1.12" # Set of higher-level helper methods for image processing.
 gem "jbuilder" # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jsbundling-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "twilio-ruby" # twilio helper functions
 gem "draper" # adds decorators for cleaner presentation logic
 gem "faker" # creates realistic seed data, valuable for staging and demos
 gem "filterrific" # filtering and sorting of models
-gem 'friendly_id', '~> 5.4.0' # allows us to use a slug instead of casa case ids in their URLs
+gem "friendly_id", "~> 5.4.0" # allows us to use a slug instead of casa case ids in their URLs
 gem "image_processing", "~> 1.12" # Set of higher-level helper methods for image processing.
 gem "jbuilder" # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jsbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,8 @@ GEM
       ffi (>= 1.0.0)
       rake
     filterrific (5.2.3)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -498,6 +500,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   filterrific
+  friendly_id (~> 5.4.0)
   httparty
   image_processing (~> 1.12)
   jbuilder

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -137,7 +137,7 @@ class CasaCasesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_casa_case
-    @casa_case = current_organization.casa_cases.friendly.find(params[:id])
+    @casa_case = current_organization.casa_cases.friendly.find(params[:id].parameterize)
   rescue ActiveRecord::RecordNotFound
     if params[:action] != "show"
       head :not_found

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -137,7 +137,7 @@ class CasaCasesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_casa_case
-    @casa_case = current_organization.casa_cases.find(params[:id])
+    @casa_case = current_organization.casa_cases.friendly.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     if params[:action] != "show"
       head :not_found

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -137,7 +137,7 @@ class CasaCasesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_casa_case
-    @casa_case = current_organization.casa_cases.friendly.find(params[:id].parameterize)
+    @casa_case = current_organization.casa_cases.friendly.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     if params[:action] != "show"
       head :not_found

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -76,7 +76,7 @@ class CaseAssignmentsController < ApplicationController
     if params[:volunteer_id]
       User.find(params[:volunteer_id])
     else
-      CasaCase.find(params[:casa_case_id])
+      CasaCase.friendly.find(params[:casa_case_id])
     end
   end
 

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -66,7 +66,7 @@ class CourtDatesController < ApplicationController
   private
 
   def set_casa_case
-    @casa_case = current_organization.casa_cases.find(params[:casa_case_id])
+    @casa_case = current_organization.casa_cases.friendly.find(params[:casa_case_id])
   end
 
   def set_court_date
@@ -77,6 +77,10 @@ class CourtDatesController < ApplicationController
     params.require(:court_date).tap do |p|
       p[:case_court_orders_attributes]&.reject! do |k, _|
         p[:case_court_orders_attributes][k][:text].blank? && p[:case_court_orders_attributes][k][:implementation_status].blank?
+      end
+
+      p[:case_court_orders_attributes]&.each do |k, _|
+        p[:case_court_orders_attributes][k][:casa_case_id] = @casa_case.id
       end
     end
   end

--- a/app/controllers/emancipations_controller.rb
+++ b/app/controllers/emancipations_controller.rb
@@ -9,7 +9,7 @@ class EmancipationsController < ApplicationController
   CHECK_ITEM_ACTIONS = [ADD_CATEGORY, ADD_OPTION, DELETE_CATEGORY, DELETE_OPTION, SET_OPTION].freeze
 
   def show
-    @current_case = CasaCase.find(params[:casa_case_id])
+    @current_case = CasaCase.friendly.find(params[:casa_case_id])
     authorize @current_case
     @emancipation_form_data = EmancipationCategory.all
 
@@ -36,7 +36,7 @@ class EmancipationsController < ApplicationController
     params.permit(:casa_case_id, :check_item_action)
 
     begin
-      current_case = CasaCase.find(params[:casa_case_id])
+      current_case = CasaCase.friendly.find(params[:casa_case_id])
       authorize current_case, :update_emancipation_option?
     rescue ActiveRecord::RecordNotFound
       render json: {error: "Could not find case from id given by casa_case_id"}

--- a/app/controllers/fund_requests_controller.rb
+++ b/app/controllers/fund_requests_controller.rb
@@ -2,13 +2,13 @@ class FundRequestsController < ApplicationController
   # after_action :verify_authorized
 
   def new
-    @casa_case = CasaCase.find(params[:casa_case_id])
+    @casa_case = CasaCase.friendly.find(params[:casa_case_id])
     # authorize @casa_case
     @fund_request = FundRequest.new
   end
 
   def create
-    @casa_case = CasaCase.find(params[:casa_case_id])
+    @casa_case = CasaCase.friendly.find(params[:casa_case_id])
     # authorize @casa_case
     @fund_request = FundRequest.new(parsed_params)
     FundRequestMailer.send_request(nil, @fund_request).deliver

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -63,7 +63,7 @@ class VolunteersController < ApplicationController
     if @volunteer.activate
       VolunteerMailer.account_setup(@volunteer).deliver
 
-      if (params[:redirect_to_path] == "casa_case") && (casa_case = CasaCase.find(params[:casa_case_id]))
+      if (params[:redirect_to_path] == "casa_case") && (casa_case = CasaCase.friendly.find(params[:casa_case_id]))
         redirect_to edit_casa_case_path(casa_case), notice: "Volunteer was activated. They have been sent an email."
       else
         redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated. They have been sent an email."

--- a/app/javascript/__tests__/court_order_list.test.js
+++ b/app/javascript/__tests__/court_order_list.test.js
@@ -12,7 +12,7 @@ window.location = { reload: jest.fn() }
 beforeEach(() => {
   // jest doesn't support window.location like a browser but URL is pretty close
   // see https://stackoverflow.com/a/60697570
-  window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/2151')
+  window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151')
   document.body.innerHTML = '<div id="court-orders-list-container"></div>'
 
   $(document).ready(() => {
@@ -25,29 +25,29 @@ describe('CourtOrderList constructor', () => {
   test('the constructor should be able to extract the rescource name from the url', (done) => {
     $(document).ready(() => {
       try {
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/2151')
+        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151')
         courtOrderList = new CourtOrderList(courtOrderListElement)
 
         expect(courtOrderList.resourceName).toBe('casa_case')
-        expect(courtOrderList.casaCaseId).toBe('2151')
+        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
 
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/2151/court_dates/new')
+        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/new')
         courtOrderList = new CourtOrderList(courtOrderListElement)
 
         expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('2151')
+        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
 
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/2151/court_dates/3')
+        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/3')
         courtOrderList = new CourtOrderList(courtOrderListElement)
 
         expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('2151')
+        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
 
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/2151/court_dates/3/edit')
+        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/3/edit')
         courtOrderList = new CourtOrderList(courtOrderListElement)
 
         expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('2151')
+        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
         done()
       } catch (error) {
         done(error)
@@ -58,8 +58,8 @@ describe('CourtOrderList constructor', () => {
   test('the constructor should be able to extract the casa case id from the url', (done) => {
     $(document).ready(() => {
       try {
-        const casaCaseId1 = '2151'
-        const casaCaseId2 = '1988'
+        const casaCaseId1 = 'CINA-2151'
+        const casaCaseId2 = 'CINA-1988'
         window.location = new URL(`https://casa-qa.herokuapp.com/casa_cases/${casaCaseId1}`)
         courtOrderList = new CourtOrderList(courtOrderListElement)
 

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -36,7 +36,7 @@ $(() => {
     document.onload = load()
   }
 
-  if (/\/casa_cases\/\d+$/.test(window.location.pathname)) {
+  if (/\/casa_cases\/.*\d+\/$/.test(window.location.pathname)) {
     window.localStorage.removeItem(formId)
   }
 })

--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -36,7 +36,8 @@ $(() => {
     document.onload = load()
   }
 
-  if (/\/casa_cases\/.*\d+\/$/.test(window.location.pathname)) {
+  // The following regex will match to string like this: "/casa_cases/cina-5"
+  if (/\/casa_cases\/.*\d$/.test(window.location.pathname)) {
     window.localStorage.removeItem(formId)
   }
 })

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -13,7 +13,7 @@ module.exports = class CourtOrderList {
   // @param {object} courtOrdersWidget The div containing the list of court orders
   constructor (courtOrdersWidget) {
     // The following regex is intended for pathnames such as "/casa_cases/CINA-19-1004/court_dates/new"
-    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
+    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(\w+-+\d+)(\/(([a-z_]+)s))?/).filter(match => match !== undefined)
     this.courtOrdersWidget = courtOrdersWidget
     this.resourceName = urlMatch.length > 3 ? urlMatch[5] : urlMatch[1]
     // The casaCaseId will be something like "CINA-19-1004"

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -12,7 +12,7 @@ function replaceNumberWithDecrement (str, num) {
 module.exports = class CourtOrderList {
   // @param {object} courtOrdersWidget The div containing the list of court orders
   constructor (courtOrdersWidget) {
-    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(\d+)(\/(([a-z_]+)s))?/).filter(match => match !== undefined)
+    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d\-\d+)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
 
     this.courtOrdersWidget = courtOrdersWidget
     this.resourceName = urlMatch.length > 3 ? urlMatch[5] : urlMatch[1]

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -12,9 +12,11 @@ function replaceNumberWithDecrement (str, num) {
 module.exports = class CourtOrderList {
   // @param {object} courtOrdersWidget The div containing the list of court orders
   constructor (courtOrdersWidget) {
-    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d-\d+)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
+    // The following regex is intended for pathnames such as "/casa_cases/CINA-19-1004/court_dates/new"
+    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
     this.courtOrdersWidget = courtOrdersWidget
     this.resourceName = urlMatch.length > 3 ? urlMatch[5] : urlMatch[1]
+    // The casaCaseId will be something like "CINA-19-1004"
     this.casaCaseId = urlMatch[2]
   }
 

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -12,8 +12,7 @@ function replaceNumberWithDecrement (str, num) {
 module.exports = class CourtOrderList {
   // @param {object} courtOrdersWidget The div containing the list of court orders
   constructor (courtOrdersWidget) {
-    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d\-\d+)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
-
+    const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(.*\d-\d+)\/((([a-z_]+)s))?/).filter(match => match !== undefined)
     this.courtOrdersWidget = courtOrdersWidget
     this.resourceName = urlMatch.length > 3 ? urlMatch[5] : urlMatch[1]
     this.casaCaseId = urlMatch[2]

--- a/app/javascript/src/require_communication_preference.js
+++ b/app/javascript/src/require_communication_preference.js
@@ -33,7 +33,7 @@ $('document').ready(() => {
     displayPopUpIfPreferencesIsInvalid()
   })
 
-  smsToggle.addEventListener('change', () => {
+  smsToggle?.addEventListener('change', () => {
     displayPopUpIfPreferencesIsInvalid()
   })
 

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -21,7 +21,7 @@ class CasaCase < ApplicationRecord
   TRANSITION_AGE_YOUTH_ICON = "🦋".freeze
   NON_TRANSITION_AGE_YOUTH_ICON = "🐛".freeze
 
-  friendly_id :case_number, :use => :scoped, :scope => :casa_org
+  friendly_id :case_number, use: :scoped, scope: :casa_org
 
   has_many :case_assignments, dependent: :destroy
   has_many(:volunteers, through: :case_assignments, source: :volunteer, class_name: "User")

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,6 +1,7 @@
 class CasaCase < ApplicationRecord
   include ByOrganizationScope
   include DateHelper
+  extend FriendlyId
 
   self.ignored_columns = %w[court_date hearing_type_id judge_id transition_aged_youth]
 
@@ -20,7 +21,7 @@ class CasaCase < ApplicationRecord
   TRANSITION_AGE_YOUTH_ICON = "🦋".freeze
   NON_TRANSITION_AGE_YOUTH_ICON = "🐛".freeze
 
-  before_create :set_slug
+  friendly_id :case_number, :use => :scoped, :scope => :casa_org
 
   has_many :case_assignments, dependent: :destroy
   has_many(:volunteers, through: :case_assignments, source: :volunteer, class_name: "User")
@@ -196,10 +197,6 @@ class CasaCase < ApplicationRecord
     volunteers_unassigned_to_case.with_no_assigned_cases + volunteers_unassigned_to_case.with_assigned_cases
   end
 
-  def set_slug
-    self.slug = case_number.parameterize preserve_case: true
-  end
-
   def full_attributes_hash
     attributes.symbolize_keys.merge({contact_types: contact_types.reload.map(&:attributes), court_orders: case_court_orders.map(&:attributes)})
   end
@@ -207,15 +204,6 @@ class CasaCase < ApplicationRecord
   def contact_type_validation?
     validate_update
   end
-
-  # def set_validate_update
-
-  # end
-
-  # def to_param
-  #   id
-  #   # slug # TODO use slug eventually for routes
-  # end
 end
 
 # == Schema Information

--- a/app/models/case_court_report.rb
+++ b/app/models/case_court_report.rb
@@ -7,7 +7,7 @@ class CaseCourtReport
   attr_reader :report_path, :context, :template
 
   def initialize(args = {})
-    @casa_case = CasaCase.find(args[:case_id])
+    @casa_case = CasaCase.friendly.find(args[:case_id])
     @volunteer = Volunteer.find(args[:volunteer_id]) if args[:volunteer_id]
     @time_zone = args[:time_zone]
 

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe CasaCase, type: :model do
   describe "slug" do
     let(:casa_case) { create(:casa_case, case_number: "CINA-21-1234") }
     it "should be parameterized from the case number" do
-      expect(casa_case.slug).to eq "CINA-21-1234"
+      expect(casa_case.slug).to eq "cina-21-1234"
     end
   end
 end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -614,7 +614,7 @@ RSpec.describe "/casa_cases", type: :request do
         expect(flash[:notice]).to eq("Sorry you are not authorized to perform this action.")
       end
     end
-    
+
     describe "GET /new" do
       it "renders a successful response" do
         get new_casa_case_url

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -460,6 +460,22 @@ RSpec.describe "/casa_cases", type: :request do
     let(:user) { create(:volunteer, casa_org: organization) }
     let!(:case_assignment) { create(:case_assignment, volunteer: user, casa_case: casa_case) }
 
+    describe "GET /show" do
+      it "renders a successful response" do
+        get casa_case_url(casa_case)
+        expect(response).to be_successful
+      end
+
+      it "fails across organizations" do
+        other_org = build(:casa_org)
+        other_case = create(:casa_case, casa_org: other_org)
+
+        get casa_case_url(other_case)
+        expect(response).to be_redirect
+        expect(flash[:notice]).to eq("Sorry you are not authorized to perform this action.")
+      end
+    end
+
     describe "GET /new" do
       it "denies access and redirects elsewhere" do
         get new_casa_case_url
@@ -583,6 +599,22 @@ RSpec.describe "/casa_cases", type: :request do
   describe "as a supervisor" do
     let(:user) { create(:supervisor, casa_org: organization) }
 
+    describe "GET /show" do
+      it "renders a successful response" do
+        get casa_case_url(casa_case)
+        expect(response).to be_successful
+      end
+
+      it "fails across organizations" do
+        other_org = build(:casa_org)
+        other_case = create(:casa_case, casa_org: other_org)
+
+        get casa_case_url(other_case)
+        expect(response).to be_redirect
+        expect(flash[:notice]).to eq("Sorry you are not authorized to perform this action.")
+      end
+    end
+    
     describe "GET /new" do
       it "renders a successful response" do
         get new_casa_case_url

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "/case_contacts", type: :request do
               duration_minutes: 60
             }
           }
-          expect(response).to redirect_to(casa_case_path(casa_case.case_number.downcase))
+          expect(response).to redirect_to(casa_case_path(casa_case.case_number.parameterize))
 
           expect(case_contact.reload.contact_types.first.name).to eq "Attorney"
         end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "/case_contacts", type: :request do
               duration_minutes: 60
             }
           }
-          expect(response).to redirect_to(casa_case_path(case_contact.casa_case_id))
+          expect(response).to redirect_to(casa_case_path(casa_case.case_number.downcase))
 
           expect(case_contact.reload.contact_types.first.name).to eq "Attorney"
         end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "/volunteers", type: :request do
   describe "PATCH /activate" do
     let(:volunteer) { create(:volunteer, :inactive, casa_org: organization) }
     let(:volunteer_with_cases) { create(:volunteer, :with_cases_and_contacts, casa_org: organization) }
-    let(:case_id) { volunteer_with_cases.casa_cases.first.id }
+    let(:case_number) { volunteer_with_cases.casa_cases.first.case_number.parameterize }
 
     it "activates an inactive volunteer" do
       sign_in admin
@@ -275,9 +275,9 @@ RSpec.describe "/volunteers", type: :request do
       it "shows a flash message indicating the volunteer has been activated and sent an email" do
         sign_in admin
 
-        patch activate_volunteer_path(id: volunteer_with_cases, redirect_to_path: "casa_case", casa_case_id: case_id)
+        patch activate_volunteer_path(id: volunteer_with_cases, redirect_to_path: "casa_case", casa_case_id: case_number)
 
-        expect(response).to redirect_to(edit_casa_case_path(case_id))
+        expect(response).to redirect_to(edit_casa_case_path(case_number))
         follow_redirect!
         expect(flash[:notice]).to match(/Volunteer was activated. They have been sent an email./)
       end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       let(:text) { casa_case.case_court_orders.first.text }
 
       it "can delete a court order" do
-        visit edit_casa_case_path(casa_case.id)
+        visit edit_casa_case_path(casa_case.case_number)
 
         expect(page).to have_text(text)
 

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       let(:text) { casa_case.case_court_orders.first.text }
 
       it "can delete a court order" do
-        visit edit_casa_case_path(casa_case.case_number)
+        visit edit_casa_case_path(casa_case.case_number.parameterize)
 
         expect(page).to have_text(text)
 

--- a/spec/system/casa_cases/index_spec.rb
+++ b/spec/system/casa_cases/index_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "casa_cases/index", type: :system do
     visit casa_cases_path
 
     expect(page).to have_link("Cool Volunteer", href: "/volunteers/#{volunteer.id}/edit")
-    expect(page).to have_link("CINA-1", href: "/casa_cases/#{cina.id}")
-    expect(page).to have_link("TPR-100", href: "/casa_cases/#{tpr.id}")
-    expect(page).to have_link("123-12-123", href: "/casa_cases/#{no_prefix.id}")
+    expect(page).to have_link("CINA-1", href: "/casa_cases/#{cina.case_number.parameterize}")
+    expect(page).to have_link("TPR-100", href: "/casa_cases/#{tpr.case_number.parameterize}")
+    expect(page).to have_link("123-12-123", href: "/casa_cases/#{no_prefix.case_number.parameterize}")
 
     click_on "Status"
     click_on "Assigned to Volunteer"

--- a/spec/system/dashboard/show_spec.rb
+++ b/spec/system/dashboard/show_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "dashboard/show", type: :system do
       expect(page).to have_text("Bob Loblaw")
       expect(page).to have_no_link("Bob Loblaw")
       expect(page).to have_css("td", text: "Bob Loblaw")
-      expect(page).to have_link("Detail View", href: casa_case_path(casa_case.id))
+      expect(page).to have_link("Detail View", href: casa_case_path(casa_case.case_number.parameterize))
     end
 
     it "displays 'No active cases' when they don't have any assignments", js: true do

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -141,11 +141,11 @@ RSpec.describe "volunteers/edit", type: :system do
       visit edit_volunteer_path(volunteer)
 
       within "#case_assignment_#{case_assignment_1.id}" do
-        expect(page).to have_link("CINA1", href: "/casa_cases/#{casa_case_1.id}")
+        expect(page).to have_link("CINA1", href: "/casa_cases/#{casa_case_1.case_number.parameterize}")
       end
 
       within "#case_assignment_#{case_assignment_2.id}" do
-        expect(page).to have_link("CINA2", href: "/casa_cases/#{casa_case_2.id}")
+        expect(page).to have_link("CINA2", href: "/casa_cases/#{casa_case_2.case_number.parameterize}")
       end
     end
 

--- a/spec/views/casa_cases/edit.html.erb_spec.rb
+++ b/spec/views/casa_cases/edit.html.erb_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "casa_cases/edit", type: :view do
 
       render template: "casa_cases/edit"
 
-      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}")
+      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.case_number.parameterize}")
       expect(rendered).to_not have_selector("input[value='#{casa_case.case_number}']")
     end
 
@@ -43,7 +43,7 @@ RSpec.describe "casa_cases/edit", type: :view do
 
       render template: "casa_cases/edit"
 
-      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}")
+      expect(rendered).to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.case_number.parameterize}")
       expect(rendered).to have_selector("input[value='#{casa_case.case_number}']")
     end
 

--- a/spec/views/court_dates/new.html.erb_spec.rb
+++ b/spec/views/court_dates/new.html.erb_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "court_dates/new", type: :view do
 
   it { is_expected.to have_selector("h1", text: "New Court Date") }
   it { is_expected.to have_selector("h6", text: casa_case.case_number) }
-  it { is_expected.to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.id}") }
+  it { is_expected.to have_link(casa_case.case_number, href: "/casa_cases/#{casa_case.case_number.parameterize}") }
   it { is_expected.to have_selector(".btn-primary") }
 end

--- a/spec/views/court_dates/show.html.erb_spec.rb
+++ b/spec/views/court_dates/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "court_dates/show", type: :view do
     before { render template: "court_dates/show" }
 
     it "displays all court details" do
-      expect(rendered).to include("/casa_cases/#{court_date.casa_case.id}")
+      expect(rendered).to include("/casa_cases/#{court_date.casa_case.case_number.downcase}")
       expect(rendered).to include(ERB::Util.html_escape(court_date.judge.name))
       expect(rendered).to include(court_date.hearing_type.name)
 
@@ -26,7 +26,7 @@ RSpec.describe "court_dates/show", type: :view do
 
     it "displays the download button for .docx" do
       expect(rendered).to include "Download Report (.docx)"
-      expect(rendered).to include "/casa_cases/#{court_date.casa_case.id}/court_dates/#{court_date.id}.docx"
+      expect(rendered).to include "/casa_cases/#{court_date.casa_case.case_number.downcase}/court_dates/#{court_date.id}.docx"
     end
   end
 

--- a/spec/views/court_dates/show.html.erb_spec.rb
+++ b/spec/views/court_dates/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "court_dates/show", type: :view do
     before { render template: "court_dates/show" }
 
     it "displays all court details" do
-      expect(rendered).to include("/casa_cases/#{court_date.casa_case.case_number.downcase}")
+      expect(rendered).to include("/casa_cases/#{court_date.casa_case.case_number.parameterize}")
       expect(rendered).to include(ERB::Util.html_escape(court_date.judge.name))
       expect(rendered).to include(court_date.hearing_type.name)
 
@@ -26,7 +26,7 @@ RSpec.describe "court_dates/show", type: :view do
 
     it "displays the download button for .docx" do
       expect(rendered).to include "Download Report (.docx)"
-      expect(rendered).to include "/casa_cases/#{court_date.casa_case.case_number.downcase}/court_dates/#{court_date.id}.docx"
+      expect(rendered).to include "/casa_cases/#{court_date.casa_case.case_number.parameterize}/court_dates/#{court_date.id}.docx"
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2416 

### What changed, and why?
This PR introduces the `friendly_id` gem, which we will apply to the `CasaCase` model so that we can use URLs like this: `/casa_cases/CINA-15-1002` instead of `/casa_cases/42`. The advantage of the former is that it is recognizable by users and the disadvantage of the latter is that it reveals little bits of information about the data in our database... not desirable.

You may notice I had to call `parameterize` all over the place. This is basically just to downcase the slug since `friendly_id` expects parameterized slugs.

### How will this affect user permissions?
Should have no effect here.

### How is this tested? (please write tests!) 💖💪
Tests are updated and passing. No new tests were necessary.

### Screenshots please :)
<img width="1325" alt="Screen Shot 2022-10-20 at 1 16 28 PM" src="https://user-images.githubusercontent.com/10481391/197015520-be52f582-374b-4873-8624-5906550ca6d3.png">


### Feelings gif (optional)
My approach to testing in gif form
![](https://media.giphy.com/media/8EmeieJAGjvUI/giphy.gif)