### PR TITLE
deleted webpack server command from procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 release: bundle exec rake db:migrate && bundle exec rake after_party:run
 web: bundle exec puma
-assets: bin/webpack-dev-server
 custom_web: bundle exec puma


### PR DESCRIPTION
### What changed, and why?
Removed webpack server command from `Procfile` because we don't use webpack or have it installed  
also cloud66 emailed us a lot about it  

Commit that added it:
https://github.com/rubyforgood/casa/commit/80d497678998b94273a7d13bb300126471664f2b