### PR TITLE
Site update notes now appear in notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,6 +2,16 @@ class NotificationsController < ApplicationController
   def index
     @deploy_time = Health.instance.latest_deploy_time
     @notifications = current_user.notifications.newest_first
-    @patch_notes = PatchNote.notes_available_for_user(current_user)
+    @patch_notes = {}
+
+    PatchNote.notes_available_for_user(current_user).each do |patch_note|
+      patch_note_type_name = patch_note.patch_note_type.name
+
+      unless @patch_notes.has_key?(patch_note_type_name)
+        @patch_notes[patch_note_type_name] = []
+      end
+
+      @patch_notes[patch_note_type_name].push(patch_note.note)
+    end
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,5 +1,6 @@
 class NotificationsController < ApplicationController
   def index
+    @deploy_time = Health.instance.latest_deploy_time
     @notifications = current_user.notifications.newest_first
     @patch_notes = PatchNote.notes_available_for_user(current_user)
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,16 +2,6 @@ class NotificationsController < ApplicationController
   def index
     @deploy_time = Health.instance.latest_deploy_time
     @notifications = current_user.notifications.newest_first
-    @patch_notes = {}
-
-    PatchNote.notes_available_for_user(current_user).each do |patch_note|
-      patch_note_type_name = patch_note.patch_note_type.name
-
-      unless @patch_notes.has_key?(patch_note_type_name)
-        @patch_notes[patch_note_type_name] = []
-      end
-
-      @patch_notes[patch_note_type_name].push(patch_note.note)
-    end
+    @patch_notes = PatchNote.notes_available_for_user(current_user)
   end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,6 +1,12 @@
 module NotificationsHelper
   def notifications_after_and_including_deploy(notifications)
-    notifications.where(created_at: Health.instance.latest_deploy_time..)
+    latest_deploy_time = Health.instance.latest_deploy_time
+
+    unless latest_deploy_time.nil?
+      notifications.where(created_at: latest_deploy_time..)
+    else
+      []
+    end
   end
 
   def notifications_before_deploy(notifications)

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -22,4 +22,20 @@ module NotificationsHelper
     return "" if notification.unread?
     " bg-light text-muted "
   end
+
+  def patch_notes_as_hash_keyed_by_type_name(patch_notes)
+    patch_notes_hash = {}
+
+    patch_notes.each do |patch_note|
+      patch_note_type_name = patch_note.patch_note_type.name
+
+      unless patch_notes_hash.has_key?(patch_note_type_name)
+        patch_notes_hash[patch_note_type_name] = []
+      end
+
+      patch_notes_hash[patch_note_type_name].push(patch_note.note)
+    end
+
+    patch_notes_hash
+  end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -2,10 +2,10 @@ module NotificationsHelper
   def notifications_after_and_including_deploy(notifications)
     latest_deploy_time = Health.instance.latest_deploy_time
 
-    unless latest_deploy_time.nil?
-      notifications.where(created_at: latest_deploy_time..)
-    else
+    if latest_deploy_time.nil?
       []
+    else
+      notifications.where(created_at: latest_deploy_time..)
     end
   end
 

--- a/app/views/notifications/_patch_notes.html.erb
+++ b/app/views/notifications/_patch_notes.html.erb
@@ -1,10 +1,18 @@
-<div class="list-group-item">
+<div id="patch-note-notification" class="list-group-item">
   <div class="d-flex flex-row">
     <div class="ml-2 flex-grow-1">
       <div class="d-flex justify-content-between">
         <h3 class="mb-1">Patch Notes for <%= deploy_time.strftime("%B %e") %></h3>
       </div>
       <div class="my-1">
+        <% patch_notes.each do |type, notes_per_type| %>
+          <h5 class="ml-4"><%=type%></h5>
+          <ul>
+            <% notes_per_type.each do |note| %>
+              <li><%=note%></li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/notifications/_patch_notes.html.erb
+++ b/app/views/notifications/_patch_notes.html.erb
@@ -1,0 +1,11 @@
+<div class="list-group-item">
+  <div class="d-flex flex-row">
+    <div class="ml-2 flex-grow-1">
+      <div class="d-flex justify-content-between">
+        <h3 class="mb-1">Patch Notes for <%= deploy_time.strftime("%B %e") %></h3>
+      </div>
+      <div class="my-1">
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/_patch_notes.html.erb
+++ b/app/views/notifications/_patch_notes.html.erb
@@ -6,10 +6,10 @@
       </div>
       <div class="my-1">
         <% patch_notes.each do |type, notes_per_type| %>
-          <h5 class="ml-4"><%=type%></h5>
+          <h5 class="ml-4"><%= type %></h5>
           <ul>
             <% notes_per_type.each do |note| %>
