### PR TITLE
Fix Patch Note Group Reference Error

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,6 @@
 class NotificationsController < ApplicationController
   def index
     @notifications = current_user.notifications.newest_first
+    @patch_notes = PatchNote.notes_available_for_user(current_user)
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,10 +1,10 @@
 module NotificationsHelper
-  def notifications_after_deploy(notifications)
+  def notifications_after_and_including_deploy(notifications)
     notifications.where(created_at: Health.instance.latest_deploy_time..)
   end
 
   def notifications_before_deploy(notifications)
-    notifications.where(created_at: ..Health.instance.latest_deploy_time)
+    notifications.where(created_at: ...Health.instance.latest_deploy_time)
   end
 
   def notification_icon(notification)

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,11 +1,19 @@
 module NotificationsHelper
-  def notification_row_class(notification)
-    return "" if notification.unread?
-    " bg-light text-muted "
+  def notifications_after_deploy(notifications)
+    notifications.where(created_at: Health.instance.latest_deploy_time..)
+  end
+
+  def notifications_before_deploy(notifications)
+    notifications.where(created_at: ..Health.instance.latest_deploy_time)
   end
 
   def notification_icon(notification)
     return "" if notification.read?
     "<i class='fas fa-bell'></i>".html_safe
+  end
+
+  def notification_row_class(notification)
+    return "" if notification.unread?
+    " bg-light text-muted "
   end
 end

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -119,25 +119,25 @@ patchNoteFunctions.deletePatchNote = function (patchNoteId) {
 }
 
 // Disables all form elements of a patch note form
