### PR TITLE
2959 email preview

### DIFF
--- a/config/initializers/sent_email_event.rb
+++ b/config/initializers/sent_email_event.rb
@@ -1,5 +1,7 @@
 ActiveSupport::Notifications.subscribe "process.action_mailer" do |*args|
   data = args.extract_options!
+  next if data[:mailer] == "DebugPreviewMailer"
+
   user = data[:args][0]
   if user&.role != "All Casa Admin"
     SentEmail.create(

--- a/lib/mailers/debug_preview_mailer.rb
+++ b/lib/mailers/debug_preview_mailer.rb
@@ -1,5 +1,5 @@
 class DebugPreviewMailer < ActionMailer::Base
-  def invalid_user(_user, role)
+  def invalid_user(role)
     mail(
       from: "reply@example.com",
       to: "missing_#{role}@example.com",

--- a/lib/mailers/debug_preview_mailer.rb
+++ b/lib/mailers/debug_preview_mailer.rb
@@ -1,0 +1,10 @@
+class DebugPreviewMailer < ActionMailer::Base
+  def invalid_user(_user, role)
+    mail(
+      from: "reply@example.com",
+      to: "missing_#{role}@example.com",
+      subject: "invalid_user_id",
+      body: "User does not exist or is not a #{role}"
+    )
+  end
+end

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -1,14 +1,9 @@
+require_relative "../debug_preview_mailer"
 class CasaAdminMailerPreview < ActionMailer::Preview
   def account_setup
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
     if casa_admin.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_casa_admin@example.com",
-        subject: "No Casa Admin has been found",
-        body: "This is a debugging message letting you know no Casa admin has been found"
-      )
+      DebugPreviewMailer.invalid_user(casa_admin, "casa_admin")
     else
       CasaAdminMailer.account_setup(casa_admin)
     end
@@ -17,13 +12,7 @@ class CasaAdminMailerPreview < ActionMailer::Preview
   def deactivation
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
     if casa_admin.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_casa_admin@example.com",
-        subject: "No Casa Admin has been found",
-        body: "This is a debugging message letting you know no Casa admin has been found"
-      )
+      DebugPreviewMailer.invalid_user(casa_admin, "casa_admin")
     else
       CasaAdminMailer.deactivation(casa_admin)
     end

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -3,7 +3,7 @@ class CasaAdminMailerPreview < ActionMailer::Preview
   def account_setup
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
     if casa_admin.nil?
-      DebugPreviewMailer.invalid_user(casa_admin, "casa_admin")
+      DebugPreviewMailer.invalid_user("casa_admin")
     else
       CasaAdminMailer.account_setup(casa_admin)
     end
@@ -12,7 +12,7 @@ class CasaAdminMailerPreview < ActionMailer::Preview
   def deactivation
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
     if casa_admin.nil?
-      DebugPreviewMailer.invalid_user(casa_admin, "casa_admin")
+      DebugPreviewMailer.invalid_user("casa_admin")
     else
       CasaAdminMailer.deactivation(casa_admin)
     end

--- a/lib/mailers/previews/casa_admin_mailer_preview.rb
+++ b/lib/mailers/previews/casa_admin_mailer_preview.rb
@@ -1,11 +1,31 @@
 class CasaAdminMailerPreview < ActionMailer::Preview
   def account_setup
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
-    CasaAdminMailer.account_setup(casa_admin)
+    if casa_admin.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "missing_casa_admin@example.com",
+        subject: "No Casa Admin has been found",
+        body: "This is a debugging message letting you know no Casa admin has been found"
+      )
+    else
+      CasaAdminMailer.account_setup(casa_admin)
+    end
   end
 
   def deactivation
     casa_admin = params.has_key?(:id) ? CasaAdmin.find_by(id: params[:id]) : CasaAdmin.last
-    CasaAdminMailer.deactivation(casa_admin)
+    if casa_admin.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "missing_casa_admin@example.com",
+        subject: "No Casa Admin has been found",
+        body: "This is a debugging message letting you know no Casa admin has been found"
+      )
+    else
+      CasaAdminMailer.deactivation(casa_admin)
+    end
   end
 end

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -7,7 +7,7 @@ class DeviseMailerPreview < ActionMailer::Preview
       ActiveSupport::Notifications.unsubscribe("process.action_mailer")
       ActionMailer::Base.mail(
         from: "no-rply@example.com",
-        to: "user_not_found@example.com",
+        to: "missing_user@example.com",
         subject: "This user not found",
         body: "Sorry, this user was not found"
       )

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -1,16 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/devise_mailer
 # :nocov:
