### PR TITLE
Remove jQuery from two tests so that they run

### DIFF
--- a/app/javascript/__tests__/case_button_states.test.js
+++ b/app/javascript/__tests__/case_button_states.test.js
@@ -19,18 +19,14 @@ beforeEach(() => {
 
 describe('casa_case generate report button applies correct classes and attributes', () => {
   test('show button', () => {
-    $(document).ready(() => {
-      button.classList.add('d-none')
-      showBtn(button)
-      expect($(button).is(':visible')).toBe(true)
-    })
+    button.classList.add('d-none')
+    showBtn(button)
+    expect(button.classList.contains('d-none')).toBe(false)
   })
 
   test('hide button', () => {
-    $(document).ready(() => {
-      hideBtn(button)
-      expect($(button).is(':visible')).toBe(false)
-    })
+    hideBtn(button)
+    expect(button.classList.contains('d-none')).toBe(true)
   })
 
   test('disable button', () => {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4107

### What changed, and why?
I removed jQuery from two jest tests. I believe the tests were never running. The `expect` statements are now noticeably different but I think the tests are still valuable.

### How is this tested? (please write tests!) 💖💪
This is nothing _but_ tests :D