### PR TITLE
Add js dependency install step to mac setup doc

### DIFF
--- a/doc/MAC_SETUP.md
+++ b/doc/MAC_SETUP.md
@@ -91,6 +91,11 @@ Setup the database with:
 bin/rails db:setup
 ```
 
+Install javascript dependencies with:
+```bash
+yarn install
+```
+
 Compile assets with:
 
 ```bash


### PR DESCRIPTION
### What github issue is this PR for, if any?
N/A

### What changed, and why?
Adds `yarn install` step to mac setup doc. This was something I bumped into while getting up and running.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
N/A

### Feelings gif (optional)
N/A

### Feedback please? (optional)
N/A
