### PR TITLE
apply correct permissions to edit_organization btn in header partial

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -81,12 +81,14 @@
                   Messages
                 <% end %>
               </li>
-              <li>
-                <%= link_to edit_casa_org_path(current_organization) do %>
-                  <i class="lni lni-cogs mr-10"></i>
-                  Edit Organization
-                <% end %>
-              </li>
+              <% if policy(:application).modify_organization? %>
+                <li>
+                  <%= link_to edit_casa_org_path(current_organization) do %>
+                    <i class="lni lni-cogs mr-10"></i>
+                    Edit Organization
+                  <% end %>
+                </li>
+              <% end %>
               <li>
                 <%= link_to destroy_user_session_path do %>
                   <i class="lni lni-exit"></i>

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -8,6 +8,8 @@ end
 RSpec.describe "layout/header", type: :view do
   before do
     view.class.include PretenderContext
+
+    enable_pundit(view, user)
     allow(view).to receive(:true_user).and_return(user)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(1)
@@ -53,6 +55,14 @@ RSpec.describe "layout/header", type: :view do
       expect(rendered).to match "<strong>Role: Volunteer</strong>"
       expect(rendered).to match CGI.escapeHTML user.display_name
       expect(rendered).to match CGI.escapeHTML user.email
+    end
+
+    it "does not render unauthorized links" do
+      sign_in user
+
+      render partial: "layouts/header"
+
+      expect(rendered).to_not have_link("Edit Organization")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4700

### What changed, and why?
Volunteers were able to view the linkt to 'Edit Organization' in the header partial. 
Change was to display btn only if user had the correct permissions policy. 

### How will this affect user permissions?
- Volunteer permissions: Volunteers will no longer see 'Edit Organization' btn
- Supervisor permissions: NA
- Admin permissions:NA

### How is this tested? (please write tests!) 💖💪
added test to check for presence of link.

### Screenshots please :)
![image](https://user-images.githubusercontent.com/3953492/228303781-9e40e53d-329d-4b44-ae5d-25111865948e.png)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9