-              <li><%=note%></li>
+              <li><%= note %></li>
             <% end %>
           </ul>
         <% end %>

--- a/app/views/notifications/_patch_notes.html.erb
+++ b/app/views/notifications/_patch_notes.html.erb
@@ -8,8 +8,8 @@
         <% patch_notes.each do |type, notes_per_type| %>
           <h5 class="ml-4"><%= type %></h5>
           <ul>
-            <% notes_per_type.each do |note| %>
-              <li><%= note %></li>
+            <% notes_per_type.each do |note_text| %>
+              <li><%= note_text %></li>
             <% end %>
           </ul>
         <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,6 +8,9 @@
   <% notifications_after_and_including_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
+  <% unless @deploy_time.nil? %>
+    <%= render partial: "patch_notes", locals: {deploy_time: @deploy_time, patch_notes: @patch_notes} %>
+  <% end %>
   <% notifications_before_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -9,7 +9,7 @@
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
   <% unless @deploy_time.nil? %>
-    <%= render partial: "patch_notes", locals: {deploy_time: @deploy_time, patch_notes: @patch_notes} %>
+    <%= render partial: "patch_notes", locals: {deploy_time: @deploy_time, patch_notes: patch_notes_as_hash_keyed_by_type_name(@patch_notes)} %>
   <% end %>
   <% notifications_before_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>

--- a/spec/factories/patch_note_groups.rb
+++ b/spec/factories/patch_note_groups.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     end
 
     trait :all_users do
-      value { "Admin+Supervisor+Volunteer" }
+      value { "CasaAdmin+Supervisor+Volunteer" }
     end
 
     trait :only_supervisors_and_admins do
-      value { "Admin+Supervisor" }
+      value { "CasaAdmin+Supervisor" }
     end
   end
 end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -83,4 +83,21 @@ RSpec.describe NotificationsHelper do
       end
     end
   end
+
+  describe "#patch_notes_as_hash_keyed_by_type_name" do
+    it "returns a hash where the keys are the names of the patch note type and the values are lists of patch note strings belonging to the type" do
+      patch_note_type_a = create(:patch_note_type, name: "patch_note_type_a")
+      patch_note_type_b = create(:patch_note_type, name: "patch_note_type_b")
+      patch_note_1 = create(:patch_note, note: "Patch Note 1", patch_note_type: patch_note_type_a)
+      patch_note_2 = create(:patch_note, note: "Patch Note 2", patch_note_type: patch_note_type_b)
+      patch_note_3 = create(:patch_note, note: "Patch Note 3", patch_note_type: patch_note_type_b)
+
+      patch_notes_hash = helper.patch_notes_as_hash_keyed_by_type_name(PatchNote.all)
+
+      expect(patch_notes_hash).to have_key(patch_note_type_a.name)
+      expect(patch_notes_hash).to have_key(patch_note_type_b.name)
+      expect(patch_notes_hash[patch_note_type_a.name]).to contain_exactly(patch_note_1.note)
+      expect(patch_notes_hash[patch_note_type_b.name]).to contain_exactly(patch_note_2.note, patch_note_3.note)
+    end
+  end
 end

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -40,16 +40,25 @@ RSpec.describe "notifications/index", type: :view do
       let(:patch_note_group_no_volunteers) { create(:patch_note_group, :only_supervisors_and_admins) }
       let(:patch_note_type_a) { create(:patch_note_type, name: "patch_note_type_a") }
       let(:patch_note_type_b) { create(:patch_note_type, name: "patch_note_type_b") }
-      let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7") }
-      let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}") }
+      let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7", patch_note_type: patch_note_type_a) }
+      let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}", patch_note_type: patch_note_type_b) }
 
       before do
         Health.instance.update_attribute(:latest_deploy_time, Date.today)
-        assign(:patch_notes, PatchNote.all)
+        assign(:notifications, Notification.all)
       end
 
       context "as an admin" do
+        before do
+          patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
+          patch_note_2.update_attribute(:patch_note_group, patch_note_group_no_volunteers)
+        end
+
         it "shows all the patch notes available to the admin" do
+          assign(:patch_notes, PatchNote.all)
+          assign(:deploy_time, Time.now)
+
+          render template: "notifications/index"
         end
 
         it "shows the patch notes under the correct type" do

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -59,6 +59,9 @@ RSpec.describe "notifications/index", type: :view do
           assign(:deploy_time, Time.now)
 
           render template: "notifications/index"
+
+          expect(rendered).to have_text(patch_note_1.note)
+          expect(rendered).to have_text(patch_note_2.note)
         end
 
         it "shows the patch notes under the correct type" do

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe "notifications/index", type: :view do
 
           patch_note_notification_information_container = queryable_html.css("#patch-note-notification div.my-1").first
 
