### PR TITLE
4305 new theme casa admins pages

### DIFF
--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -1,78 +1,77 @@
-<section class="table-components">
-  <div class="container-fluid">
-    <!-- ========== title start ========== -->
-    <div class="title-wrapper pt-30">
-      <div class="row align-items-center">
-        <div class="col-md-6">
-          <div class="title mb-10">
-            <h1><%= title %></h1>
-          </div>
+<div class="container-fluid">
+  <!-- ========== title start ========== -->
+  <div class="title-wrapper pt-30">
+    <div class="row align-items-center">
+      <div class="col-md-6">
+        <div class="title mb-10">
+          <h1><%= title %></h1>
         </div>
       </div>
     </div>
-    <!-- ========== title end ========== -->
+  </div>
+  <!-- ========== title end ========== -->
 
-    <!-- ========== Form Start ========== -->
-    <div class="row">
-      <div class="col-lg-12">
-        <div class="card-style">
-          <%= form_with(model: casa_admin, local: true) do |form| %>
-            <div class="alert-box danger-alert">
-            <%= render "/shared/error_messages", resource: casa_admin %>
-            </div>
-            <div class="min-wdth">
-            <%= render "/shared/edit_form", resource: casa_admin, f: form %>
-            </div>
-            <div class="mb-30">
-            <%= render "/shared/invite_login", resource: casa_admin %>
-            </div>
-            <% if casa_admin.persisted? %>
-              <div class="mb-20 col">
-                <% if casa_admin.active? %>
-                    <strong class="text-dark mr-5 h4">Admin is</strong> <span class="mr-10 mb-1 status-btn success-bg text-white text-uppercase display-1">Active</span>
-                  <%= link_to "Deactivate",
-                              deactivate_casa_admin_path(casa_admin),
+  <!-- ========== Form Start ========== -->
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card-style">
+        <%= form_with(model: casa_admin, local: true) do |form| %>
+          <div class="alert-box danger-alert">
+          <%= render "/shared/error_messages", resource: casa_admin %>
+          </div>
+          <div class="min-wdth">
+          <%= render "/shared/edit_form", resource: casa_admin, f: form %>
+          </div>
+          <div class="mb-30">
+          <%= render "/shared/invite_login", resource: casa_admin %>
+          </div>
+          <% if casa_admin.persisted? %>
+            <div class="mb-20 col">
+              <% if casa_admin.active? %>
+                  <strong class="text-dark mr-5 h4">Admin is</strong> <span class="mr-10 mb-1 status-btn success-bg text-white text-uppercase display-1">Active</span>
+                <%= link_to "Deactivate",
+                            deactivate_casa_admin_path(casa_admin),
+                            method: :patch,
+                            class: "status-btn light-bg btn-outline-danger",
+                            data: {
+                                confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure" +
+                                    " you want to do this?"
+                            } %>
+              <% else %>
+                <div class="alert-box danger-alert">
+                  Admin was deactivated on: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
+                </div>
+                <% if policy(casa_admin).activate? %>
+                  <%= link_to "Activate Admin",
+                              activate_casa_admin_path(casa_admin),
                               method: :patch,
-                              class: "status-btn light-bg btn-outline-danger",
-                              data: {
-                                  confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure" +
-                                      " you want to do this?"
-                              } %>
-                <% else %>
-                  <div class="alert-box danger-alert">
-                    Admin was deactivated on: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
-                  </div>
-                  <% if policy(casa_admin).activate? %>
-                    <%= link_to "Activate Admin",
-                                activate_casa_admin_path(casa_admin),
-                                method: :patch,
-                                class: "status-btn btn-outline-success" %>
-                  <% end %>
+                              class: "status-btn btn-outline-success" %>
                 <% end %>
+              <% end %>
 
-                <% if current_user.casa_admin? && casa_admin.invitation_accepted_at.nil? %>
-                  <%= link_to "Resend Invitation",
-                              resend_invitation_casa_admin_path(casa_admin),
-                              method: :patch,
-                              class: "status-btn light-bg  btn-outline-danger" %>
-                <% end %>
+              <% if current_user.casa_admin? && casa_admin.invitation_accepted_at.nil? %>
+                <%= link_to "Resend Invitation",
+                            resend_invitation_casa_admin_path(casa_admin),
+                            method: :patch,
+                            class: "status-btn light-bg  btn-outline-danger" %>
+              <% end %>
 
