### PR TITLE
2647: Modify case_assignment actions to accept JSON requests

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -4,41 +4,27 @@ class CaseAssignmentsController < ApplicationController
 
   def create
     authorize CaseAssignment
-    case_assignments = case_assignment_parent.case_assignments
-    existing_case_assignment = if params[:volunteer_id]
-      case_assignments.where(casa_case_id: case_assignment_params[:casa_case_id], active: false).first
-    else
-      case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], active: false).first
-    end
 
     if existing_case_assignment.present?
       if existing_case_assignment.update(active: true)
-        message = "Volunteer reassigned to case"
-        flash.notice = message
-        status = :ok
+        handle_successful_assignment("Volunteer reassigned to case")
       else
         errors = existing_case_assignment.errors.full_messages.join(". ")
-        message = "Unable to reassigned volunteer to case: #{errors}."
-        flash.alert = message
-        status = :unprocessable_entity
+        handle_failed_assignment("Unable to reassign volunteer to case: #{errors}.")
       end
     else
       case_assignment = case_assignment_parent.case_assignments.new(case_assignment_params)
       if case_assignment.save
-        message = "Volunteer assigned to case"
-        flash.notice = message
-        status = :ok
+        handle_successful_assignment("Volunteer assigned to case")
       else
         errors = case_assignment.errors.full_messages.join(". ")
-        message = "Unable to assign volunteer to case: #{errors}."
-        flash.alert = message
-        status = :unprocessable_entity
+        handle_failed_assignment("Unable to assign volunteer to case: #{errors}.")
       end
     end
 
     respond_to do |format|
       format.html { redirect_to after_action_path(case_assignment_parent) }
-      format.json { render json: message, status: status }
+      format.json { render json: @message, status: @status }
     end
   end
 
@@ -117,5 +103,30 @@ class CaseAssignmentsController < ApplicationController
         .find(params[:id])
   rescue ActiveRecord::RecordNotFound
     head :not_found
+  end
+
+  def load_existing_case_assignment
+    case_assignments = case_assignment_parent.case_assignments
+    if params[:volunteer_id]
+      case_assignments.where(casa_case_id: case_assignment_params[:casa_case_id], active: false).first
+    else
+      case_assignments.where(volunteer_id: case_assignment_params[:volunteer_id], active: false).first
+    end
+  end
+
+  def existing_case_assignment
+    @existing_case_assignment ||= load_existing_case_assignment
+  end
+
+  def handle_successful_assignment(msg)
+    @message = msg
+    flash.notice = msg
+    @status = :ok
+  end
+
+  def handle_failed_assignment(msg)
+    @message = msg
+    flash.alert = msg
+    @status = :unprocessable_entity
   end
 end

--- a/doc/API.md
+++ b/doc/API.md
@@ -15,3 +15,17 @@ Creates a casa case
      The id of the hearing type for the next court date.
    - **judge_id**: 1  
      The id of the case judge
+
+### POST `/case_assignments.json`
+Creates a case_assignment
+- **Params:**
+   - **casa_case_id**: 1,  
+     Required. The id of the casa case the volunteer is being assigned to.
+   - **volunteer_id**: 1,  
+     Required. The id of the volunteer being assigned to the casa case.
+
+### PATCH   `/case_assignments/:id/unassign.json`
+Unassigns a case_assignment
+- **Params:**
+   - **id**: 1,  
+     Required. The id of the case_assignment to be unassigned.

--- a/spec/controllers/case_assignments_controller_spec.rb
+++ b/spec/controllers/case_assignments_controller_spec.rb
@@ -8,46 +8,99 @@ RSpec.describe CaseAssignmentsController, type: :controller do
 
   describe "POST create" do
     context "when the volunteer has been previously assigned to the casa_case" do
-      it "reassigns the volunteer to the casa_case" do
-        create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
+      context "when request format is html" do
+        it "reassigns the volunteer to the casa_case" do
+          create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
+  
+          sign_in admin
+  
+          expect {
+            post :create, params: {casa_case_id: casa_case.id, case_assignment: {
+              volunteer_id: volunteer.id
+            }}
+          }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
+  
+          expect(response).to redirect_to edit_casa_case_path(casa_case)
+        end
+      end
 
