### PR TITLE
added trait follow up for notification factory

### DIFF
--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     association :recipient, factory: :volunteer
     recipient_type { "Volunteer" }
     type { "FollowupResolvedNotification" }
+
+    trait :followup do
+      type { "FollowupNotification" }
+    end
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -5,7 +5,17 @@ FactoryBot.define do
     type { "FollowupResolvedNotification" }
 
     trait :followup do
+      transient do
+        creator { build(:user) }
+      end
+
       type { "FollowupNotification" }
+      params {
+        {
+          followup: create(:followup, creator: creator),
+          created_by: creator
+        }
+      }
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4258

### What changed, and why?
Added trait to the notifcation factory for the FollowupNotification type

### How will this affect user permissions?
- Volunteer permissions: none
- Supervisor permissions: none 
- Admin permissions: none

### How is this tested? (please write tests!) 💖💪
No associated test yet

### Screenshots please :)
No UI changes

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9