### PR TITLE
4079 remove language

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,5 +1,5 @@
 class LanguagesController < ApplicationController
-  before_action :set_language, only: %i[edit update remove_from_volunteer]
+  before_action :set_language, only: %i[edit update]
 
   def new
     authorize Language
@@ -31,16 +31,6 @@ class LanguagesController < ApplicationController
       else
         format.html { render :edit, status: :unprocessable_entity }
       end
-    end
-  end
-
-  def remove_from_volunteer
-    authorize @language
-    current_user.languages.delete @language
-    if current_user.save
-      redirect_to edit_users_path, notice: "#{@language.name} was removed from your languages list."
-    else
-      redirect_to edit_users_path, notice: "Error unable to remove #{@language.name} from your languages list!"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,8 @@ class UsersController < ApplicationController
 
   def remove_language
     set_language
+    raise ActiveRecord::RecordNotFound unless @language
+    
     current_user.languages.delete @language
     if current_user.save
       redirect_to edit_users_path, notice: "#{@language.name} was removed from your languages list."

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :get_user
   before_action :authorize_user_with_policy
   before_action :set_active_casa_admins
-  before_action :set_language, only: [:add_language]
+  before_action :set_language, only: %i[add_language remove_language]
   after_action :verify_authorized
   before_action :set_custom_error_heading, only: [:update_password]
   after_action :reset_custom_error_heading, only: [:update_password]
@@ -31,6 +31,16 @@ class UsersController < ApplicationController
       redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
     else
       redirect_to edit_users_path, alert: "Error unable to add #{@language.name} to your languages list!"
+    end
+  end
+
+  def remove_language
+    set_language
+    current_user.languages.delete @language
+    if current_user.save
+      redirect_to edit_users_path, notice: "#{@language.name} was removed from your languages list."
+    else
+      redirect_to edit_users_path, alert: "Unable to remove language."
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
   def remove_language
     set_language
     raise ActiveRecord::RecordNotFound unless @language
-    
+
     current_user.languages.delete @language
     if current_user.save
       redirect_to edit_users_path, notice: "#{@language.name} was removed from your languages list."

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,6 +3,10 @@ class UserPolicy < ApplicationPolicy
     admin_or_supervisor_same_org? || record == user
   end
 
+  def remove_language?
+    admin_or_supervisor_same_org? || record == user
+  end
+
   def edit?
     admin_or_supervisor_or_volunteer?
   end

--- a/app/views/users/_languages.html.erb
+++ b/app/views/users/_languages.html.erb
@@ -24,7 +24,7 @@
               <tr>
                 <td><%= lang.name %></td>
                 <td>
-                  <%= link_to "Delete", "/users/remove_language?language_id=#{lang.id}", class: "btn btn-danger",
+                  <%= link_to "Delete", remove_language_users_path(language_id: lang.id), class: "btn btn-danger",
   method: :delete %>
                 </td>
               </tr>

--- a/app/views/users/_languages.html.erb
+++ b/app/views/users/_languages.html.erb
@@ -24,7 +24,7 @@
               <tr>
                 <td><%= lang.name %></td>
                 <td>
-                  <%= link_to "Delete", language_remove_from_volunteer_path(lang), class: "btn btn-danger",
+                  <%= link_to "Delete", "/users/remove_language?language_id=#{lang.id}", class: "btn btn-danger",
   method: :delete %>
                 </td>
               </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
       patch :update
       patch "update_password"
       patch :add_language
+      delete :remove_language
     end
   end
   resources :languages, only: %i[new create edit update] do

--- a/spec/requests/languages_spec.rb
+++ b/spec/requests/languages_spec.rb
@@ -44,35 +44,5 @@ RSpec.describe LanguagesController, type: :request do
         end
       end
     end
-  end
-
-  context "when logged in as a volunteer" do
-    before do
-      sign_in volunteer
-      allow(controller).to receive(:current_user).and_return(volunteer)
-      allow(controller).to receive(:current_organization).and_return(organization)
-    end
-
-    describe "#remove_from_volunteer" do
-      context "when request params are valid" do
-        let!(:user_language) { create(:user_language, user_id: volunteer.id, language_id: random_lang.id) }
-
-        it "should remove a language from a volunteer languages list" do
-          delete language_remove_from_volunteer_path(random_lang)
-
-          expect(response.status).to eq 302
-          expect(response).to redirect_to(edit_users_path)
-          expect(flash[:notice]).to eq "#{random_lang.name} was removed from your languages list."
-          expect(volunteer.languages).not_to include random_lang
-        end
-      end
-      context "when request params are invalid" do
-        let!(:user_language) { create(:user_language, user_id: volunteer.id, language_id: random_lang.id) }
-
-        it "should raise error when Language do not exist" do
-          expect { delete language_remove_from_volunteer_path(800) }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-  end
+  end  
 end

--- a/spec/requests/languages_spec.rb
+++ b/spec/requests/languages_spec.rb
@@ -44,5 +44,5 @@ RSpec.describe LanguagesController, type: :request do
         end
       end
     end
-  end  
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -271,21 +271,19 @@ RSpec.describe "/users", type: :request do
         expect(flash[:notice]).to eq "#{language.name} was removed from your languages list."
         expect(volunteer.languages).not_to include language
       end
-    end   
-    
+    end
+
     context "when request params are invalid" do
       let(:language) { create(:language) }
       before(:each) do
         patch add_language_users_path(volunteer), params: {
           language_id: language.id
         }
-      end     
+      end
 
       it "should raise error when Language do not exist" do
         expect { delete remove_language_users_path(999) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
-     
-
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -252,4 +252,40 @@ RSpec.describe "/users", type: :request do
       end
     end
   end
+  describe "DELETE /remove_language" do
+    let(:volunteer) { create(:volunteer) }
+    before { sign_in volunteer }
+
+    context "when request params are valid" do
+      let(:language) { create(:language) }
+      before(:each) do
+        patch add_language_users_path(volunteer), params: {
+          language_id: language.id
+        }
+      end
+      it "should remove a language from a volunteer languages list" do
+        delete remove_language_users_path(language_id: language.id)
+
+        expect(response.status).to eq 302
+        expect(response).to redirect_to(edit_users_path)
+        expect(flash[:notice]).to eq "#{language.name} was removed from your languages list."
+        expect(volunteer.languages).not_to include language
+      end
+    end   
+    
+    context "when request params are invalid" do
+      let(:language) { create(:language) }
+      before(:each) do
+        patch add_language_users_path(volunteer), params: {
+          language_id: language.id
+        }
+      end     
+
+      it "should raise error when Language do not exist" do
+        expect { delete remove_language_users_path(999) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+     
+
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4079

### What changed, and why?
Move the Remove Language method from the Languages Controller to the User's Controller.
There are changes in
- languages_controller.rb (remove the remove_from_volunteer method)
- users_controller.rb (add remove_language method)
- user_policy.rb (add remove_language? method)
- routes.rb (add delete :remove_language inside user resources)
- _languages.html.rb (change the path to /users/remove_language?language_id=#{lang.id})

### How will this affect user permissions?
- Volunteer permissions: when removing language(s).

### How is this tested? (please write tests!) 💖💪
- Remove tests for remove_from_volunteer method from languages_spec.rb
- Add tests for remove_language method in users_spec.rb

### Screenshots please :)
- NA (I guess!)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