-                <% if current_user.casa_admin? %>
-                  <%= link_to "Change to Supervisor",
-                              change_to_supervisor_casa_admin_path(casa_admin),
-                              method: :patch,
-                              class: "status-btn light-bg btn-outline-danger" %>
-                <% end %>
-              </div>
-            <% end %>
-
-            <div class="actions">
-              <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+              <% if current_user.casa_admin? %>
+                <%= link_to "Change to Supervisor",
+                            change_to_supervisor_casa_admin_path(casa_admin),
+                            method: :patch,
+                            class: "status-btn light-bg btn-outline-danger" %>
+              <% end %>
             </div>
           <% end %>
-        </div>
+
+          <div class="actions">
+            <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+          </div>
+        <% end %>
       </div>
     </div>
-    <!-- ========== Form End ========== -->
   </div>
-</section>
+  <!-- ========== Form End ========== -->
+</div>
+

--- a/app/views/casa_admins/_form.html.erb
+++ b/app/views/casa_admins/_form.html.erb
@@ -1,57 +1,78 @@
-<h1><%= title %></h1>
+<section class="table-components">
+  <div class="container-fluid">
+    <!-- ========== title start ========== -->
+    <div class="title-wrapper pt-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <div class="title mb-10">
+            <h1><%= title %></h1>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- ========== title end ========== -->
 
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: casa_admin, local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: casa_admin %>
-
-      <%= render "/shared/edit_form", resource: casa_admin, f: form %>
-
-      <%= render "/shared/invite_login", resource: casa_admin %>
-
-      <% if casa_admin.persisted? %>
-        <div class="field form-group">
-          <% if casa_admin.active? %>
-            Admin is <span class="badge badge-success text-uppercase display-1">Active</span>
-            <%= link_to "Deactivate",
-                        deactivate_casa_admin_path(casa_admin),
-                        method: :patch,
-                        class: "btn btn-outline-danger",
-                        data: {
-                            confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure" +
-                                " you want to do this?"
-                        } %>
-          <% else %>
-            <div class="alert alert-danger">
-              Admin was deactivated on: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
+    <!-- ========== Form Start ========== -->
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="card-style">
+          <%= form_with(model: casa_admin, local: true) do |form| %>
+            <div class="alert-box danger-alert">
+            <%= render "/shared/error_messages", resource: casa_admin %>
             </div>
-            <% if policy(casa_admin).activate? %>
-              <%= link_to "Activate Admin",
-                          activate_casa_admin_path(casa_admin),
-                          method: :patch,
-                          class: "btn btn-outline-success" %>
+            <div class="min-wdth">
+            <%= render "/shared/edit_form", resource: casa_admin, f: form %>
+            </div>
+            <div class="mb-30">
+            <%= render "/shared/invite_login", resource: casa_admin %>
+            </div>
+            <% if casa_admin.persisted? %>
+              <div class="mb-20 col">
+                <% if casa_admin.active? %>
+                    <strong class="text-dark mr-5 h4">Admin is</strong> <span class="mr-10 mb-1 status-btn success-bg text-white text-uppercase display-1">Active</span>
+                  <%= link_to "Deactivate",
+                              deactivate_casa_admin_path(casa_admin),
+                              method: :patch,
+                              class: "status-btn light-bg btn-outline-danger",
+                              data: {
+                                  confirm: "WARNING: Marking an admin inactive will make them unable to login. Are you sure" +
+                                      " you want to do this?"
+                              } %>
+                <% else %>
+                  <div class="alert-box danger-alert">
+                    Admin was deactivated on: <%= I18n.l(casa_admin.updated_at, format: :standard, default: nil) %>
+                  </div>
+                  <% if policy(casa_admin).activate? %>
+                    <%= link_to "Activate Admin",
+                                activate_casa_admin_path(casa_admin),
+                                method: :patch,
+                                class: "status-btn btn-outline-success" %>
+                  <% end %>
+                <% end %>
+
+                <% if current_user.casa_admin? && casa_admin.invitation_accepted_at.nil? %>
+                  <%= link_to "Resend Invitation",
+                              resend_invitation_casa_admin_path(casa_admin),
+                              method: :patch,
+                              class: "status-btn light-bg  btn-outline-danger" %>
+                <% end %>
+
+                <% if current_user.casa_admin? %>
+                  <%= link_to "Change to Supervisor",
+                              change_to_supervisor_casa_admin_path(casa_admin),
+                              method: :patch,
+                              class: "status-btn light-bg btn-outline-danger" %>
+                <% end %>
+              </div>
             <% end %>
