### PR TITLE
Resolves #4050 Add js and css bundling to docker/build script

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -11,9 +11,7 @@ Install [Docker Community Edition](https://docs.docker.com/install/) if it is no
 The automatic setup explained here relies on Bash scripts in the docker directory to execute the most basic and frequent tasks in Docker.  There is substantially less typing to do under the automatic setup than under the manual setup.
 
 ### Initial setup
-1. Clone the repository to your local machine: `git clone
-   https://github.com/rubyforgood/casa.git` or create a fork in GitHub if you
-   don't have permission to commit directly to this repo.
+1. Clone the repository to your local machine: `git clone https://github.com/rubyforgood/casa.git` or create a fork in GitHub if you don't have permission to commit directly to this repo.
 2. Change into the application directory: `cd casa`
 3. Run `docker/build` to build the app, seed the database, run the local web server (in a detached state), run the test suite, and log the screen outputs of these processes in the log directory.  The web application will be available at http://localhost:3000.
 4. Run `docker/test` to run the test suite and log the screen output in the log directory.
@@ -33,20 +31,20 @@ The automatic setup explained here relies on Bash scripts in the docker director
 The manual setup instructions walk you through building the images and starting
 the containers using Docker Compose commands directly. This setup method is particularly
 recommended if you are new to Docker.
+
 ### Initial setup
 The following commands should just be run for the initial setup only. Rebuilding the docker images is only necessary when upgrading, if there are changes to the Dockerfile, or if gems have been added or updated.
-1. Clone the respository to your local machine: `git clone
-   https://github.com/rubyforgood/casa.git` or create a fork in GitHub if you
-   don't have permission to commit directly to this repo.
+1. Clone the respository to your local machine: `git clone https://github.com/rubyforgood/casa.git` or create a fork in GitHub if you don't have permission to commit directly to this repo.
 2. Change into the application directory: `cd casa`
 3. Run `docker-compose build` to build images for all services.
-4. Run `docker-compose run --rm web rails db:reset` to create the dev and test
-   databases, load the schema, and run the seeds file.
-5. Run `docker-compose up -d` to start all the remaining services.
-6. Run `docker-compose ps` to view status of the containers. All should have
-   state "Up". Check the [logs](#viewing-logs) if there are any containers that
-   did not start.
-7. The web application will be available at http://localhost:3000
+4. Run `docker-compose run --rm web bundle install` to install ruby dependencies
+5. Run `docker-compose run --rm web rails db:reset` to create the dev and test databases, load the schema, and run the seeds file.
+6. Run `docker-compose run --rm web yarn` to install javascript dependencies
+7. Run `docker-compose run --rm web yarn build` to bundle javascript assets
+8. Run `docker-compose run --rm web yarn build:css` to bundle the css
+9. Run `docker-compose up` to start all the remaining services. Or use `docker-compose up -d` to start containers in the background.
+10. Run `docker-compose ps` to view status of the containers. All should have state "Up". Check the [logs](#viewing-logs) if there are any containers that did not start.
+11. The web application will be available at http://localhost:3000
 
 ### For ongoing development:
 * Run `docker-compose up -d` to start all services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - "4000:4000"
     volumes:
       - .:/usr/src/app
-      - /usr/src/app/node_modules
+      - node_modules:/usr/src/app/node_modules
+      - bundle_data:/usr/local/bundle/gems
     env_file:
       - config/docker.env
     depends_on:
@@ -38,3 +39,5 @@ services:
 
 volumes:
   db_data:
+  bundle_data:
+  node_modules:

--- a/docker/build
+++ b/docker/build
@@ -9,6 +9,8 @@ docker/build-log 2>&1 | tee log/$DATE/build.log
 wait
 docker/seed 2>&1 | tee log/$DATE/seed.log
 wait
+docker/build-assets 2>&1 | tee log/$DATE/build-assets.log
+wait
 docker/server-log 2>&1 | tee log/$DATE/server.log
 wait
 docker/test-log 2>&1 | tee log/$DATE/test.log

--- a/docker/build-assets
+++ b/docker/build-assets
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +e
+
+# Bundle JS and CSS assets
+
+echo 'Bundling js and css assets...'
+docker-compose run --rm web bundle install # usually will be a no-op
+docker-compose run --rm web yarn install   # usually will be a no-op
+
+docker-compose run --rm web yarn build
+docker-compose run --rm web yarn build:css
+echo 'Done bundling js and css assets.'

--- a/docker/build-log
+++ b/docker/build-log
@@ -3,11 +3,7 @@ set +e
 
 docker-compose down -v --remove-orphans
 wait
-echo '###########################'
-echo 'BEGIN: docker-compose build'
-echo '###########################'
+
+echo 'Building docker containers...'
 docker-compose build # Set up the Docker containers
-wait
-echo '##############################'
-echo 'FINISHED: docker-compose build'
-echo '##############################'
+echo 'Done building docker containers.'

--- a/docker/seed
+++ b/docker/seed
@@ -1,27 +1,19 @@
 #!/bin/bash
-
+set +e
 # This is the data seeding script.
 
-echo '-------------------------------------'
-echo 'docker-compose run web bundle install'
-docker-compose run web bundle install
-
 # If the local web server is running, it must be stopped to allow the database to be reseeded.
-echo '-------------------'
-echo 'docker-compose stop'
+echo 'Stopping existing containers...'
 docker-compose stop
+echo 'Done stopping existing containers.'
 
 # NOTE: "rails db:reset" creates the development and test databases AND seeds the database.
 # This app will not work until you run this command.
-echo '--------------------------------------------'
-echo 'BEGIN: docker-compose run web rails db:reset'
-echo '--------------------------------------------'
-docker-compose run web rails db:reset
-echo '------------------------------------------'
-echo 'END: docker-compose run web rails db:reset'
-echo '------------------------------------------'
+echo 'Resetting rails db...'
+docker-compose run --rm web rails db:reset
+echo 'Done resetting rails db.'
+
 echo ''
-echo '-----------------------------------------'
 echo 'The database seeding process is complete!'
 echo 'At this point, the local web server is NOT running.'
 echo 'You must enter "docker/server" to start it.'

--- a/docker/server-log
+++ b/docker/server-log
@@ -1,9 +1,7 @@
 #!/bin/bash
 set +e
 
-echo '###########################'
-echo 'BEGIN: docker-compose up -d'
-echo '###########################'
+echo 'Starting web server...'
 echo 'View this app in your web browser at'
 echo 'http://localhost:3000/'
 docker-compose up -d

--- a/docker/test-log
+++ b/docker/test-log
@@ -1,21 +1,13 @@
 #!/bin/bash
+set +e
 
-echo '-------------------------------------'
-echo 'docker-compose run web bundle install'
-docker-compose run web bundle install
+# Update db and run tests
+# All containers must be already running
 
-echo '----------------------------------------------'
-echo 'BEGIN: docker-compose run web rails db:migrate'
-echo '----------------------------------------------'
-docker-compose run web rails db:migrate
-echo '--------------------------------------------'
-echo 'END: docker-compose run web rails db:migrate'
-echo '--------------------------------------------'
+echo 'Running migrations...'
+docker-compose exec web rails db:migrate
+echo 'Done running migrations.'
 
-echo '-----------------------------------------'
-echo 'BEGIN: docker-compose exec web rspec spec'
-echo '-----------------------------------------'
+echo 'Running rspec...'
 docker-compose exec web rspec spec
-echo '---------------------------------------'
-echo 'END: docker-compose exec web rspec spec'
-echo '---------------------------------------'
+echo 'Done running rspec.'


### PR DESCRIPTION
This fixes the issue with running docker/build (#4050). However, is docker and the various scripts in the docker directory being used to facilitate easy local development setup, CI, deployment etc.? Depending on the answer we could recommend additional changes and would be happy to issue a follow up PR.

### What github issue is this PR for, if any?
Resolves #4050

### What changed, and why?
- Add `docker/build-assets` to the `docker/build` script to include asset bundling before launching the web server.
- Updated existing docker helper scripts to be more compatible with the `docker/build` command.
- Update docker-compose file to store bundler and yarn packges in persistent volumes. This should speed up local startup times.
- Update the echo output from the various docker/ scripts to have more consistent and concise status updates.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

This PR does not affect user permissions.

### How is this tested? (please write tests!) 💖💪
Ran docker/build locally.  No automated tests.
