### PR TITLE
Refactor full data method for export volunteer emails CSV

### DIFF
--- a/app/services/volunteers_emails_export_csv_service.rb
+++ b/app/services/volunteers_emails_export_csv_service.rb
@@ -19,7 +19,7 @@ class VolunteersEmailsExportCsvService
   private
 
   def full_data(volunteer = nil)
-    active_casa_cases = volunteer&.casa_cases&.active&.map { |c| [c.case_number, c.decorate.transition_aged_youth] }.to_h
+    active_casa_cases = volunteer&.casa_cases&.active&.map { |c| [c.case_number, c.in_transition_age?] }.to_h
 
     {
       email: volunteer&.email,

--- a/app/services/volunteers_emails_export_csv_service.rb
+++ b/app/services/volunteers_emails_export_csv_service.rb
@@ -19,11 +19,13 @@ class VolunteersEmailsExportCsvService
   private
 
   def full_data(volunteer = nil)
+    active_casa_cases = volunteer&.casa_cases&.active&.map { |c| [c.case_number, c.decorate.transition_aged_youth] }.to_h
+
     {
       email: volunteer&.email,
-      case_number: volunteer&.casa_cases&.active&.pluck(:case_number).to_a.join(", "),
+      case_number: active_casa_cases.keys.join(", "),
       volunteer_name: volunteer&.display_name,
-      case_transition_aged_status: volunteer&.casa_cases&.active&.pluck(:transition_aged_youth).to_a.join(", ")
+      case_transition_aged_status: active_casa_cases.values.join(", "),
     }
   end
 end

--- a/app/services/volunteers_emails_export_csv_service.rb
+++ b/app/services/volunteers_emails_export_csv_service.rb
@@ -25,7 +25,7 @@ class VolunteersEmailsExportCsvService
       email: volunteer&.email,
       case_number: active_casa_cases.keys.join(", "),
       volunteer_name: volunteer&.display_name,
-      case_transition_aged_status: active_casa_cases.values.join(", "),
+      case_transition_aged_status: active_casa_cases.values.join(", ")
     }
   end
 end

--- a/spec/services/volunteers_emails_export_csv_service_spec.rb
+++ b/spec/services/volunteers_emails_export_csv_service_spec.rb
@@ -4,15 +4,14 @@ RSpec.describe VolunteersEmailsExportCsvService do
   subject { described_class.new.perform }
   let!(:active_volunteer) { create(:volunteer, :with_casa_cases) }
   let!(:inactive_volunteer) { create(:volunteer, :inactive) }
-  let(:active_volunteer_cases) { active_volunteer.casa_cases.active.pluck(:case_number).to_a.join(", ") }
-  let(:active_volunteer_case_transition_aged) { active_volunteer.casa_cases.active.pluck(:transition_aged_youth).to_a.join(", ") }
+  let(:active_volunteer_cases) { active_volunteer.casa_cases.active.map { |c| [c.case_number, c.decorate.transition_aged_youth] }.to_h }
 
   describe "#perform" do
     it "Exports correct data from volunteers" do
       results = subject.split("\n")
       expect(results.count).to eq(2)
       expect(results[0].split(",")).to eq(["Email", "Case Number", "Volunteer Name", "Case Transition Aged Status"])
-      expect(results[1]).to eq("#{active_volunteer.email},\"#{active_volunteer_cases}\",#{active_volunteer.display_name},\"#{active_volunteer_case_transition_aged}\"")
+      expect(results[1]).to eq("#{active_volunteer.email},\"#{active_volunteer_cases.keys.join(', ')}\",#{active_volunteer.display_name},\"#{active_volunteer_cases.values.join(', ')}\"")
     end
 
     it "includes active volunteers" do

--- a/spec/services/volunteers_emails_export_csv_service_spec.rb
+++ b/spec/services/volunteers_emails_export_csv_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe VolunteersEmailsExportCsvService do
   subject { described_class.new.perform }
   let!(:active_volunteer) { create(:volunteer, :with_casa_cases) }
   let!(:inactive_volunteer) { create(:volunteer, :inactive) }
-  let(:active_volunteer_cases) { active_volunteer.casa_cases.active.map { |c| [c.case_number, c.decorate.transition_aged_youth] }.to_h }
+  let(:active_volunteer_cases) { active_volunteer.casa_cases.active.map { |c| [c.case_number, c.in_transition_age?] }.to_h }
 
   describe "#perform" do
     it "Exports correct data from volunteers" do

--- a/spec/services/volunteers_emails_export_csv_service_spec.rb
+++ b/spec/services/volunteers_emails_export_csv_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe VolunteersEmailsExportCsvService do
       results = subject.split("\n")
       expect(results.count).to eq(2)
       expect(results[0].split(",")).to eq(["Email", "Case Number", "Volunteer Name", "Case Transition Aged Status"])
-      expect(results[1]).to eq("#{active_volunteer.email},\"#{active_volunteer_cases.keys.join(', ')}\",#{active_volunteer.display_name},\"#{active_volunteer_cases.values.join(', ')}\"")
+      expect(results[1]).to eq("#{active_volunteer.email},\"#{active_volunteer_cases.keys.join(", ")}\",#{active_volunteer.display_name},\"#{active_volunteer_cases.values.join(", ")}\"")
     end
 
     it "includes active volunteers" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #4122 

### What changed, and why?

- Avoids a duplicate query by calling `volunteer&.casa_cases&.active` once 
- Removes need to call `.to_a` on `.pluck` which already returns an array, which is there to avoid `.join(", ")` throwing an error with nil values

**Current Refactor**
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.0037770000053569674,
 @stime=0.00018099999999954264,
 @total=0.002789999999999182,
 @utime=0.0026089999999996394

**Existing Code**
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.009794000012334436,
 @stime=0.002467000000000219,
 @total=0.007600000000000939,
 @utime=0.00513300000000072

### How is this tested? (please write tests!) 💖💪
Refactored a recently added test

### Screenshots please :)

<img width="956" alt="Screen Shot 2022-10-27 at 3 22 35 PM" src="https://user-images.githubusercontent.com/8033031/198380112-55be4840-7fe0-419b-8832-d97c1a5557bc.png">

