### PR TITLE
Add plainadmin theme to court_dates pages

### DIFF
--- a/app/views/court_dates/_form.html.erb
+++ b/app/views/court_dates/_form.html.erb
@@ -1,53 +1,67 @@
-<div class="card card-container">
-  <div class="card-body">
-    <%= form_with(model: court_date, url: [casa_case, court_date], local: true) do |form| %>
-      <%= render "/shared/error_messages", resource: court_date %>
-
-      <div class="top-page-actions pull-right">
-        <%= form.submit court_date.persisted? ? "Update" : "Create", class: "btn btn-primary" %>
-      </div>
-
-      <p>
+<div class="card-style mb-30">
+  <%= form_with(model: court_date, url: [casa_case, court_date], local: true) do |form| %>
+    <%= render "/shared/error_messages", resource: court_date %>
+    <div class="row align-items-center">
+      <div class="col-md-6">
         <h6><strong>Case Number:</strong> <%= link_to casa_case.case_number, casa_case %></h6>
-      </p>
-
-      <div class="field form-group">
+      </div>
+      <div class="col-md-6">
+        <div class="breadcrumb-wrapper">
+          <span class="ml-5">
+            <%= button_tag(
+            type: "submit",
+            class: "btn-sm main-btn primary-btn btn-hover"
+          ) do %>
+              <% if court_date.persisted? %>
+                <i class="lni lni-pencil-alt"></i>
+                Update
+              <% else %>
+                <i class="lni lni-plus"></i>
+                Create
+              <% end %>
+            <% end %>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="row align-items-center">
+      <div class="input-style-1">
         <%= form.label :date, "Add Court Date" %>
         <%= form.text_field :date,
                         value: court_date.date&.to_date || Time.zone.now,
                         data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                         class: "form-control" %>
       </div>
-      <br>
-
-      <div class="field form-group">
+      <div class="input-style-1">
         <%= form.label :court_report_due_date, "Add Court Report Due Date" %>
         <%= form.text_field :court_report_due_date,
                         value: court_date.court_report_due_date&.to_date,
                         data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                         class: "form-control" %>
       </div>
-      <br>
-
-      <div class="field form-group">
+      <div class="select-style-1">
         <%= form.label :judge_id, "Judge" %>
