### PR TITLE
4652: Drop phone_number field from all_casa_admins table

### DIFF
--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -4,8 +4,6 @@ class AllCasaAdmin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, invite_for: 1.weeks
-
-  self.ignored_columns = ["phone_number"]
 end
 
 # == Schema Information
@@ -21,7 +19,6 @@ end
 #  invitation_sent_at     :datetime
 #  invitation_token       :string
 #  invited_by_type        :string
-#  phone_number           :string           default("")
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  created_at             :datetime         not null

--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -4,6 +4,8 @@ class AllCasaAdmin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, invite_for: 1.weeks
+
+  self.ignored_columns = ["phone_number"]
 end
 
 # == Schema Information

--- a/db/migrate/20230314201527_remove_phone_number_from_all_casa_admin_resource.rb
+++ b/db/migrate/20230314201527_remove_phone_number_from_all_casa_admin_resource.rb
@@ -1,0 +1,5 @@
+class RemovePhoneNumberFromAllCasaAdminResource < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :all_casa_admins, :phone_number }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_210146) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_201527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,7 +73,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_210146) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
-    t.string "phone_number", default: ""
     t.index ["email"], name: "index_all_casa_admins_on_email", unique: true
     t.index ["invitation_token"], name: "index_all_casa_admins_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_all_casa_admins_on_reset_password_token", unique: true


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4652

### What changed, and why?
Dropped the phone_number field safely from all_casa_admins table

### How will this affect user permissions?
- Volunteer permissions: x
- Supervisor permissions: x
- Admin permissions: x

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9