### PR TITLE
Casa Case Assignment - unassign must respect same_org

### DIFF
--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -21,7 +21,7 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def unassign?
-    record.active? && admin_or_supervisor?
+    record.active? && admin_or_supervisor? && same_org?
   end
 
   def hide_contacts?
@@ -30,5 +30,9 @@ class CaseAssignmentPolicy < ApplicationPolicy
 
   def show_or_hide_contacts?
     hide_contacts? || !hide_contacts?
+  end
+
+  def same_org?
+    user.casa_org_id == record.casa_case.casa_org_id
   end
 end

--- a/spec/policies/case_assignment_policy_spec.rb
+++ b/spec/policies/case_assignment_policy_spec.rb
@@ -4,14 +4,20 @@ RSpec.describe CaseAssignmentPolicy do
   subject { described_class }
 
   let(:organization) { build(:casa_org) }
-
   let(:casa_admin) { build(:casa_admin, casa_org: organization) }
   let(:casa_case) { build(:casa_case, casa_org: organization) }
   let(:volunteer) { build(:volunteer, casa_org: organization) }
   let(:case_assignment) { build(:case_assignment, casa_case: casa_case, volunteer: volunteer) }
   let(:case_assignment_inactive) { build(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: false) }
-  let(:supervisor) { build(:supervisor, casa_org: organization) }
-  let(:casa_admin) { build(:casa_admin, casa_org: organization) }
+  let(:supervisor) { create(:supervisor, casa_org: organization) }
+
+  let(:other_organization) { create(:casa_org) }
+  let(:other_casa_case) do
+    create(:casa_case, casa_org: other_organization)
+  end
+  let(:other_case_assignment) do
+    create(:case_assignment, casa_case: other_casa_case)
+  end
 
   permissions :create?, :destroy? do
     it "allows casa_admins" do
@@ -47,6 +53,12 @@ RSpec.describe CaseAssignmentPolicy do
     context "when user is a volunteer" do
       it "does not allow unassign" do
         is_expected.not_to permit(volunteer, case_assignment)
+      end
+    end
+
+    context "when is a different organization" do
+      it "does not allow unassign" do
+        is_expected.not_to permit(supervisor, other_case_assignment)
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Related to https://github.com/rubyforgood/casa/issues/4065

### What changed, and why?

Only allow unassign same organization users


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: [x]
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Rspec tests

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
