### PR TITLE
Add plainadmin theme to case_org pages

### DIFF
--- a/app/views/casa_org/_contact_type_groups.html.erb
+++ b/app/views/casa_org/_contact_type_groups.html.erb
@@ -1,32 +1,57 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Contact Type Groups</h3>
-    <%= link_to "New Group", new_contact_type_group_path, class: "btn btn-primary" %>
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <h3>Contact Type Groups</h3>
+        </div>
+        <div class="col-md-6">
+          <div class="breadcrumb-wrapper">
+            <span class="ml-5">
+              <%= link_to new_contact_type_group_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+                <i class="lni lni-plus mr-10"></i>
+                New Group
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <!-- end col -->
+      <!-- end col -->
+      <!-- end col -->
+      <!-- end col -->
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table" id="contact-type-groups">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Active?</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% contact_type_groups.each do |group| %>
+              <tr id="group-<%= group.id %>">
+                <td scope="row" class="min-width">
+                  <%= group.name %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= group.active? ? "Yes" : "No" %>
+                </td>
+                <td>
+                  <%= link_to edit_contact_type_group_path(group) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
-
-<table class="table table-striped table-bordered" id="contact-type-groups">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Active?</th>
-    <th>Actions</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% contact_type_groups.each do |group| %>
-    <tr id="group-<%= group.id %>">
-      <td scope="row">
-        <%= group.name %>
-      </td>
-      <td scope="row">
-        <%= group.active? ? "Yes" : "No" %>
-      </td>
-      <td>
-        <%= link_to "Edit", edit_contact_type_group_path(group) %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/_contact_types.html.erb
+++ b/app/views/casa_org/_contact_types.html.erb
@@ -1,36 +1,57 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Contact Types</h3>
-    <%= link_to "New Contact Type", new_contact_type_path, class: "btn btn-primary" %>
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <h3>Contact Types</h3>
+        </div>
+        <div class="col-md-6">
+          <div class="breadcrumb-wrapper">
+            <span class="ml-5">
+              <%= link_to new_contact_type_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+                <i class="lni lni-plus mr-10"></i>
+                New Contact Type
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table" id="contact-types">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Group</th>
+              <th>Active?</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% contact_types.each do |contact_type| %>
+              <tr id="contact_type-<%= contact_type.id %>">
+                <td scope="row" class="min-width">
+                  <%= contact_type.name %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= contact_type.contact_type_group.name %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= contact_type.active? ? "Yes" : "No" %>
+                </td>
+                <td>
+                  <%= link_to edit_contact_type_path(contact_type) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
-
-<table class="table table-striped table-bordered" id="contact-types">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Group</th>
-    <th>Active></th>
-    <th>Actions</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% contact_types.each do |contact_type| %>
-    <tr id="contact_type-<%= contact_type.id %>">
-      <td scope="row">
-        <%= contact_type.name %>
-      </td>
-      <td scope="row">
-        <%= contact_type.contact_type_group.name %>
-      </td>
-      <td scope="row">
-        <%= contact_type.active? ? "Yes" : "No" %>
-      </td>
-      <td>
-        <%= link_to "Edit", edit_contact_type_path(contact_type) %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/_hearing_types.html.erb
+++ b/app/views/casa_org/_hearing_types.html.erb
@@ -1,36 +1,57 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Hearing Types</h3>
-    <%= link_to "New Hearing Type", new_hearing_type_path, class: "btn btn-primary" %>
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <h3>Hearing Types</h3>
+        </div>
+        <div class="col-md-6">
+          <div class="breadcrumb-wrapper">
+            <span class="ml-5">
+              <%= link_to new_hearing_type_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+                <i class="lni lni-plus mr-10"></i>
+                New Hearing Type
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table" id="hearing-types">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Checklist</th>
+              <th>Active?</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @hearing_types.each do |hearing_type| %>
+              <tr id="hearing_type-<%= hearing_type.id %>">
+                <td scope="row" class="min-width">
+                  <%= hearing_type.name %>
+                </td>
+                <td class="min-width">
+                  <%= "#{hearing_type.checklist_updated_date}" %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= hearing_type.active ? "Yes" : "No" %>
+                </td>
+                <td>
+                  <%= link_to edit_hearing_type_path(hearing_type) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
-
-<table class="table table-striped table-bordered" id="hearing-types">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Checklist</th>
-    <th>Active?</th>
-    <th>Actions</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @hearing_types.each do |hearing_type| %>
-    <tr id="hearing_type-<%= hearing_type.id %>">
-      <td scope="row">
-        <%= hearing_type.name %>
-      </td>
-      <td>
-        <%= "#{hearing_type.checklist_updated_date}" %>
-      </td>
-      <td scope="row">
-        <%= hearing_type.active ? "Yes" : "No" %>
-      </td>
-      <td>
-        <%= link_to "Edit", edit_hearing_type_path(hearing_type) %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/_judges.html.erb
+++ b/app/views/casa_org/_judges.html.erb
@@ -1,32 +1,53 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Judge</h3>
-    <%= link_to "New Judge", new_judge_path, class: "btn btn-primary" %>
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <h3>Judge</h3>
+        </div>
+        <div class="col-md-6">
+          <div class="breadcrumb-wrapper">
+            <span class="ml-5">
+              <%= link_to new_judge_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+                <i class="lni lni-plus mr-10"></i>
+                New Judge
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Active?</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @judges.each do |judge| %>
+              <tr id="judge-<%= judge.id %>">
+                <td scope="row" class="min-width">
+                  <%= judge.name %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= judge.active ? "Yes" : "No" %>
+                </td>
+                <td>
+                  <%= link_to edit_judge_path(judge) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
-
-<table class="table table-striped table-bordered">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Active?</th>
-    <th>Actions</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @judges.each do |judge| %>
-    <tr id="judge-<%= judge.id %>">
-      <td scope="row">
-        <%= judge.name %>
-      </td>
-      <td scope="row">
-        <%= judge.active ? "Yes" : "No" %>
-      </td>
-      <td>
-        <%= link_to "Edit", edit_judge_path(judge) %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/_languages.html.erb
+++ b/app/views/casa_org/_languages.html.erb
@@ -1,34 +1,47 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Languages</h3>
-    <div>
-      A list of languages volunteers can choose from to add to their profile to let supervisors and admins know they can speak the language.
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <h3 class="mb-10">Languages</h3>
+      <p class="text-sm mb-20">
+        A list of languages volunteers can choose from to add to their profile to let supervisors and admins know they can speak the language.
+      </p>
+      <%= link_to new_language_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+        <i class="lni lni-plus mr-10"></i>
+        New Language
+      <% end %>
+      <!-- end table title -->
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Actions</th>
+            </tr>
+            <!-- end table row-->
+          </thead>
+          <tbody>
+            <tr>
+              <td class="min-width">English (default language)</td>
+              <td></td>
+            </tr>
+            <% languages.each do |lang| %>
+              <tr id="language-<%= lang.id %>">
+                <td class="min-width">
+                  <%= lang.name %>
+                </td>
+                <td>
+                  <%= link_to edit_language_path(lang) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-    <%= link_to "New Language", new_language_path, class: "btn btn-primary" %>
   </div>
