### PR TITLE
Fix two flaky specs

### DIFF
--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe CaseCourtReport, type: :model do
           end
 
           it "displays today's date formatted" do
-            expect(document_inspector.word_list_document_contains?(Date.today.strftime("%B %-d, %Y"))).to eq(true)
+            expect(document_inspector.word_list_document_contains?(Date.current.strftime("%B %-d, %Y"))).to eq(true)
           end
 
           it "displays the case hearing date date formatted" do
@@ -213,7 +213,7 @@ RSpec.describe CaseCourtReport, type: :model do
           end
 
           it "displays today's date formatted" do
-            expect(document_inspector.word_list_document_contains?(Date.today.strftime("%B %-d, %Y"))).to eq(true)
+            expect(document_inspector.word_list_document_contains?(Date.current.strftime("%B %-d, %Y"))).to eq(true)
           end
 
           it "displays the case hearing date formatted" do


### PR DESCRIPTION
### What changed, and why?
Used `Date.current` instead of `Date.today` to fix flaky specs. [Ref](https://thoughtbot.com/blog/its-about-time-zones#a-summary-of-do39s-and-don39ts-with-time-zones).

### Screenshots please :)

Before change:

<img width="1402" alt="Screen Shot 2023-03-18 at 5 12 14 PM" src="https://user-images.githubusercontent.com/1938665/226146643-db6f94a2-30f2-49c3-bb36-c28f3132a60e.png">

After change:

<img width="1368" alt="Screen Shot 2023-03-18 at 5 12 44 PM" src="https://user-images.githubusercontent.com/1938665/226146648-66dbe04b-61c2-44ab-b1dc-99fffbaca53f.png">
