### PR TITLE
Add 'highlight button' to New Case Contact Form

### DIFF
--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -138,3 +138,20 @@ legend {
     font-style: italic;
 }
 
+.notes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5em;
+
+  h2 {
+    margin-bottom: 0;
+  }
+}
+
+.highlight-button {
+  background: none;
+  border: none;
+  color: var(--blue);
+  font-size: 1.1em;
+}

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -180,9 +180,15 @@ async function fireSwalFollowupAlert () {
   })
 }
 
+function displayHighlightModal (event) {
+  event.preventDefault()
+  $('#caseContactHighlight').modal('show')
+}
+
 $('document').ready(() => {
   $('[data-toggle="tooltip"]').tooltip()
   $('.followup-button').on('click', displayFollowupAlert)
+  $('#open-highlight-modal').on('click', displayHighlightModal)
 })
 
 export {

--- a/app/models/user_reminder_time.rb
+++ b/app/models/user_reminder_time.rb
@@ -8,7 +8,7 @@ end
 #
 #  id                 :bigint           not null, primary key
 #  case_contact_types :datetime
-#  no_contact_made    :datetime
+#  reminder_sent      :datetime
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  user_id            :bigint           not null

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -211,7 +211,10 @@ readonly: true %>
   </div>
 
   <div class="field notes form-group field-card">
-    <h2><%= form.label :notes, "5. Enter Notes" %></h2>
+    <div class="notes-header">
+      <h2><%= form.label :notes, "5. Enter Notes" %></h2>
+      <button id="open-highlight-modal" class="highlight-button" data-toggle="modal" data-target="#visibleColumns">+ Highlight</button>
+    </div>
     <div class="cc-italic">
       Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth.
     </div>
@@ -224,3 +227,22 @@ readonly: true %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>
   <% end %>
+
+<div class="modal fade" id="caseContactHighlight" tabindex="-1" role="dialog" aria-labelledby="caseContactHighlight" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="caseContactHighlightLabel">Highlight</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Coming Soon.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Add simple 'Highlight' button and placeholder modal to new case contact form. Actual implementation of highlight feature to follow.

### What github issue is this PR for, if any?
Resolves #3566

### What changed, and why?
Add 'highlight button' to New Case Contact Form

Add simple 'Highlight' button and placeholder modal to new case contact
form. Actual implementation of highlight feature to follow.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
No tests yet. Not sure how/if we do feature specs

### Screenshots please :)
![Screen Shot 2022-10-21 at 1 03 29 AM](https://user-images.githubusercontent.com/1638226/197116205-b49f161a-fffc-4d95-aca6-a75a1164de1c.png)
![Screen Shot 2022-10-21 at 1 03 47 AM](https://user-images.githubusercontent.com/1638226/197116240-bffc13b9-ea9a-4051-89a4-f5fad182b8f7.png)

### Feelings gif (optional)
![Coming soon](https://media.giphy.com/media/KzeZ3OXHoSDVZH9cmy/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9