-</div>
-
-<table class="table table-striped table-bordered">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Actions</th>
-  </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>English (default language)</td>
-    </tr>
-  <% languages.each do |lang| %>
-    <tr id="language-<%= lang.id %>">
-      <td>
-        <%= lang.name %>
-      </td>
-      <td>
-        <%= link_to "Edit", edit_language_path(lang) %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/_sent_emails.html.erb
+++ b/app/views/casa_org/_sent_emails.html.erb
@@ -1,35 +1,37 @@
 <div class="row">
-  <div class="col-sm-12 dashboard-table-header pt-2 pb-2">
-    <h3>Sent Emails</h3>
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <h3 class="mb-10">Sent Emails</h3>
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table" id="sent-emails">
+          <thead>
+            <tr>
+              <th>Mailer Type</th>
+              <th>Category</th>
+              <th>Recipient</th>
+              <th>Time Sent</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @sent_emails.each do |sent_email| %>
+              <tr id="email-<%= sent_email.id %>">
+                <td scope="row" class="min-width">
+                  <%= sent_email.mailer_type %>
+                </td>
+                <td scope="row" class="min-width">
+                  <%= sent_email.category %>
+                </td>
+                <td class="min-width">
+                  <%= sent_email.user.display_name %> &lt;<%= sent_email.sent_address %>&gt;
+                </td>
+                <td>
+                  <%= sent_email.created_at.strftime("%l:%M%P %d %b %Y") %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
-
-<table class="table table-striped table-bordered" id="sent-emails">
-  <thead>
-  <tr>
-    <th>Mailer Type</th>
-    <th>Category</th>
-    <th>Recipient</th>
-    <th>Time Sent</th>
-  </tr>
-  </thead>
-
-  <tbody>
-  <% @sent_emails.each do |sent_email| %>
-    <tr id="email-<%= sent_email.id %>">
-      <td scope="row">
-        <%= sent_email.mailer_type %>
-      </td>
-      <td scope="row">
-        <%= sent_email.category %>
-      </td>
-      <td>
-        <%= sent_email.user.display_name %> &lt;<%= sent_email.sent_address %>&gt;
-      </td>
-      <td>
-        <%= sent_email.created_at.strftime("%l:%M%P %d %b %Y") %>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -1,80 +1,101 @@
-<h1>Editing CASA Organization</h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: current_organization, local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: current_organization %>
-      <div class="field form-group">
-        <%= form.label :name, "Name" %>
-        <%= form.text_field :name, class: "form-control", required: true %>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>
+          Editing CASA Organization
+        </h2>
       </div>
