### PR TITLE
Update case_assignment_policy#destroy

### DIFF
--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -17,7 +17,7 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    admin_or_supervisor?
+    admin_or_supervisor? && same_org?
   end
 
   def unassign?

--- a/spec/policies/case_assignment_policy_spec.rb
+++ b/spec/policies/case_assignment_policy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CaseAssignmentPolicy do
     create(:case_assignment, casa_case: other_casa_case)
   end
 
-  permissions :create?, :destroy? do
+  permissions :create? do
     it "allows casa_admins" do
       is_expected.to permit(casa_admin)
     end
@@ -58,6 +58,30 @@ RSpec.describe CaseAssignmentPolicy do
 
     context "when is a different organization" do
       it "does not allow unassign" do
+        is_expected.not_to permit(supervisor, other_case_assignment)
+      end
+    end
+  end
+
+  permissions :destroy? do
+    context "when user is an admin" do
+      it "allow destroy" do
+        is_expected.to permit(casa_admin, case_assignment)
+      end
+    end
+
+    context "when user is a supervisor" do
+      it "allow destroy" do
+        is_expected.to permit(supervisor, case_assignment)
+      end
+    end
+
+    context "when is a different organization" do
+      it "does not allow admins to destroy" do
+        is_expected.not_to permit(casa_admin, other_case_assignment)
+      end
+
+      it "does not allow supervisor to destroy" do
         is_expected.not_to permit(supervisor, other_case_assignment)
       end
     end


### PR DESCRIPTION
### What GitHub issue is this PR for if any?
Resolves https://github.com/rubyforgood/casa/issues/4065

### What changed, and why?

We updated the case assignment policy to allow only admins and supervisors from the same organization to destroy them. 

### How will this affect user permissions?
- [ ] Volunteer permissions
- [x] Supervisor permissions
- [x] Admin permissions

### How is this tested? (please write tests!) 💖💪

Automated tests

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
