### PR TITLE
health supports html and json pages

### DIFF
--- a/.github/workflows/after-deploy.yml
+++ b/.github/workflows/after-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     name: On Deploy
     steps:
       - name: After Deploy
-        uses: Firelemons/on-deploy@v2.2
+        uses: Firelemons/on-deploy@v2.2.1
         with:
           project_name: "CASA Volunteer Portal"
           done_column_card_limit: "16"

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -2,6 +2,12 @@ class HealthController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    render json: {latest_deploy_time: Health.instance.latest_deploy_time}
+    respond_to do |format|
+      format.html do
+        render :index
+      end
+
+      format.json { render json: {latest_deploy_time: Health.instance.latest_deploy_time} }
+    end
   end
 end

--- a/app/views/health/index.html.erb
+++ b/app/views/health/index.html.erb
@@ -1,0 +1,2 @@
+<div id="health">
+</div>

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,11 +1,25 @@
 require "rails_helper"
 
 RSpec.describe "Health", type: :request do
+  before do
+    Casa::Application.load_tasks
+    Rake::Task["after_party:store_deploy_time"].invoke
+  end
+
   describe "GET /health" do
     before do
-      Casa::Application.load_tasks
-      Rake::Task["after_party:store_deploy_time"].invoke
       get "/health"
+    end
+
+    it "renders an html file" do
+      # delete this test when there are more specific tests about the page
+      expect(response.header["Content-Type"]).to include("text/html")
+    end
+  end
+
+  describe "GET /health.json" do
+    before do
+      get "/health.json"
     end
 
     it "renders a json file" do


### PR DESCRIPTION
### What changed, and why?
Prepare `/health` for metrics
`/health` shows a blank html page
`/health.json` will show a json with the latest deploy date

### How is this tested? (please write tests!) 💖💪
manually