-          patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{ patch_note_type_a.name }')]]").first
+          patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_a.name}')]]").first
           patch_note_type_a_header_index = patch_note_notification_information_container.children.index(patch_note_type_a_header)
-          patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{ patch_note_type_b.name }')]]").first
+          patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_b.name}')]]").first
           patch_note_type_b_header_index = patch_note_notification_information_container.children.index(patch_note_type_b_header)
 
           patch_note_1_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_1.note}')]]").first
@@ -86,6 +86,14 @@ RSpec.describe "notifications/index", type: :view do
 
           expect(patch_note_type_a_header_index).to be < patch_note_1_unordered_list_index
           expect(patch_note_type_b_header_index).to be < patch_note_2_unordered_list_index
+
+          if patch_note_type_a_header_index < patch_note_type_b_header_index
+            expect(patch_note_type_b_header_index).to be > patch_note_1_unordered_list_index
+          end
+
+          if patch_note_type_b_header_index < patch_note_type_a_header_index
+            expect(patch_note_type_a_header_index).to be > patch_note_2_unordered_list_index
+          end
         end
       end
 

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -46,62 +46,49 @@ RSpec.describe "notifications/index", type: :view do
       before do
         Health.instance.update_attribute(:latest_deploy_time, Date.today)
         assign(:notifications, Notification.all)
+        patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
+        patch_note_2.update_attribute(:patch_note_group, patch_note_group_no_volunteers)
       end
 
-      context "as an admin" do
-        before do
-          patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
-          patch_note_2.update_attribute(:patch_note_group, patch_note_group_no_volunteers)
-        end
+      it "shows all the patch notes available" do
+        assign(:patch_notes, PatchNote.all)
+        assign(:deploy_time, Time.now)
 
-        it "shows all the patch notes available to the admin" do
-          assign(:patch_notes, PatchNote.all)
-          assign(:deploy_time, Time.now)
+        render template: "notifications/index"
 
-          render template: "notifications/index"
-
-          expect(rendered).to have_text(patch_note_1.note)
-          expect(rendered).to have_text(patch_note_2.note)
-        end
-
-        it "shows the patch notes under the correct type" do
-          assign(:patch_notes, PatchNote.all)
-          assign(:deploy_time, Time.now)
-
-          render template: "notifications/index"
-
-          queryable_html = Nokogiri.HTML5(rendered)
-
-          patch_note_notification_information_container = queryable_html.css("#patch-note-notification div.my-1").first
-
-          patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_a.name}')]]").first
-          patch_note_type_a_header_index = patch_note_notification_information_container.children.index(patch_note_type_a_header)
-          patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_b.name}')]]").first
-          patch_note_type_b_header_index = patch_note_notification_information_container.children.index(patch_note_type_b_header)
-
-          patch_note_1_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_1.note}')]]").first
-          patch_note_1_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_1_list_item.parent)
-          patch_note_2_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_2.note}')]]").first
-          patch_note_2_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_2_list_item.parent)
-
-          expect(patch_note_type_a_header_index).to be < patch_note_1_unordered_list_index
-          expect(patch_note_type_b_header_index).to be < patch_note_2_unordered_list_index
-
-          if patch_note_type_a_header_index < patch_note_type_b_header_index
-            expect(patch_note_type_b_header_index).to be > patch_note_1_unordered_list_index
-          end
-
-          if patch_note_type_b_header_index < patch_note_type_a_header_index
-            expect(patch_note_type_a_header_index).to be > patch_note_2_unordered_list_index
-          end
-        end
+        expect(rendered).to have_text(patch_note_1.note)
+        expect(rendered).to have_text(patch_note_2.note)
       end
 
-      context "as a volunteer" do
-        it "shows all the patch notes available to the volunteer" do
+      it "shows the patch notes under the correct type" do
+        assign(:patch_notes, PatchNote.all)
+        assign(:deploy_time, Time.now)
+
+        render template: "notifications/index"
+
+        queryable_html = Nokogiri.HTML5(rendered)
+
+        patch_note_notification_information_container = queryable_html.css("#patch-note-notification div.my-1").first
+
+        patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_a.name}')]]").first
+        patch_note_type_a_header_index = patch_note_notification_information_container.children.index(patch_note_type_a_header)
+        patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_b.name}')]]").first
+        patch_note_type_b_header_index = patch_note_notification_information_container.children.index(patch_note_type_b_header)
+
+        patch_note_1_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_1.note}')]]").first
+        patch_note_1_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_1_list_item.parent)
+        patch_note_2_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_2.note}')]]").first
+        patch_note_2_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_2_list_item.parent)
+
+        expect(patch_note_type_a_header_index).to be < patch_note_1_unordered_list_index
+        expect(patch_note_type_b_header_index).to be < patch_note_2_unordered_list_index
+
+        if patch_note_type_a_header_index < patch_note_type_b_header_index
+          expect(patch_note_type_b_header_index).to be > patch_note_1_unordered_list_index
         end
 
