### PR TITLE
Show dropdown open when any of the child anchor is active

### DIFF
--- a/app/javascript/src/sidebar.js
+++ b/app/javascript/src/sidebar.js
@@ -11,4 +11,11 @@ function toggleSidebar () {
 
 $('document').ready(() => {
   $('#toggle-sidebar-js, #sidebar-js').on('click', toggleSidebar)
+
+  // Show group actions dropdown expanded when any of the child is active
+  if ($("#ddmenu_55 li").children("a").hasClass("active")) {
+    $("#ddmenu_55").addClass("show")
+  } else {
+    $("#ddmenu_55").removeClass("show")
+  }
 })


### PR DESCRIPTION
### What github issue is this PR for, if any?
Hey @seanmarcia, this is regarding the group actions in the sidebar. Now it will be expanded when any of the child is active.

### What changed, and why?
I tried the approach of making it like `active_class` in the sidebar helper but found that an additional `show` class was added by javascript on render. It was beyond the control of the helper method.

So I took the javascript approach. Let me know if any changes are required. 

### How will this affect user permissions?
- Volunteer permissions: No effect
- Supervisor permissions: No effect
- Admin permissions: No effect

### How is this tested? (please write tests!) 💖💪
Visually.

### Screenshots please :)

<img width="1728" alt="Screenshot 2023-01-08 at 1 40 41 PM" src="https://user-images.githubusercontent.com/13817656/211187002-fa09917e-078e-4b25-b2a0-97b38352059c.png">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9