### PR TITLE
use created_at attribute in notifications partial

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -6,7 +6,7 @@
     <div class="ml-2 flex-grow-1">
       <div class="d-flex justify-content-between">
         <h5 class="mb-1"><%= notification.to_notification.title %></h5>
-        <small><%= time_ago_in_words(notification.updated_at) %> ago</small>
+        <small><%= time_ago_in_words(notification.created_at) %> ago</small>
       </div>
       <div class="my-1">
         <%= simple_format notification.to_notification.message %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4679

### What changed, and why?
Use the created_at attribute instead of updated_at in notifications partial/index page.


### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
No tests added here.
I think test coverage will be added by this ticket: https://github.com/rubyforgood/casa/issues/4681

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9