### PR TITLE
Convert imports pages to plainadmin theme

### DIFF
--- a/app/views/imports/_cases.html.erb
+++ b/app/views/imports/_cases.html.erb
@@ -3,7 +3,7 @@
     1.
     <%= link_to "/casa_cases.csv", format: :csv, download: "casa_cases.csv" do %>
       Download and reference example Case CSV file
-      <i class="fa fa-file-download"></i>
+      <i class="lni lni-download"></i>
     <% end %>
   </h4>
 </div>
@@ -11,21 +11,26 @@
 <div class="mb-3">
   <h4>
     2. Upload your CSV file
-    <i class="fa fa-file-csv" aria-hidden="true"></i>
+    <i class="lni lni-upload" aria-hidden="true"></i>
   </h4>
   <%= form_with(url: imports_path, local: :true) do |f| %>
     <%= f.hidden_field :import_type, value: "casa_case" %>
-    <ul>
+    <ul style="list-style-type: disc;" class="mx-4">
       <li>Click the choose file button and navigate to the saved file and select it.</li>
       <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
       <li>Then click the "Import Cases CSV" button to import your cases.</li>
     </ul>
-    <%= f.file_field :file, id: 'case-file', accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
+    <%= f.file_field :file,
+                     id: 'case-file',          
+                     accept: 'text/csv', 
+                     class: 'form-control mt-4', 
+                     type: 'file',
+                     style: "margin: auto;" %>
     </div>
 
-    <%= button_tag id: "case-import-button", class: "btn btn-md btn-success pull-right",
+    <%= button_tag id: "case-import-button", class: "main-btn success-btn btn-hover pull-right",
                    disabled: true, data: {disable_with: "<i class='fa fa-spinner fa-spin'></i> Importing File"} do %>
-      <i class="fa fa-upload"></i> Import Cases CSV
+      <i class="lni lni-upload"></i> Import Cases CSV
     <% end %>
 
     <script type="text/javascript">

--- a/app/views/imports/_csv_error_modal.html.erb
+++ b/app/views/imports/_csv_error_modal.html.erb
@@ -8,7 +8,7 @@
         <%= sanitize import_error %>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" onclick="dismissCsvErrorModal()">OK</button>
+        <button type="button" class="main-btn primary-btn btn-hover" onclick="dismissCsvErrorModal()">OK</button>
       </div>
     </div>
   </div>

--- a/app/views/imports/_sms_opt_in_modal.html.erb
+++ b/app/views/imports/_sms_opt_in_modal.html.erb
@@ -5,23 +5,23 @@
         <h5 class="modal-title" id="smsOptIn">
           SMS Opt In
         </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <a type="button" class="close " data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
-        </button>
+        </a>
       </div>
       <div class="modal-body">
         <div>
           Please check this box to verify that these mobile numbers have opted in to receive SMS notifications. (They will have the opportunity to opt out or update their preferences.)
         </div>
         <br>
-        <span>
-          <%= form.label :sms_opt_in_label, "Opt into SMS notifications" %>
-          <%= form.check_box :sms_opt_in, { id: "sms-opt-in-checkbox" } %>
+        <span class="form-check checkbox-style">
+          <%= form.label :sms_opt_in_label, "Opt into SMS notifications", { class: "form-check-label"} %>
+          <%= form.check_box :sms_opt_in, { id: "sms-opt-in-checkbox", class: "form-check-input" } %>
         <span>
       </div>
       <div class="modal-footer">
         <%= form.submit "Continue Import",
-{ id: "sms-opt-in-continue-button", class: "btn btn-primary", disabled: true } %>
+{ id: "sms-opt-in-continue-button", class: "main-btn primary-btn btn-hover", disabled: true } %>
       </div>
     </div>
   </div>

--- a/app/views/imports/_sms_opt_in_modal.html.erb
+++ b/app/views/imports/_sms_opt_in_modal.html.erb
@@ -5,7 +5,7 @@
         <h5 class="modal-title" id="smsOptIn">
           SMS Opt In
         </h5>
-        <a type="button" class="close " data-dismiss="modal" aria-label="Close">
+        <a type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </a>
       </div>

