### PR TITLE
unescape page body for string comparison

### DIFF
--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe "/volunteers", type: :request do
     it "shows correct supervisor options", :aggregate_failures do
       supervisors = create_list(:supervisor, 3, casa_org: organization)
 
-      page = request.parsed_body
-      supervisors.each { |supervisor| expect(page).to include(supervisor.display_name.html_safe) }
+      page = CGI.unescapeHTML(request.parsed_body)
+      supervisors.each { |supervisor| expect(page).to include(supervisor.display_name) }
     end
   end
 

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe "/volunteers", type: :request do
     it "shows correct supervisor options", :aggregate_failures do
       supervisors = create_list(:supervisor, 3, casa_org: organization)
 
-      page = CGI.unescapeHTML(request.parsed_body)
-      supervisors.each { |supervisor| expect(page).to include(supervisor.display_name) }
+      page = request.parsed_body
+      supervisors.each { |supervisor| expect(page).to include(CGI.escape_html(supervisor.display_name)) }
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4683

### What changed, and why?
The updated test was breaking when a supervisor name included an apostrophe as `request.parse_body` was returning an escaped string (Nicolas O'Kon -> Nicolas O&#39;Kon).
Updated the test to compare with escaped string.

### How will this affect user permissions?
- Volunteer permissions: na
- Supervisor permissions: na
- Admin permissions: na

### How is this tested? (please write tests!) 💖💪
na

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9