### PR TITLE
Add Pundit authorization for notes controller

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -59,6 +59,7 @@ notifications/youth_birthday_notification.rb
 notifications/delivery_methods/sms.rb
 policies/case_court_order_policy.rb
 policies/learning_hour_policy.rb
+policies/note_policy.rb
 presenters/base_presenter.rb
 presenters/case_contact_presenter.rb
 services/case_contacts_export_csv_service.rb

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -20,6 +20,7 @@ class NotesController < ApplicationController
   end
 
   def destroy
+    authorize @note
     @note.destroy
 
     redirect_to edit_volunteer_path(@volunteer)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -30,18 +30,12 @@ class NotesController < ApplicationController
 
   def find_note
     @note = @volunteer.notes.find_by(id: params[:id])
-    unless @note
-      redirect_to root_path
-      return
-    end
+    redirect_to root_path unless @note
   end
 
   def find_volunteer
     @volunteer = current_user.casa_org.volunteers.find_by(id: params[:volunteer_id])
-    unless @volunteer
-      redirect_to root_path
-      return
-    end
+    redirect_to root_path unless @volunteer
   end
 
   def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
-  before_action :find_note, only: %i[edit update destroy]
   before_action :find_volunteer
+  before_action :find_note, only: %i[edit update destroy]
 
   def create
     @volunteer.notes.create(note_params)
@@ -8,6 +8,7 @@ class NotesController < ApplicationController
   end
 
   def edit
+    authorize @note
   end
 
   def update
@@ -25,7 +26,11 @@ class NotesController < ApplicationController
   private
 
   def find_note
-    @note = Note.find(params[:id])
+    @note = @volunteer.notes.find_by(id: params[:id])
+    unless @note
+      redirect_to root_path
+      return
+    end
   end
 
   def find_volunteer

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,6 +13,7 @@ class NotesController < ApplicationController
   end
 
   def update
+    authorize @note
     @note.update(note_params)
 
     redirect_to edit_volunteer_path(@volunteer)

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -29,7 +29,11 @@ class NotesController < ApplicationController
   end
 
   def find_volunteer
-    @volunteer = Volunteer.find(params[:volunteer_id])
+    @volunteer = current_user.casa_org.volunteers.find_by(id: params[:volunteer_id])
+    unless @volunteer
+      redirect_to root_path
+      return
+    end
   end
 
   def note_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -3,6 +3,7 @@ class NotesController < ApplicationController
   before_action :find_note, only: %i[edit update destroy]
 
   def create
+    authorize Note
     @volunteer.notes.create(note_params)
     redirect_to edit_volunteer_path(@volunteer)
   end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,5 @@
+class NotePolicy < ApplicationPolicy
+  def edit?
+    true
+  end
+end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,5 +1,9 @@
 class NotePolicy < ApplicationPolicy
+  def create?
+    admin_or_supervisor?
+  end
+
   def edit?
-    true
+    create?
   end
 end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -6,4 +6,8 @@ class NotePolicy < ApplicationPolicy
   def edit?
     create?
   end
+
+  def update?
+    edit?
+  end
 end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -10,4 +10,8 @@ class NotePolicy < ApplicationPolicy
   def update?
     edit?
   end
+
+  def destroy?
+    edit?
+  end
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :note do
+    association :notable, factory: :user
+    association :creator, factory: :user
+  end
+end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :note do
     association :notable, factory: :user
     association :creator, factory: :user
+    content { "I am a note" }
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -3,4 +3,10 @@ require "rails_helper"
 RSpec.describe Note, type: :model do
   it { is_expected.to belong_to(:notable) }
   it { is_expected.to belong_to(:creator) }
+
+  it "has a valid factory" do
+    note = build(:note)
+
+    expect(note).to be_valid
+  end
 end

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -57,6 +57,98 @@ RSpec.describe "/volunteers/notes", type: :request do
     end
   end
 
