### PR TITLE
Don't show group actions expanded by default

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -107,12 +107,11 @@
             aria-expanded="true"
             aria-label="Toggle navigation">
               <span class="icon">
-              <i class="lni lni-list mr-10"></i>
-
+                <i class="lni lni-list mr-10"></i>
               </span>
             <span class="text">Group Actions</span>
           </a>
-          <ul id="ddmenu_55" class="collapse dropdown-nav show">
+          <ul id="ddmenu_55" class="collapse dropdown-nav">
             <% if policy(:application).see_court_reports_page? %>
               <li>
                 <%= link_to case_court_reports_path, class: "#{active_class(case_court_reports_path)}" do %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Hey @seanmarcia, here is the fix you requested.

Issue description: [Fix requested in comment](https://github.com/rubyforgood/casa/pull/4387#issuecomment-1369111839)

### What changed, and why?
CSS class for not showing the dropdown expanded by default.

### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: None
- Admin permissions: None

### How is this tested? (please write tests!) 💖💪
Visually

### Screenshots please :)

<img width="1717" alt="Screenshot 2023-01-06 at 8 40 15 PM" src="https://user-images.githubusercontent.com/13817656/211040947-28e53840-04f7-4667-9db6-d2bfae09c388.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9