### PR TITLE
4652: Remove phone number for all casa admin password reset

### DIFF
--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -4,6 +4,8 @@ class AllCasaAdmin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, invite_for: 1.weeks
+
+  self.ignored_columns = ["phone_number"]
 end
 
 # == Schema Information

--- a/app/views/all_casa_admins/passwords/new.html.erb
+++ b/app/views/all_casa_admins/passwords/new.html.erb
@@ -1,0 +1,36 @@
+<div class="row">
+  <div class="col-lg-5 col-md-12 vertically-center">
+    <div class="container">
+      <div class="row">
+        <div class="offset-xl-2 col-xl-8 col-lg-12 col-sm-8 col-md-8">
+          <br>
+          <h2>Forgot your password?</h2>
+          <br>
+
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post}) do |f| %>
+            <%= render "/shared/error_messages", resource: resource %>
+
+            <h4>Please enter email or phone number to recieve reset instructions.</h4>
+
+            <div class="field form-group">
+              <%= f.label :email %><br>
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+            </div>
+
+            <div class="actions">
+              <%= f.submit "Send me reset password instructions", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+
+          <br>
+          <%= render "devise/shared/links" %>
+          <br>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-7 d-none d-lg-block">
+    <aside class="display-image"></aside>
+  </div>
+</div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Partially resolves #4652

### What changed, and why?
Removed the phone number validation from all_casa_admins reset password since they can't be texted
The `phone_number` column is ignored at the moment.

The following [PR](https://github.com/rubyforgood/casa/pull/4661) will be then merged with a migration that will delete the column safely.

### How will this affect user permissions?
- Volunteer permissions: x
- Supervisor permissions: x
- Admin permissions: x

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9