### PR TITLE
Issue2627 prepwork decouple selection expansion emancipation checklist

### DIFF
--- a/app/javascript/__tests__/case_emancipations.test.js
+++ b/app/javascript/__tests__/case_emancipations.test.js
@@ -1,11 +1,12 @@
 /* eslint-env jest */
-import { openChildren, closeChildren, deselectChildren, manageTogglerText } from '../src/case_emancipation'
+import { Toggler } from '../src/case_emancipation'
 
 require('jest')
 
 let category
 let categoryCollapseIcon
 let checkBox
+let toggler
 
 beforeEach(() => {
   document.body.innerHTML = `
@@ -33,34 +34,35 @@ beforeEach(() => {
   category = $('.emancipation-category')
   categoryCollapseIcon = $('.category-collapse-icon')
   checkBox = $('.emancipation-option-check-box')
+  toggler = new Toggler(category)
 })
 
 describe('Function that changes the text of the Toggler based on the state of the parent', () => {
   test('Changes the toggler text to -', () => {
     category.attr('data-is-open', 'false')
 
-    manageTogglerText(category)
+    toggler.manageTogglerText()
     expect(categoryCollapseIcon.text()).toEqual('+')
   })
 })
 
 describe('Function that opens the children of a given parent', () => {
   test('Opens the categoryOptionsContainer', () => {
-    openChildren(category)
+    toggler.openChildren()
     expect(category.data('is-open')).toEqual(true)
   })
 })
 
 describe('Function that closes the children of a given parent', () => {
   test('Closes the categoryOptionsContainer', () => {
-    closeChildren(category)
+    toggler.closeChildren()
     expect(category.data('is-open')).toEqual(false)
   })
 })
 
 describe('Function that deselects the children of a deselected parent', () => {
   test('Deselects the inputs in the categoryOptionsContainer', () => {
-    deselectChildren(category, () => '')
+    toggler.deselectChildren(() => '')
     expect(checkBox.prop('checked')).toBe(false)
   })
 })

--- a/app/javascript/__tests__/case_emancipations.test.js
+++ b/app/javascript/__tests__/case_emancipations.test.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+import { openChildren, closeChildren, deselectChildren, manageTogglerText } from '../src/case_emancipation'
+
+require('jest')
+
+let category
+let categoryCollapseIcon
+let checkBox
+
+beforeEach(() => {
+  document.body.innerHTML = `
+  <div class="card card-container">
+    <div class="card-body">
+        <div>
+          <h6 class="emancipation-category no-select" data-is-open='false'>
+            <input type="checkbox" class="emancipation-category-check-box" value="1">
+            <label>Youth has housing.</label>
+              <span class="category-collapse-icon">+</span>
+          </h6>
+          <div
+            class="category-options"
+            style="display: none;">
+              <div class="check-item">
+                <input type="checkbox" id="O1" class="emancipation-option-check-box" value="1" checked>
+                <label>With Friend</label>
+              </div>
+          </div>
+        </div>
+    </div>
+  </div>
+  `
+
+  category = $('.emancipation-category')
+  categoryCollapseIcon = $('.category-collapse-icon')
+  checkBox = $('.emancipation-option-check-box')
+})
+
+describe('Function that changes the text of the Toggler based on the state of the parent', () => {
+  test('Changes the toggler text to -', () => {
+    category.attr('data-is-open', 'false')
+
+    manageTogglerText(category)
+    expect(categoryCollapseIcon.text()).toEqual('+')
+  })
+})
+
+describe('Function that opens the children of a given parent', () => {
+  test('Opens the categoryOptionsContainer', () => {
+    openChildren(category)
+    expect(category.data('is-open')).toEqual(true)
+  })
+})
+
+describe('Function that closes the children of a given parent', () => {
+  test('Closes the categoryOptionsContainer', () => {
+    closeChildren(category)
+    expect(category.data('is-open')).toEqual(false)
+  })
+})
+
+describe('Function that deselects the children of a deselected parent', () => {
+  test('Deselects the inputs in the categoryOptionsContainer', () => {
+    deselectChildren(category, () => '')
+    expect(checkBox.prop('checked')).toBe(false)
+  })
+})

--- a/app/javascript/__tests__/case_emancipations.test.js
+++ b/app/javascript/__tests__/case_emancipations.test.js
@@ -63,6 +63,6 @@ describe('Function that closes the children of a given parent', () => {
 describe('Function that deselects the children of a deselected parent', () => {
   test('Deselects the inputs in the categoryOptionsContainer', () => {
     toggler.deselectChildren(() => '')
-    expect(checkBox.prop('checked')).toBe(false)
+    expect(checkBox.prop('checked')).toEqual(false)
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -62,28 +62,31 @@ function saveCheckState (action, checkItemId) {
     })
 }
 
-export function manageTogglerText (parent) {
-  const categoryCollapseIcon = parent.find('.category-collapse-icon')
+class Toggler {
+  constructor(parent) {
+    this.parent = parent
+    this.categoryCollapseIcon = this.parent.find('.category-collapse-icon')
+    this.categoryOptionsContainer = this.parent.siblings('.category-options')
 
-  if (parent.attr('data-is-open') === 'true') {
-    categoryCollapseIcon.text('–')
-  } else if (parent.attr('data-is-open') === 'false') {
-    categoryCollapseIcon.text('+')
   }
-}
 
-export function openChildren (parent) {
-  const categoryOptionsContainer = parent.siblings('.category-options')
+  manageTogglerText() {
+    if (this.parent.attr('data-is-open') === 'true') {
+      this.categoryCollapseIcon.text('–')
+    } else if (this.parent.attr('data-is-open') === 'false') {
+      this.categoryCollapseIcon.text('+')
+    }
+  }
 
-  categoryOptionsContainer.show()
-  parent.attr('data-is-open', 'true')
-}
+  openChildren() {
+    this.categoryOptionsContainer.show()
+    this.parent.attr('data-is-open', 'true')
+  }
 
-export function closeChildren (parent) {
-  const categoryOptionsContainer = parent.siblings('.category-options')
-
-  categoryOptionsContainer.hide()
-  parent.attr('data-is-open', 'false')
+  closeChildren() {
+    this.categoryOptionsContainer.hide()
+    this.parent.attr('data-is-open', 'false')
+  }
 }
 
 export function deselectChildren (parent, notifierCallback) {
@@ -109,6 +112,7 @@ $('document').ready(() => {
 
   $('.emancipation-category').on('click', function () {
     const category = $(this)
+    const toggler = new Toggler(category)
     const categoryCheckbox = category.find('.emancipation-category-check-box')
     const categoryCheckboxChecked = categoryCheckbox.is(':checked')
 
@@ -122,15 +126,15 @@ $('document').ready(() => {
 
       if (categoryCheckboxChecked) {
         doneCallback = () => {
-          closeChildren(category)
-          manageTogglerText(category)
+          toggler.closeChildren()
+          toggler.manageTogglerText()
           deselectChildren(category, (text) => emancipationPage.notifier.notify('Unchecked ' + text, 'info'))
         }
         saveAction = 'delete_category'
       } else {
         doneCallback = () => {
-          openChildren(category)
-          manageTogglerText(category)
+          toggler.openChildren()
+          toggler.manageTogglerText()
         }
         saveAction = 'add_category'
       }
@@ -139,7 +143,7 @@ $('document').ready(() => {
         .done(function () {
           doneCallback()
           categoryCheckbox.prop('checked', !categoryCheckboxChecked)
-          manageTogglerText(category)
+          toggler.manageTogglerText()
         })
         .always(function () {
           category.data('disabled', false)

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -62,15 +62,14 @@ function saveCheckState (action, checkItemId) {
     })
 }
 
-class Toggler {
-  constructor(parent) {
+export class Toggler {
+  constructor (parent) {
     this.parent = parent
     this.categoryCollapseIcon = this.parent.find('.category-collapse-icon')
     this.categoryOptionsContainer = this.parent.siblings('.category-options')
-
   }
 
-  manageTogglerText() {
+  manageTogglerText () {
     if (this.parent.attr('data-is-open') === 'true') {
       this.categoryCollapseIcon.text('–')
     } else if (this.parent.attr('data-is-open') === 'false') {
@@ -78,28 +77,26 @@ class Toggler {
     }
   }
 
-  openChildren() {
+  openChildren () {
     this.categoryOptionsContainer.show()
     this.parent.attr('data-is-open', 'true')
   }
 
-  closeChildren() {
+  closeChildren () {
     this.categoryOptionsContainer.hide()
     this.parent.attr('data-is-open', 'false')
   }
-}
 
-export function deselectChildren (parent, notifierCallback) {
-  const categoryOptionsContainer = parent.siblings('.category-options')
+  deselectChildren (notifierCallback) {
+    this.categoryOptionsContainer.children().filter(function () {
+      return $(this).find('input').prop('checked')
+    }).each(function () {
+      const checkbox = $(this).find('input')
 
-  categoryOptionsContainer.children().filter(function () {
-    return $(this).find('input').prop('checked')
-  }).each(function () {
-    const checkbox = $(this).find('input')
-
-    checkbox.prop('checked', false)
-    notifierCallback(checkbox.next().text())
-  })
+      checkbox.prop('checked', false)
+      notifierCallback(checkbox.next().text())
+    })
+  }
 }
 
 $('document').ready(() => {
@@ -128,7 +125,7 @@ $('document').ready(() => {
         doneCallback = () => {
           toggler.closeChildren()
           toggler.manageTogglerText()
-          deselectChildren(category, (text) => emancipationPage.notifier.notify('Unchecked ' + text, 'info'))
+          toggler.deselectChildren((text) => emancipationPage.notifier.notify('Unchecked ' + text, 'info'))
         }
         saveAction = 'delete_category'
       } else {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Progress on #2627

### What changed, and why?
Refactored the function to be more modular, so it's easier to track the collapse icon state and decouple actions. Right now it still works the same as before.

### How is this tested? (please write tests!) 💖💪
JS tests:

- will add some 🙂 

Rspec:

- spec/system/emancipations
- spec/views/emancipations
- spec/controllers/emancipations_controller_spec.rb
- spec/helpers/emancipations_helper_spec.rb

### Screenshots please :)
<img width="999" alt="Screen Shot 2022-10-18 at 23 24 23" src="https://user-images.githubusercontent.com/87862340/196582553-c8c6ea81-7319-43d7-87b0-64ff74dcdb0b.png">