### PR TITLE
4533 court order bugfix

### DIFF
--- a/app/javascript/__tests__/court_order_list.test.js
+++ b/app/javascript/__tests__/court_order_list.test.js
@@ -13,7 +13,7 @@ beforeEach(() => {
   // jest doesn't support window.location like a browser but URL is pretty close
   // see https://stackoverflow.com/a/60697570
   window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151')
-  document.body.innerHTML = '<div id="court-orders-list-container"></div>'
+  document.body.innerHTML = '<div id="court-orders-list-container" data-resource="casa_case"></div>'
 
   $(document).ready(() => {
     courtOrderListElement = $('#court-orders-list-container')
@@ -22,32 +22,12 @@ beforeEach(() => {
 })
 
 describe('CourtOrderList constructor', () => {
-  test('the constructor should be able to extract the rescource name from the url', (done) => {
+  test('the constructor should be able to extract the resource name from element', (done) => {
     $(document).ready(() => {
       try {
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151')
         courtOrderList = new CourtOrderList(courtOrderListElement)
 
         expect(courtOrderList.resourceName).toBe('casa_case')
-        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
-
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/new')
-        courtOrderList = new CourtOrderList(courtOrderListElement)
-
-        expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
-
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/3')
-        courtOrderList = new CourtOrderList(courtOrderListElement)
-
-        expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
-
-        window.location = new URL('https://casa-qa.herokuapp.com/casa_cases/CINA-2151/court_dates/3/edit')
-        courtOrderList = new CourtOrderList(courtOrderListElement)
-
-        expect(courtOrderList.resourceName).toBe('court_date')
-        expect(courtOrderList.casaCaseId).toBe('CINA-2151')
         done()
       } catch (error) {
         done(error)

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -142,8 +142,7 @@ $('document').ready(() => {
 
   if (courtOrdersListContainer.length) {
     let courtOrders = new CourtOrderList({
-      el: courtOrdersListContainer,
-      resource: 'casa_case'
+      el: courtOrdersListContainer
     })
 
     $('button#add-court-order-button').on('click', () => {

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -7,54 +7,6 @@
 import Swal from 'sweetalert2'
 
 const CourtOrderList = require('./court_order_list.js')
-let courtOrders
-
-function removeCourtOrderWithConfirmation () {
-  const text = 'Are you sure you want to remove this court order? Doing so will ' +
-    'delete all records of it unless it was included in a previous court report.'
-  Swal.fire({
-    icon: 'warning',
-    title: 'Delete court order?',
-    text,
-    showCloseButton: true,
-    showCancelButton: true,
-    focusConfirm: false,
-
-    confirmButtonColor: '#d33',
-    cancelButtonColor: '#39c',
-
-    confirmButtonText: 'Delete',
-    cancelButtonText: 'Go back'
-  }).then((result) => {
-    if (result.isConfirmed) {
-      removeCourtOrderAction($(this).parent())
-    }
-  })
-}
-
-function removeCourtOrderAction (order) {
-  const orderHiddenIdInput = order.next('input[type="hidden"]')
-
-  $.ajax({
-    url: `/case_court_orders/${orderHiddenIdInput.val()}`,
-    method: 'delete',
-    success: () => {
-      courtOrders.removeCourtOrder(order, orderHiddenIdInput)
-      Swal.fire({
-        icon: 'success',
-        text: 'Court order has been removed.',
-        showCloseButton: true
-      })
-    },
-    error: () => {
-      Swal.fire({
-        icon: 'error',
-        text: 'Something went wrong when attempting to delete this court order.',
-        showCloseButton: true
-      })
-    }
-  })
-}
 
 function copyOrdersFromCaseWithConfirmation () {
   const id = $(this).next().val()
@@ -189,7 +141,7 @@ $('document').ready(() => {
   })
 
   if (courtOrdersListContainer.length) {
-    courtOrders = new CourtOrderList({
+    let courtOrders = new CourtOrderList({
       el: courtOrdersListContainer,
       resource: 'casa_case'
     })
@@ -198,10 +150,9 @@ $('document').ready(() => {
       courtOrders.addCourtOrder()
     })
 
-    $('button.remove-court-order-button').on('click', removeCourtOrderWithConfirmation)
-
-    $('.court-orders textarea').each(function () {
-      $(this).height($(this).prop('scrollHeight'))
+    $('button.remove-court-order-button').on('click', (event) => {
+      const orderHTML = $(event.target).parent();
+      courtOrders.removeCourtOrderWithConfirmation(orderHTML)
     })
   }
 

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -141,9 +141,7 @@ $('document').ready(() => {
   })
 
   if (courtOrdersListContainer.length) {
-    let courtOrders = new CourtOrderList({
-      el: courtOrdersListContainer
-    })
+    let courtOrders = new CourtOrderList(courtOrdersListContainer)
 
     $('button#add-court-order-button').on('click', () => {
       courtOrders.addCourtOrder()

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -141,14 +141,14 @@ $('document').ready(() => {
   })
 
   if (courtOrdersListContainer.length) {
-    let courtOrders = new CourtOrderList(courtOrdersListContainer)
+    const courtOrders = new CourtOrderList(courtOrdersListContainer)
 
     $('button#add-court-order-button').on('click', () => {
       courtOrders.addCourtOrder()
     })
 
     $('button.remove-court-order-button').on('click', (event) => {
-      const orderHTML = $(event.target).parent();
+      const orderHTML = $(event.target).parent()
       courtOrders.removeCourtOrderWithConfirmation(orderHTML)
     })
   }

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -189,7 +189,10 @@ $('document').ready(() => {
   })
 
   if (courtOrdersListContainer.length) {
-    courtOrders = new CourtOrderList(courtOrdersListContainer)
+    courtOrders = new CourtOrderList({
+      el: courtOrdersListContainer,
+      resource: 'casa_case'
+    })
 
     $('button#add-court-order-button').on('click', () => {
       courtOrders.addCourtOrder()

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -11,11 +11,11 @@ function replaceNumberWithDecrement (str, num) {
 
 module.exports = class CourtOrderList {
   // @param {object} courtOrdersWidget The div containing the list of court orders
-  constructor (courtOrdersWidget) {
+  constructor (options) {
     // The following regex is intended for pathnames such as "/casa_cases/CINA-19-1004/court_dates/new"
     const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(\w+-+\d+)(\/(([a-z_]+)s))?/).filter(match => match !== undefined)
-    this.courtOrdersWidget = courtOrdersWidget
-    this.resourceName = urlMatch.length > 3 ? urlMatch[5] : urlMatch[1]
+    this.courtOrdersWidget = options.el
+    this.resourceName = options.resource
     // The casaCaseId will be something like "CINA-19-1004"
     this.casaCaseId = urlMatch[2]
   }

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -80,4 +80,51 @@ module.exports = class CourtOrderList {
       courtOrderSiblingId.attr('name', replaceNumberWithDecrement(courtOrderSiblingId.attr('name'), originalSiblingIndex + index + 1))
     })
   }
+
+  removeCourtOrderWithConfirmation (order) {
+    const text = 'Are you sure you want to remove this court order? Doing so will ' +
+      'delete all records of it unless it was included in a previous court report.'
+    Swal.fire({
+      icon: 'warning',
+      title: 'Delete court order?',
+      text,
+      showCloseButton: true,
+      showCancelButton: true,
+      focusConfirm: false,
+  
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#39c',
+  
+      confirmButtonText: 'Delete',
+      cancelButtonText: 'Go back'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        this.removeCourtOrderAction(order)
+      }
+    })
+  }
+
+  removeCourtOrderAction (order) {
+    const orderHiddenIdInput = order.next('input[type="hidden"]')
+  
+    $.ajax({
+      url: `/case_court_orders/${orderHiddenIdInput.val()}`,
+      method: 'delete',
+      success: () => {
+        this.removeCourtOrder(order, orderHiddenIdInput)
+        Swal.fire({
+          icon: 'success',
+          text: 'Court order has been removed.',
+          showCloseButton: true
+        })
+      },
+      error: () => {
+        Swal.fire({
+          icon: 'error',
+          text: 'Something went wrong when attempting to delete this court order.',
+          showCloseButton: true
+        })
+      }
+    })
+  }
 }

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -10,21 +10,19 @@ function replaceNumberWithDecrement (str, num) {
 }
 
 module.exports = class CourtOrderList {
-  // @param {object} Options for court order list instance
-  // @param {object} Options.el The HTMLElement to contain the list items
-  constructor (options) {
+  // @param {object} The HTMLElement to contain the list items
+  constructor (courtOrdersWidget) {
     // The following regex is intended for pathnames such as "/casa_cases/CINA-19-1004/court_dates/new"
     const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(\w+-+\d+)(\/(([a-z_]+)s))?/).filter(match => match !== undefined)
-    this.courtOrdersWidget = options.el
-    this.resourceName = this.courtOrdersWidget.data('resource')
+    this.courtOrdersWidget = courtOrdersWidget
+    this.resourceName = this.courtOrdersWidget[0].dataset.resource
     // The casaCaseId will be something like "CINA-19-1004"
     this.casaCaseId = urlMatch[2]
   }
 
   // Adds a row containing a text field to write the court order and a dropdown to specify the order status
   addCourtOrder () {
-    const courtOrdersWidget = this.courtOrdersWidget
-    const index = courtOrdersWidget.children('.court-order-entry').length
+    const index = this.courtOrdersWidget.children('.court-order-entry').length
     const resourceName = this.resourceName
     const courtOrderRow = $(`\
     <div class="court-order-entry">\
@@ -47,7 +45,7 @@ module.exports = class CourtOrderList {
         value="${this.casaCaseId}">
     </div>`)
 
-    courtOrdersWidget.append(courtOrderRow)
+    this.courtOrdersWidget.append(courtOrderRow)
     courtOrderRow.children('textarea').trigger('focus')
   }
 

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -10,12 +10,13 @@ function replaceNumberWithDecrement (str, num) {
 }
 
 module.exports = class CourtOrderList {
-  // @param {object} courtOrdersWidget The div containing the list of court orders
+  // @param {object} Options for court order list instance
+  // @param {object} Options.el The HTMLElement to contain the list items
   constructor (options) {
     // The following regex is intended for pathnames such as "/casa_cases/CINA-19-1004/court_dates/new"
     const urlMatch = window.location.pathname.match(/^\/([a-z_]+)s\/(\w+-+\d+)(\/(([a-z_]+)s))?/).filter(match => match !== undefined)
     this.courtOrdersWidget = options.el
-    this.resourceName = options.resource
+    this.resourceName = this.courtOrdersWidget.data('resource')
     // The casaCaseId will be something like "CINA-19-1004"
     this.casaCaseId = urlMatch[2]
   }

--- a/app/javascript/src/court_order_list.js
+++ b/app/javascript/src/court_order_list.js
@@ -1,3 +1,5 @@
+import Swal from 'sweetalert2'
+
 // Replaces a number in a string with its value -1
 //   @param  {string} str The string containing the number to replace
 //   @param  {number} num The number to replace
@@ -90,10 +92,10 @@ module.exports = class CourtOrderList {
       showCloseButton: true,
       showCancelButton: true,
       focusConfirm: false,
-  
+
       confirmButtonColor: '#d33',
       cancelButtonColor: '#39c',
-  
+
       confirmButtonText: 'Delete',
       cancelButtonText: 'Go back'
     }).then((result) => {
@@ -105,7 +107,7 @@ module.exports = class CourtOrderList {
 
   removeCourtOrderAction (order) {
     const orderHiddenIdInput = order.next('input[type="hidden"]')
-  
+
     $.ajax({
       url: `/case_court_orders/${orderHiddenIdInput.val()}`,
       method: 'delete',

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -84,7 +84,8 @@
         <div class="field form-group court-orders">
           <% if policy(casa_case).update_court_orders? %>
             <%= render partial: "shared/court_order_list",
-                       locals: {casa_case: @casa_case, siblings_casa_cases: @siblings_casa_cases, form: form} %>
+                       locals: {casa_case: @casa_case, siblings_casa_cases: @siblings_casa_cases, form: form,
+                                resource: 'casa_case'} %>
           <% else %>
             <%= form.label :case_court_orders, "Court Orders" %>
             <div id="court-orders-list-container">

--- a/app/views/court_dates/_form.html.erb
+++ b/app/views/court_dates/_form.html.erb
@@ -65,7 +65,7 @@
       </div>
       <div class="field form-group court-orders">
         <%= render partial: "shared/court_order_list",
-        locals: {casa_case: casa_case, siblings_casa_cases: nil, form: form} %>
+        locals: {casa_case: casa_case, siblings_casa_cases: nil, form: form, resource: 'court_date'} %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_court_order_list.erb
+++ b/app/views/shared/_court_order_list.erb
@@ -1,5 +1,5 @@
 <%= form.label :case_court_orders, "Court Orders - Please check that you didn't enter any youth names" %>
-<div id="court-orders-list-container">
+<div id="court-orders-list-container" data-resource="<%= resource %>">
   <% if siblings_casa_cases && siblings_casa_cases.count >= 1 %>
     <div class="mb-4 mt-2">
       <% siblings_casa_cases_options = siblings_casa_cases.map { |scc| [scc.case_number, scc.id] } %>

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -222,6 +222,7 @@ class DbPopulator
       random_court_order_count.times do
         CaseCourtOrder.create!(
           casa_case_id: new_casa_case.id,
+          court_date: _new_court_date,
           text: order_choices.sample(random: rng),
           implementation_status: CaseCourtOrder::IMPLEMENTATION_STATUSES.values.sample(random: rng)
         )

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -199,7 +199,7 @@ class DbPopulator
         court_report_status: court_report_submitted ? :submitted : :not_submitted,
         birth_month_year_youth: birth_month_year_youth
       )
-      _new_court_date = CourtDate.find_or_create_by!(
+      new_court_date = CourtDate.find_or_create_by!(
         casa_case: new_casa_case,
         court_report_due_date: court_date + 1.month,
         date: court_date
@@ -222,7 +222,7 @@ class DbPopulator
       random_court_order_count.times do
         CaseCourtOrder.create!(
           casa_case_id: new_casa_case.id,
-          court_date: _new_court_date,
+          court_date: new_court_date,
           text: order_choices.sample(random: rng),
           implementation_status: CaseCourtOrder::IMPLEMENTATION_STATUSES.values.sample(random: rng)
         )


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/4533 (bugfix)

### What changed, and why?
Currently regex is used to glean resource type from the URL. This regex fails when the resource is not a `casa_case`, and is a `court_date` instead, causing mismatched [nested attributes](https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html), and resulting in inability to edit court orders from court dates view.

This PR sets the resource in court order list erb, where `CourtOrderList` js will find it on page load. Also does a tiny bit of refactoring and moves some responsibilities out of casa_case.js and into court_order_list.js because it feels like they belong there.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
Court order list element spec updated to check resource via element instead of URL.

### Screenshots please :)
https://user-images.githubusercontent.com/51330983/232187008-9e30539b-2cba-4806-be80-00e003b75a55.mp4

### Feelings gif (optional)
![Tappa tappa tappa](https://media.giphy.com/media/Hcw7rjsIsHcmk/giphy.gif)