+require_relative "../debug_preview_mailer"
 class DeviseMailerPreview < ActionMailer::Preview
   def reset_password_instructions
     user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
     if user.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_user@example.com",
-        subject: "This user not found",
-        body: "Sorry, this user was not found"
-      )
+      DebugPreviewMailer.invalid_user(user, "user")
     else
       Devise::Mailer.reset_password_instructions(user, "faketoken")
     end

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -3,7 +3,17 @@
 class DeviseMailerPreview < ActionMailer::Preview
   def reset_password_instructions
     user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
-    Devise::Mailer.reset_password_instructions(user, "faketoken")
+    if user.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "user_not_found@example.com",
+        subject: "This user not found",
+        body: "Sorry, this user was not found"
+      )
+    else
+      Devise::Mailer.reset_password_instructions(user, "faketoken")
+    end
   end
 
   def invitation_instructions_as_all_casa_admin

--- a/lib/mailers/previews/devise_mailer_preview.rb
+++ b/lib/mailers/previews/devise_mailer_preview.rb
@@ -5,7 +5,7 @@ class DeviseMailerPreview < ActionMailer::Preview
   def reset_password_instructions
     user = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.last
     if user.nil?
-      DebugPreviewMailer.invalid_user(user, "user")
+      DebugPreviewMailer.invalid_user("user")
     else
       Devise::Mailer.reset_password_instructions(user, "faketoken")
     end

--- a/lib/mailers/previews/supervisor_mailer_preview.rb
+++ b/lib/mailers/previews/supervisor_mailer_preview.rb
@@ -1,16 +1,12 @@
 # Preview all emails at http://localhost:3000/rails/mailers/supervisor_mailer
 # :nocov:
+require_relative "../debug_preview_mailer"
+
 class SupervisorMailerPreview < ActionMailer::Preview
   def account_setup
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
     if supervisor.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_supervisor@example.com",
-        subject: "No Supervisor has been found",
-        body: "This is a debugging message letting you know no supervisor has been found"
-      )
+      DebugPreviewMailer.invalid_user(supervisor, "supervisor")
     else
       SupervisorMailer.account_setup(supervisor)
     end
@@ -19,13 +15,7 @@ class SupervisorMailerPreview < ActionMailer::Preview
   def weekly_digest
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
     if supervisor.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_supervisor@example.com",
-        subject: "No Supervisor has been found",
-        body: "This is a debugging message letting you know no supervisor has been found"
-      )
+      DebugPreviewMailer.invalid_user(supervisor, "supervisor")
     else
       SupervisorMailer.account_setup(supervisor)
     end

--- a/lib/mailers/previews/supervisor_mailer_preview.rb
+++ b/lib/mailers/previews/supervisor_mailer_preview.rb
@@ -6,7 +6,7 @@ class SupervisorMailerPreview < ActionMailer::Preview
   def account_setup
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
     if supervisor.nil?
-      DebugPreviewMailer.invalid_user(supervisor, "supervisor")
+      DebugPreviewMailer.invalid_user("supervisor")
     else
       SupervisorMailer.account_setup(supervisor)
     end
@@ -15,7 +15,7 @@ class SupervisorMailerPreview < ActionMailer::Preview
   def weekly_digest
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
     if supervisor.nil?
-      DebugPreviewMailer.invalid_user(supervisor, "supervisor")
+      DebugPreviewMailer.invalid_user("supervisor")
     else
       SupervisorMailer.account_setup(supervisor)
     end

--- a/lib/mailers/previews/supervisor_mailer_preview.rb
+++ b/lib/mailers/previews/supervisor_mailer_preview.rb
@@ -3,12 +3,32 @@
 class SupervisorMailerPreview < ActionMailer::Preview
   def account_setup
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
-    SupervisorMailer.account_setup(supervisor)
+    if supervisor.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "missing_supervisor@example.com",
+        subject: "No Supervisor has been found",
+        body: "This is a debugging message letting you know no supervisor has been found"
+      )
+    else
+      SupervisorMailer.account_setup(supervisor)
+    end
   end
 
   def weekly_digest
     supervisor = params.has_key?(:id) ? Supervisor.find_by(id: params[:id]) : Supervisor.last