--- a/app/views/imports/_supervisors.html.erb
+++ b/app/views/imports/_supervisors.html.erb
@@ -3,7 +3,7 @@
     1.
     <%= link_to "/supervisors.csv", format: :csv, download: "supervisors.csv" do %>
        Download and reference example Supervisor CSV file
-      <i class="fa fa-file-download"></i>
+      <i class="lni lni-download"></i>
     <% end %>
   </h4>
 </div>
@@ -11,11 +11,11 @@
 <div class="mb-3">
   <h4>
     2. Upload your CSV file
-    <i class="fa fa-file-csv" aria-hidden="true"></i>
+    <i class="lni lni-upload" aria-hidden="true"></i>
   </h4>
   <%= form_with(url: imports_path, local: :true, id: "supervisor-import-form") do |f| %>
     <%= f.hidden_field :import_type, value: "supervisor" %>
-    <ul>
+    <ul style="list-style-type: disc;" class="mx-4">
       <li>Click the choose file button and navigate to the saved file and select it.</li>
       <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
       <li>Then click the "Import Supervisors CSV" button to import your supervisors.</li>
@@ -23,13 +23,14 @@
     <%= f.file_field :file,
                      id: 'supervisor-file',
                      accept: 'text/csv',
-                     class: 'form-control-file',
+                     class: 'form-control mt-4', 
+                     type: 'file',
                      style: "margin: auto;" %>
     </div>
 
     <%= render "sms_opt_in_modal", { form: f } if @sms_opt_in_warning == "supervisor" %>
-    <%= button_tag id: "supervisor-import-button", class: "btn btn-md btn-success pull-right",
-                   disabled: true, data: { disable_with: "<i class='fa fa-spinner fa-spin'></i> Importing File"} do %>
-      <i class="fa fa-upload"></i> Import Supervisors CSV
+    <%= button_tag id: "supervisor-import-button", class: "main-btn success-btn btn-hover pull-right",
+                   disabled: true, data: { disable_with: "<div class='spinner-border spinner-border-sm'></div> Importing File"} do %>
+      <i class="lni lni-upload"></i> Import Supervisors CSV
     <% end %>
   <% end %>

--- a/app/views/imports/_volunteers.html.erb
+++ b/app/views/imports/_volunteers.html.erb
@@ -3,7 +3,7 @@
     1.
     <%= link_to "/volunteers.csv", format: :csv, download: "volunteers.csv" do %>
       Download and reference example Volunteer CSV file
-      <i class="fa fa-file-download"></i>
+      <i class="lni lni-download"></i>
     <% end %>
   </h4>
 </div>
@@ -11,23 +11,27 @@
 <div class="mb-3">
   <h4>
     2. Upload your CSV file
-    <i class="fa fa-file-csv" aria-hidden="true"></i>
+    <i class="lni lni-upload" aria-hidden="true"></i>
   </h4>
   <%= form_with(url: imports_path, local: :true, id: "volunteer-import-form") do |f| %>
     <%= f.hidden_field :import_type, value: "volunteer" %>
     <%= f.hidden_field :sms_opt_in, value: false %>
-
-    <ul>
+    <ul style="list-style-type: disc;" class="mx-4">
       <li>Click the choose file button and navigate to the saved file and select it.</li>
       <li><strong>Do not</strong> change any of the values in the first line of the example csv file.</li>
       <li>Then click the "Import Volunteers CSV" button to import your volunteers. <strong>This will email the new volunteers asking them to log in!</strong></li>
     </ul>
-    <%= f.file_field :file, id: 'volunteer-file', accept: 'text/csv', class: 'form-control-file', style: "margin: auto;" %>
+    <%= f.file_field :file, 
+                     id: 'volunteer-file',
+                     accept: 'text/csv',
+                     class: 'form-control mt-4', 
+                     type: 'file',
+                     style: "margin: auto;" %>
     </div>
 
     <%= render "sms_opt_in_modal", { form: f } if @sms_opt_in_warning == "volunteer" %>