-          <% end %>
 
-          <% if current_user.casa_admin? && casa_admin.invitation_accepted_at.nil? %>
-            <%= link_to "Resend Invitation",
-                        resend_invitation_casa_admin_path(casa_admin),
-                        method: :patch,
-                        class: "btn btn-outline-danger" %>
-          <% end %>
-
-          <% if current_user.casa_admin? %>
-            <%= link_to "Change to Supervisor",
-                        change_to_supervisor_casa_admin_path(casa_admin),
-                        method: :patch,
-                        class: "btn btn-outline-danger" %>
+            <div class="actions">
+              <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+            </div>
           <% end %>
         </div>
-      <% end %>
-
-      <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
       </div>
-    <% end %>
+    </div>
+    <!-- ========== Form End ========== -->
   </div>
-</div>
+</section>

--- a/app/views/casa_admins/index.html.erb
+++ b/app/views/casa_admins/index.html.erb
@@ -1,51 +1,49 @@
-<section class="table-components">
-  <div class="container-fluid">
-    <div class="title-wrapper pt-30">
-      <div class="row align-items-center">
-        <div class="col-md-6">
-          <div class="title mb-10">
-            <h1>Admins</h1>
-            <%= link_to "New Admin", new_casa_admin_path, class: "main-btn primary-btn btn-hover mt-30" %>
-          </div>
-        </div>
-      </div>
-    </div>
-      <!-- end col -->   
-    <div class="tables-wrapper">
-      <div class="row">
-        <div class="col-lg-12">
-          <div class="card-style mb-30">
-            <table class="table " id="admins">
-              <thead>
-              <tr>
-                <th><h5 class="ml-10 ">Admin Email</h5></th>
-                <th><h5 class="ml-10 ">Actions</h5></th>
-              </tr>
-              </thead>
-
-              <tbody>
-              <% @admins.each do |admin| %>
-                <tr id="admin-<%= admin.id %>" class="">
-                  <td scope="row" class="min-wdth">
-                    <span class="ml-10 mb-10 mt-10  pb-1"><%= admin.email %></span>
-                    <% unless admin.active? %>
-                      <span class="status-btn close-btn">
-                        Deactivated
-                      </span>
-                    <% end %>       
-                  </td>
-                  <td class="min-width">
-                    <span class="ml-10 mb-10 mt-10 pb-1">
-                    <%= link_to "Edit", edit_casa_admin_path(admin) %>
-                    </span>
-                  </td>
-                </tr>
-              <% end %>
-              </tbody>
-            </table>
-          </div>
+<div class="container-fluid">
+  <div class="title-wrapper pt-30">
+    <div class="row align-items-center">
+      <div class="col-md-6">
+        <div class="title mb-10">
+          <h1>Admins</h1>
+          <%= link_to "New Admin", new_casa_admin_path, class: "main-btn primary-btn btn-hover mt-30" %>
         </div>
       </div>
     </div>
   </div>
