### PR TITLE
fix: Update Casa Case #new policy

### DIFF
--- a/app/policies/casa_case_policy.rb
+++ b/app/policies/casa_case_policy.rb
@@ -103,16 +103,9 @@ class CasaCasePolicy < ApplicationPolicy
   alias_method :save_emancipation?, :index? # Should this be the same as edit?
   alias_method :edit?, :same_org_supervisor_admin_or_assigned?
   alias_method :update?, :same_org_supervisor_admin_or_assigned?
-  alias_method :new?, :same_org_supervisor_admin?
-  alias_method :create?, :same_org_supervisor_admin?
-  alias_method :destroy?, :same_org_supervisor_admin?
-
-  # TODO:
-  # The dashboard policy only shows the "New Case" button to admins, but here
-  # we allow supervisors to also access new. View spec specifically tests the
-  # casa_cases/new.html.erb view against supervisors.
-  #
-  # Should supervisors be able to create cases?
+  alias_method :new?, :is_admin_same_org?
+  alias_method :create?, :is_admin_same_org?
+  alias_method :destroy?, :is_admin_same_org?
 
   private
 

--- a/spec/policies/casa_case_policy_spec.rb
+++ b/spec/policies/casa_case_policy_spec.rb
@@ -429,10 +429,13 @@ RSpec.describe CasaCasePolicy do
       end
     end
 
-    # TODO: What can supervisors do?
+    it "does not allow superivsors" do
+      is_expected.not_to permit(supervisor, casa_case)
+    end
 
     it "does not allow volunteers" do
       is_expected.not_to permit(volunteer, casa_case)
+      is_expected.not_to permit(other_org_volunteer, casa_case)
     end
   end
 

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -624,9 +624,10 @@ RSpec.describe "/casa_cases", type: :request do
     end
 
     describe "GET /new" do
-      it "renders a successful response" do
+      it "renders a redirect" do
         get new_casa_case_url
-        expect(response).to be_successful
+        expect(response).to be_redirect
+        expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
       end
     end
 

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -3,87 +3,57 @@ require "rails_helper"
 RSpec.describe "casa_cases/new", type: :system do
   let(:casa_org) { build(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: casa_org) }
+  let(:supervisor) { create(:supervisor, casa_org: casa_org) }
   let(:case_number) { "12345" }
   let!(:next_year) { (Date.today.year + 1).to_s }
   let(:court_date) { 21.days.from_now }
   let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
   let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
 
-  before do
-    sign_in admin
-    visit root_path
-    click_on "Cases"
+  context "when signed in as a Casa Org Admin" do
+    before do
+      sign_in admin
+      visit root_path
+      click_on "Cases"
 
-    click_on "New Case"
-  end
+      click_on "New Case"
+    end
 
-  context "when all fields are filled" do
-    it "is successful", js: true do
-      travel_to Time.zone.local(2020, 12, 1) do
-        fourteen_years = (Date.today.year - 14).to_s
-        fill_in "Case number", with: case_number
+    context "when all fields are filled" do
+      it "is successful", js: true do
+        travel_to Time.zone.local(2020, 12, 1) do
+          fourteen_years = (Date.today.year - 14).to_s
+          fill_in "Case number", with: case_number
 
-        fill_in "Court Date", with: court_date.strftime("%Y/%m/%d")
+          fill_in "Court Date", with: court_date.strftime("%Y/%m/%d")
 
-        select "March", from: "casa_case_birth_month_year_youth_2i"
-        select fourteen_years, from: "casa_case_birth_month_year_youth_1i"
+          select "March", from: "casa_case_birth_month_year_youth_2i"
+          select fourteen_years, from: "casa_case_birth_month_year_youth_1i"
 
-        select "Submitted", from: "casa_case_court_report_status"
+          select "Submitted", from: "casa_case_court_report_status"
 
-        check contact_type.name
+          check contact_type.name
 
