### PR TITLE
No duplicate language options

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -2,8 +2,15 @@ class Language < ApplicationRecord
   belongs_to :casa_org
   has_many :user_languages
   has_many :users, through: :user_languages
+  before_validation :strip_name
 
   validates :name, presence: true, uniqueness: {scope: :casa_org, case_sensitive: false}
+
+  private
+
+  def strip_name
+    self.name = self.name.strip if self.name
+  end
 end
 
 # == Schema Information

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -9,7 +9,7 @@ class Language < ApplicationRecord
   private
 
   def strip_name
-    self.name = self.name.strip if self.name
+    self.name = name.strip if name
   end
 end
 

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe Language, type: :model do
 
     expect(subject).not_to be_valid
   end
+
+  context "when calling valid?" do
+    it "removes surrounding spaces from the name attribute" do
+      subject = build(:language, name: "  spanish  ", casa_org: organization)
+      subject.valid?
+      expect(subject.name).to eq "spanish"
+    end
+
+    it "removes surrounding spaces from the name attribute but leaves in middle spaces" do
+      subject = build(:language, name: " Western Punjabi ", casa_org: organization)
+      subject.valid?
+      expect(subject.name).to eq "Western Punjabi"
+    end
+  end
 end


### PR DESCRIPTION
Resolves #4585 

### What changed, and why?

If a language already exists for a casa organization with the name "Spanish" and a user tries to make a new language with a name like "Spanish " or " Spanish" or " Spanish ",  these entries will still be considered invalid regardless of any surrounding spaces. This behavior also applies to language updates.
 
### How will this affect user permissions?

n/a

### How is this tested? (please write tests!) 💖💪

Visual confirmation and I wrote some tests.

### Screenshots please :)

![noduplicatelanguageoptions](https://user-images.githubusercontent.com/42154066/221329692-7e49ae4e-c76e-433b-b3fa-83e882c9d24d.gif)

If anything needs to change please let me know.