### PR TITLE
edit and delete button patch notes

### DIFF
--- a/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
+++ b/app/views/all_casa_admins/patch_notes/_patch_note.html.erb
@@ -30,8 +30,8 @@
       </select>
     </div>
     <div class="patch-note-button-controls">
-      <button type="button" class="main-btn primary-btn btn-hover"><i class="lni lni-pencil-alt mr-10"></i>Edit</button>
-      <button type="button" class="main-btn danger-btn btn-hover"><i class="lni lni-trash-can mr-10"></i>Delete</button>
+      <button type="button" class="main-btn primary-btn btn-hover button-edit"><i class="lni lni-pencil-alt mr-10"></i>Edit</button>
+      <button type="button" class="main-btn danger-btn btn-hover button-delete"><i class="lni lni-trash-can mr-10"></i>Delete</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4562 (new theme)

### What changed, and why?

edit and delete button patch notes were not working

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: patch notes

### How is this tested? (please write tests!) 💖💪

manually tested

### Screenshots please :)

Before:

![image](https://user-images.githubusercontent.com/70678718/222317315-2b3668e5-9e40-4470-952d-d0a630fbc1fd.png)


After clicking delete:

![image](https://user-images.githubusercontent.com/70678718/222317380-28015d17-3e6d-49c7-b6dd-feed9da0ef04.png)