-    <%= button_tag id: "volunteer-import-button", class: "btn btn-md btn-success pull-right",
-      disabled: true, data: { disable_with: "<i class='fa fa-spinner fa-spin'></i> Importing File" } do %>
-      <i class="fa fa-upload"></i> Import Volunteers CSV
+    <%= button_tag id: "volunteer-import-button", class: "main-btn success-btn btn-hover pull-right",
+      disabled: true, data: { disable_with: "<div class='spinner-border spinner-border-sm'></div> Importing File" } do %>
+      <i class="lni lni-upload"></i> Import Volunteers CSV
     <% end %>
   <% end %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -113,7 +113,6 @@
         <br>
       </div>
     </div>
-    <%= link_to "Return To Dashboard", root_path, class: 'main-btn secondary-btn btn-hover mt-5' %>
   </div>
   <%= render "csv_error_modal", {import_error: @import_error} if @import_error %>
 </div>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -1,12 +1,15 @@
-<div class="row">
-  <div class="col-sm-12">
-    <h1>Imports</h1>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center"> 
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>Imports</h1>
+      </div>
+    </div>
   </div>
 </div>
-<br>
 <div class="row">
   <div class="col-sm-12">
-    <div class="card">
+    <div class="card card-style">
       <div class="card-body">
         <h5 class="card-title"><strong>System Imports</strong></h5>
         <p class="card-text">
@@ -17,9 +20,8 @@
           <li>Supervisors</li>
           <li>Cases</li>
         </ol>
-        <div>
-          <ul class="nav nav-tabs nav-justified" role="tablist">
-            <li class="nav-item">
+        <div class="tab-style-1">
+          <nav class="nav" id="nav-tab">
               <%= content_tag :a,
                               role: "tab",
                               href: "#volunteer",
@@ -28,13 +30,14 @@
                                   "nav-link",
                                   ("active" if @import_type == "volunteer")
                               ].compact,
-                              data: {toggle: "tab"},
+                              data: {
+                                "bs-toggle" => "tab",
+                                "bs-target" => "#volunteer"
+                              },
                               aria: {controls: "volunteer", selected: (@import_type == "volunteer")} do %>
-                Import Volunteers
-              <% end %>
-            </li>
-            <li class="nav-item">
-              <%= content_tag :a,
+                  Import Volunteers
+                <% end %>
+                <%= content_tag :a,
                               role: "tab",
                               href: "#supervisor",
                               id: "supervisor-tab",
@@ -42,28 +45,31 @@
                                   "nav-link",
                                   ("active" if @import_type == "supervisor")
                               ].compact,
-                              data: {toggle: "tab"},
+                              data: {
+                                "bs-toggle" => "tab",
+                                "bs-target" => "#supervisor"
+                              },
                               aria: {controls: "supervisor", selected: (@import_type == "supervisor")} do %>
-              Import Supervisors
-              <% end %>
-            </li>
-            <li class="nav-item">
-              <%= content_tag :a,
+                  Import Supervisors
+                <% end %>
+                <%= content_tag :a,
                               role: "tab",
-                              href: "#casa-case",
-                              id: "casa-case-tab",
+                              href: "#case",
+                              id: "case-tab",
                               class: [
                                   "nav-link",
                                   ("active" if @import_type == "casa_case")
                               ].compact,
-                              data: {toggle: "tab"},
-                              aria: {controls: "casa-case", selected: (@import_type == "casa_case")} do %>
-                Import Cases
-              <% end %>
-            </li>
-          </ul>
+                              data: {
+                                "bs-toggle" => "tab",
+                                "bs-target" => "#casa-case"
+                              },
+                              aria: {controls: "case", selected: (@import_type == "casa_case")} do %>
+                  Import Cases
+                <% end %>
+          </nav>
           <div class="tab-content">
-            <%= content_tag :div,
+              <%= content_tag :div,
                             role: "tabpanel",
                             id: "volunteer",
                             class: [
@@ -73,23 +79,23 @@
                                 ("active" if @import_type == "volunteer")
                             ].compact,
                             aria: {labelledby: "volunteer-tab"} do %>
-              <br>
+                <br>
               <%= render "volunteers" %>
