### PR TITLE
Remove link to new theme from Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,6 @@ ex:
 
 _Login Details:_  
 [Link to QA site](https://casa-qa.herokuapp.com/)  
-[Link to new theme site](https://casa-new-theme.herokuapp.com/languages/new)  
 
 Login Emails: 
 - volunteer1@example.com  view site as a volunteer

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,7 +18,6 @@ You can paste images on the clipboard here
 
 _Login Details:_  
 [Link to QA site](https://casa-qa.herokuapp.com/)  
-[Link to new theme site](https://casa-new-theme.herokuapp.com/languages/new)  
 
 Login Emails: 
 - volunteer1@example.com  view site as a volunteer


### PR DESCRIPTION
The new theme has been merged and deployed to production, so we no longer need a link to the temp app (which no longer exists anyway).