### PR TITLE
Add new plainadmin theme to the judges form

### DIFF
--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -1,22 +1,34 @@
-<h1><%= title %></h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: judge, local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: judge %>
-      <div class="field form-group">
-        <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control", required: true %>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>
+          <%= title %>
+        </h1>
       </div>
-      <div class="field form-group">
-        <div class="form-check">
-          <%= form.check_box :active, class: 'form-check-input' %>
-          <%= form.label :active, "Active?", class: 'form-check-label' %>
-        </div>
-      </div>
-      <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
-      </div>
-    <% end %>
+    </div>
   </div>
+</div><!-- ==== end title ==== -->
+
+<!-- ========== card start ========== -->
+<div class="card-style mb-30">
+  <%= form_with(model: judge, local: true) do |form| %>
+    <div class="alert-box danger-alert">
+      <%= render "/shared/error_messages", resource: judge %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :name, "Name" %>
+      <%= form.text_field :name, class: "form-control", required: true %>
+    </div>
+
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :active, class: 'form-check-input' %>
+      <%= form.label :active, "Active?", class: 'form-check-label' %>
+    </div>
+
+    <div class="actions mb-10">
+      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+    </div>
+  <% end %>
 </div>
+<!-- card end -->


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #4318

### What changed, and why?

This PR updates the views in the the `/views/judges` directory to use the new [plainadmin](https://plainadmin.com/) theme.

### How will this affect user permissions?

It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

* [Before](https://user-images.githubusercontent.com/1179668/208986966-434ec832-e8b6-4a32-96ed-2076e4fcc114.png)
* [After](https://user-images.githubusercontent.com/1179668/208987005-21e66172-a331-4cf4-aec5-a828319440cb.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9