### PR TITLE
Issue #4772 improve design of password reset screen

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,7 +10,7 @@
                 <%= f.hidden_field :reset_password_token %>
 
                 <div class="input-style-1">
-                  <%= f.label :password, "New password" %><br>
+                  <%= f.label :password, "New password" %>
                   <% if @minimum_password_length %>
                     <em>(<%= @minimum_password_length %> characters minimum)</em><br>
                   <% end %>
@@ -22,9 +22,9 @@
                     required: true,
                     minlength: @minimum_password_length %>
                 </div>
-                
+
                 <div class="input-style-1">
-                  <%= f.label :password_confirmation, "Confirm new password" %><br>
+                  <%= f.label :password_confirmation, "Confirm new password" %>
                   <%= f.password_field :password_confirmation,
                     autocomplete: "new-password",
                     class: "password-confirmation",
@@ -32,7 +32,7 @@
                     required: true,
                     minlength: @minimum_password_length %>
                 </div>
-
+                
                 <div class="actions my-2">
                   <%= button_tag(
                     type: "submit",

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,47 +1,55 @@
-<div class="password-box">
-  <h2 class="mt-2">Change your password</h2>
+<div class="row">
+  <div class="col-lg-9 col-md-12 vertically-center">
+    <div class="container">
+      <div class="row">
+        <div class="offset-xl-2 col-xl-8 col-lg-12 col-sm-8 col-md-8 pb-4">
+          <h2 class="my-4">Change your password</h2>
 
-  <div class="row">
-    <div class="col-sm-6">
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :put}) do |f| %>
-        <%= render "/shared/error_messages", resource: resource %>
-        <%= f.hidden_field :reset_password_token %>
+              <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :put}) do |f| %>
+                <%= render "/shared/error_messages", resource: resource %>
+                <%= f.hidden_field :reset_password_token %>
 
-        <div class="input-style-1">
-          <%= f.label :password, "New password" %><br>
-          <% if @minimum_password_length %>
-            <em>(<%= @minimum_password_length %> characters minimum)</em><br>
-          <% end %>
-          <%= f.password_field :password,
-            autofocus: true,
-            autocomplete: "new-password",
-            class: "password-new",
-            placeholder: "New Password",
-            required: true,
-            minlength: @minimum_password_length %>
+                <div class="input-style-1">
+                  <%= f.label :password, "New password" %><br>
+                  <% if @minimum_password_length %>
+                    <em>(<%= @minimum_password_length %> characters minimum)</em><br>
+                  <% end %>
+                  <%= f.password_field :password,
+                    autofocus: true,
+                    autocomplete: "new-password",
+                    class: "password-new",
+                    placeholder: "New Password",
+                    required: true,
+                    minlength: @minimum_password_length %>
+                </div>
+                
+                <div class="input-style-1">
+                  <%= f.label :password_confirmation, "Confirm new password" %><br>
+                  <%= f.password_field :password_confirmation,
+                    autocomplete: "new-password",
+                    class: "password-confirmation",
+                    placeholder: "Confirm Password",
+                    required: true,
+                    minlength: @minimum_password_length %>
+                </div>
+
+                <div class="actions my-2">
+                  <%= button_tag(
+                    type: "submit",
+                    class: "main-btn primary-btn btn-hover btn-sm submit-password"
+                  ) do %>
+                    <i class="lni lni-save mr-10"></i>Change my password
+                  <% end %>
+                </div>
+              <% end %>
+
+          <%= render "devise/shared/links" %>
         </div>
-
-        <div class="input-style-1">
-          <%= f.label :password_confirmation, "Confirm new password" %><br>
-          <%= f.password_field :password_confirmation,
-            autocomplete: "new-password",
-            class: "password-confirmation",
-            placeholder: "Confirm Password",
-            required: true,
-            minlength: @minimum_password_length %>
-        </div>
-
-        <div class="actions my-2">
-          <%= button_tag(
-            type: "submit",
-            class: "main-btn primary-btn btn-hover btn-sm submit-password"
-          ) do %>
-            <i class="lni lni-save mr-10"></i>Change my password
-          <% end %>
-        </div>
-      <% end %>
+      </div>
     </div>
   </div>
 
-  <%= render "devise/shared/links" %>
+  <div class="col-lg-7 d-none d-lg-block">
+    <aside class="display-image"></aside>
+  </div>
 </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -12,7 +12,7 @@
                 <div class="input-style-1">
                   <%= f.label :password, "New password" %>
                   <% if @minimum_password_length %>
-                    <em>(<%= @minimum_password_length %> characters minimum)</em>
+                    <em >(<%= @minimum_password_length %> characters minimum)</em>
                   <% end %>
                   <%= f.password_field :password,
                     autofocus: true,

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -32,7 +32,7 @@
                     required: true,
                     minlength: @minimum_password_length %>
                 </div>
-                
+
                 <div class="actions my-2">
                   <%= button_tag(
                     type: "submit",

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -12,7 +12,7 @@
                 <div class="input-style-1">
                   <%= f.label :password, "New password" %>
                   <% if @minimum_password_length %>
-                    <em >(<%= @minimum_password_length %> characters minimum)</em>
+                    <em>(<%= @minimum_password_length %> characters minimum)</em>
                   <% end %>
                   <%= f.password_field :password,
                     autofocus: true,

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -12,7 +12,7 @@
                 <div class="input-style-1">
                   <%= f.label :password, "New password" %>
                   <% if @minimum_password_length %>
-                    <em>(<%= @minimum_password_length %> characters minimum)</em><br>
+                    <em>(<%= @minimum_password_length %> characters minimum)</em>
                   <% end %>
                   <%= f.password_field :password,
                     autofocus: true,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4772 

### What changed, and why?
Styling in file `edit.html.erb` was changed to match `new.html.erb`. Added some <div> tags for this purpose. Also removed <br> tags since they created space between labels and inputs, breaking up UX flow and readability.

### How will this affect user permissions?
No effect.

### How is this tested? (please write tests!) 💖💪
Ran linter and tested with `bundle exec rspec`. There were some failing tests, but none for files `new.html.erb` or `edit.html.erb`. If any additional tests need to be written, happy to do so and please message @ElBrewster.

### Screenshots please :)
##Styling of edit password view changed to:
<img width="514" alt="Screen Shot 2023-05-05 at 5 42 36 PM" src="https://user-images.githubusercontent.com/113723085/236589164-bd5be153-3452-437a-9951-e9258657bdcf.png">

<img width="1632" alt="change pass" src="https://user-images.githubusercontent.com/113723085/236589332-aefa3ab7-20b0-4fcd-abb8-aea852a25a3c.png">


##To mirror styling of new password view (aka forgot password):
<img width="516" alt="forgot" src="https://user-images.githubusercontent.com/113723085/236589264-ba8a8834-e4da-420a-9d8f-2a273f8cfb78.png">

<img width="1629" alt="forgot pass" src="https://user-images.githubusercontent.com/113723085/236589327-9cab0f81-e283-49e7-9772-238b6454b80f.png">

### Feelings gif (optional)
`![Happy Friday!](https://giphy.com/gifs/ComedianHollyLogan-friday-tgif-holly-logan-U36MU9uqkIJ0L9gpR2)`