-    SupervisorMailer.weekly_digest(supervisor)
+    if supervisor.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "missing_supervisor@example.com",
+        subject: "No Supervisor has been found",
+        body: "This is a debugging message letting you know no supervisor has been found"
+      )
+    else
+      SupervisorMailer.account_setup(supervisor)
+    end
   end
 end
 # :nocov:

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -2,26 +2,55 @@
 # :nocov:
 class VolunteerMailerPreview < ActionMailer::Preview
   def account_setup
-    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
-    VolunteerMailer.account_setup(user)
+    volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
+    if volunteer.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "not_a_volunteer@example.com",
+        subject: "No Volunteer has been found",
+        body: "This is a debugging message letting you know no volunteer has been found"
+      )
+    else
+      VolunteerMailer.account_setup(volunteer)
+    end
   end
 
   def court_report_reminder
-    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
-    VolunteerMailer.court_report_reminder(user, Date.today)
+    volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
+    if volunteer.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "not_a_volunteer@example.com",
+        subject: "No Volunteer has been found",
+        body: "This is a debugging message letting you know no volunteer has been found"
+      )
+    else
+      VolunteerMailer.court_report_reminder(volunteer, Date.today)
+    end
   end
 
   def case_contacts_reminder
-    user = params.has_key?(:id) ? get_user(params[:id]) : Volunteer.last
-    user.supervisor = params.has_key?(:id) ? User.find_by(id: params[:id]) : User.first
-    VolunteerMailer.case_contacts_reminder(user, true)
+    volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
+    if volunteer.nil?
+      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
+      ActionMailer::Base.mail(
+        from: "no-rply@example.com",
+        to: "not_a_volunteer@example.com",
+        subject: "No Volunteer has been found",
+        body: "This is a debugging message letting you know no volunteer has been found"
+      )
+    else
+      VolunteerMailer.court_report_reminder(volunteer, Date.today)
+    end
   end
 
-  private
+  #   private
 
-  def get_user(user_id)
-    user = User.find_by(id: user_id)
-    user&.volunteer? ? user : Volunteer.last
-  end
+  #   def get_user(user_id)
+  #     user = User.find_by(id: user_id)
+  #     user&.volunteer? ? user : Volunteer.last
+  #   end
 end
 # :nocov:

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -7,7 +7,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
       ActiveSupport::Notifications.unsubscribe("process.action_mailer")
       ActionMailer::Base.mail(
         from: "no-rply@example.com",
-        to: "not_a_volunteer@example.com",
+        to: "missing_volunteer@example.com",
         subject: "No Volunteer has been found",
         body: "This is a debugging message letting you know no volunteer has been found"
       )
@@ -22,7 +22,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
       ActiveSupport::Notifications.unsubscribe("process.action_mailer")
       ActionMailer::Base.mail(
         from: "no-rply@example.com",
-        to: "not_a_volunteer@example.com",
+        to: "missing_volunteer@example.com",
         subject: "No Volunteer has been found",
         body: "This is a debugging message letting you know no volunteer has been found"
       )
@@ -37,12 +37,12 @@ class VolunteerMailerPreview < ActionMailer::Preview
       ActiveSupport::Notifications.unsubscribe("process.action_mailer")
       ActionMailer::Base.mail(
         from: "no-rply@example.com",
-        to: "not_a_volunteer@example.com",
+        to: "missing_volunteer@example.com",
         subject: "No Volunteer has been found",
         body: "This is a debugging message letting you know no volunteer has been found"
       )
     else
-      VolunteerMailer.court_report_reminder(volunteer, Date.today)
+      VolunteerMailer.court_report_reminder(volunteer, true)
     end
   end
 

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -5,7 +5,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
   def account_setup
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
+      DebugPreviewMailer.invalid_user("volunteer")
     else
       VolunteerMailer.account_setup(volunteer)
     end
@@ -14,7 +14,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
   def court_report_reminder
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
+      DebugPreviewMailer.invalid_user("volunteer")
     else
       VolunteerMailer.court_report_reminder(volunteer, Date.today)
     end
@@ -23,7 +23,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
   def case_contacts_reminder
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
+      DebugPreviewMailer.invalid_user("volunteer")
     else
       VolunteerMailer.court_report_reminder(volunteer, true)
     end

--- a/lib/mailers/previews/volunteer_mailer_preview.rb
+++ b/lib/mailers/previews/volunteer_mailer_preview.rb
@@ -1,16 +1,11 @@
 # Preview all emails at http://localhost:3000/rails/mailers/volunteer_mailer
 # :nocov:
+require_relative "../debug_preview_mailer"
 class VolunteerMailerPreview < ActionMailer::Preview
   def account_setup
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_volunteer@example.com",
-        subject: "No Volunteer has been found",
-        body: "This is a debugging message letting you know no volunteer has been found"
-      )
+      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
     else
       VolunteerMailer.account_setup(volunteer)
     end
@@ -19,13 +14,7 @@ class VolunteerMailerPreview < ActionMailer::Preview
   def court_report_reminder
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_volunteer@example.com",
-        subject: "No Volunteer has been found",
-        body: "This is a debugging message letting you know no volunteer has been found"
-      )
+      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
     else
       VolunteerMailer.court_report_reminder(volunteer, Date.today)
     end
@@ -34,23 +23,10 @@ class VolunteerMailerPreview < ActionMailer::Preview
   def case_contacts_reminder
     volunteer = params.has_key?(:id) ? Volunteer.find_by(id: params[:id]) : Volunteer.last
     if volunteer.nil?
-      ActiveSupport::Notifications.unsubscribe("process.action_mailer")
-      ActionMailer::Base.mail(
-        from: "no-rply@example.com",
-        to: "missing_volunteer@example.com",
-        subject: "No Volunteer has been found",
-        body: "This is a debugging message letting you know no volunteer has been found"
-      )
+      DebugPreviewMailer.invalid_user(volunteer, "volunteer")
     else
       VolunteerMailer.court_report_reminder(volunteer, true)
     end
   end
-
-  #   private
-
-  #   def get_user(user_id)
-  #     user = User.find_by(id: user_id)
-  #     user&.volunteer? ? user : Volunteer.last
-  #   end
 end
 # :nocov:

--- a/spec/mailers/previews/casa_admin_mailer_preview_spec.rb
+++ b/spec/mailers/previews/casa_admin_mailer_preview_spec.rb
@@ -2,18 +2,51 @@ require "rails_helper"
 require File.join(Rails.root, "lib", "mailers", "previews", "casa_admin_mailer_preview")
 
 RSpec.describe CasaAdminMailerPreview do
-  let(:subject) { described_class.new }
   let!(:casa_admin) { create(:casa_admin) }
-
+  
   describe "#account_setup" do
-    let(:message) { subject.account_setup }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.account_setup }
 
-    it { expect(message.to).to eq [casa_admin.email] }
+      it { expect(email.to).to eq [casa_admin.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: casa_admin.id) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq [casa_admin.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq ["missing_casa_admin@example.com"] }
+    end
   end
 
   describe "#deactivation" do
-    let(:message) { subject.deactivation }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.deactivation }
 
