### PR TITLE
Change default value of No Supervisor filter to true

### DIFF
--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -17,7 +17,7 @@
       </button>
       <div class="dropdown-menu supervisor-options">
         <div class="dropdown-item form-check">
-          <%= check_box_tag "supervisor-option-none", "", false,
+          <%= check_box_tag "supervisor-option-none", "", true,
                     class: "form-check-input",
                     data: { value: "" },
                     id: "unassigned-vol-filter" %>

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -90,17 +90,13 @@ RSpec.describe "view all volunteers", type: :system do
       expect(page).to have_selector(".volunteer-filters")
 
       # by default, only active users are shown
-      expect(page.all("table#volunteers tbody tr").count).to eq assigned_volunteers.count
+      expect(page.all("table#volunteers tbody tr").count).to eq(assigned_volunteers.count + unassigned_volunteers.count)
       assigned_volunteers.each do |assigned_volunteer|
         expect(page).to have_text assigned_volunteer.display_name
       end
-
-      click_on "Supervisor"
-      find(:css, "#unassigned-vol-filter").set(true)
       unassigned_volunteers.each do |unassigned_volunteer|
         expect(page).to have_text unassigned_volunteer.display_name
       end
-      expect(page.all("table#volunteers tbody tr").count).to eq unassigned_volunteers.count
 
       click_on "Status"
       find(:css, 'input[data-value="true"]').set(false)
@@ -111,6 +107,14 @@ RSpec.describe "view all volunteers", type: :system do
         expect(page).to have_text inactive_volunteer.display_name
       end
       expect(page.all("table#volunteers tbody tr").count).to eq inactive_volunteers.count
+
+      visit volunteers_path
+      click_on "Supervisor"
+      find(:css, "#unassigned-vol-filter").set(false)
+      assigned_volunteers.each do |assigned_volunteer|
+        expect(page).to have_text assigned_volunteer.display_name
+      end
+      expect(page.all("table#volunteers tbody tr").count).to eq assigned_volunteers.count
     end
 
     it "can go to the volunteer edit page from the volunteer list", js: true do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3779

### What changed, and why?
- Changed default value of "No supervisor assignment" filter on Volunteers page to "true" so you can seen all active volunteers on page load

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Updated existing system test

### Screenshots please :)
<img width="688" alt="image" src="https://user-images.githubusercontent.com/4965672/196796368-2b1c631d-f19d-4820-881c-13d3e7931a4f.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9