### PR TITLE
Update theme for notes and notifications

### DIFF
--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -1,12 +1,18 @@
 <%= form_with(model: @note, local: true, url: volunteer_note_path(@volunteer, @note)) do |form| %>
   <h3>Update Volunteer Note</h3>
 
-  <div class="form-group">
+  <div class="input-style-1">
     <%= form.text_area :content,
       rows: 5,
       placeholder: "Enter a note regarding the volunteer. These notes are only visible to CASA administrators and supervisors.",
       class: "form-control" %>
   </div>
 
-  <%= form.submit "Update Note", class: "btn btn-primary", id: "note-submit" %>
+  <%= button_tag(
+    type: "submit",
+    class: "main-btn primary-btn btn-hover btn-sm",
+    id: "note-submit"
+  ) do %>
+    Update Note
+  <% end %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,6 +1,10 @@
-<div class="row">
-  <div class="col-sm-12 dashboard-table-header">
-    <h1>Notifications</h1>
+<div class="title-wrapper pt-30">
+  <div class="row">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>Notifications</h2>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -16,7 +20,7 @@
   <% end %>
 
   <% if @notifications.empty? and (@patch_notes.empty? or @deploy_time.nil?) %>
-    <div class="card-style my-4 border-warning">
+    <div class="card-style my-4">
       <div class="card-body">
         You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.
       </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -16,7 +16,7 @@
   <% end %>
 
   <% if @notifications.empty? and (@patch_notes.empty? or @deploy_time.nil?) %>
-    <div class="card card-container my-4 border-warning">
+    <div class="card-style my-4 border-warning">
       <div class="card-body">
         You currently don't have any notifications. Notifications are generated when someone requests follow-up on a case contact.
       </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4332

### What changed, and why?
Update theme for notes and notifications views

### How will this affect user permissions?
- Volunteer permissions: No changes
- Supervisor permissions: No changes
- Admin permissions: No changes

### How is this tested? (please write tests!) 💖💪
Verified locally. Theses changes are CSS-based and so probably should not be tested in an automated fashion.

### Screenshots please :)
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/39019266/211154203-42311efb-a704-4b56-8de2-9b75eca3ded1.png">
<img width="1152" alt="image" src="https://user-images.githubusercontent.com/39019266/211154245-80cb97e0-20ac-461c-b413-9ef1676af8e0.png">

### Further Notes
Please note the following issues:
1. The footer styling is not consistent with the rest of the site (background color)
2. I was not able to test notifications since creating them locally is a pain (testing on heroku should make this easier)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9