-</section>
+    <!-- end col -->   
+  <div class="tables-wrapper">
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="card-style mb-30">
+          <table class="table " id="admins">
+            <thead>
+            <tr>
+              <th><h5 class="ml-10 ">Admin Email</h5></th>
+              <th><h5 class="ml-10 ">Actions</h5></th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <% @admins.each do |admin| %>
+              <tr id="admin-<%= admin.id %>" class="">
+                <td scope="row" class="min-wdth">
+                  <span class="ml-10 mb-10 mt-10  pb-1"><%= admin.email %></span>
+                  <% unless admin.active? %>
+                    <span class="status-btn close-btn">
+                      Deactivated
+                    </span>
+                  <% end %>       
+                </td>
+                <td class="min-width">
+                  <span class="ml-10 mb-10 mt-10 pb-1">
+                  <%= link_to "Edit", edit_casa_admin_path(admin) %>
+                  </span>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/casa_admins/index.html.erb
+++ b/app/views/casa_admins/index.html.erb
@@ -1,42 +1,51 @@
-<div class="title-wrapper pt-30">
-  <div class="row align-items-center">
-    <div class="col-md-6">
-      <div class="title mb-30">
-        <h1>Admins</h1>
-        <%= link_to "New Admin", new_casa_admin_path, class: "main-btn primary-btn btn-hover mt-10 mb-10" %>
+<section class="table-components">
+  <div class="container-fluid">
+    <div class="title-wrapper pt-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <div class="title mb-10">
+            <h1>Admins</h1>
+            <%= link_to "New Admin", new_casa_admin_path, class: "main-btn primary-btn btn-hover mt-30" %>
+          </div>
+        </div>
+      </div>
+    </div>
+      <!-- end col -->   
+    <div class="tables-wrapper">
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="card-style mb-30">
+            <table class="table " id="admins">
+              <thead>
+              <tr>
+                <th><h5 class="ml-10 ">Admin Email</h5></th>
+                <th><h5 class="ml-10 ">Actions</h5></th>
+              </tr>
+              </thead>
+
+              <tbody>
+              <% @admins.each do |admin| %>
+                <tr id="admin-<%= admin.id %>" class="">
+                  <td scope="row" class="min-wdth">
+                    <span class="ml-10 mb-10 mt-10  pb-1"><%= admin.email %></span>
+                    <% unless admin.active? %>
+                      <span class="status-btn close-btn">
+                        Deactivated
+                      </span>
+                    <% end %>       
+                  </td>
+                  <td class="min-width">
+                    <span class="ml-10 mb-10 mt-10 pb-1">
+                    <%= link_to "Edit", edit_casa_admin_path(admin) %>
+                    </span>
+                  </td>
+                </tr>
+              <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
-  <!-- end col -->   
-
-<div class="card card-container">
-  <div class="card-body">
-    <table class="table table-striped table-bordered" id="admins">
-      <thead>
-      <tr>
-        <th>Admin Email</th>
-        <th>Actions</th>
-      </tr>
-      </thead>
-
-      <tbody>
-      <% @admins.each do |admin| %>
-        <tr id="admin-<%= admin.id %>">
-          <th scope="row">
-            <%= admin.email %>
-            <% unless admin.active? %>
-              <span class="badge badge-danger display-1 text-uppercase">
-                Deactivated
-              </span>
-            <% end %>
-          </th>
-          <td>
-            <%= link_to "Edit", edit_casa_admin_path(admin) %>
-          </td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
-  </div>
-</div>
+</section>

--- a/app/views/casa_admins/index.html.erb
+++ b/app/views/casa_admins/index.html.erb
@@ -1,9 +1,14 @@
-<div class="row">
-  <div class="col-sm-12 dashboard-table-header">
-    <h1>Admins</h1>
-    <%= link_to "New Admin", new_casa_admin_path, class: "btn btn-primary" %>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>Admins</h1>
+        <%= link_to "New Admin", new_casa_admin_path, class: "main-btn primary-btn btn-hover mt-10 mb-10" %>
+      </div>
+    </div>
   </div>
 </div>
+  <!-- end col -->   
 
 <div class="card card-container">
   <div class="card-body">

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -1,39 +1,39 @@
-<div class="field form-group">
+<div class="input-style-1">
   <%= f.label :email, "Email" %>
   <% if policy(resource).update_user_setting? %>
-    <%= f.text_field :email, class: "form-control" %>
+    <%= f.text_field :email%>
   <% else %>
-    <input class="form-control" type="text" placeholder="<%= resource.email %>" autocomplete="off" readonly>
+    <input type="text" placeholder="<%= resource.email %>" autocomplete="off" readonly>
   <% end %>
 </div>
 
-<div class="field form-group">
+<div class="input-style-1">
   <%= f.label :display_name, "Display name" %>
   <% if policy(resource).update_user_setting? %>
-    <%= f.text_field :display_name, class: "form-control" %>
+    <%= f.text_field :display_name%>
   <% else %>
-    <input class="form-control" type="text" placeholder="<%= resource.display_name %>" autocomplete="off" readonly>
+    <input type="text" placeholder="<%= resource.display_name %>" autocomplete="off" readonly>
   <% end %>
 </div>
 
-<div class="field form-group">
+<div class="input-style-1">
   <%= f.label :phone_number, "Phone number" %>
   <% if policy(resource).update_user_setting? %>
-    <%= f.text_field :phone_number, class: "form-control" %>
+    <%= f.text_field :phone_number %>
   <% else %>
-    <input class="form-control" type="text" placeholder="<%= resource.phone_number %>" autocomplete="off" readonly>
+    <input type="text" placeholder="<%= resource.phone_number %>" autocomplete="off" readonly>
   <% end %>
 </div>
 <% if current_organization.show_driving_reimbursement && resource.role == "Volunteer" %>
