### PR TITLE
Prompt for both past and future court dates when none exist

### DIFF
--- a/app/helpers/court_dates_helper.rb
+++ b/app/helpers/court_dates_helper.rb
@@ -8,9 +8,9 @@ module CourtDatesHelper
     court_dates = casa_case.court_dates.ordered_ascending
     date_now = Date.current
 
-    return if court_dates.blank?
-
-    if court_dates.last.date < date_now
+    if court_dates.blank?
+      "none"
+    elsif court_dates.last.date < date_now
       "past"
     elsif court_dates.first.date > date_now
       "future"

--- a/app/views/casa_cases/_thank_you_modal.html.erb
+++ b/app/views/casa_cases/_thank_you_modal.html.erb
@@ -14,6 +14,10 @@
           <div id="prompt-update-user" class="modal-body">
             Please enter the next court date if you know it so that court reports can be generated with the correct case contacts.
           </div>
+        <% elsif when_do_we_have_court_dates == "none" %>
+          <div id="prompt-update-user" class="modal-body">
+            Please enter any past or future court dates if you know them so that court reports can be generated with the correct case contacts.
+          </div>
         <% end %>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/spec/helpers/court_dates_helper_spec.rb
+++ b/spec/helpers/court_dates_helper_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe CourtDatesHelper do
   describe "#when_do_we_have_court_dates" do
     subject { helper.when_do_we_have_court_dates(casa_case) }
 
+    describe "when casa case has no court dates" do
+      let(:casa_case) { create(:casa_case) }
+
+      it { expect(subject).to eq("none") }
+    end
+
     describe "when casa case has only dates in the past" do
       let(:casa_case) { create(:casa_case, :with_past_court_date) }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4280 

### What changed, and why?
Add a state that checks for there being no court dates on a case and prompts the user to add past and future court dates. 

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
There is a test that the state that triggers the prompt is set under the correct circumstances. 

### Screenshots please :)
<img width="747" alt="Screenshot 2022-12-23 at 3 50 25 PM" src="https://user-images.githubusercontent.com/7007647/209416192-2326c693-1d4f-4def-b315-eb6afdf4eeab.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![A robot with the text "I'm coding"](https://media.giphy.com/media/aEwLTJvYxwo1L09oyP/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9