### PR TITLE
Fix date parsing reimbursements firefox

### DIFF
--- a/app/javascript/src/reimbursements.js
+++ b/app/javascript/src/reimbursements.js
@@ -4,7 +4,7 @@ $('document').ready(() => {
   const { groupBy, map, mapValues } = require('lodash')
   const strftime = require('strftime')
 
-  const formatOccurredAtDate = (record) => strftime('%B %d %Y', new Date(record.occurred_at))
+  const formatOccurredAtDate = (record) => new Date(Date.parse(record.occurred_at.replaceAll('-', ' '))).toDateString()
 
   const mapContactTypes = (contactTypes) => {
     return mapValues(

--- a/app/javascript/src/reimbursements.js
+++ b/app/javascript/src/reimbursements.js
@@ -2,7 +2,6 @@
 
 $('document').ready(() => {
   const { groupBy, map, mapValues } = require('lodash')
-  const strftime = require('strftime')
 
   const formatOccurredAtDate = (record) => new Date(Date.parse(record.occurred_at.replaceAll('-', ' '))).toDateString()
 

--- a/app/javascript/src/reimbursements.js
+++ b/app/javascript/src/reimbursements.js
@@ -3,7 +3,7 @@
 $('document').ready(() => {
   const { groupBy, map, mapValues } = require('lodash')
 
-  const formatOccurredAtDate = (record) => new Date(Date.parse(record.occurred_at.replaceAll('-', ' '))).toDateString()
+  const formatOccurredAtDate = (record) => new Date(record.occurred_at.replaceAll('-', ' ')).toDateString()
 
   const mapContactTypes = (contactTypes) => {
     return mapValues(

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "popper.js": "^1.16.1",
     "sass": "^1.58.2",
     "select2": "^4.0.13",
-    "strftime": "^0.10.1",
     "sweetalert2": "^11.3.5",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,11 +4837,6 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
-strftime@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/strftime/-/strftime-0.10.1.tgz#108af1176a7d5252cfbddbdb2af044dfae538389"
-  integrity sha512-nVvH6JG8KlXFPC0f8lojLgEsPA18lRpLZ+RrJh/NkQV2tqOgZfbas8gcU8SFgnnqR3rWzZPYu6N2A3xzs/8rQg==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"


### PR DESCRIPTION
Resolves #4570

### What changed, and why?
 - fixed a bug where the reimbursement date could not be parsed on firefox
 - removed an unnecessary dependency 

### Screenshots please :)
Before
![image](https://user-images.githubusercontent.com/8918762/220508363-2244040c-d359-4bab-8e44-aefb6e0a2478.png)

After
![image](https://user-images.githubusercontent.com/8918762/220508401-90baa209-8141-4f0c-85fe-4fa510803c98.png)