-  <div class="field form-group">
+  <div class="input-style-1">
     <%= f.label :address, "Mailing address" %>
     <% if policy(resource).update_user_setting? %>
       <%= f.fields_for :address, (resource.address ? nil : Address.new) do |a| %>
-        <%= a.text_field :content, class: "form-control" %>
+        <%= a.text_field :content %>
       <% end %>
     <% else %>
       <%= f.fields_for :address, (resource.address ? nil : Address.new) do |a| %>
-        <%= a.text_field :content, class: "form-control", readonly: true %>
+        <%= a.text_field :content,  readonly: true %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" class="alert alert-danger">
+  <div id="error_explanation" class="alert">
     <h6><%= pluralize(resource.errors.count, "error") %> prohibited this
         <%= @custom_error_header || resource.model_name.human %> from being saved:</h6>
 

--- a/app/views/shared/_invite_login.html.erb
+++ b/app/views/shared/_invite_login.html.erb
@@ -1,31 +1,31 @@
-<div>
-  <span class="font-weight-bold">CASA organization </span>
+<div class="mb-1">
+  <strong class="text-dark">CASA organization </strong>
   <%= resource&.casa_org&.name %>
 </div>
-<div>
-  <span class="font-weight-bold">Added to system </span>
+<div class="mb-1">
+  <strong class="text-dark">Added to system </strong>
   <%= resource&.decorate&.formatted_created_at %>
 </div>
-<div>
-  <span class="font-weight-bold">Invitation email sent </span>
+<div class="mb-1">
+  <strong class="text-dark">Invitation email sent </strong>
   <%= resource&.decorate&.formatted_invitation_sent_at || "never" %>
 </div>
-<div>
-  <span class="font-weight-bold">Last logged in </span>
+<div class="mb-1">
+  <strong class="text-dark">Last logged in </strong>
   <%= resource&.decorate&.formatted_current_sign_in_at || "never" %>
 </div>
-<div>
-  <span class="font-weight-bold">Invitation accepted </span>
+<div class="mb-1">
+  <strong class="text-dark">Invitation accepted </strong>
   <%= resource&.decorate&.formatted_invitation_accepted_at || "never" %>
 </div>
-<div>
-  <span class="font-weight-bold">Password reset last sent </span>
+<div class="mb-1">
+  <strong class="text-dark">Password reset last sent </strong>
   <%= resource&.decorate&.formatted_reset_password_sent_at || "never" %>
 </div>
 
 <% if resource.is_a?(Volunteer) %>
-  <div>
-    <span class="font-weight-bold">Learning Hours This Year</span>
+  <div class="mb-1">
+    <strong class="text-dark">Learning Hours This Year</strong>
     <%= resource.learning_hours_spent_in_one_year %>
   </div>
 <% end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4305 

### What changed, and why?
-Adds plainadmin container wrapper, title wrapper, card wrapper, as well as other plainadmin stylings for casa_admin index and form. 
-Converted shared/_edit_form - /_error_messages - /inite_login style classes to plainadmin ones as well as removing "field" and "form" style classes.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
-ran spec/views/casa_admins and all passed!

### Screenshots please :)
Admins Index
![Screenshot 2022-12-21 at 4 56 43 PM](https://user-images.githubusercontent.com/70528966/209011833-4db18a32-dc32-4fc8-abd7-4f347861c964.png)

Admins New
![Screenshot 2022-12-21 at 4 58 17 PM](https://user-images.githubusercontent.com/70528966/209011859-43d7099d-5d0c-4935-9cc6-6f636a0875ca.png)

Edit Admins (I added a plainadmin effect for the button so it changes the bg color and font color when hovered, I thought it'd be a cute touch)
![Screenshot 2022-12-21 at 4 56 35 PM](https://user-images.githubusercontent.com/70528966/209011887-aa1a87a9-4e84-4881-83be-a147543f2083.png)

Admins New w/ Error
![Screenshot 2022-12-21 at 4 59 36 PM](https://user-images.githubusercontent.com/70528966/209011923-7e244770-ba08-4e06-921b-221437c4ff87.png)

Admins Edit w/Error
![Screenshot 2022-12-21 at 5 00 10 PM](https://user-images.githubusercontent.com/70528966/209011947-85c9f73c-d021-443a-b546-8cb0e1b65245.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9