### PR TITLE
Improved Defaults for Case Selection on Case Contacts page

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -28,16 +28,20 @@ class CaseContactsController < ApplicationController
     authorize CaseContact
     @casa_cases = policy_scope(current_organization.casa_cases)
 
-    # Admins and supervisors who are navigating to this page from a specific
-    # case detail page will only see that case as an option
-    if params.dig(:case_contact, :casa_case_id).present?
-      @casa_cases = @casa_cases.where(id: params.dig(:case_contact, :casa_case_id))
-    end
+    # Select the most likely case option
+    # - If there are cases defined in the params, select those cases (often coming from the case page)
+    # - If there is only one case, select that case
+    # - If there are no hints, let them select their case
+    @selected_cases =
+      if params.dig(:case_contact, :casa_case_id).present?
+        @casa_cases.where(id: params.dig(:case_contact, :casa_case_id))
+      elsif @casa_cases.count == 1
+        @casa_cases[0, 1]
+      else
+        []
+      end
 
     @case_contact = CaseContact.new
-
-    # By default the first case is selected
-    @selected_cases = @casa_cases[0, 1]
 
     @selected_case_contact_types = @selected_cases.flat_map(&:contact_types)
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -43,7 +43,7 @@ class CaseContactsController < ApplicationController
 
     @case_contact = CaseContact.new
 
-    @selected_case_contact_types = @selected_cases.flat_map(&:contact_types)
+    @selected_case_contact_types = @casa_cases.flat_map(&:contact_types)
 
     @current_organization_groups =
       if @selected_case_contact_types.present?

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -604,6 +604,41 @@ RSpec.describe "case_contacts/new", type: :system do
       end
     end
 
+    describe "case default selection" do
+      let(:volunteer) { create(:volunteer, :with_casa_cases) }
+      let(:first_case) { volunteer.casa_cases.first }
+      let(:second_case) { volunteer.casa_cases.second }
+
+      before(:each) do
+        sign_in volunteer
+      end
+
+      it "selects no cases" do
+        visit new_case_contact_path
+
+        expect(page).not_to have_checked_field(first_case.case_number)
+        expect(page).not_to have_checked_field(second_case.case_number)
+      end
+
+      context "when there are params defined" do
+        it "select the cases defined in the params" do
+          visit new_case_contact_path(case_contact: {casa_case_id: first_case.id})
+
+          expect(page).to have_checked_field(first_case.case_number)
+          expect(page).not_to have_checked_field(second_case.case_number)
+        end
+      end
+
+      context "when there's only one case" do
+        it "selects the only case" do
+          second_case.destroy!
+          visit new_case_contact_path
+
+          expect(page).to have_checked_field(first_case.case_number)
+        end
+      end
+    end
+
     private
 
     def create_contact_types(org)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3334

### What changed, and why?
The user says:
> I have two cases in the same family and often the case contacts need to have both case numbers tagged. After I have put in a contact and it takes me back to the list of all case contacts, if I select New Case Contact there, I am only given a form with one of the two case numbers.

The issue interprets this to mean that all cases should be selected by default. (At least that's how I understood it.) However, creating a new case contact redirects to the case page. The case page has a "new case contact" button, and that button opens a new case contact form with only one case on it (the case from the page). I believe this form is what the user is actually having issues with.

Here's a little clip explaining how it works today and the issue I'm quoting:
https://clips.twitch.tv/MoldyPatientPistachioCeilingCat-CAd_vwCrwNCqA04E

Instead of removing the cases when there's a param, let's default the case if there's a param supplied. Also, we should only select a case by default if there's only one case. Unselecting cases is pretty annoying, so let's only select them if we have hints on which they want selected.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
There are system specs describing the default behavior of case number.

### Screenshots please :)

[Demo here](https://clips.twitch.tv/ModernVibrantCamelBIRB-6skCUIaeU06S736O)

Source | Defaults
--- | ---
From Case page |  ![multiple cases - only the case is selected](https://user-images.githubusercontent.com/8124558/198893465-2c82f38d-5595-4e19-96fa-7fff03def34c.png)
Multiple Cases |  ![multiple cases - none selected](https://user-images.githubusercontent.com/8124558/198893372-b35783bc-d651-4264-962a-d9aa2cd49067.png)
Only one case |  ![only one case - selected](https://user-images.githubusercontent.com/8124558/198893417-904ba332-1dac-4bb2-a3a7-f6a630e1db4e.png)

### GIF
![hacking cat](https://media.giphy.com/media/6vj5quVNRhoQw/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9