-        within ".top-page-actions" do
-          click_on "Create CASA Case"
+          within ".top-page-actions" do
+            click_on "Create CASA Case"
+          end
+
+          expect(page.body).to have_content(case_number)
+          expect(page).to have_content(I18n.l(court_date, format: :day_and_date))
+          expect(page).to have_content("CASA case was successfully created.")
+          expect(page).not_to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time
+          expect(page).to have_content("Transition Aged Youth: Yes")
         end
-
-        expect(page.body).to have_content(case_number)
-        expect(page).to have_content(I18n.l(court_date, format: :day_and_date))
-        expect(page).to have_content("CASA case was successfully created.")
-        expect(page).not_to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time
-        expect(page).to have_content("Transition Aged Youth: Yes")
       end
     end
-  end
 
-  context "when non-mandatory fields are not filled" do
-    it "is successful" do
-      fill_in "Case number", with: case_number
-      fill_in "Next Court Date", with: DateTime.now.next_month.strftime("%Y/%m/%d")
-      five_years = (Date.today.year - 5).to_s
-      select "March", from: "casa_case_birth_month_year_youth_2i"
-      select five_years, from: "casa_case_birth_month_year_youth_1i"
-
-      within ".actions" do
-        click_on "Create CASA Case"
-      end
-
-      expect(page.body).to have_content(case_number)
-      expect(page).to have_content("CASA case was successfully created.")
-      expect(page).to have_content("Next Court Date:")
-      expect(page).not_to have_content("Court Report Due Date:")
-      expect(page).to have_content("Transition Aged Youth: No")
-    end
-  end
-
-  context "when the case number field is not filled" do
-    it "does not create a new case" do
-      within ".actions" do
-        click_on "Create CASA Case"
-      end
-
-      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
-      expect(page).to have_content("Case number can't be blank")
-    end
-  end
-
-  context "when the court date field is not filled" do
-    context "when empty court date checkbox is checked" do
-      it "creates a new case" do
+    context "when non-mandatory fields are not filled" do
+      it "is successful" do
         fill_in "Case number", with: case_number
+        fill_in "Next Court Date", with: DateTime.now.next_month.strftime("%Y/%m/%d")
         five_years = (Date.today.year - 5).to_s
         select "March", from: "casa_case_birth_month_year_youth_2i"
         select five_years, from: "casa_case_birth_month_year_youth_1i"
-        check "casa_case_empty_court_date"
 
         within ".actions" do
           click_on "Create CASA Case"
@@ -97,55 +67,100 @@ RSpec.describe "casa_cases/new", type: :system do
       end
     end
 
-    context "when empty court date checkbox is not checked" do
+    context "when the case number field is not filled" do
       it "does not create a new case" do
-        fill_in "Case number", with: case_number
-        five_years = (Date.today.year - 5).to_s
-        select "March", from: "casa_case_birth_month_year_youth_2i"
-        select five_years, from: "casa_case_birth_month_year_youth_1i"
-
         within ".actions" do
           click_on "Create CASA Case"
         end
 
         expect(page).to have_current_path(casa_cases_path, ignore_query: true)