-        sign_in admin
-
-        expect {
-          post :create, params: {casa_case_id: casa_case.id, case_assignment: {
-            volunteer_id: volunteer.id
-          }}
-        }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
-
-        expect(response).to redirect_to edit_casa_case_path(casa_case)
+      context "when request format is json" do
+        it "reassigns the volunteer to the casa_case" do
+          create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
+  
+          sign_in admin
+  
+          expect {
+            post :create, format: :json, params: {casa_case_id: casa_case.id, case_assignment: {
+              volunteer_id: volunteer.id
+            }}
+          }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
+  
+          expect(response.status).to eq 200
+          expect(response.body).to eq "Volunteer reassigned to case"
+        end
       end
     end
 
     context "when the case assignment parent is a volunteer" do
-      it "creates a new case assignment for the volunteer" do
-        sign_in admin
+      context "when request format is html" do
+        it "creates a new case assignment for the volunteer" do
+          sign_in admin
+  
+          expect {
+            post :create, params: {
+              volunteer_id: volunteer.id, case_assignment: {casa_case_id: casa_case.id}
+            }
+          }.to change(volunteer.casa_cases, :count).by(1)
+  
+          expect(response).to redirect_to edit_volunteer_path(volunteer)
+        end
+      end
 
-        expect {
-          post :create, params: {
-            volunteer_id: volunteer.id, case_assignment: {casa_case_id: casa_case.id}
-          }
-        }.to change(volunteer.casa_cases, :count).by(1)
-
-        expect(response).to redirect_to edit_volunteer_path(volunteer)
+      context "when request format is json" do
+        it "creates a new case assignment for the volunteer" do
+          sign_in admin
+  
+          expect {
+            post :create, format: :json, params: {
+              volunteer_id: volunteer.id, case_assignment: {casa_case_id: casa_case.id}
+            }
+          }.to change(volunteer.casa_cases, :count).by(1)
+  
+          expect(response.status).to eq 200
+          expect(response.body).to eq "Volunteer assigned to case"
+        end
       end
     end
 
     context "when the case assignment parent is a casa_case" do
-      it "creates a new case assignment for the casa_case" do
-        sign_in admin
+      context "when request format is html" do
+        it "creates a new case assignment for the casa_case" do
+          sign_in admin
+  
+          expect {
+            post :create, params: {
+              casa_case_id: casa_case.id, case_assignment: {volunteer_id: volunteer.id}
+            }
+          }.to change(casa_case.volunteers, :count).by(1)
+  
+          expect(response).to redirect_to edit_casa_case_path(casa_case)
+        end
+      end
 
-        expect {
-          post :create, params: {
-            casa_case_id: casa_case.id, case_assignment: {volunteer_id: volunteer.id}
-          }
-        }.to change(casa_case.volunteers, :count).by(1)
-
-        expect(response).to redirect_to edit_casa_case_path(casa_case)
+      context "when request format is json" do
+        it "creates a new case assignment for the casa_case" do
+          sign_in admin
+  
+          expect {
+            post :create, format: :json, params: {
+              casa_case_id: casa_case.id, case_assignment: {volunteer_id: volunteer.id}
+            }
+          }.to change(casa_case.volunteers, :count).by(1)
+  
+          expect(response.status).to eq 200
+          expect(response.body).to eq "Volunteer assigned to case"
+        end
       end
     end
 
@@ -148,16 +201,33 @@ RSpec.describe CaseAssignmentsController, type: :controller do
     end
 
     context "when redirect_to_path is not volunteer" do
-      it "deactivates the case assignment and redirects to edit casa case" do
-        assignment = create(:case_assignment, casa_case: casa_case)
+      context "when request format is html" do
+        it "deactivates the case assignment and redirects to edit casa case" do
+          assignment = create(:case_assignment, casa_case: casa_case)
 
-        sign_in admin
+          sign_in admin
 
-        expect {
-          patch :unassign, params: {id: assignment.id}
-        }.to change { assignment.reload.active? }.to(false)
+          expect {
+            patch :unassign, params: {id: assignment.id}
+          }.to change { assignment.reload.active? }.to(false)
 
