### PR TITLE
fix for #4084, contact type validation added for create

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -47,6 +47,7 @@ class CasaCasesController < ApplicationController
     )
     authorize @casa_case
 
+    @casa_case.validate_contact_type = true
     if @casa_case.save
       respond_to do |format|
         format.html { redirect_to @casa_case, notice: "CASA case was successfully created." }
@@ -154,7 +155,8 @@ class CasaCasesController < ApplicationController
       :case_number,
       :birth_month_year_youth,
       :court_report_due_date,
-      court_dates_attributes: [:date]
+      court_dates_attributes: [:date],
+      casa_case_contact_types_attributes: [:contact_type_id]
     )
   end
 

--- a/spec/controllers/casa_cases_controller_spec.rb
+++ b/spec/controllers/casa_cases_controller_spec.rb
@@ -73,5 +73,31 @@ RSpec.describe CasaCasesController, type: :controller do
         end
       end
     end
+
+    describe "POST #create" do
+      let!(:contact_type) { create(:contact_type) }
+      context "with invalid params, missing contact types" do
+        let(:params) {
+          {
+            "case_number" => "TestCase-1",
+            "birth_month_year_youth(3i)" => "1",
+            "birth_month_year_youth(2i)" => "3",
+            "birth_month_year_youth(1i)" => "1990",
+            "date_in_care(3i)" => "1",
+            "date_in_care(2i)" => "2",
+            "date_in_care(1i)" => "2020",
+            "court_dates_attributes" => {"0" => {"date" => "2022/10/31"}},
+            "court_report_status" => "submitted"          }
+        }
+
+        it "does not create a new casa case" do
+          expect {
+            post :create, params: {casa_case: params}, format: :json
+          }.to change(CasaCase, :count).by(0)
+          expect(response).to have_http_status(422)
+          expect(assigns(:casa_case).errors[:casa_case_contact_types]).to include(": At least one contact type must be selected")
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/casa_cases_controller_spec.rb
+++ b/spec/controllers/casa_cases_controller_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe CasaCasesController, type: :controller do
             "date_in_care(2i)" => "2",
             "date_in_care(1i)" => "2020",
             "court_dates_attributes" => {"0" => {"date" => "2022/10/31"}},
-            "court_report_status" => "submitted"          }
+            "court_report_status" => "submitted"
+          }
         }
 
         it "does not create a new casa case" do

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -2,11 +2,14 @@ require "rails_helper"
 
 RSpec.describe "/casa_cases", type: :request do
   let(:organization) { build(:casa_org) }
+  let(:group) { build(:contact_type_group) }
+  let(:type1) { create(:contact_type, contact_type_group: group) }
   let(:valid_attributes) do
     {
       case_number: "1234",
       birth_month_year_youth: pre_transition_aged_youth_age,
-      casa_org_id: organization.id
+      casa_org_id: organization.id,
+      casa_case_contact_types_attributes: [{contact_type_id: type1.id}]
     }
   end
   let(:invalid_attributes) { {case_number: nil, birth_month_year_youth: nil} }
@@ -168,7 +171,8 @@ RSpec.describe "/casa_cases", type: :request do
         attributes = {
           case_number: "1234",
           birth_month_year_youth: pre_transition_aged_youth_age,
-          casa_org_id: other_org.id
+          casa_org_id: other_org.id,
+          casa_case_contact_types_attributes: [{contact_type_id: type1.id}]
         }
 
         expect { post casa_cases_url, params: {casa_case: attributes} }.to(
@@ -195,7 +199,7 @@ RSpec.describe "/casa_cases", type: :request do
 
             expect(response.content_type).to eq("application/json; charset=utf-8")
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.body).to eq(["Case number can't be blank", "Birth month year youth can't be blank"].to_json)
+            expect(response.body).to eq(["Case number can't be blank", "Birth month year youth can't be blank", "Casa case contact types : At least one contact type must be selected"].to_json)
           end
         end
 

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "casa_cases/new", type: :system do
   let(:case_number) { "12345" }
   let!(:next_year) { (Date.today.year + 1).to_s }
   let(:court_date) { 21.days.from_now }
+  let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
+  let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
 
   before do
     sign_in admin
@@ -27,6 +29,8 @@ RSpec.describe "casa_cases/new", type: :system do
         select fourteen_years, from: "casa_case_birth_month_year_youth_1i"
 
         select "Submitted", from: "casa_case_court_report_status"
+
+        check contact_type.name
 
         within ".top-page-actions" do
           click_on "Create CASA Case"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4084 

### What changed, and why?
We have added the call for validation before a case is created. We have specifically not checked this for "volunteers" as we figured volunteers cannot create a case.

### How will this affect user permissions?
- Volunteer permissions: No impact
- Supervisor permissions: No impact
- Admin permissions: No impact

### How is this tested? (please write tests!) 💖💪
Added a spec for the change, and manual testing on the browser.