### PR TITLE
fill casa org policy

### DIFF
--- a/app/policies/casa_org_policy.rb
+++ b/app/policies/casa_org_policy.rb
@@ -1,2 +1,9 @@
 class CasaOrgPolicy < ApplicationPolicy
+  def edit?
+    record.users.include?(user) && is_admin?
+  end
+
+  def update?
+    record.users.include?(user) && is_admin?
+  end
 end

--- a/spec/policies/casa_org_policy_spec.rb
+++ b/spec/policies/casa_org_policy_spec.rb
@@ -3,21 +3,32 @@ require "rails_helper"
 RSpec.describe CasaOrgPolicy do
   subject { described_class }
 
-  let(:casa_admin) { build_stubbed(:casa_admin) }
-  let(:volunteer) { build_stubbed(:volunteer) }
-  let(:supervisor) { build_stubbed(:supervisor) }
+  let(:organization) { build(:casa_org, users: [volunteer, supervisor, casa_admin]) }
+  let(:different_organization) { create(:casa_org) }
+
+  let(:volunteer) { build(:volunteer) }
+  let(:supervisor) { build(:supervisor) }
+  let(:casa_admin) { build(:casa_admin) }
 
   permissions :edit?, :update? do
-    it "allows casa_admins" do
-      is_expected.to permit(casa_admin)
+    context "when admin belongs to the same org" do
+      it "allows casa_admins" do
+        is_expected.to permit(casa_admin, organization)
+      end
+    end
+
+    context "when admin does not belong to org" do
+      it "does not permit admin" do
+        is_expected.to_not permit(casa_admin, different_organization)
+      end
     end
 
     it "does not permit supervisor" do
-      is_expected.to_not permit(supervisor)
+      is_expected.to_not permit(supervisor, organization)
     end
 
     it "does not permit volunteer" do
-      is_expected.to_not permit(volunteer)
+      is_expected.to_not permit(volunteer, organization)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4061 

### What changed, and why?
- Filled out `casa_org_policy` to ensure that a Casa Organization can only be edit or updated by  admins from the same org.

### How will this affect user permissions?
- Volunteer permissions: Not able to edit or update Casa Organization
- Supervisor permissions: Not able to edit or update Casa Organization
- Admin permissions: Can edit or update Casa Organization

### How is this tested? (please write tests!) 💖💪
- Tests were written considering two context. One on which an admin belongs to the organization and has permission to edit or update and the other where an organization doesn't have admins and so any other admin is not allowed to edit or update.