### PR TITLE
Ensure warning for disabled js on landing page

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../builds .js
 //= link_tree ../images
 //= link_tree ../fonts
+//= link shared/noscript.css

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -7,7 +7,7 @@
 
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
     <script src="https://cdn.tailwindcss.com"></script>
-
+    <%= stylesheet_link_tag "shared/noscript" %>
     <style>
 .app-images {
   height: 400px;
@@ -16,6 +16,16 @@
   </head>
 
   <body>
+    <noscript>
+      <div>
+        <h2>
+          Please enable javascript
+        </h2>
+        <p>
+          This app requires javascript to work
+        </p>
+      </div>
+    </noscript>
     <header class="pt-2" style="background: #0949D7">
       <div class="container max-w-7xl mx-auto pt-5 px-5">
         <nav>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -17,8 +17,8 @@
 
   <body>
     <noscript>
-      <div>
-        <h2>
+      <div class="noscript alert alert-danger">
+        <h2 class="alert-heading">
           Please enable javascript
         </h2>
         <p>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4567

### What changed, and why?
- Added a `noscript` tag to the static page
- Added noscript.css to static page to style the tag

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
![image](https://user-images.githubusercontent.com/40617327/221768680-48eb1b87-ee40-4c93-adcf-5839aaee9beb.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9