+  describe "GET /edit" do
+    context "when logged in as admin" do
+      context "when volunteer in same organization" do
+        it "is successful if note belongs to volunteer" do
+          organization = create(:casa_org)
+          admin = create(:casa_admin, casa_org: organization)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: volunteer)
+
+          sign_in admin
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to be_successful
+        end
+
+        it "redirects to root path if note does not belong to volunteer" do
+          organization = create(:casa_org)
+          admin = create(:casa_admin, casa_org: organization)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          other_volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: other_volunteer)
+
+          sign_in admin
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      context "when volunteer in different organization" do
+        it "redirects to root path" do
+          organization = create(:casa_org)
+          other_organization = create(:casa_org)
+          admin = create(:casa_admin, casa_org: organization)
+
+          volunteer = create(:volunteer, casa_org: other_organization)
+          note = create(:note, notable: volunteer)
+
+          sign_in admin
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+
+    context "when logged in as supervisor" do
+      context "when volunteer in same organization" do
+        it "is successful if note belongs to volunteer" do
+          organization = create(:casa_org)
+          supervisor = create(:supervisor, casa_org: organization)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: volunteer)
+
+          sign_in supervisor
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to be_successful
+        end
+
+        it "redirects to root path if note does not belong to volunteer" do
+          organization = create(:casa_org)
+          supervisor = create(:supervisor, casa_org: organization)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          other_volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: other_volunteer)
+
+          sign_in supervisor
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      context "when volunteer in different organization" do
+        it "redirects to root path" do
+          organization = create(:casa_org)
+          other_organization = create(:casa_org)
+          supervisor = create(:supervisor, casa_org: organization)
+
+          volunteer = create(:volunteer, casa_org: other_organization)
+          note = create(:note, notable: volunteer)
+
+          sign_in supervisor
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+  end
+
   describe "PATCH /update" do
     context "when logged in as an admin" do
       context "with valid params" do

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,24 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "/volunteers/notes", type: :request do
-  let(:organization) { create(:casa_org) }
-  let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
-  let(:volunteer) { create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id) }
-  let(:note) { volunteer.notes.create(creator: admin, content: "Good job.") }
-
   describe "PATCH /update" do
-    subject(:request) { patch volunteer_note_path(volunteer, note), params: params }
-
     context "when logged in as an admin" do
-      before do
-        sign_in admin
-        request
-      end
-
       context "with valid params" do
-        let(:params) { {note: {content: "Very nice!"}} }
+        it "redirects to edit volunteer page and updates note" do
+          organization = create(:casa_org)
+          admin = create(:casa_admin, casa_org: organization)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: volunteer, creator: admin, content: "Good job.")
 
-        it "returns success response" do
+          sign_in admin
+          patch volunteer_note_path(volunteer, note), params: {note: {content: "Very nice!"}}
+
           expect(response).to redirect_to(edit_volunteer_path(volunteer))
           expect(note.reload.content).to eq "Very nice!"
         end
@@ -27,26 +21,32 @@ RSpec.describe "/volunteers/notes", type: :request do
   end
 
   describe "DELETE /destroy" do
-    let!(:note_1) { volunteer.notes.create(creator: admin, content: "Note_1") }
-
-    before do
-      sign_in admin
-      request
-    end
-
     context "when logged in as an admin" do
       it "can delete notes about a volunteer" do
-        expect do
-          delete volunteer_note_path(volunteer, note_1)
-        end.to change(Note, :count).by(-1)
+        organization = create(:casa_org)
+        admin = create(:casa_admin, casa_org: organization)
+        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+        note = create(:note, creator: admin, notable: volunteer)
+
+        sign_in admin
+        expect {
+          delete volunteer_note_path(volunteer, note)
+        }.to change(Note, :count).by(-1)
       end
     end
 
     context "when logged in as a supervisor" do
       it "can delete notes about a volunteer" do
