### PR TITLE
moved language description to under language section

### DIFF
--- a/app/views/casa_org/_languages.html.erb
+++ b/app/views/casa_org/_languages.html.erb
@@ -1,6 +1,9 @@
 <div class="row">
   <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
     <h3>Languages</h3>
+    <div>
+      A list of languages volunteers can choose from to add to their profile to let supervisors and admins know they can speak the language.
+    </div>
     <%= link_to "New Language", new_language_path, class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -4,13 +4,7 @@
   <div class="card-body">
     <%= form_with(model: language, local: true) do |form| %>
       <%= render "/shared/error_messages", resource: language %>
-
-      <div>
-        A list of languages volunteers can add to their profile to let supervisors and admins know they can speak the language.
-      </div>
-
       <br>
-
       <div class="field form-group">
         <%= form.label :name, "Name" %>
         <%= form.text_field :name, placeholder: "e.g.: English", class: "form-control", required: true %>


### PR DESCRIPTION
### What changed, and why?
Moved language description out of new page to under section header.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/8918762/209873317-70a41b7d-b94e-420f-a32a-a7fd7d4a39a0.png)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9