-//  @param    {object} patchNoteFormElements An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param    {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws   {TypeError} for a parameter of the incorrect type
-patchNoteFunctions.disablePatchNoteForm = function (patchNoteFormElements) {
-  for (const formElement of Object.values(patchNoteFormElements)) {
-    formElement.prop('disabled', true)
+patchNoteFunctions.disablePatchNoteForm = function (patchNoteFormInputs) {
+  for (const formInput of Object.values(patchNoteFormInputs)) {
+    formInput.prop('disabled', true)
   }
 }
 
 // Enables all form elements of a patch note form
-//  @param    {object} patchNoteFormElements An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param    {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws   {TypeError} for a parameter of the incorrect type
-patchNoteFunctions.enablePatchNoteForm = function (patchNoteFormElements) {
-  for (const formElement of Object.values(patchNoteFormElements)) {
-    formElement.removeAttr('disabled')
+patchNoteFunctions.enablePatchNoteForm = function (patchNoteFormInputs) {
+  for (const formInput of Object.values(patchNoteFormInputs)) {
+    formInput.removeAttr('disabled')
   }
 }
 
 // Change a patch note form into edit mode
-//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) {
   TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
@@ -165,7 +165,7 @@ patchNoteFunctions.enablePatchNoteFormEditMode = function (patchNoteFormInputs) 
 }
 
 // Change a patch note form out of edit mode
-//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.exitPatchNoteFormEditMode = function (patchNoteFormInputs) {
   TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
@@ -354,7 +354,7 @@ patchNoteFunctions.onSavePatchNote = function () {
 }
 
 // Set the value of a patch note form's inputs to before the form was put in edit mode
-//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.patchNoteFormDataResetBeforeEdit = function (patchNoteFormInputs) {
   TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
@@ -374,7 +374,7 @@ patchNoteFunctions.patchNoteFormDataResetBeforeEdit = function (patchNoteFormInp
 }
 
 // Save the values of the patch note form inputs
-//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormElements()
+//  @param  {object} patchNoteFormInputs An object containing the form elements as jQuery objects like the object returned from getPatchNoteFormInputs()
 //  @throws {TypeError} for a parameter of the incorrect type
 patchNoteFunctions.patchNoteFormDataSaveTemp = function (patchNoteFormInputs) {
   TypeChecker.checkObject(patchNoteFormInputs, 'patchNoteFormInputs')
@@ -456,33 +456,33 @@ $('document').ready(() => {
     pageNotifier = new AsyncNotifier(asyncNotificationsElement)
 
     const patchNoteList = $('#patch-note-list')
-    const newPatchNoteFormElements = patchNoteFunctions.getPatchNoteFormInputs($('#new-patch-note'))
+    const newPatchNoteFormInputs = patchNoteFunctions.getPatchNoteFormInputs($('#new-patch-note'))
 
-    newPatchNoteFormElements.buttonControls.click(() => {
-      if (!(newPatchNoteFormElements.noteTextArea.val())) {
+    newPatchNoteFormInputs.buttonControls.click(() => {
+      if (!(newPatchNoteFormInputs.noteTextArea.val())) {
         pageNotifier.notify('Cannot save an empty patch note', 'warn')
         return
       }
 
-      patchNoteFunctions.disablePatchNoteForm(newPatchNoteFormElements)
+      patchNoteFunctions.disablePatchNoteForm(newPatchNoteFormInputs)
 
-      const patchNoteGroupId = Number.parseInt(newPatchNoteFormElements.dropdownGroup.val())
-      const patchNoteTypeId = Number.parseInt(newPatchNoteFormElements.dropdownType.val())
-      const patchNoteText = newPatchNoteFormElements.noteTextArea.val()
+      const patchNoteGroupId = Number.parseInt(newPatchNoteFormInputs.dropdownGroup.val())
+      const patchNoteTypeId = Number.parseInt(newPatchNoteFormInputs.dropdownType.val())
+      const patchNoteText = newPatchNoteFormInputs.noteTextArea.val()
 
       patchNoteFunctions.createPatchNote(
         patchNoteGroupId,
         patchNoteText,
         patchNoteTypeId
       ).then(function (response) {
-        newPatchNoteFormElements.noteTextArea.val('')
+        newPatchNoteFormInputs.noteTextArea.val('')
         patchNoteFunctions.addPatchNoteUI(patchNoteGroupId, response.id, patchNoteList, patchNoteText, patchNoteTypeId)
       }).fail(function (err) {
         pageNotifier.notify('Failed to update UI', 'error')
         pageNotifier.notify(err.message, 'error')
         console.error(err)
       }).always(function () {
-        patchNoteFunctions.enablePatchNoteForm(newPatchNoteFormElements)
+        patchNoteFunctions.enablePatchNoteForm(newPatchNoteFormInputs)
       })
     })
 

--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -259,6 +259,44 @@ patchNoteFunctions.onCancelEdit = function () {
   patchNoteFunctions.exitPatchNoteFormEditMode(formInputs)
 }
 
+// Called when the create button is pressed on the new patch note form
+patchNoteFunctions.onCreate = function () {
+  try {
+    const patchNoteList = $('#patch-note-list')
+    const newPatchNoteFormInputs = patchNoteFunctions.getPatchNoteFormInputs($('#new-patch-note'))
+
+    if (!(newPatchNoteFormInputs.noteTextArea.val())) {
+      pageNotifier.notify('Cannot save an empty patch note', 'warn')
+      return
+    }
+
+    patchNoteFunctions.disablePatchNoteForm(newPatchNoteFormInputs)
+
+    const patchNoteGroupId = Number.parseInt(newPatchNoteFormInputs.dropdownGroup.val())
+    const patchNoteTypeId = Number.parseInt(newPatchNoteFormInputs.dropdownType.val())
+    const patchNoteText = newPatchNoteFormInputs.noteTextArea.val()
+
+    patchNoteFunctions.createPatchNote(
+      patchNoteGroupId,
+      patchNoteText,
+      patchNoteTypeId
+    ).then(function (response) {
+      newPatchNoteFormInputs.noteTextArea.val('')
+      patchNoteFunctions.addPatchNoteUI(patchNoteGroupId, response.id, patchNoteList, patchNoteText, patchNoteTypeId)
+    }).fail(function (err) {
+      pageNotifier.notify('Failed to update UI', 'error')
+      pageNotifier.notify(err.message, 'error')
+      console.error(err)
+    }).always(function () {
+      patchNoteFunctions.enablePatchNoteForm(newPatchNoteFormInputs)
+    })
+  } catch (err) {
+    pageNotifier.notify('Failed to save patch note', 'error')
+    pageNotifier.notify(err.message, 'error')
+    console.error(err)
+  }
+}
+
 // Called when the delete button is pressed on a patch note form
 patchNoteFunctions.onDeletePatchNote = function () {
   const deleteButton = $(this)
@@ -455,37 +493,7 @@ $('document').ready(() => {
     const asyncNotificationsElement = $('#async-notifications')
     pageNotifier = new AsyncNotifier(asyncNotificationsElement)
 
-    const patchNoteList = $('#patch-note-list')
-    const newPatchNoteFormInputs = patchNoteFunctions.getPatchNoteFormInputs($('#new-patch-note'))
-
-    newPatchNoteFormInputs.buttonControls.click(() => {
-      if (!(newPatchNoteFormInputs.noteTextArea.val())) {
-        pageNotifier.notify('Cannot save an empty patch note', 'warn')
-        return
-      }
-
-      patchNoteFunctions.disablePatchNoteForm(newPatchNoteFormInputs)
-
-      const patchNoteGroupId = Number.parseInt(newPatchNoteFormInputs.dropdownGroup.val())
-      const patchNoteTypeId = Number.parseInt(newPatchNoteFormInputs.dropdownType.val())
-      const patchNoteText = newPatchNoteFormInputs.noteTextArea.val()
-
-      patchNoteFunctions.createPatchNote(
-        patchNoteGroupId,
-        patchNoteText,
-        patchNoteTypeId
-      ).then(function (response) {
-        newPatchNoteFormInputs.noteTextArea.val('')
-        patchNoteFunctions.addPatchNoteUI(patchNoteGroupId, response.id, patchNoteList, patchNoteText, patchNoteTypeId)
-      }).fail(function (err) {
-        pageNotifier.notify('Failed to update UI', 'error')
-        pageNotifier.notify(err.message, 'error')
-        console.error(err)
-      }).always(function () {
-        patchNoteFunctions.enablePatchNoteForm(newPatchNoteFormInputs)
-      })
-    })
-
+    $('#new-patch-note button').click(patchNoteFunctions.onCreate)
     $('#patch-note-list .button-delete').click(patchNoteFunctions.onDeletePatchNote)
     $('#patch-note-list .button-edit').click(patchNoteFunctions.onEditPatchNote)
   } catch (err) {

--- a/app/views/all_casa_admins/patch_notes/index.html.erb
+++ b/app/views/all_casa_admins/patch_notes/index.html.erb
@@ -27,7 +27,7 @@
         </div>
       </div>
     </div>
-    <% # Paginate this %>
+    <%# Paginate this %>
     <% @patch_notes&.each do |patch_note| %>
       <%= render "all_casa_admins/patch_notes/patch_note", patch_note: patch_note %>
     <% end %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,16 @@
+<a
+  href="<%= notification.to_notification.url %>"
+  class="<%= notification_row_class(notification) %> list-group-item list-group-item-action flex-column align-items-start">
+  <div class="d-flex flex-row">
+    <div class="d-flex-shrink-0"><%= notification_icon(notification) %></div>
+    <div class="ml-2 flex-grow-1">
+      <div class="d-flex justify-content-between">
+        <h5 class="mb-1"><%= notification.to_notification.title %></h5>
+        <small><%= time_ago_in_words(notification.updated_at) %> ago</small>
+      </div>
+      <div class="my-1">
+        <%= simple_format notification.to_notification.message %>
+      </div>
+    </div>
+  </div>
+</a>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -5,7 +5,10 @@
 </div>
 
 <div class="list-group">
-  <% @notifications.each do | notification | %>
+  <% notifications_after_deploy(@notifications).each do | notification | %>
+    <%= render partial: "notification", locals: {notification: notification} %>
+  <% end %>
+  <% notifications_before_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="list-group">
-  <% notifications_after_deploy(@notifications).each do | notification | %>
+  <% notifications_after_and_including_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
   <% notifications_before_deploy(@notifications).each do | notification | %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -6,22 +6,7 @@
 
 <div class="list-group">
   <% @notifications.each do | notification | %>
-    <a
-      href="<%= notification.to_notification.url %>"
-      class="<%= notification_row_class(notification) %> list-group-item list-group-item-action flex-column align-items-start">
-      <div class="d-flex flex-row">
-        <div class="d-flex-shrink-0"><%= notification_icon(notification) %></div>
-        <div class="ml-2 flex-grow-1">
-          <div class="d-flex justify-content-between">
-            <h5 class="mb-1"><%= notification.to_notification.title %></h5>
-            <small><%= time_ago_in_words(notification.updated_at) %> ago</small>
-          </div>
-          <div class="my-1">
-            <%= simple_format notification.to_notification.message %>
-          </div>
-        </div>
-      </div>
-    </a>
+    <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
 
   <% if @notifications.empty? %>

--- a/db/seeds/patch_note_group_data.rb
+++ b/db/seeds/patch_note_group_data.rb
@@ -1,4 +1,4 @@
 # PatchNote Section Headers
 
-PatchNoteGroup.where(value: "Admin+Supervisor").first_or_create
-PatchNoteGroup.where(value: "Admin+Supervisor+Volunteer").first_or_create
+PatchNoteGroup.where(value: "CasaAdmin+Supervisor").first_or_create
+PatchNoteGroup.where(value: "CasaAdmin+Supervisor+Volunteer").first_or_create

--- a/lib/tasks/deployment/20221104005957_create_initial_patch_note_groups.rake
+++ b/lib/tasks/deployment/20221104005957_create_initial_patch_note_groups.rake
@@ -3,6 +3,8 @@ namespace :after_party do
   task create_initial_patch_note_groups: :environment do
     puts "Running deploy task 'create_initial_patch_note_groups'"
 
+    PatchNote.destroy_all
+    PatchNoteGroup.destroy_all
     load(Rails.root.join("db", "seeds", "patch_note_group_data.rb"))
 
     # Update task as completed.  If you remove the line below, the task will

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -1,22 +1,6 @@
 require "rails_helper"
 
 RSpec.describe NotificationsHelper do
-  describe "#notification_row_class" do
-    context "notification has been read" do
-      it "returns 'bg-light text-muted'" do
-        notification = build_stubbed(:notification, read_at: Time.current)
-        expect(helper.notification_row_class(notification)).to eq(" bg-light text-muted ")
-      end
-    end
-
-    context "notification has not been read" do
-      it "is blank" do
-        notification = build_stubbed(:notification, read_at: nil)
-        expect(helper.notification_row_class(notification)).to be_blank
-      end
-    end
-  end
-
   describe "#notification_icon" do
     context "notification has been read" do
       it "is blank" do
@@ -29,6 +13,22 @@ RSpec.describe NotificationsHelper do
       it "shows the bell icon" do
         notification = build_stubbed(:notification, read_at: nil)
         expect(helper.notification_icon(notification)).to eq("<i class='fas fa-bell'></i>")
+      end
+    end
+  end
+
+  describe "#notification_row_class" do
+    context "notification has been read" do
+      it "returns 'bg-light text-muted'" do
+        notification = build_stubbed(:notification, read_at: Time.current)
+        expect(helper.notification_row_class(notification)).to eq(" bg-light text-muted ")
+      end
+    end
+
+    context "notification has not been read" do
+      it "is blank" do
+        notification = build_stubbed(:notification, read_at: nil)
+        expect(helper.notification_row_class(notification)).to be_blank
       end
     end
   end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe NotificationsHelper do
 
     describe "#notifications_after_and_including_deploy" do
       let(:notifications_after_and_including_deploy) { helper.notifications_after_and_including_deploy(Notification.all) }
+
       it "returns all notifications from the given list after and including deploy time" do
         expect(notifications_after_and_including_deploy).to include(notification_created_after_deploy_a)
         expect(notifications_after_and_including_deploy).to include(notification_created_after_deploy_b)
@@ -35,7 +36,19 @@ RSpec.describe NotificationsHelper do
       end
     end
 
-    describe "notifications_before_deploy" do
+    describe "#notifications_before_deploy" do
+      let(:notifications_before_deploy) { helper.notifications_before_deploy(Notification.all) }
+
+      it "returns all notifications from the given list before deploy time" do
+        expect(notifications_before_deploy).to include(notification_created_before_deploy_a)
+        expect(notifications_before_deploy).to include(notification_created_before_deploy_b)
+      end
+
+      it "does not contain notifications after and including the deploy time" do
+        expect(notifications_before_deploy).to_not include(notification_created_after_deploy_a)
+        expect(notifications_before_deploy).to_not include(notification_created_after_deploy_b)
+        expect(notifications_before_deploy).to_not include(notification_created_at_deploy)
+      end
     end
   end
 

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -1,6 +1,44 @@
 require "rails_helper"
 
 RSpec.describe NotificationsHelper do
+  context "notifications with respect to deploy time" do
+    let(:notification_created_after_deploy_a) { create(:notification) }
+    let(:notification_created_after_deploy_b) { create(:notification, created_at: 1.day.ago) }
+    let(:notification_created_at_deploy) { create(:notification, created_at: 2.days.ago) }
+    let(:notification_created_before_deploy_a) { create(:notification, created_at: 2.days.ago - 1.hour) }
+    let(:notification_created_before_deploy_b) { create(:notification, created_at: 3.days.ago) }
+
+    before do
+      travel_to Time.new(2022, 1, 1, 0, 0, 0)
+
+      notification_created_after_deploy_a.update_attribute(:created_at, 1.hour.ago)
+      notification_created_after_deploy_b.update_attribute(:created_at, 1.day.ago)
+
+      Health.instance.update_attribute(:latest_deploy_time, 2.days.ago)
+      notification_created_at_deploy.update_attribute(:created_at, 2.days.ago)
+
+      notification_created_before_deploy_a.update_attribute(:created_at, 2.days.ago - 1.hour)
+      notification_created_before_deploy_b.update_attribute(:created_at, 3.days.ago)
+    end
+
+    describe "#notifications_after_and_including_deploy" do
+      let(:notifications_after_and_including_deploy) { helper.notifications_after_and_including_deploy(Notification.all) }
+      it "returns all notifications from the given list after and including deploy time" do
+        expect(notifications_after_and_including_deploy).to include(notification_created_after_deploy_a)
+        expect(notifications_after_and_including_deploy).to include(notification_created_after_deploy_b)
+        expect(notifications_after_and_including_deploy).to include(notification_created_at_deploy)
+      end
+
+      it "does not contain notifications before the deploy time" do
+        expect(notifications_after_and_including_deploy).to_not include(notification_created_before_deploy_a)
+        expect(notifications_after_and_including_deploy).to_not include(notification_created_before_deploy_b)
+      end
+    end
+
+    describe "notifications_before_deploy" do
+    end
+  end
+
   describe "#notification_icon" do
     context "notification has been read" do
       it "is blank" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
 - js variable name refactor
 - split notifications between before and after deploy to prepare to insert patch notes
 - Fixed a bug where casa admins were not in any patch note viewing group

### How will this affect user permissions?
Not yet

### How is this tested? (please write tests!) 💖💪
added tests in app/helpers/notifications_helper.rb for new functions

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9