-        expect(page).to have_content("Court dates date can't be blank")
+        expect(page).to have_content("Case number can't be blank")
+      end
+    end
+
+    context "when the court date field is not filled" do
+      context "when empty court date checkbox is checked" do
+        it "creates a new case" do
+          fill_in "Case number", with: case_number
+          five_years = (Date.today.year - 5).to_s
+          select "March", from: "casa_case_birth_month_year_youth_2i"
+          select five_years, from: "casa_case_birth_month_year_youth_1i"
+          check "casa_case_empty_court_date"
+
+          within ".actions" do
+            click_on "Create CASA Case"
+          end
+
+          expect(page.body).to have_content(case_number)
+          expect(page).to have_content("CASA case was successfully created.")
+          expect(page).to have_content("Next Court Date:")
+          expect(page).not_to have_content("Court Report Due Date:")
+          expect(page).to have_content("Transition Aged Youth: No")
+        end
+      end
+
+      context "when empty court date checkbox is not checked" do
+        it "does not create a new case" do
+          fill_in "Case number", with: case_number
+          five_years = (Date.today.year - 5).to_s
+          select "March", from: "casa_case_birth_month_year_youth_2i"
+          select five_years, from: "casa_case_birth_month_year_youth_1i"
+
+          within ".actions" do
+            click_on "Create CASA Case"
+          end
+
+          expect(page).to have_current_path(casa_cases_path, ignore_query: true)
+          expect(page).to have_content("Court dates date can't be blank")
+        end
+      end
+    end
+
+    context "when the case number already exists in the organization" do
+      let!(:casa_case) { create(:casa_case, case_number: case_number, casa_org: casa_org) }
+
+      it "does not create a new case" do
+        fill_in "Case number", with: case_number
+        within ".actions" do
+          click_on "Create CASA Case"
+        end
+
+        expect(page).to have_current_path(casa_cases_path, ignore_query: true)
+        expect(page).to have_content("Case number has already been taken")
+      end
+    end
+
+    context "contact types" do
+      let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
+      let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
+
+      it "are shown in groups" do
+        visit new_casa_case_path
+
+        expect(page).to have_content(contact_type.name)
+        expect(page).to have_content(contact_type_group.name)
+      end
+    end
+
+    context "when trying to assign a volunteer to a case" do
+      it "should not be able to assign volunteers" do
+        visit new_casa_case_path
+
+        expect(page).not_to have_content("Manage Volunteers")
+        expect(page).not_to have_css("#volunteer-assignment")
       end
     end
   end
 
-  context "when the case number already exists in the organization" do
-    let!(:casa_case) { create(:casa_case, case_number: case_number, casa_org: casa_org) }
-
-    it "does not create a new case" do
-      fill_in "Case number", with: case_number
-      within ".actions" do
-        click_on "Create CASA Case"
-      end
-
-      expect(page).to have_current_path(casa_cases_path, ignore_query: true)
-      expect(page).to have_content("Case number has already been taken")
+  context "when signed in as a supervisor" do
+    before do
+      sign_in supervisor
+      visit root_path
+      click_on "Cases"
     end
-  end
 
-  context "contact types" do
-    let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
-    let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
-
-    it "are shown in groups" do
-      visit new_casa_case_path
-
-      expect(page).to have_content(contact_type.name)
-      expect(page).to have_content(contact_type_group.name)
-    end
-  end
-
-  context "when trying to assign a volunteer to a case" do
-    it "should not be able to assign volunteers" do
-      visit new_casa_case_path
-
-      expect(page).not_to have_content("Manage Volunteers")
-      expect(page).not_to have_css("#volunteer-assignment")
+    it "should not provide option to make new case" do
+      expect(page).not_to have_button("New Case")
     end
   end
 end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -21,15 +21,4 @@ RSpec.describe "casa_cases/new", type: :view do
 
     it { is_expected.to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
   end
-
-  context "while signed in as supervisor" do
-    let(:user) { build_stubbed(:supervisor) }
-
-    before do
-      sign_in user
-    end
-
-    it { is_expected.not_to include(CGI.escapeHTML("Youth's Birth Month & Year")) }
-    it { is_expected.to have_selector("label", text: "2. Select All Contact Types") }
-  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4610

### What changed, and why?
* Updates policy to deny superivsors
* Updates request tests for Casa Case to capture the right behaviour
* Updates the view spec to remove supervisor specific tests
* Updates CasaCase system spec to test for "New" button visibility

### How will this affect user permissions?
- Volunteer permissions: no change
- Supervisor permissions: no longer allowed on `#new`, `#create` and `#destroy` on Casa Cases.
- Admin permissions: no change

### How is this tested? (please write tests!) 💖💪
System and request tests were updated to reflect these permissions changes. View spec had some tests removed as they were no longer applicable.

### Screenshots please :)
None required, UI previously reflected these limitations, but policy and tests did not.

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9