### PR TITLE
Fix the noscript style bug and update notification styling

### DIFF
--- a/app/assets/stylesheets/shared/noscript.css
+++ b/app/assets/stylesheets/shared/noscript.css
@@ -1,9 +1,8 @@
-noscript div {
-  color: #b71c1c;
+.noscript {
   position: fixed;
   left: 50%;
+  top: 25%;
   transform: translateX(-50%);
-  background: #eee;
-  padding: 0 1em;
+  padding: 5vw;
   z-index: 99;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,8 +30,8 @@
 </head>
 <body class="<%= body_class %>">
 <noscript>
-  <div>
-    <h2>
+  <div class="noscript alert alert-danger">
+    <h2 class="alert-heading">
       Please enable javascript
     </h2>
     <p>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4568

### What changed, and why?
An issue was identifed with the noscript tag wrapper not appearing on Linux versions of Chrome/Firefox, but the inner content was still rendering.  This fix moves the styling from the noscript tag to an inner div tag to ensure the styling appears.

Moved the styling from the noscript tag to the inner div.
Added the plainadmin alert, alert-danger, and alert-heading classes to their respective divs.
Changed the noscript tag selector to a class.
Changed the noscript styles to move the notification in to a more prominent position in the middle of the page and made it larger.


### How will this affect user permissions?
- Volunteer permissions: unaffected
- Supervisor permissions: unaffected
- Admin permissions: unaffected

### How is this tested? (please write tests!) 💖💪
Unable to test noscript style existence.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/95185795/224391447-69deeb66-f171-4121-a8b0-0497ba26f452.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
![alt text](https://media.giphy.com/media/c6YbhJZ9PZ54dbjR1C/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9