### PR TITLE
Remove refresh on unauthorized response

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -1,4 +1,3 @@
-/* global location */
 /* global alert */
 /* global $ */
 

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -70,7 +70,7 @@ $('document').ready(() => {
   )
 
   const handleAjaxError = e => {
-    console.log(e)
+    console.error(e)
     if (e.responseJSON && e.responseJSON.error) {
       alert(e.responseJSON.error)
     } else {

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -71,20 +71,16 @@ $('document').ready(() => {
   )
 
   const handleAjaxError = e => {
-    if (e.status === 401) {
-      location.reload()
+    console.log(e)
+    if (e.responseJSON && e.responseJSON.error) {
+      alert(e.responseJSON.error)
     } else {
-      console.log(e)
-      if (e.responseJSON && e.responseJSON.error) {
-        alert(e.responseJSON.error)
-      } else {
-        const responseErrorMessage = e.response.statusText
-          ? `\n${e.response.statusText}\n`
-          : ''
+      const responseErrorMessage = e.response.statusText
+        ? `\n${e.response.statusText}\n`
+        : ''
 
-        alert(`Sorry, try that again?\n${responseErrorMessage}\nIf you're seeing a problem, please fill out the Report A Site Issue
-        link to the bottom left near your email address.`)
-      }
+      alert(`Sorry, try that again?\n${responseErrorMessage}\nIf you're seeing a problem, please fill out the Report A Site Issue
+      link to the bottom left near your email address.`)
     }
   }
 


### PR DESCRIPTION
### What changed, and why?
When one the datatable's ajax requests returns with status 401(Unauthorized) instead of refreshing the page, it displays the error as an alert and prints it to console

### How is this tested? (please write tests!) 💖💪
nope

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9