### PR TITLE
4757 Remove all reimbursement functionality when opted out

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -126,11 +126,15 @@ class ApplicationPolicy
   end
 
   def see_mileage_rate?
-    is_admin? # && matches_casa_org? # TODO do this *in* is_admin - what might that break?
+    is_admin? && reimbursement_enabled? # && matches_casa_org? # TODO do this *in* is_admin - what might that break?
   end
 
   def matches_casa_org?
     @record&.casa_org == @user&.casa_org && !@record.casa_org.nil?
+  end
+
+  def reimbursement_enabled?
+    current_organization&.show_driving_reimbursement
   end
 
   def current_organization

--- a/app/policies/reimbursement_policy.rb
+++ b/app/policies/reimbursement_policy.rb
@@ -7,14 +7,14 @@ class ReimbursementPolicy < ApplicationPolicy
   end
 
   def index?
-    is_admin?
+    is_admin? && reimbursement_enabled?
   end
 
   def datatable?
-    is_admin?
+    is_admin? && reimbursement_enabled?
   end
 
   def change_complete_status?
-    index?
+    index? && reimbursement_enabled?
   end
 end

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -115,7 +115,7 @@
               </li>
             <% end %>
 
-            <% if policy(:reimbursement).index? %>
+            <% if policy(:reimbursement).index? && current_organization.show_driving_reimbursement %>
               <li>
                 <%= link_to reimbursements_path, class: "#{active_class(reimbursements_path)}" do %>
                   <i class="lni lni-money-location mr-10"></i>
@@ -142,7 +142,7 @@
               </li>
             <% end %>
 
-            <% if policy(:application).see_mileage_rate? %>
+            <% if policy(:application).see_mileage_rate? && current_organization.show_driving_reimbursement %>
               <li>
                 <%= link_to mileage_rates_path, class: "#{active_class(mileage_rates_path)}" do %>
                   <i class="lni lni-car mr-10"></i>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -115,7 +115,7 @@
               </li>
             <% end %>
 
-            <% if policy(:reimbursement).index? && current_organization.show_driving_reimbursement %>
+            <% if policy(:reimbursement).index? %>
               <li>
                 <%= link_to reimbursements_path, class: "#{active_class(reimbursements_path)}" do %>
                   <i class="lni lni-money-location mr-10"></i>
@@ -142,7 +142,7 @@
               </li>
             <% end %>
 
-            <% if policy(:application).see_mileage_rate? && current_organization.show_driving_reimbursement %>
+            <% if policy(:application).see_mileage_rate? %>
               <li>
                 <%= link_to mileage_rates_path, class: "#{active_class(mileage_rates_path)}" do %>
                   <i class="lni lni-car mr-10"></i>

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -76,5 +76,15 @@ RSpec.describe ApplicationPolicy do
     it "allow casa_admins for same org" do
       is_expected.to permit(casa_admin)
     end
+
+    context "when org reimbursement is disabled" do
+      before do
+        casa_org.show_driving_reimbursement = false
+      end
+
+      it "does not allow casa_admins" do
+        is_expected.not_to permit(casa_admin)
+      end
+    end
   end
 end

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -6,18 +6,36 @@ RSpec.describe ReimbursementPolicy do
   let(:casa_admin) { build_stubbed(:casa_admin) }
   let(:volunteer) { build_stubbed(:volunteer) }
   let(:supervisor) { build_stubbed(:supervisor) }
+  let(:organization) { build(:casa_org, users: [volunteer, supervisor, casa_admin]) }
 
-  permissions :index?, :change_complete_status? do
-    it { is_expected.to permit(casa_admin) }
-    it { is_expected.to_not permit(supervisor) }
-    it { is_expected.to_not permit(volunteer) }
+  context "when org reimbursement is enabled" do
+    permissions :index?, :change_complete_status? do
+      it { is_expected.to permit(casa_admin) }
+      it { is_expected.to_not permit(supervisor) }
+      it { is_expected.to_not permit(volunteer) }
+    end
+
+    permissions :datatable? do
+      it { is_expected.to permit(casa_admin) }
+      it { is_expected.to_not permit(supervisor) }
+      it { is_expected.to_not permit(volunteer) }
+    end
   end
 
-  permissions :datatable? do
-    it { is_expected.to permit(casa_admin) }
-    it { is_expected.to_not permit(supervisor) }
-    it { is_expected.to_not permit(volunteer) }
+  context "when org reimbursement is disabled" do
+    before do
+      organization.show_driving_reimbursement = false
+    end
+
+    permissions :index?, :change_complete_status? do
+      it { is_expected.to_not permit(casa_admin) }
+    end
+
+    permissions :datatable? do
+      it { is_expected.to_not permit(casa_admin) }
+    end
   end
+
 
   describe "ReimbursementPolicy::Scope #resolve" do
     subject { described_class::Scope.new(user, scope).resolve }

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe ReimbursementPolicy do
     end
   end
 
-
   describe "ReimbursementPolicy::Scope #resolve" do
     subject { described_class::Scope.new(user, scope).resolve }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4757 

### What changed, and why?
When an org's `show_driving_reimbursement` field is `false`, hides reimbursement navigation from sidebar and updates policies to prevent manual navigation to reimbursement related routes:
* `/reimbursements`
* `/mileage_rates`


### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: prevents admins from seeing and accessing routes mentioned above.

### How is this tested? (please write tests!) 💖💪
`ApplicationPolicy` and `ReimbursementPolicy` test cases now include tests for disabled state.

### Screenshots please :)
What the sidebar looks like for admins when their org's reimbursement is disabled:
<img width="384" alt="Screenshot 2023-05-05 at 2 42 56 PM" src="https://user-images.githubusercontent.com/51330983/236573578-e503ce3f-0d28-4de8-98d6-7ae375485b7d.png">
