### PR TITLE
add default sorted_by attribute to filterrific for casa_contacts

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -119,6 +119,7 @@ class CaseContact < ApplicationRecord
   }
 
   filterrific(
+    default_filter_params: {sorted_by: "occurred_at_desc"},
     available_filters: [
       :sorted_by,
       :occurred_starting_at,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4699

### What changed, and why?
Added a default_filter_params to filterrific to sort case_contacts by occurred_at.

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Check order of contacts in Contacts index page

### Screenshots please :)
![image](https://user-images.githubusercontent.com/3953492/230224801-edfeee16-4d2a-42a6-a25e-f9a4c31e73c7.png)



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