-    it { expect(message.to).to eq [casa_admin.email] }
+      it { expect(email.to).to eq [casa_admin.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: casa_admin.id) }
+      let(:email) { preview.deactivation }
+
+      it { expect(email.to).to eq [casa_admin.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.deactivation }
+
+      it { expect(email.to).to eq ["missing_casa_admin@example.com"] }
+    end
   end
 end

--- a/spec/mailers/previews/casa_admin_mailer_preview_spec.rb
+++ b/spec/mailers/previews/casa_admin_mailer_preview_spec.rb
@@ -3,7 +3,7 @@ require File.join(Rails.root, "lib", "mailers", "previews", "casa_admin_mailer_p
 
 RSpec.describe CasaAdminMailerPreview do
   let!(:casa_admin) { create(:casa_admin) }
-  
+
   describe "#account_setup" do
     context "When no ID is passed" do
       let(:preview) { described_class.new }
@@ -11,16 +11,16 @@ RSpec.describe CasaAdminMailerPreview do
 
       it { expect(email.to).to eq [casa_admin.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: casa_admin.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: casa_admin.id) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq [casa_admin.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq ["missing_casa_admin@example.com"] }
@@ -34,16 +34,16 @@ RSpec.describe CasaAdminMailerPreview do
 
       it { expect(email.to).to eq [casa_admin.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: casa_admin.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: casa_admin.id) }
       let(:email) { preview.deactivation }
 
       it { expect(email.to).to eq [casa_admin.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.deactivation }
 
       it { expect(email.to).to eq ["missing_casa_admin@example.com"] }

--- a/spec/mailers/previews/devise_mailer_preview_spec.rb
+++ b/spec/mailers/previews/devise_mailer_preview_spec.rb
@@ -6,9 +6,26 @@ RSpec.describe DeviseMailerPreview do
   let!(:user) { create(:user) }
 
   describe "#reset_password_instructions" do
-    let(:message) { subject.reset_password_instructions }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.reset_password_instructions }
 
-    it { expect(message.to).to eq [user.email] }
+      it { expect(email.to).to eq [user.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: user.id) }
+      let(:email) { preview.reset_password_instructions }
+
+      it { expect(email.to).to eq [user.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.reset_password_instructions }
+
+      it { expect(email.to).to eq ["missing_user@example.com"] }
+    end
   end
 
   describe "#invitation_instructions_as_all_casa_admin" do

--- a/spec/mailers/previews/devise_mailer_preview_spec.rb
+++ b/spec/mailers/previews/devise_mailer_preview_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe DeviseMailerPreview do
 
       it { expect(email.to).to eq [user.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: user.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: user.id) }
       let(:email) { preview.reset_password_instructions }
 
       it { expect(email.to).to eq [user.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.reset_password_instructions }
 
       it { expect(email.to).to eq ["missing_user@example.com"] }

--- a/spec/mailers/previews/supervisor_mailer_preview_spec.rb
+++ b/spec/mailers/previews/supervisor_mailer_preview_spec.rb
@@ -2,18 +2,51 @@ require "rails_helper"
 require File.join(Rails.root, "lib", "mailers", "previews", "supervisor_mailer_preview")
 
 RSpec.describe SupervisorMailerPreview do
-  let(:subject) { described_class.new }
   let!(:supervisor) { create(:supervisor) }
 
   describe "#account_setup" do
-    let(:message) { subject.account_setup }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.account_setup }
 
-    it { expect(message.to).to eq [supervisor.email] }
+      it { expect(email.to).to eq [supervisor.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: supervisor.id) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq [supervisor.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq ["missing_supervisor@example.com"] }
+    end
   end
 
   describe "#weekly_digest" do
-    let(:message) { subject.weekly_digest }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.weekly_digest }
 
-    it { expect(message.to).to eq [supervisor.email] }
+      it { expect(email.to).to eq [supervisor.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: supervisor.id) }
+      let(:email) { preview.weekly_digest }
+      
+      it { expect(email.to).to eq [supervisor.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: 3500) }
+      let(:email) { preview.weekly_digest }
+
+      it { expect(email.to).to eq ["missing_supervisor@example.com"] }
+    end
   end
 end

--- a/spec/mailers/previews/supervisor_mailer_preview_spec.rb
+++ b/spec/mailers/previews/supervisor_mailer_preview_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe SupervisorMailerPreview do
 
       it { expect(email.to).to eq [supervisor.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: supervisor.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: supervisor.id) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq [supervisor.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq ["missing_supervisor@example.com"] }
@@ -34,16 +34,16 @@ RSpec.describe SupervisorMailerPreview do
 
       it { expect(email.to).to eq [supervisor.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: supervisor.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: supervisor.id) }
       let(:email) { preview.weekly_digest }
-      
+
       it { expect(email.to).to eq [supervisor.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: 3500) }
+      let(:preview) { described_class.new(id: 3500) }
       let(:email) { preview.weekly_digest }
 
       it { expect(email.to).to eq ["missing_supervisor@example.com"] }

--- a/spec/mailers/previews/volunteer_mailer_preview_spec.rb
+++ b/spec/mailers/previews/volunteer_mailer_preview_spec.rb
@@ -2,60 +2,73 @@ require "rails_helper"
 require File.join(Rails.root, "lib", "mailers", "previews", "volunteer_mailer_preview")
 
 RSpec.describe VolunteerMailerPreview do
-  let(:subject) { described_class.new }
   let!(:volunteer) { create(:volunteer) }
-  let!(:supervisor) { create(:supervisor) }
-  let!(:admin) { create(:casa_admin) }
 
   describe "#account_setup" do
-    let(:message) { subject.account_setup }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.account_setup }
 
-    it { expect(message.to).to eq [volunteer.email] }
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: volunteer.id) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.account_setup }
+
+      it { expect(email.to).to eq ["missing_volunteer@example.com"] }
+    end
   end
 
   describe "#court_report_reminder" do
-    let(:message) { subject.court_report_reminder }
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.court_report_reminder }
 
-    it { expect(message.to).to eq [volunteer.email] }
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: volunteer.id) }
+      let(:email) { preview.court_report_reminder }
+
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.court_report_reminder }
+
+      it { expect(email.to).to eq ["missing_volunteer@example.com"] }
+    end
   end
+describe "#case_contacts_reminder" do
+    context "When no ID is passed" do
+      let(:preview) { described_class.new }
+      let(:email) { preview.case_contacts_reminder }
 