-        expect(response).to redirect_to edit_casa_case_path(casa_case)
+          expect(response).to redirect_to edit_casa_case_path(casa_case)
+        end
+      end
+
+      context "when request format is json" do
+        it "deactivates the case assignment and returns success message" do
+          assignment = create(:case_assignment, casa_case: casa_case)
+
+          sign_in admin
+
+          expect {
+            patch :unassign, params: {id: assignment.id}, format: :json
+          }.to change { assignment.reload.active? }.to(false)
+
+          expect(response.status).to eq 200
+          expect(response.body).to eq "Volunteer was unassigned from Case #{casa_case.case_number}."
+        end
       end
     end
 

--- a/spec/controllers/case_assignments_controller_spec.rb
+++ b/spec/controllers/case_assignments_controller_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is html" do
         it "reassigns the volunteer to the casa_case" do
           create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
-  
+
           sign_in admin
-  
+
           expect {
             post :create, params: {casa_case_id: casa_case.id, case_assignment: {
               volunteer_id: volunteer.id
             }}
           }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
-  
+
           expect(response).to redirect_to edit_casa_case_path(casa_case)
         end
       end
@@ -27,15 +27,15 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is json" do
         it "reassigns the volunteer to the casa_case" do
           create(:case_assignment, active: false, volunteer: volunteer, casa_case: casa_case)
-  
+
           sign_in admin
-  
+
           expect {
             post :create, format: :json, params: {casa_case_id: casa_case.id, case_assignment: {
               volunteer_id: volunteer.id
             }}
           }.to change { casa_case.case_assignments.first.active }.from(false).to(true)
-  
+
           expect(response.status).to eq 200
           expect(response.body).to eq "Volunteer reassigned to case"
         end
@@ -46,13 +46,13 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is html" do
         it "creates a new case assignment for the volunteer" do
           sign_in admin
-  
+
           expect {
             post :create, params: {
               volunteer_id: volunteer.id, case_assignment: {casa_case_id: casa_case.id}
             }
           }.to change(volunteer.casa_cases, :count).by(1)
-  
+
           expect(response).to redirect_to edit_volunteer_path(volunteer)
         end
       end
@@ -60,13 +60,13 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is json" do
         it "creates a new case assignment for the volunteer" do
           sign_in admin
-  
+
           expect {
             post :create, format: :json, params: {
               volunteer_id: volunteer.id, case_assignment: {casa_case_id: casa_case.id}
             }
           }.to change(volunteer.casa_cases, :count).by(1)
-  
+
           expect(response.status).to eq 200
           expect(response.body).to eq "Volunteer assigned to case"
         end
@@ -77,13 +77,13 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is html" do
         it "creates a new case assignment for the casa_case" do
           sign_in admin
-  
+
           expect {
             post :create, params: {
               casa_case_id: casa_case.id, case_assignment: {volunteer_id: volunteer.id}
             }
           }.to change(casa_case.volunteers, :count).by(1)
-  
+
           expect(response).to redirect_to edit_casa_case_path(casa_case)
         end
       end
@@ -91,13 +91,13 @@ RSpec.describe CaseAssignmentsController, type: :controller do
       context "when request format is json" do
         it "creates a new case assignment for the casa_case" do
           sign_in admin
-  
+
           expect {
             post :create, format: :json, params: {
               casa_case_id: casa_case.id, case_assignment: {volunteer_id: volunteer.id}
             }
           }.to change(casa_case.volunteers, :count).by(1)
-  
+
           expect(response.status).to eq 200
           expect(response.body).to eq "Volunteer assigned to case"
         end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2647 

### What changed, and why?
Completes API epic by modifying `CaseAssignments#create` and `CaseAssignment#unassign` to accept JSON requests. Adds endpoint info to the API doc as well.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: Adds ability for case assignments to be created via the API.
- Admin permissions: Adds the ability for case assignments to be created via the API.

### How is this tested? (please write tests!) 💖💪
Adds tests to `spec/controllers/case_assignments_controller_spec.rb` to ensure calls to the actions via HTML or JSON are handled properly.

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9