-            <%- end %>
-            <%= content_tag :div,
-                            role: "tabpanel",
-                            id: "supervisor",
-                            class: [
-                                "tab-pane",
-                                "fade",
-                                ("show" if @import_type == "supervisor"),
-                                ("active" if @import_type == "supervisor")
-                            ].compact,
-                            aria: {labelledby: "supervisor-tab"} do %>
-              <br>
-              <%= render "supervisors" %>
-            <%- end %>
-            <%= content_tag :div,
+              <%- end %>
+              <%= content_tag :div,
+                          role: "tabpanel",
+                          id: "supervisor",
+                          class: [
+                              "tab-pane",
+                              "fade",
+                              ("show" if @import_type == "supervisor"),
+                              ("active" if @import_type == "supervisor")
+                          ].compact,
+                          aria: {labelledby: "supervisor-tab"} do %>
+                <br>
+                <%= render "supervisors" %>
+              <%- end %>
+              <%= content_tag :div,
                             role: "tabpanel",
                             id: "casa-case",
                             class: [
@@ -99,9 +105,9 @@
                                 ("active" if @import_type == "casa_case")
                             ].compact,
                             aria: {labelledby: "casa-case-tab"} do %>
-              <br>
-              <%= render "cases" %>
-            <%- end %>
+                <br>
+                <%= render "cases" %>
+              <%- end %>
           </div>
         </div>
         <br>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -21,55 +21,55 @@
           <li>Cases</li>
         </ol>
         <div>
-          <nav class="nav nav-tabs justify-content-center">
-              <%= content_tag :a,
-                              role: "tab",
-                              href: "#volunteer",
-                              id: "volunteer-tab",
-                              class: [
-                                  "nav-link",
-                                  ("active" if @import_type == "volunteer")
-                              ].compact,
-                              data: {
-                                "bs-toggle" => "tab",
-                                "bs-target" => "#volunteer"
-                              },
-                              aria: {controls: "volunteer", selected: (@import_type == "volunteer")} do %>
-                  Import Volunteers
-                <% end %>
-                <%= content_tag :a,
-                              role: "tab",
-                              href: "#supervisor",
-                              id: "supervisor-tab",
-                              class: [
-                                  "nav-link",
-                                  ("active" if @import_type == "supervisor")
-                              ].compact,
-                              data: {
-                                "bs-toggle" => "tab",
-                                "bs-target" => "#supervisor"
-                              },
-                              aria: {controls: "supervisor", selected: (@import_type == "supervisor")} do %>
-                  Import Supervisors
-                <% end %>
-                <%= content_tag :a,
-                              role: "tab",
-                              href: "#case",
-                              id: "case-tab",
-                              class: [
-                                  "nav-link",
-                                  ("active" if @import_type == "casa_case")
-                              ].compact,
-                              data: {
-                                "bs-toggle" => "tab",
-                                "bs-target" => "#casa-case"
-                              },
-                              aria: {controls: "case", selected: (@import_type == "casa_case")} do %>
-                  Import Cases
-                <% end %>
+          <nav class="nav nav-tabs justify-content-center nav-justified mt-3">
+            <%= content_tag :a,
+                            role: "tab",
+                            href: "#volunteer",
+                            id: "volunteer-tab",
+                            class: [
+                                "nav-link",
+                                ("active" if @import_type == "volunteer")
+                            ].compact,
+                            data: {
+                              "bs-toggle" => "tab",
+                              "bs-target" => "#volunteer"
+                            },
+                            aria: {controls: "volunteer", selected: (@import_type == "volunteer")} do %>
+              Import Volunteers
+            <% end %>
+            <%= content_tag :a,
+                            role: "tab",
+                            href: "#supervisor",
+                            id: "supervisor-tab",
+                            class: [
+                                "nav-link",
+                                ("active" if @import_type == "supervisor")
+                            ].compact,
+                            data: {
+                              "bs-toggle" => "tab",
+                              "bs-target" => "#supervisor"
+                            },
+                            aria: {controls: "supervisor", selected: (@import_type == "supervisor")} do %>
+              Import Supervisors
+            <% end %>
+            <%= content_tag :a,
+                            role: "tab",
+                            href: "#casa-case",
+                            id: "casa-case-tab",
+                            class: [
+                                "nav-link",
+                                ("active" if @import_type == "casa_case")
+                            ].compact,
+                            data: {
+                              "bs-toggle" => "tab",
+                              "bs-target" => "#casa-case"
+                            },
+                            aria: {controls: "case", selected: (@import_type == "casa_case")} do %>
+              Import Cases
+            <% end %>
           </nav>
           <div class="tab-content">
