### PR TITLE
Fix/preserve case contact notes when editing form

### DIFF
--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -2,8 +2,13 @@
 
 $(() => {
   const formId = 'casa-contact-form'
+  let localStorageKey = formId
 
-  if ($('.case_contacts-new').length > 0) {
+  if ($('.case_contacts-new').length > 0 || $('.case_contacts-edit').length > 0) {
+    if ($('.case_contacts-edit').length > 0) {
+      const caseContactId = $(`#${formId}`)[0].action.split('/').pop()
+      localStorageKey = `${formId}-${caseContactId}`
+    }
     const save = () => {
       const data = []
 
@@ -13,12 +18,13 @@ $(() => {
         }
       })
 
-      window.localStorage.setItem(formId, JSON.stringify(data))
+      window.localStorage.setItem(localStorageKey, JSON.stringify(data))
     }
 
     const load = () => {
-      if (window.localStorage.key(formId)) {
-        const data = JSON.parse(window.localStorage.getItem(formId))
+      const rawData = window.localStorage.getItem(localStorageKey)
+      if (rawData !== null) {
+        const data = JSON.parse(rawData)
 
         data.forEach(({ id, value, checked }) => {
           const element = document.querySelector(`#${id}`)
@@ -32,12 +38,11 @@ $(() => {
     }
 
     $(`#${formId}`).on('keyup change paste', 'input, select, textarea', save)
+    $('#modal-case-contact-submit').on('click', () => {
+      window.localStorage.removeItem(formId)
+      window.localStorage.removeItem(localStorageKey)
+    })
 
     document.onload = load()
-  }
-
-  // The following regex will match to string like this: "/casa_cases/cina-5"
-  if (/\/casa_cases\/.*\d$/.test(window.location.pathname)) {
-    window.localStorage.removeItem(formId)
   }
 })

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -142,5 +142,25 @@ you are trying to set the address for both of them. This is not currently possib
       expect(case_contact.medium_type).to eq "in-person"
       expect(case_contact.contact_made).to eq true
     end
+
+    it "autosaves notes", js: true do
+      case_contact = create(:case_contact, duration_minutes: 105, casa_case: casa_case, creator: volunteer, notes: "Hello from the other side")
+      sign_in volunteer
+      visit edit_case_contact_path(case_contact)
+
+      within "#enter-contact-details" do
+        choose "Yes"
+      end
+
+      fill_in "Notes", with: "Hello world"
+
+      click_on "Log out"
+
+      sign_in volunteer
+
+      visit edit_case_contact_path(case_contact)
+
+      expect(page).to have_field("Notes", with: "Hello world")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2656

### What changed, and why?
The way we store case contacts on local storage to make autosave available for editing cases

### How will this affect user permissions?
- Volunteer permissions: No affect
- Supervisor permissions: No affect
- Admin permissions: No affect

### How is this tested? (please write tests!) 💖💪
- Enter one case contact edit page as volunteer and edit something
- Logout
- Login and enter the case contact edit page again
- The changes you have done will be there

### Screenshots please :)
![casa](https://user-images.githubusercontent.com/2593231/197361110-9fb7e334-7977-42b2-a924-0e124396b261.gif)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![Happy](https://media4.giphy.com/media/ZYEv0EmAncKu6gf6Ft/giphy.gif?cid=ecf05e47oqojd4m0vl7fzidy23i3was32r8ob8klkombhl7y&rid=giphy.gif&ct=g)
