### PR TITLE
2907: Create migration to remove court_date from casa_cases table

### DIFF
--- a/db/migrate/20230121174227_remove_court_data_from_casa_cases.rb
+++ b/db/migrate/20230121174227_remove_court_data_from_casa_cases.rb
@@ -1,0 +1,5 @@
+class RemoveCourtDataFromCasaCases < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :casa_cases, :court_date }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_12_203806) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_21_174227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,7 +103,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_12_203806) do
     t.datetime "updated_at", null: false
     t.bigint "casa_org_id", null: false
     t.datetime "birth_month_year_youth", precision: nil
-    t.datetime "court_date", precision: nil
     t.datetime "court_report_due_date", precision: nil
     t.bigint "hearing_type_id"
     t.boolean "active", default: true, null: false


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2907

### What changed, and why?
Removes `court_date` field from `casa_cases` table since it is no longer being used. This is part 1 of 2 PRs, the [other](https://github.com/rubyforgood/casa/pull/4465) will remove `court_date` from `ignored_columns` in the `CasaCase` model. This migration but be deployed and ran before https://github.com/rubyforgood/casa/pull/4465 is deployed.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9