-              <%= content_tag :div,
+            <%= content_tag :div,
                             role: "tabpanel",
                             id: "volunteer",
                             class: [
@@ -79,32 +79,32 @@
                                 ("active" if @import_type == "volunteer")
                             ].compact,
                             aria: {labelledby: "volunteer-tab"} do %>
-                <br>
+              <br>
               <%= render "volunteers" %>
-              <%- end %>
-              <%= content_tag :div,
-                          role: "tabpanel",
-                          id: "supervisor",
-                          class: [
-                              "tab-pane",
-                              "fade",
-                              ("show" if @import_type == "supervisor"),
-                              ("active" if @import_type == "supervisor")
-                          ].compact,
-                          aria: {labelledby: "supervisor-tab"} do %>
+            <%- end %>
+            <%= content_tag :div,
+                            role: "tabpanel",
+                            id: "supervisor",
+                            class: [
+                                "tab-pane",
+                                "fade",
+                                ("show" if @import_type == "supervisor"),
+                                ("active" if @import_type == "supervisor")
+                            ].compact,
+                            aria: {labelledby: "supervisor-tab"} do %>
                 <br>
                 <%= render "supervisors" %>
               <%- end %>
               <%= content_tag :div,
-                            role: "tabpanel",
-                            id: "casa-case",
-                            class: [
-                                "tab-pane",
-                                "fade",
-                                ("show" if @import_type == "casa_case"),
-                                ("active" if @import_type == "casa_case")
-                            ].compact,
-                            aria: {labelledby: "casa-case-tab"} do %>
+                              role: "tabpanel",
+                              id: "casa-case",
+                              class: [
+                                  "tab-pane",
+                                  "fade",
+                                  ("show" if @import_type == "casa_case"),
+                                  ("active" if @import_type == "casa_case")
+                              ].compact,
+                              aria: {labelledby: "casa-case-tab"} do %>
                 <br>
                 <%= render "cases" %>
               <%- end %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -11,17 +11,17 @@
   <div class="col-sm-12">
     <div class="card card-style">
       <div class="card-body">
-        <h5 class="card-title"><strong>System Imports</strong></h5>
+        <h5 class="card-title">System Imports</h5>
         <p class="card-text">
           You should import files in the following order:
         </p>
-        <ol>
+        <ol style="list-style-type: decimal;" class="mx-4">
           <li>Volunteers</li>
           <li>Supervisors</li>
           <li>Cases</li>
         </ol>
-        <div class="tab-style-1">
-          <nav class="nav" id="nav-tab">
+        <div>
+          <nav class="nav nav-tabs justify-content-center">
               <%= content_tag :a,
                               role: "tab",
                               href: "#volunteer",
@@ -113,7 +113,7 @@
         <br>
       </div>
     </div>
-    <%= link_to "Return To Dashboard", root_path, class: 'btn btn-info' %>
+    <%= link_to "Return To Dashboard", root_path, class: 'main-btn secondary-btn btn-hover mt-5' %>
   </div>
   <%= render "csv_error_modal", {import_error: @import_error} if @import_error %>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4317 

### What changed, and why?
Updates to (mostly) CSS classes and a bit of the tag structure to move over to the new theme.

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
Visually tested.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/78568904/211105410-34c4f621-f40a-4c77-84b2-46afb40e9352.png)
![image](https://user-images.githubusercontent.com/78568904/211105430-e6fc4f00-3eaa-47f2-81ff-62e64b2a1dc1.png)
![image](https://user-images.githubusercontent.com/78568904/211105454-c2f4900a-4fce-47ef-951a-1e9a5f206bfd.png)
![image](https://user-images.githubusercontent.com/78568904/211105709-de392563-6be3-43a6-89c8-129a2a928241.png)
![image](https://user-images.githubusercontent.com/78568904/211105743-4d535c17-0a5e-4748-b7d3-2adbdaa07bd9.png)

Of course if there's anything you'd like me to improve upon/fix, I'd be more than happy to do so :)