### PR TITLE
Fix patch notes section appearing when there are no patch notes, fixed patch notes viewable after deploy

### DIFF
--- a/app/models/patch_note.rb
+++ b/app/models/patch_note.rb
@@ -7,6 +7,7 @@ class PatchNote < ApplicationRecord
   scope :notes_available_for_user, ->(user) {
     joins(:patch_note_group)
       .where("POSITION(? IN value)>0", user.type)
+      .where("patch_notes.created_at < ?", Health.instance.latest_deploy_time)
   }
 end
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,7 +8,7 @@
   <% notifications_after_and_including_deploy(@notifications).each do | notification | %>
     <%= render partial: "notification", locals: {notification: notification} %>
   <% end %>
-  <% unless @deploy_time.nil? %>
+  <% unless (@deploy_time.nil? or @patch_notes.empty?) %>
     <%= render partial: "patch_notes", locals: {deploy_time: @deploy_time, patch_notes: patch_notes_as_hash_keyed_by_type_name(@patch_notes)} %>
   <% end %>
   <% notifications_before_deploy(@notifications).each do | notification | %>

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe "/notifications", type: :request do
         end
       end
 
+      context "when there are no patch notes" do
+        context "when there is a deploy date" do
+          before do
+            Health.instance.update_attribute(:latest_deploy_time, Date.today)
+          end
+
+          it "does not show the patch notes section" do
+            get notifications_url
+
+            queryable_html = Nokogiri.HTML5(response.body)
+
+            expect(queryable_html.css("h3").text).to_not include("Patch Notes")
+          end
+        end
+      end
+
       context "when there are only patch notes" do
         before do
           patch_note_1.update_attribute(:patch_note_group, patch_note_group_all_users)
@@ -35,6 +51,14 @@ RSpec.describe "/notifications", type: :request do
             get notifications_url
 
             expect(response.body).to include("You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.")
+          end
+
+          it "does not show the patch notes section" do
+            get notifications_url
+
+            queryable_html = Nokogiri.HTML5(response.body)
+
+            expect(queryable_html.css("h3").text).to_not include("Patch Notes")
           end
         end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to: https://github.com/rubyforgood/casa/issues/3651

### What changed, and why?
Fixed patch notes section appearing when there are no patch notes
Fixed patch notes created after deploy being viewable(patch notes created after the deploy should not include changes part of the current deploy)

### How is this tested? (please write tests!) 💖💪
Tested above feature
Created a test to make sure patch notes section does not appear if there is no deploy date