### PR TITLE
Add new plainadmin theme to the languages form

### DIFF
--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -1,18 +1,30 @@
-<h1><%= title %></h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: language, local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: language %>
-
-      <div class="field form-group">
-        <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control", required: true %>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>
+          <%= title %>
+        </h1>
       </div>
-
-      <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
-      </div>
-    <% end %>
+    </div>
   </div>
+</div><!-- ==== end title ==== -->
+
+<div class="card-style mb-30">
+  <%= form_with(model: language, local: true) do |form| %>
+    <div class="alert-box danger-alert">
+      <%= render "/shared/error_messages", resource: language %>
+    </div>
+
+
+    <div class="input-style-1">
+      <%= form.label :name, "Name" %>
+      <%= form.text_field :name, class: "form-control", required: true %>
+    </div>
+
+    <div class="actions mb-10">
+      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+    </div>
+  <% end %>
 </div>
+<!-- card end -->


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #4319

### What changed, and why?

This PR updates the views in the the /views/languages directory to use the new [plainadmin](https://plainadmin.com/) theme.

### How will this affect user permissions?
It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)

* [Before](https://user-images.githubusercontent.com/1179668/208991777-fb5ccc3b-c0fb-4cff-b183-eb544905dec0.png)
* [After (new)](https://user-images.githubusercontent.com/1179668/208991399-d01fc1ad-ca87-4262-881d-bdbac64d7c16.png)
* [After (edit)](https://user-images.githubusercontent.com/1179668/208991511-4d78a032-61a9-47be-868f-e9e5a70b36c6.png)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9