-        expect do
-          delete volunteer_note_path(volunteer, note_1)
-        end.to change(Note, :count).by(-1)
+        organization = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: organization)
+        other_supervisor = create(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+        note = create(:note, creator: other_supervisor, notable: volunteer)
+
+        sign_in supervisor
+        expect {
+          delete volunteer_note_path(volunteer, note)
+        }.to change(Note, :count).by(-1)
       end
     end
   end

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,6 +1,62 @@
 require "rails_helper"
 
 RSpec.describe "/volunteers/notes", type: :request do
+  describe "POST /create" do
+    context "when logged in as admin" do
+      it "can create a note for volunteer in same organization" do
+        organization = create(:casa_org)
+        admin = create(:casa_admin, casa_org: organization)
+        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+        sign_in admin
+        expect{
+          post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
+        }.to change(Note, :count).by(1)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
+        expect(Note.last.content).to eq "Very nice!"
+      end
+
+      it "cannot create a note for volunteer in different organization" do
+        organization = create(:casa_org)
+        other_organization = create(:casa_org)
+        admin = create(:casa_admin, casa_org: organization)
+        volunteer = create(:volunteer, casa_org: other_organization)
+
+        sign_in admin
+        expect{
+          post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
+        }.to_not change(Note, :count)
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "when logged in as a supervisor" do
+      it "can create a note for volunteer in same organization" do
+        organization = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+        sign_in supervisor
+        expect{
+          post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
+        }.to change(Note, :count).by(1)
+        expect(response).to redirect_to edit_volunteer_path(volunteer)
+        expect(Note.last.content).to eq "Very nice!"
+      end
+
+      it "cannot create a note for volunteer in different organization" do
+        organization = create(:casa_org)
+        other_organization = create(:casa_org)
+        supervisor = create(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, casa_org: other_organization)
+
+        sign_in supervisor
+        expect{
+          post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
+        }.to_not change(Note, :count)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
   describe "PATCH /update" do
     context "when logged in as an admin" do
       context "with valid params" do

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "/volunteers/notes", type: :request do
         admin = create(:casa_admin, casa_org: organization)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
         sign_in admin
-        expect{
+        expect {
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
         }.to change(Note, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
@@ -22,7 +22,7 @@ RSpec.describe "/volunteers/notes", type: :request do
         volunteer = create(:volunteer, casa_org: other_organization)
 
         sign_in admin
-        expect{
+        expect {
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
         }.to_not change(Note, :count)
         expect(response).to redirect_to root_path
@@ -35,7 +35,7 @@ RSpec.describe "/volunteers/notes", type: :request do
         supervisor = create(:supervisor, casa_org: organization)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
         sign_in supervisor
-        expect{
+        expect {
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
         }.to change(Note, :count).by(1)
         expect(response).to redirect_to edit_volunteer_path(volunteer)
@@ -49,7 +49,7 @@ RSpec.describe "/volunteers/notes", type: :request do
         volunteer = create(:volunteer, casa_org: other_organization)
 
         sign_in supervisor
-        expect{
+        expect {
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
         }.to_not change(Note, :count)
         expect(response).to redirect_to root_path
@@ -57,11 +57,12 @@ RSpec.describe "/volunteers/notes", type: :request do
     end
 
     context "when logged in as volunteer" do
-      it "may not create a note" do
+      it "cannot create a note" do
         organization = create(:casa_org)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+
         sign_in volunteer
-        expect{
+        expect {
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
         }.to_not change(Note, :count)
         expect(response).to redirect_to root_path

--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe "/volunteers/notes", type: :request do
         expect(response).to redirect_to root_path
       end
     end
+
+    context "when logged in as volunteer" do
+      it "may not create a note" do
+        organization = create(:casa_org)
+        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+        sign_in volunteer
+        expect{
+          post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
+        }.to_not change(Note, :count)
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe "GET /edit" do
@@ -141,6 +153,21 @@ RSpec.describe "/volunteers/notes", type: :request do
           note = create(:note, notable: volunteer)
 
           sign_in supervisor
+          get edit_volunteer_note_path(volunteer, note)
+
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+
+    context "when logged in as volunteer" do
+      context "when note belongs to volunteer" do
+        it "redirects to root path" do
+          organization = create(:casa_org)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
+          note = create(:note, notable: volunteer)
+
+          sign_in volunteer
           get edit_volunteer_note_path(volunteer, note)
 
           expect(response).to redirect_to root_path


### PR DESCRIPTION
### What github issue is this PR for, if any?
Ref #2897 

### What changed, and why?
This adds authorization for the notes controller, ensuring that only supervisors and admins can create, update, or destroy notes for any volunteers in their organization.

### How will this affect user permissions?
- Volunteer permissions: Cannot do any note actions
- Supervisor permissions: Can do all note actions for volunteers in their own organization
- Admin permissions: Can do all note actions for volunteers in their own organization

### How is this tested? (please write tests!) 💖💪
Updated and fleshed out the Note request spec