### PR TITLE
Add new plainadmin theme to the mileage_rates views

### DIFF
--- a/app/views/mileage_rates/_form.html.erb
+++ b/app/views/mileage_rates/_form.html.erb
@@ -1,20 +1,30 @@
-<%= form_for @mileage_rate, url: form_url, id: :new_mileage_rate do |form| %>
-  <%= render "/shared/error_messages", resource: mileage_rate %>
-
-  <div class="field form-group">
-    <%= form.label :effective_date, 'Effective date' %>
-    <%= form.text_field :effective_date, value: effective_date_parser(mileage_rate.effective_date),
-                                      data: { provide: "datepicker",
-                                      date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
-                                      class: "form-control" %>
-  </div>
-
-  <div class="field form-group">
-    <%= form.label :amount, 'Amount' %>
-    <div class="input-group">
-      <div class="input-group-prepend">
-        <span class="input-group-text">$</span>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>
+          <%= title %>
+        </h1>
       </div>
+    </div>
+  </div>
+</div><!-- ==== end title ==== -->
+
+<!-- ========== card start ========== -->
+<div class="card-style mb-30">
+  <%= form_with(model: mileage_rate, local: true, id: :new_mileage_rate) do |form| %>
+    <div class="alert-box danger-alert">
+      <%= render "/shared/error_messages", resource: mileage_rate %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :effective_date, 'Effective date' %>
+      <%= form.text_field :effective_date, value: effective_date_parser(mileage_rate.effective_date),
+                                        data: { provide: "datepicker",
+                                        date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+                                        class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :effective_date, 'Amount' %>
       <%= form.number_field :amount,
                       required: true,
                       placeholder: '0.0',
@@ -23,16 +33,15 @@
                       class: "form-control",
                       aria: { label: "Amount in US Dollars" } %>
     </div>
-  </div>
 
-  <div class="field form-group">
-    <div class="form-check">
+    <div class="form-check checkbox-style mb-20">
       <%= form.check_box :is_active, class: 'form-check-input' %>
-      <%= form.label :is_active, 'Currently active?', class: 'form-check-label' %>
+      <%= form.label :is_active, "Currently active?", class: "form-check-label" %>
     </div>
-  </div>
 
-  <div class="actions">
-    <%= form.submit "Save Mileage Rate", class: "btn btn-primary" %>
-  </div>
-<% end %>
+    <div class="actions mb-10">
+      <%= form.submit "Save Mileage Rate", class: "main-btn primary-btn btn-hover" %>
+    </div>
+  <% end %>
+</div>
+<!-- card end -->

--- a/app/views/mileage_rates/edit.html.erb
+++ b/app/views/mileage_rates/edit.html.erb
@@ -1,7 +1,3 @@
-<h1>Editing Mileage Rate</h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= render 'form', mileage_rate: @mileage_rate, form_url: mileage_rate_path(@mileage_rate) %>
-  </div>
-</div>
+<%= render partial: "form", locals: { mileage_rate: @mileage_rate,
+                                      form_url: mileage_rate_path(@mileage_rate),
+                                      title: "Edit Milage Rate" } %>

--- a/app/views/mileage_rates/index.html.erb
+++ b/app/views/mileage_rates/index.html.erb
@@ -1,38 +1,61 @@
-<div class="row">
-  <div class="col-sm-12 dashboard-table-header">
-    <h1>Mileage Rates</h1>
-    <%= link_to "New Mileage Rate", new_mileage_rate_path, class: "btn btn-primary mb-2 mb-md-0" %>
-
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>Mileage Rates</h2>
+      </div>
+    </div>
+    <!-- end col -->
+    <div class="col-md-6">
+      <div class="breadcrumb-wrapper mb-30">
+          <span class="ml-5">
+            <%= link_to new_mileage_rate_path, class: "btn-sm main-btn secondary-btn" do %>
+              <i class="lni lni-plus mr-10"></i>
+              New Mileage Rate
+            <% end %>
+          </span>
+      </div>
+    </div>
   </div>
 </div>
-<hr>
 
-<div class="card card-container">
-  <div class="card-body">
-    <table
-      class="table table-striped table-bordered"
-      id="mileage_rates">
-      <thead>
-      <tr>
-        <th>Effective date</th>
-        <th>Amount</th>
-        <th>Active?</th>
-        <th>Actions</th>
-      </tr>
-      </thead>
-      <tbody>
-        <% @mileage_rates.each do |mileage_rate| %>
-          <tr>
-            <td><%= I18n.l(mileage_rate.effective_date, format: :full, default: :nil) %></td>
-            <td><%= number_to_currency(mileage_rate.amount) %></td>
-            <td><%= mileage_rate.is_active? ? 'Yes' : 'No' %></td>
-            <td>
-              <%= link_to "Edit", edit_mileage_rate_path(mileage_rate) %>
-            </td>
-          </tr>
+<div class="tables-wrapper">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card-style mb-30">
+        <div class="table-wrapper table-responsive">
+          <table class="table" id="mileage_rates">
+            <thead>
+            <tr>
+              <th><h6>Effective date</h6></th>
+              <th><h6>Amount</h6></th>
+              <th><h6>Active?</h6></th>
+              <th><h6>Actions</h6></th>
+            </tr>
+            </thead>
+            <tbody>
+              <% @mileage_rates.each do |mileage_rate| %>
+                <tr>
+                  <td><%= I18n.l(mileage_rate.effective_date, format: :full, default: :nil) %></td>
+                  <td><%= number_to_currency(mileage_rate.amount) %></td>
+                  <td><%= mileage_rate.is_active? ? 'Yes' : 'No' %></td>
+                  <td>
+                  <%= link_to edit_mileage_rate_path(mileage_rate) do %>
 
-          <% end %>
-      </tbody>
-    </table>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+                </tr>
+                <!-- end table row-->
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/mileage_rates/new.html.erb
+++ b/app/views/mileage_rates/new.html.erb
@@ -1,7 +1,3 @@
-<h1>New Mileage Rate</h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= render 'form', mileage_rate: @mileage_rate, form_url: mileage_rates_path %>
-  </div>
-</div>
+<%= render partial: "form", locals: { mileage_rate: @mileage_rate,
+                                      form_url: mileage_rates_path,
+                                      title: "New Milage Rate" } %>


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves [#4321](https://github.com/rubyforgood/casa/issues/4321)

### What changed, and why?

This PR updates the views in the the `/views/mileage_rates` directory to use the new [plainadmin](https://plainadmin.com/) theme.

See https://github.com/rubyforgood/casa/issues/4304 for more context.

### How will this affect user permissions?

It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪

The diff on this PR seems to have pretty good test coverage via the existing request tests at `./spec/requests/mileage_rates_spec.rb` and `spec/views/mileage_rates/index.html.erb_spec.rb`. I'm open to adding more test coverage if reviewers are aware of any additional edge cases they'd like coverage for.

I also did manual testing (filling out the form, etc.)

### Screenshots please :)

##### Index Page:

* [Before](https://user-images.githubusercontent.com/1179668/208957780-92914a55-b2fd-4248-9ef8-09cbe7549d5a.png)
* [After](https://user-images.githubusercontent.com/1179668/208958002-0790393c-b22d-45f2-b459-1cb13d8060cc.png)
* [Supervisors Index (as a reference)](https://user-images.githubusercontent.com/1179668/208958164-dd83abd4-e06c-423a-8fbb-400347bdc7d3.png)

##### Forms (new and edit):

* [Before](https://user-images.githubusercontent.com/1179668/208975327-19b82116-ba68-40d4-8156-ddb83f3bb757.png)
* [After (screen recording)](https://user-images.githubusercontent.com/1179668/208974932-0d8aeed5-b565-47f4-a619-16f8676775dd.mov)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

![Happy](https://media.giphy.com/media/3o7abldj0b3rxrZUxW/giphy.gif)

### Feedback please? (optional)

We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9