### PR TITLE
change scroll to auto

### DIFF
--- a/app/assets/stylesheets/pages/reimbursements.scss
+++ b/app/assets/stylesheets/pages/reimbursements.scss
@@ -2,7 +2,7 @@
   .select2-container {
     .select2-selection {
       max-height: 60px;
-      overflow-y: scroll;
+      overflow-y: auto;
       overflow-x: hidden;
     }
   }


### PR DESCRIPTION
### What changed, and why?
`auto` is better than `scroll` because on some browsers, `scroll` always shows the scrollbar even if you can't scroll