### PR TITLE
2907: Remove court_date from ignored_columns in CasaCase model

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -3,7 +3,7 @@ class CasaCase < ApplicationRecord
   include DateHelper
   extend FriendlyId
 
-  self.ignored_columns = %w[court_date hearing_type_id judge_id transition_aged_youth court_report_due_date]
+  self.ignored_columns = %w[hearing_type_id judge_id transition_aged_youth court_report_due_date]
 
   attr_accessor :validate_contact_type
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2907

### What changed, and why?
Removes `court_date` from `ignored_columns` in the `CasaCase` model since its no longer being used. This PR is a continuation of https://github.com/rubyforgood/casa/pull/4464 and should not be deployed until https://github.com/rubyforgood/casa/pull/4464 has been deployed and the migration has been ran.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9