### PR TITLE
fix: typo causing test failure

### DIFF
--- a/spec/system/other_duties/new_spec.rb
+++ b/spec/system/other_duties/new_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "other_duties/new", type: :system do
       click_on "Submit"
 
       message = page.find("#other_duty_notes").native.attribute("validationMessage")
-      expect(message).to eq "Please fill out this field."
+      expect(message).to match(/Please fill (in|out) this field./)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What changed, and why?
Changes a typo in spec causing test failure to use regex matcher due to testing native validation message which can differ.

### How will this affect user permissions?
- Volunteer permissions: none
- Supervisor permissions: none
- Admin permissions: none

### How is this tested? (please write tests!) 💖💪
Changes `expect(message).to eq('Please fill out this field.')` to `expect(message).to match(/Please fill (in|out) this field.`

### Screenshots please :)
Previous: 
![image](https://user-images.githubusercontent.com/36272822/224559851-3cf51709-5470-4f91-820c-aaf4e9afbb21.png)

After:
![image](https://user-images.githubusercontent.com/36272822/224559893-2eea8a9f-ecb0-4825-b525-524563d447e1.png)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9