-      <div class="field form-group">
-        <%= form.label :display_name, "Display name" %>
-        <%= form.text_field :display_name, class: "form-control" %>
-      </div>
-      <div class="field form-group">
-        <%= form.label :address, "Address" %>
-        <%= form.text_field :address, class: "form-control" %>
-      </div>
-      <div class="custom-file mb-5">
-        <%= form.label :logo, "Logo" %>
-        <%= form.file_field :logo, class: "form-control", accept: ".png,.gif,.jpg,.jpeg,.webp,.svg" %>
-      </div>
-      <div class="custom-file mb-5">
-        <%= form.label :court_report_template, "Court report template" %>
-        <%= form.file_field :court_report_template, class: "form-control" %>
-      </div>
-      <div class="field form-group">
-        <div class="form-check">
-          <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
-          <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label' %>
-        </div>
-      </div>
-      <hr>
-      <div class="field form-group">
-          <%= form.label :twilio_phone_number, "Twilio Phone Number" %>
-          <%= form.text_field :twilio_phone_number, class: "form-control" %>
-      </div>
-      <div class="field form-group">
-          <%= form.label :twilio_account_sid, "Twilio Account SID" %>
-          <%= form.text_field :twilio_account_sid, class: "form-control" %>
-      </div>
-      <div class="field form-group">
-          <%= form.label :twilio_api_key_sid, "Twilio API Key SID" %>
-          <%= form.text_field :twilio_api_key_sid, class: "form-control" %>
-      </div>
-      <div class="field form-group">
-          <%= form.label :twilio_api_key_secret, "Twilio API Key Secret" %>
-          <%= form.text_field :twilio_api_key_secret, class: "form-control" %>
-      </div>
-      <div class="actions">
-        <%= form.submit "Submit", class: "btn btn-primary" %>
-      </div>
-    <% end %>
+    </div>
   </div>
 </div>
-
-<div class="mt-5 card card-container">
-  <div class="card-body">
-    <%= render "languages", languages: current_organization.languages %>
+<div class="card-style mb-30">
+  <%= form_with(model: current_organization, local: true) do |form| %>
+    <%= render "/shared/error_messages", resource: current_organization %>
+    <div class="input-style-1">
+      <%= form.label :name, "Name" %>
+      <%= form.text_field :name, class: "form-control", required: true %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :display_name, "Display name" %>
+      <%= form.text_field :display_name, class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :address, "Address" %>
+      <%= form.text_field :address, class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :logo, "Logo" %>
+      <%= form.file_field :logo, class: "form-control h-auto", accept: ".png,.gif,.jpg,.jpeg,.webp,.svg" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :court_report_template, "Court report template" %>
+      <%= form.file_field :court_report_template, class: "form-control" %>
+    </div>
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
+      <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label' %>
+    </div>
+    <hr>
+    <div class="input-style-1">
+      <%= form.label :twilio_phone_number, "Twilio Phone Number" %>
+      <%= form.text_field :twilio_phone_number, class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :twilio_account_sid, "Twilio Account SID" %>
+      <%= form.text_field :twilio_account_sid, class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :twilio_api_key_sid, "Twilio API Key SID" %>
+      <%= form.text_field :twilio_api_key_sid, class: "form-control" %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :twilio_api_key_secret, "Twilio API Key Secret" %>
+      <%= form.text_field :twilio_api_key_secret, class: "form-control" %>
+    </div>
+    <div class="actions mb-10">
+      <%= button_tag(
+            type: "submit",
+            class: "btn-sm main-btn primary-btn btn-hover"
+          ) do %>
+        <i class="lni lni-checkmark-circle mr-10"></i> Submit
+      <% end %>
+    </div>
+  <% end %>
+</div>
+<div class="tables-wrapper">
+  <%= render "languages", languages: current_organization.languages %>
+</div>
+<!-- end -->
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>
+          Manage Contact Types
+        </h2>
+      </div>
+    </div>
   </div>
 </div>
-
-<h1 class="pt-5">Manage Contact Types</h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= render "contact_type_groups", contact_type_groups: @contact_type_groups %>
-    <%= render "contact_types", contact_types: @contact_types %>
+<div class="tables-wrapper">
+  <%= render "contact_type_groups", contact_type_groups: @contact_type_groups %>
+  <%= render "contact_types", contact_types: @contact_types %>
+</div>
+<!-- end -->
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>
+          Manage Court Details
+        </h2>
+      </div>
+    </div>
   </div>
 </div>
-
-<h1 class="pt-5">Manage Court Details</h1>
-
-<div class="card card-container">
-  <div class="card-body">
-    <%= render "hearing_types" %>
-    <%= render "judges" %>
-    <%= render "sent_emails" %>
-  </div>
+<div class="tables-wrapper">
+  <%= render "hearing_types" %>
+  <%= render "judges" %>
+  <%= render "sent_emails" %>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4307

### What changed, and why?
This PR updates the views in the `/views/casa_org` directory to use the new [plainadmin](https://plainadmin.com/) theme.

### How will this affect user permissions?
It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)
`/views/casa_org` :
![localhost_3000_casa_org_1_edit (2)](https://user-images.githubusercontent.com/27422266/210813102-5a940002-37ca-4f2f-a1b8-dab8a47571e1.png)