-        it "does not show the patch notes unavailable to the volunteer" do
+        if patch_note_type_b_header_index < patch_note_type_a_header_index
+          expect(patch_note_type_a_header_index).to be > patch_note_2_unordered_list_index
         end
       end
     end

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "notifications/index", type: :view do
+  before do
+    travel_to Date.new(2021, 1, 1)
+  end
+
+  context "when there is a deploy date" do
+    let(:notification_created_after_deploy_a) { create(:notification) }
+    let(:notification_created_after_deploy_b) { create(:notification) }
+    let(:notification_created_at_deploy) { create(:notification) }
+    let(:notification_created_before_deploy_a) { create(:notification) }
+    let(:notification_created_before_deploy_b) { create(:notification) }
+
+    before do
+      Health.instance.update_attribute(:latest_deploy_time, 2.days.ago)
+    end
+
+    context "when there are notifications" do
+      before do
+        # TODO invalid notifications that break the view
+        # notification_created_after_deploy_a.update_attribute(:created_at, 1.hour.ago)
+        # notification_created_after_deploy_b.update_attribute(:created_at, 1.day.ago)
+        # notification_created_at_deploy.update_attribute(:created_at, 2.days.ago)
+        # notification_created_before_deploy_a.update_attribute(:created_at, 2.days.ago - 1.hour)
+        # notification_created_before_deploy_b.update_attribute(:created_at, 3.days.ago)
+      end
+
+      xit "has all notifications created after and including the deploy date above the patch note" do
+        # TODO fill in after notification factory is given ability to create a notification with notes
+      end
+
+      xit "has all notifications created after and including the deploy date above the patch note" do
+        # TODO fill in after notification factory is filled out
+      end
+    end
+
+    context "when there are patch notes" do
+      let(:patch_note_group_all_users) { create(:patch_note_group, :all_users) }
+      let(:patch_note_group_no_volunteers) { create(:patch_note_group, :only_supervisors_and_admins) }
+      let(:patch_note_type_a) { create(:patch_note_type, name: "patch_note_type_a") }
+      let(:patch_note_type_b) { create(:patch_note_type, name: "patch_note_type_b") }
+      let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7") }
+      let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}") }
+
+      before do
+        Health.instance.update_attribute(:latest_deploy_time, Date.today)
+        assign(:patch_notes, PatchNote.all)
+      end
+
+      context "as an admin" do
+        it "shows all the patch notes available to the admin" do
+        end
+
+        it "shows the patch notes under the correct type" do
+        end
+      end
+
+      context "as a volunteer" do
+        it "shows all the patch notes available to the volunteer" do
+        end
+
+        it "does not show the patch notes unavailable to the volunteer" do
+        end
+      end
+    end
+  end
+
+  context "without a deploy date" do
+    xit "shows the correct number of notifications" do
+      # TODO fill in after notification factory is given ability to create displayable notifications
+    end
+  end
+end

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -65,6 +65,27 @@ RSpec.describe "notifications/index", type: :view do
         end
 
         it "shows the patch notes under the correct type" do
+          assign(:patch_notes, PatchNote.all)
+          assign(:deploy_time, Time.now)
+
+          render template: "notifications/index"
+
+          queryable_html = Nokogiri.HTML5(rendered)
+
+          patch_note_notification_information_container = queryable_html.css("#patch-note-notification div.my-1").first
+
+          patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{ patch_note_type_a.name }')]]").first
+          patch_note_type_a_header_index = patch_note_notification_information_container.children.index(patch_note_type_a_header)
+          patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{ patch_note_type_b.name }')]]").first
+          patch_note_type_b_header_index = patch_note_notification_information_container.children.index(patch_note_type_b_header)
+
+          patch_note_1_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_1.note}')]]").first
+          patch_note_1_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_1_list_item.parent)
+          patch_note_2_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_2.note}')]]").first
+          patch_note_2_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_2_list_item.parent)
+
+          expect(patch_note_type_a_header_index).to be < patch_note_1_unordered_list_index
+          expect(patch_note_type_b_header_index).to be < patch_note_2_unordered_list_index
         end
       end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Fixed a bug where notifications would appear twice if there is no deploy date
Patch notes can be viewed on the notifications page

### How will this affect user permissions?
Affected in earlier pr

### How is this tested? (please write tests!) 💖💪
Will test appearance of patch notes

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/201452990-098f1289-f88f-4efb-aa13-e19312e2daa6.png)


### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9