### PR TITLE
Fix broken link to Cypress in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ There is a `doc` directory at the top level that includes:
 * an `architecture-decisions` directory containing important architectural decisions and entity relationship diagrams of various models
   (see the article [Architectural Decision Records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) describing this approach).
 * [Code of Conduct](doc/code-of-conduct.md)
-* [CYPRESS.md](doc/CYPRESS.md)
 * [productsense.md](doc/productsense.md)(for team leads & product interested contributors)
 * [SECURITY.md](doc/SECURITY.md)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4086

### What changed, and why?
- Remove the broken link to Cypress document.


### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: None
- Admin permissions: None

### How is this tested? (please write tests!) 💖💪
- View Readme and the Cypress link should not be there

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9