### PR TITLE
Add plainadmin theme to hearing_types pages

### DIFF
--- a/app/views/hearing_types/_form.html.erb
+++ b/app/views/hearing_types/_form.html.erb
@@ -9,11 +9,9 @@
     </div>
   </div>
 </div>
-
 <div class="card-style mb-30">
   <%= form_with(model: hearing_type, local: true) do |form| %>
     <%= render "/shared/error_messages", resource: hearing_type %>
-    
     <div class="input-style-1">
       <%= form.label :name, "Name" %>
       <%= form.text_field :name, class: "form-control", required: true %>
@@ -22,7 +20,6 @@
       <%= form.check_box :active, class: 'form-check-input' %>
       <%= form.label :active, class: 'form-check-label' %>
     </div>
-
     <% if !hearing_type.id.nil? %>
       <div class="dashboard-table-header pt-2 pb-2">
         <div class="row align-items-center">
@@ -33,7 +30,10 @@
           <div class="col-md-6">
             <div class="breadcrumb-wrapper">
               <span class="ml-5">
-                <%= link_to "New List Item", new_hearing_type_checklist_item_path(hearing_type), class: "btn-sm main-btn primary-btn btn-hover" %>
+                <%= link_to new_hearing_type_checklist_item_path(hearing_type), class: "btn-sm main-btn primary-btn btn-hover" do %>
+                  <i class="lni lni-plus mr-10"></i>
+                  New List Item
+                <% end %>
               </span>
             </div>
           </div>
@@ -88,9 +88,13 @@
         <!-- end table -->
       </div>
     <% end %>
-    
     <div class="actions mb-10">
-      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+      <%= button_tag(
+            type: "submit",
+            class: "main-btn primary-btn btn-hover"
+          ) do %>
+          <i class="lni lni-checkmark-circle mr-10"></i> Submit
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/hearing_types/_form.html.erb
+++ b/app/views/hearing_types/_form.html.erb
@@ -1,25 +1,48 @@
-<h1><%= title %></h1>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>
+          <%= title %>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
 
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: hearing_type, local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: hearing_type %>
-      <div class="field form-group">
-        <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control", required: true %>
-      </div>
-      <div class="field form-group">
-        <div class="form-check">
-          <%= form.check_box :active, class: 'form-check-input' %>
-          <%= form.label :active, class: 'form-check-label' %>
+<div class="card-style mb-30">
+  <%= form_with(model: hearing_type, local: true) do |form| %>
+    <%= render "/shared/error_messages", resource: hearing_type %>
+    
+    <div class="input-style-1">
+      <%= form.label :name, "Name" %>
+      <%= form.text_field :name, class: "form-control", required: true %>
+    </div>
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :active, class: 'form-check-input' %>
+      <%= form.label :active, class: 'form-check-label' %>
+    </div>
+
+    <% if !hearing_type.id.nil? %>
+      <div class="dashboard-table-header pt-2 pb-2">
+        <div class="row align-items-center">
+          <div class="col-md-6">
+            <h3>Checklist</h3>
+          </div>
+          <!-- end col -->
+          <div class="col-md-6">
+            <div class="breadcrumb-wrapper">
+              <span class="ml-5">
+                <%= link_to "New List Item", new_hearing_type_checklist_item_path(hearing_type), class: "btn-sm main-btn primary-btn btn-hover" %>
+              </span>
+            </div>
+          </div>
+          <!-- end col -->
         </div>
       </div>
-      <% if !hearing_type.id.nil? %>
-        <div class="dashboard-table-header pt-2 pb-2">
-          <h3>Checklist</h3>
-          <%= link_to "New List Item", new_hearing_type_checklist_item_path(hearing_type), class: "btn btn-primary" %>
-        </div>
-        <table class="table table-striped table-bordered" id="checklist_items">
+      <!-- end table title -->
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table" id="checklist_items">
           <thead>
             <tr>
               <th>Description</th>
@@ -27,32 +50,47 @@
               <th>Mandatory</th>
               <th>Actions</th>
             </tr>
+            <!-- end table row-->
           </thead>
           <tbody>
             <% hearing_type.checklist_items.each do |checklist_item| %>
               <tr id="checklist_item-<%= checklist_item.id %>">
-                <td scope="row">
+                <td class="min-width">
                   <%= checklist_item.description %>
                 </td>
-                <td>
+                <td class="min-width">
                   <%= checklist_item.category %>
                 </td>
-                <td scope="row">
+                <td class="min-width">
                   <%= checklist_item.mandatory ? "Yes" : "Optional" %>
                 </td>
                 <td>
-                  <%= link_to "Edit", edit_hearing_type_checklist_item_path(hearing_type, checklist_item) %>
-                  <%= link_to "Delete", hearing_type_checklist_item_path(hearing_type, checklist_item),
-                  method: :delete, data: { confirm: "Are you sure that you want to delete this checklist item?" } %>
+                  <%= link_to edit_hearing_type_checklist_item_path(hearing_type, checklist_item) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                  <%= link_to hearing_type_checklist_item_path(hearing_type, checklist_item),
+                    method: :delete, data: { confirm: "Are you sure that you want to delete this checklist item?" } do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-trash-can"></i> Delete
+                      </button>
+                    </div>
+                  <% end %>
                 </td>
               </tr>
             <% end %>
           </tbody>
         </table>
-      <% end %>
-      <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
+        <!-- end table -->
       </div>
     <% end %>
-  </div>
+    
+    <div class="actions mb-10">
+      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,16 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" class="alert">
-    <h6><%= pluralize(resource.errors.count, "error") %> prohibited this
-        <%= @custom_error_header || resource.model_name.human %> from being saved:</h6>
+  <div class="alert-box danger-alert">
+    <div id="error_explanation" class="alert">
+      <h6>
+        <%= pluralize(resource.errors.count, "error") %> prohibited this
+        <%= @custom_error_header || resource.model_name.human %> from being saved:
+      </h6>
 
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+      <ul>
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4316

### What changed, and why?
This PR updates the views in the `/views/hearing_types` directory to use the new [plainadmin](https://plainadmin.com/) theme.

### How will this affect user permissions?
It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)
`hearing_types/new` :
![image](https://user-images.githubusercontent.com/27422266/209575329-4bffdf2e-cf23-4b18-97e4-ad204ea09651.png)
![image](https://user-images.githubusercontent.com/27422266/209575311-ffb7e56a-3752-43c3-af43-3eebd15c054a.png)

`hearing_types/#/edit` :
![image](https://user-images.githubusercontent.com/27422266/209575370-22bf8b04-ebcb-4089-80ab-c50632d686d6.png)
![image](https://user-images.githubusercontent.com/27422266/209575396-fcda5e8a-6454-4fc8-8d64-6abd026626d9.png)

