### PR TITLE
Issue #3419 - Export contact report filtered by case

### DIFF
--- a/app/controllers/case_contact_reports_controller.rb
+++ b/app/controllers/case_contact_reports_controller.rb
@@ -30,6 +30,7 @@ class CaseContactReportsController < ApplicationController
       contact_type_group_ids: [],
       creator_ids: [],
       supervisor_ids: [],
+      casa_case_ids: [],
       filtered_csv_cols: {}
     ).merge(casa_org_id: current_organization.id)
     convert_radio_options_to_boolean(parameters)

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -114,6 +114,10 @@ class CaseContact < ApplicationRecord
     end
   }
 
+  scope :with_casa_case, ->(case_ids) {
+    where(casa_case_id: case_ids) if case_ids.present?
+  }
+
   filterrific(
     available_filters: [
       :sorted_by,

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -24,6 +24,7 @@ class CaseContactReport
       .want_driving_reimbursement(args[:want_driving_reimbursement])
       .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
+      .with_casa_case(args[:casa_case_ids])
   end
 
   def filtered_columns(args)

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -115,6 +115,19 @@ multiple: true}
         </div>
 
         <div class="field form-group">
+          <label><strong>Casa Case Numbers:</strong></label>
+          <%= f.collection_select(
+                  :casa_case_ids,
+                  CasaCase.by_organization(current_user.casa_org),
+                  :id,
+                  :case_number,
+                  {include_hidden: false},
+                  {class: "form-control select2", data: {placeholder: "-Select Casa Case Numbers-"},
+multiple: true}
+              ) %>
+        </div>
+
+        <div class="field form-group">
           <label><strong>Want Driving Reimbursement:</strong></label>
           <%= f.collection_radio_buttons :want_driving_reimbursement, boolean_choices, :last, :first do |b| %>
             <div class="form-check">

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe CaseContactReport, type: :model do
 
       context "when providing casa case ids" do
         it "returns all case contacts with the casa case ids" do
-          report = described_class.new({ casa_case_ids: [casa_case.id] })
+          report = described_class.new({casa_case_ids: [casa_case.id]})
           expect(report.case_contacts.length).to eq(case_contacts.length)
           expect(report.case_contacts).to eq(case_contacts)
         end
@@ -321,7 +321,7 @@ RSpec.describe CaseContactReport, type: :model do
 
       context "when not providing casa case ids" do
         it "return all case contacts" do
-          report = described_class.new({ casa_case_ids: nil })
+          report = described_class.new({casa_case_ids: nil})
           expect(report.case_contacts.length).to eq(CaseContact.count)
           expect(report.case_contacts).to eq(CaseContact.all)
         end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -305,6 +305,29 @@ RSpec.describe CaseContactReport, type: :model do
       end
     end
 
+    describe "casa case number filter" do
+      let!(:casa_case) { create(:casa_case) }
+      let!(:case_contacts) { create_list(:case_contact, 3, casa_case: casa_case) }
+
+      before { create_list(:case_contact, 8) }
+
+      context "when providing casa case ids" do
+        it "returns all case contacts with the casa case ids" do
+          report = described_class.new({ casa_case_ids: [casa_case.id] })
+          expect(report.case_contacts.length).to eq(case_contacts.length)
+          expect(report.case_contacts).to eq(case_contacts)
+        end
+      end
+
+      context "when not providing casa case ids" do
+        it "return all case contacts" do
+          report = described_class.new({ casa_case_ids: nil })
+          expect(report.case_contacts.length).to eq(CaseContact.count)
+          expect(report.case_contacts).to eq(CaseContact.all)
+        end
+      end
+    end
+
     describe "multiple filter behavior" do
       it "only returns records that occured less than 30 days ago, the youth has transitioned, and the contact type was either court or therapist" do
         court = build(:contact_type, name: "Court")

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -416,6 +416,25 @@ RSpec.describe CaseContact, type: :model do
         end
       end
     end
+
+    describe ".with_casa_case" do
+      let!(:casa_case) { create(:casa_case) }
+      let!(:case_contacts) { create_list(:case_contact, 3, casa_case: casa_case) }
+
+      before { create_list(:case_contact, 3) }
+
+      context "when parameter is nil" do
+        it "returns all casa cases" do
+          expect(described_class.with_casa_case(nil)).to eq(CaseContact.all)
+        end
+      end
+
+      context "when parameter is not nil" do
+        it "returns contacts with the given casa case ids" do
+          expect(described_class.with_casa_case(casa_case.id)).to eq(case_contacts)
+        end
+      end
+    end
   end
 
   describe "#contact_groups_with_types" do

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "/case_contact_reports", type: :request do
 
         it "returns success with proper headers" do
           get case_contact_reports_url(format: :csv),
-            params: { report: { casa_case_ids: [casa_case.id] } }
+            params: {report: {casa_case_ids: [casa_case.id]}}
 
           expect(response).to be_successful
           expect(
@@ -87,7 +87,7 @@ RSpec.describe "/case_contact_reports", type: :request do
         context "when filter is provided" do
           it "renders csv with contacts from the casa cases" do
             get case_contact_reports_url(format: :csv),
-              params: { report: { casa_case_ids: [casa_case.id] } }
+              params: {report: {casa_case_ids: [casa_case.id]}}
 
             expect(response.body.lines.length).to eq(4)
 
@@ -100,7 +100,7 @@ RSpec.describe "/case_contact_reports", type: :request do
         context "when filter not provided" do
           it "renders a csv with all case contacts" do
             get case_contact_reports_url(format: :csv),
-              params: { report: { casa_case_ids: nil } }
+              params: {report: {casa_case_ids: nil}}
 
             expect(response.body.lines.length).to eq(9)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #3419

### What changed, and why?
Filtering the Case Contact report by the Casa Case Number is now possible.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### Screenshots please :)
![image](https://user-images.githubusercontent.com/25598040/224345940-75d29c5b-f577-424f-a305-fc1eb382704c.png)
