### PR TITLE
fix no notifications message appearing when there are only patch notes

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
 
-  <% if @notifications.empty? %>
+  <% if @notifications.empty? and (@patch_notes.empty? or @deploy_time.nil?) %>
     <div class="card card-container my-4 border-warning">
       <div class="card-body">
         You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "/notifications", type: :request do
+  describe "GET /index" do
+    let(:patch_note_group_all_users) { create(:patch_note_group, :all_users) }
+    let(:patch_note_group_no_volunteers) { create(:patch_note_group, :only_supervisors_and_admins) }
+    let(:patch_note_type_a) { create(:patch_note_type, name: "patch_note_type_a") }
+    let(:patch_note_type_b) { create(:patch_note_type, name: "patch_note_type_b") }
+    let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7", patch_note_type: patch_note_type_a) }
+    let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}", patch_note_type: patch_note_type_b) }
+
+    context "when logged in as an admin" do
+    end
+
+    context "when logged in as volunteer" do
+      let(:volunteer) { create(:volunteer) }
+
+      before do
+        sign_in volunteer
+        Health.instance.update_attribute(:latest_deploy_time, Date.today)
+        patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
+        patch_note_2.update_attribute(:patch_note_group, patch_note_group_no_volunteers)
+      end
+
+      it "shows only the patch notes available to their user group" do
+        get notifications_url
+
+        expect(response.body).to include(CGI.escapeHTML(patch_note_1.note))
+        expect(response.body).to_not include(CGI.escapeHTML(patch_note_2.note))
+      end
+    end
+  end
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "/notifications", type: :request do
       before do
         sign_in admin
       end
+
       context "when there are no notifications or patch notes" do
         it "shows the no notification message" do
           get notifications_url
@@ -24,7 +25,29 @@ RSpec.describe "/notifications", type: :request do
       end
 
       context "when there are only patch notes" do
+        before do
+          patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
+          patch_note_2.update_attribute(:patch_note_group, patch_note_group_no_volunteers)
+        end
+
         context "when there is no deploy date" do
+          it "shows the no notification message" do
+            get notifications_url
+
+            expect(response.body).to include("You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.")
+          end
+        end
+
+        context "when there is a deploy date" do
+          before do
+            Health.instance.update_attribute(:latest_deploy_time, Date.today)
+          end
+
+          it "does not show the no notification message" do
+            get notifications_url
+
+            expect(response.body).to_not include("You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.")
+          end
         end
       end
     end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -10,6 +10,23 @@ RSpec.describe "/notifications", type: :request do
     let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}", patch_note_type: patch_note_type_b) }
 
     context "when logged in as an admin" do
+      let(:admin) { create(:casa_admin) }
+
+      before do
+        sign_in admin
+      end
+      context "when there are no notifications or patch notes" do
+        it "shows the no notification message" do
+          get notifications_url
+
+          expect(response.body).to include("You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.")
+        end
+      end
+
+      context "when there are only patch notes" do
+        context "when there is no deploy date" do
+        end
+      end
     end
 
     context "when logged in as volunteer" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to: https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
No notifications message appears only when there are no patch notes or notifications 

### How is this tested? (please write tests!) 💖💪
request tests