### PR TITLE
Updated submit button icons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,7 @@ GEM
     sorbet-static (0.5.10575-universal-darwin-19)
     sorbet-static (0.5.10575-universal-darwin-20)
     sorbet-static (0.5.10575-universal-darwin-21)
+    sorbet-static (0.5.10575-universal-darwin-22)
     sorbet-static (0.5.10575-x86_64-linux)
     spoom (1.1.13)
       sorbet (>= 0.5.9204)
@@ -502,6 +503,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-darwin-20

--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -26,8 +26,10 @@
       <%= form.label :active, "Active?", class: 'form-check-label' %>
     </div>
 
-    <div class="actions mb-10">
-      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+   <div class="actions mb-10">
+      <%= button_tag(type: "submit", class: "btn-sm main-btn primary-btn btn-hover") do %>
+        <i class="lni lni-checkmark-circle mr-5"></i> Submit
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/languages/_form.html.erb
+++ b/app/views/languages/_form.html.erb
@@ -22,7 +22,9 @@
     </div>
 
     <div class="actions mb-10">
-      <%= form.submit "Submit", class: "main-btn primary-btn btn-hover" %>
+      <%= button_tag(type: "submit", class: "btn-sm main-btn primary-btn btn-hover") do %>
+        <i class="lni lni-checkmark-circle mr-5"></i> Submit
+      <% end %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4435 

### What changed, and why?
The previous button styling was from prior theme, updated to have submit buttons contain small sizing and checkmarks on the new judges and language pages. 

### How will this affect user permissions?
No permissions should be affected; just visual changes.

### How is this tested? (please write tests!) 💖💪
Tested in `spec/views/languages/new.html.erb_spec.rb` and `spec/views/judges/new.html.erb_spec.rb`

### Screenshots please :)
![Image 1-12-23 at 1 47 PM](https://user-images.githubusercontent.com/101673900/212208319-13e4b53b-8627-4cab-b725-f80496a26523.jpeg)
![Image 1-12-23 at 1 46 PM](https://user-images.githubusercontent.com/101673900/212208324-fb1a2ac4-1cba-4f4a-ac01-5f04cedc4587.jpeg)


### Feelings!
What gif best describes your feeling working on this issue? 
![](https://media.giphy.com/media/gbmWwWm4sGMQvAYm1G/giphy.gif)