-        <%= form.collection_select(
+        <div class="select-position">
+          <%= form.collection_select(
                 :judge_id,
                 Judge.for_organization(current_organization),
                 :id, :name,
                 {include_hidden: false, include_blank: "-Select Judge-"},
                 {class: "form-control"}
             ) %>
+        </div>
       </div>
-      <div class="field form-group">
+      <div class="select-style-1">
         <%= form.label :hearing_type_id, "Hearing type" %>
-        <%= form.collection_select(
+        <div class="select-position">
+          <%= form.collection_select(
                 :hearing_type_id,
                 HearingType.active.for_organization(current_organization),
                 :id, :name,
                 {include_hidden: false, include_blank: "-Select Hearing Type-"},
                 {class: "form-control"}
             ) %>
+        </div>
       </div>
       <div class="field form-group court-orders">
         <%= render partial: "shared/court_order_list",
@@ -55,4 +69,3 @@
       </div>
     <% end %>
   </div>
-</div>

--- a/app/views/court_dates/edit.html.erb
+++ b/app/views/court_dates/edit.html.erb
@@ -1,3 +1,11 @@
-<h1>Editing Court Date</h1>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>Editing Court Date</h2>
+      </div>
+    </div>
+  </div>
+</div>
 
 <%= render 'form', casa_case: @casa_case, court_date: @court_date %>

--- a/app/views/court_dates/new.html.erb
+++ b/app/views/court_dates/new.html.erb
@@ -1,3 +1,11 @@
-<h1>New Court Date</h1>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>New Court Date</h2>
+      </div>
+    </div>
+  </div>
+</div>
 
 <%= render 'form', casa_case: @casa_case, court_date: @court_date %>

--- a/app/views/court_dates/show.html.erb
+++ b/app/views/court_dates/show.html.erb
@@ -1,31 +1,45 @@
-<div class="row">
-  <div class="col-sm-12 form-header">
-    <h1>Court Date</h1>
-    <%= link_to "Edit",
-        edit_casa_case_court_date_path(@casa_case, @court_date),
-        class: "btn btn-primary casa-case-button pull-right" %>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>Court Date</h2>
+        <time datetime="<%= @court_date.date %>" class="d-inline-block h4"><%= @court_date.decorate.formatted_date %></time>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="breadcrumb-wrapper mb-30">
+        <%= link_to edit_casa_case_court_date_path(@casa_case, @court_date), class: "btn-sm main-btn primary-btn btn-hover" do %>
+          <i class="lni lni-pencil-alt mr-10"></i>
+          Edit
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>
-<time datetime="<%= @court_date.date %>" class="d-inline-block h2"><%= @court_date.decorate.formatted_date %></time>
-
-<div class="card card-container">
-  <div class="card-body">
+<div class="col-lg-12">
+  <div class="card-style mb-30">
     <dl>
-      <dt class="h6 float-left mr-2"><strong>Case Number:</strong></dt>
-      <dd class="h6 mb-3"><%= link_to "#{@casa_case.case_number}", casa_case_path(@casa_case) %></dd>
-      <dt class="h6 float-left mr-2"><strong>Court Report Due Date:</strong></dt>
-      <dd class="h6 mb-3"><%= @court_date.court_report_due_date&.to_date || "None" %></dd>
-      <dt class="h6 float-left mr-2"><strong>Judge:</strong></dt>
-      <dd class="h6 mb-3"><%= @court_date.judge&.name || "None" %></dd>
-      <dt class="h6 float-left mr-2"><strong>Hearing Type:</strong></dt>
-      <dd class="h6 mb-3"><%= @court_date.hearing_type&.name || "None" %></dd>
+      <dt>
+        <h6>Case Number:</h6>
+      </dt>
+      <dd class="mb-3"><%= link_to "#{@casa_case.case_number}", casa_case_path(@casa_case) %></dd>
+      <dt>
+        <h6>Court Report Due Date:</h6>
+      </dt>
+      <dd class="mb-3"><%= @court_date.court_report_due_date&.to_date || "None" %></dd>
+      <dt>
+        <h6>Judge:</h6>
+      </dt>
+      <dd class="mb-3"><%= @court_date.judge&.name || "None" %></dd>
+      <dt>
+        <h6>Hearing Type:</h6>
+      </dt>
+      <dd class="mb-3"><%= @court_date.hearing_type&.name || "None" %></dd>
     </dl>
-    <h6>
-      <strong>Court Orders:</strong>
-    </h6>
+    <h6>Court Orders:</h6>
     <% if @court_date.case_court_orders.any? %>
-      <div class="table-responsive">
-        <table class="table table-hover">
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table">
           <thead>
             <th>Case Order Text</th>
             <th class="text-center">Implementation Status</th>
@@ -33,7 +47,7 @@
           <tbody>
             <% @court_date.case_court_orders.each do |court_order| %>
               <tr>
-                <td><%= court_order.text %></td>
+                <td class="min-width"><%= court_order.text %></td>
                 <td class="text-center"><%= court_order.implementation_status&.humanize %></td>
               </tr>
             <% end %>
@@ -45,17 +59,17 @@
         There are no court orders associated with this court date.
       </p>
     <% end %>
-
-    <%= link_to "Download Report (.docx)",
-      casa_case_court_date_path(@casa_case, @court_date, format: :docx),
-      class: "btn btn-primary" %>
+    <div class="d-flex">
+      <%= link_to casa_case_court_date_path(@casa_case, @court_date, format: :docx), class: "btn-sm main-btn primary-btn btn-hover" do %>
+        <i class="lni lni-download mr-10"></i>
+        Download Report (.docx)
+      <% end %>
+      <% if policy(:court_date).destroy? && @court_date.date > Time.now %>
+        <%= link_to [@casa_case, @court_date], method: :delete, data: { confirm: 'Are you sure?' },class: "btn-sm main-btn danger-btn-outline btn-hover ms-auto" do %>
+          <i class="lni lni-trash-can mr-10"></i>
+          Delete Future Court Date
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>
-
-<% if policy(:court_date).destroy? && @court_date.date > Time.now %>
-  <br>
-  <div class="row">
-    <%= link_to 'Delete Future Court Date', [@casa_case, @court_date], method: :delete,
-data: { confirm: 'Are you sure?' }, class: "btn btn-danger mx-auto" %>
-  </div>
-<% end %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4313

### What changed, and why?
This PR updates the views in the `/views/court_dates` directory to use the new [plainadmin](https://plainadmin.com/) theme.

### How will this affect user permissions?
It doesn't affect user permissions.

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)
`/views/court_dates/new` :
![image](https://user-images.githubusercontent.com/27422266/211114636-3695f546-8a58-4de4-b711-546c0492dd52.png)
`/views/court_dates/show` :
![image](https://user-images.githubusercontent.com/27422266/211114697-f4a1c3ab-5b15-4097-88bb-2ce3c4606469.png)
`/views/court_dates/edit` :
![image](https://user-images.githubusercontent.com/27422266/211114732-071cf9f1-6332-4783-8e96-bebe3298ba53.png)

