### PR TITLE
[resolves #4495] Ensure unique values for case contact attributes in spec setup to address flaky ordering specs

### DIFF
--- a/spec/datatables/reimbursement_datatable_spec.rb
+++ b/spec/datatables/reimbursement_datatable_spec.rb
@@ -107,14 +107,17 @@ RSpec.describe "ReimbursementDatatable" do
 
   describe "multiple record handling" do
     before do
+      possible_miles_driven_values = (0..100).to_a.shuffle
+      possible_occurred_at_offsets = (0..100).to_a.shuffle
+
       5.times.collect do
         casa_case = create(:casa_case)
         3.times.collect do
           create(
             :case_contact,
             casa_case: casa_case,
-            occurred_at: Time.new - rand(1000),
-            miles_driven: rand(1000)
+            occurred_at: Time.new - possible_occurred_at_offsets.pop,
+            miles_driven: possible_miles_driven_values.pop
           )
         end.reverse
       end.flatten


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4495

### What changed, and why?
The test setup for the case contacts was using a random value for the `occurred_at` and `miles_driven` attributes. This was occasionally causing the order checking specs to fail if there were attributes in different records with the same values. 

This PR uses an alternate method of setting those values to ensure uniqueness in the values being sorted. 

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Plenty of rspec runs with different setup to verify the failure was happening as expected and the new setup works.

### Screenshots please :)
N/A

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
![infinite testing](https://media.giphy.com/media/gw3IWyGkC0rsazTi/giphy.gif)


### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9