-  describe "#case_contacts_reminder" do
-    let(:message) { subject.case_contacts_reminder }
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+     
+     context "When passed ID is valid" do
+      let(:preview) {described_class.new(id: volunteer.id) }
+      let(:email) { preview.case_contacts_reminder }
 
-    it { expect(message.to).to eq [volunteer.email] }
-  end
+      it { expect(email.to).to eq [volunteer.email] }
+    end
+ 
+    context "When passed ID is invalid" do
+      let(:preview) {described_class.new(id: -1) }
+      let(:email) { preview.case_contacts_reminder }
 
-  describe "#get_user" do
-    context "uses a volunteer record" do
-      context "when no id is provided" do
-        let(:message) { subject.account_setup }
-
-        it { expect(message.to).to eq [volunteer.email] }
-      end
-
-      context "when a volunteer id is provided" do
-        let(:params) { {id: volunteer.id} }
-        let(:subject) { described_class.new params }
-        let(:message) { subject.account_setup }
-
-        it { expect(message.to).to eq [volunteer.email] }
-      end
-
-      context "when a supervisor id is provided" do
-        let(:params) { {id: supervisor.id} }
-        let(:subject) { described_class.new params }
-        let(:message) { subject.account_setup }
-
-        it { expect(message.to).to eq [volunteer.email] }
-      end
-
-      context "when an admin id is provided" do
-        let(:params) { {id: admin.id} }
-        let(:subject) { described_class.new params }
-        let(:message) { subject.account_setup }
-
-        it { expect(message.to).to eq [volunteer.email] }
-      end
+      it { expect(email.to).to eq ["missing_volunteer@example.com"] }
     end
   end
 end

--- a/spec/mailers/previews/volunteer_mailer_preview_spec.rb
+++ b/spec/mailers/previews/volunteer_mailer_preview_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe VolunteerMailerPreview do
 
       it { expect(email.to).to eq [volunteer.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: volunteer.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: volunteer.id) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq [volunteer.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.account_setup }
 
       it { expect(email.to).to eq ["missing_volunteer@example.com"] }
@@ -34,38 +34,38 @@ RSpec.describe VolunteerMailerPreview do
 
       it { expect(email.to).to eq [volunteer.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: volunteer.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: volunteer.id) }
       let(:email) { preview.court_report_reminder }
 
       it { expect(email.to).to eq [volunteer.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.court_report_reminder }
 
       it { expect(email.to).to eq ["missing_volunteer@example.com"] }
     end
   end
-describe "#case_contacts_reminder" do
+  describe "#case_contacts_reminder" do
     context "When no ID is passed" do
       let(:preview) { described_class.new }
       let(:email) { preview.case_contacts_reminder }
 
       it { expect(email.to).to eq [volunteer.email] }
     end
-     
-     context "When passed ID is valid" do
-      let(:preview) {described_class.new(id: volunteer.id) }
+
+    context "When passed ID is valid" do
+      let(:preview) { described_class.new(id: volunteer.id) }
       let(:email) { preview.case_contacts_reminder }
 
       it { expect(email.to).to eq [volunteer.email] }
     end
- 
+
     context "When passed ID is invalid" do
-      let(:preview) {described_class.new(id: -1) }
+      let(:preview) { described_class.new(id: -1) }
       let(:email) { preview.case_contacts_reminder }
 
       it { expect(email.to).to eq ["missing_volunteer@example.com"] }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #2959 

### What changed, and why?
1. We created a DebugPreviewMailer class that displays information to the developer in the event that an invalid user_id gets passed during email previews. We believe that this may be the best approach as the mailer previews do not have access to methods like `render` or `redirect_to` to display information. Email previews expect to render an email so we created a debugging mail preview to render in the case of an invalid id.
2. This solution will not throw errors when an invalid id is passed to a preview mailer.
3. Code added to the `sent_email_event` initializer to skip the logging and `SentEmail` creation when the DebugPreviewMailer is called. This avoids errors that would normally occur when a nil user is provided. 

### How will this affect user permissions?
NA

### How is this tested? (please write tests!) 💖💪
Modified existing MailerPreview tests to include scenarios where no id is passed, a valid id is passed or an invalid id is passed.
When an invalid id is passed, the tests check that our DebugPreviewMailer solution is working as expected.

### Screenshots please :)

<img width="616" alt="Screenshot 2023-04-17 at 2 40 37 PM" src="https://user-images.githubusercontent.com/74928397/232617156-6c18bb86-07c8-4c97-99a5-771eb577f3fc.png">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
