### PR TITLE
Elhalvers/4771 edit profile timestamp

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -6,26 +6,32 @@ class UserDecorator < Draper::Decorator
   end
 
   def formatted_created_at
-    I18n.l(object.created_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.created_at, format: format_key, default: nil)
   end
 
   def formatted_updated_at
-    I18n.l(object.updated_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.updated_at, format: format_key, default: nil)
   end
 
   def formatted_current_sign_in_at
-    I18n.l(object.current_sign_in_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.current_sign_in_at, format: format_key, default: nil)
   end
 
   def formatted_invitation_accepted_at
-    I18n.l(object.invitation_accepted_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.invitation_accepted_at, format: format_key, default: nil)
   end
 
   def formatted_reset_password_sent_at
-    I18n.l(object.reset_password_sent_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.reset_password_sent_at, format: format_key, default: nil)
   end
 
   def formatted_invitation_sent_at
-    I18n.l(object.invitation_sent_at, format: :full, default: nil)
+    format_key = context[:format] || :full
+    I18n.l(object.invitation_sent_at, format: format_key, default: nil)
   end
 end

--- a/app/views/users/_edit_profile.erb
+++ b/app/views/users/_edit_profile.erb
@@ -1,0 +1,31 @@
+<div class="mb-1">
+  <strong class="text-dark">CASA organization </strong>
+  <%= resource&.casa_org&.name %>
+</div>
+<div class="mb-1">
+  <strong class="text-dark">Added to system </strong>
+  <%= resource&.decorate(context: {format: :edit_profile})&.formatted_created_at %>
+</div>
+<div class="mb-1">
+  <strong class="text-dark">Invitation email sent </strong>
+  <%= resource&.decorate(context: {format: :edit_profile})&.formatted_invitation_sent_at || "never" %>
+</div>
+<div class="mb-1">
+  <strong class="text-dark">Last logged in </strong>
+  <%= resource&.decorate(context: {format: :edit_profile})&.formatted_current_sign_in_at || "never" %>
+</div>
+<div class="mb-1">
+  <strong class="text-dark">Invitation accepted </strong>
+  <%= resource&.decorate(context: {format: :edit_profile})&.formatted_invitation_accepted_at || "never" %>
+</div>
+<div class="mb-1">
+  <strong class="text-dark">Password reset last sent </strong>
+  <%= resource&.decorate(context: {format: :edit_profile})&.formatted_reset_password_sent_at || "never" %>
+</div>
+
+<% if resource.is_a?(Volunteer) %>
+  <div class="mb-1">
+    <strong class="text-dark">Learning Hours This Year</strong>
+    <%= resource.learning_hours_spent_in_one_year %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -38,7 +38,7 @@
 
             <%= form.hidden_field :casa_org_id, value: current_user.casa_org_id %>
 
-            <%= render "/shared/invite_login", resource: current_user %>
+            <%= render "edit_profile", resource: current_user %>
 
             <br>
           <div class="actions" id="accordionExample">

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,5 @@ module Casa
     config.active_storage.variant_processor = :mini_magick
     config.active_storage.content_types_to_serve_as_binary.delete("image/svg+xml")
     config.serve_static_assets = true
-    config.time_zone = "Eastern Time (US & Canada)"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module Casa
     config.active_storage.variant_processor = :mini_magick
     config.active_storage.content_types_to_serve_as_binary.delete("image/svg+xml")
     config.serve_static_assets = true
+    config.time_zone = "Eastern Time (US & Canada)"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
       full: "%B %-d, %Y"
       youth_date_of_birth: "%B %Y"
       short_date: "%-m/%d"
-      edit_profile: "%B %d, %Y %l:%M %p %Z"
+      edit_profile: "%B %d, %Y at %l:%M %p"
   notifications:
     emancipation_checklist_reminder_notification:
       title: "Emancipation Checklist Reminder"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
       full: "%B %-d, %Y"
       youth_date_of_birth: "%B %Y"
       short_date: "%-m/%d"
+      edit_profile: "%B %d, %Y %l:%M %p %Z"
   notifications:
     emancipation_checklist_reminder_notification:
       title: "Emancipation Checklist Reminder"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
       full: "%B %-d, %Y"
       youth_date_of_birth: "%B %Y"
       short_date: "%-m/%d"
-      edit_profile: "%B %d, %Y at %l:%M %p"
+      edit_profile: "%B %d, %Y at%l:%M %p"
   notifications:
     emancipation_checklist_reminder_notification:
       title: "Emancipation Checklist Reminder"

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -18,4 +18,109 @@ RSpec.describe UserDecorator do
       end
     end
   end
+
+  let(:user) { create(:user) }
+  let(:decorated_user) { user.decorate }
+
+  describe "#formatted_created_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.created_at, format: :full, default: nil)
+        expect(decorated_user.formatted_created_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.created_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_created_at).to eq expected_date
+      end
+  end
+
+  describe "#formatted_updated_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.updated_at, format: :full, default: nil)
+        expect(decorated_user.formatted_updated_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.updated_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_updated_at).to eq expected_date
+      end
+  end
+
+  describe "#formatted_current_sign_in_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.current_sign_in_at, format: :full, default: nil)
+        expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.current_sign_in_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
+      end
+  end
+
+  describe "#formatted_invitation_accepted_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.invitation_accepted_at, format: :full, default: nil)
+        expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.invitation_accepted_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
+      end
+  end
+
+  describe "#formatted_reset_password_sent_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.reset_password_sent_at, format: :full, default: nil)
+        expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.reset_password_sent_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
+      end
+  end
+
+  describe "#formatted_invitation_sent_at" do
+    context "when using the 'default'format string"
+      it "returns the correctly formatted date" do
+        user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.invitation_sent_at, format: :full, default: nil)
+        expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
+      end
+
+    context "when passing in the custom :edit_profile format string"
+      it "returns the correctly formatted date" do
+        user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+        expected_date = I18n.l(user.invitation_sent_at, format: :edit_profile, default: nil)
+        decorated_user.context[:format] = :edit_profile
+        expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
+      end
+  end
 end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -24,103 +24,103 @@ RSpec.describe UserDecorator do
 
   describe "#formatted_created_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.created_at, format: :full, default: nil)
-        expect(decorated_user.formatted_created_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.created_at, format: :full, default: nil)
+      expect(decorated_user.formatted_created_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.created_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_created_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(created_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.created_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_created_at).to eq expected_date
+    end
   end
 
   describe "#formatted_updated_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.updated_at, format: :full, default: nil)
-        expect(decorated_user.formatted_updated_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.updated_at, format: :full, default: nil)
+      expect(decorated_user.formatted_updated_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.updated_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_updated_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(updated_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.updated_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_updated_at).to eq expected_date
+    end
   end
 
   describe "#formatted_current_sign_in_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.current_sign_in_at, format: :full, default: nil)
-        expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.current_sign_in_at, format: :full, default: nil)
+      expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.current_sign_in_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(current_sign_in_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.current_sign_in_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_current_sign_in_at).to eq expected_date
+    end
   end
 
   describe "#formatted_invitation_accepted_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.invitation_accepted_at, format: :full, default: nil)
-        expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.invitation_accepted_at, format: :full, default: nil)
+      expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.invitation_accepted_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(invitation_accepted_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.invitation_accepted_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_invitation_accepted_at).to eq expected_date
+    end
   end
 
   describe "#formatted_reset_password_sent_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.reset_password_sent_at, format: :full, default: nil)
-        expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.reset_password_sent_at, format: :full, default: nil)
+      expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.reset_password_sent_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(reset_password_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.reset_password_sent_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_reset_password_sent_at).to eq expected_date
+    end
   end
 
   describe "#formatted_invitation_sent_at" do
     context "when using the 'default'format string"
-      it "returns the correctly formatted date" do
-        user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.invitation_sent_at, format: :full, default: nil)
-        expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.invitation_sent_at, format: :full, default: nil)
+      expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
+    end
 
     context "when passing in the custom :edit_profile format string"
-      it "returns the correctly formatted date" do
-        user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
-        expected_date = I18n.l(user.invitation_sent_at, format: :edit_profile, default: nil)
-        decorated_user.context[:format] = :edit_profile
-        expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
-      end
+    it "returns the correctly formatted date" do
+      user.update(invitation_sent_at: Time.new(2023, 5, 1, 12, 0, 0))
+      expected_date = I18n.l(user.invitation_sent_at, format: :edit_profile, default: nil)
+      decorated_user.context[:format] = :edit_profile
+      expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
+    end
   end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe "users/edit", type: :system do
     end
 
     it "displays current sign in date" do
-      formatted_current_sign_in_at = I18n.l(volunteer.current_sign_in_at, format: :full, default: nil)
-      formatted_last_sign_in_at = I18n.l(volunteer.last_sign_in_at, format: :full, default: nil)
+      formatted_current_sign_in_at = I18n.l(volunteer.current_sign_in_at, format: :edit_profile, default: nil)
+      formatted_last_sign_in_at = I18n.l(volunteer.last_sign_in_at, format: :edit_profile, default: nil)
       expect(page).to have_text("Last logged in #{formatted_current_sign_in_at}")
       expect(page).not_to have_text("Last logged in #{formatted_last_sign_in_at}")
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4771 

### What changed, and why?
Modify list of dates for "Added to System", "Last logged in", etc. to be actual timestamps (with a timezone) rather than just a date. This change was requested by CASA stakeholders during a stakeholder meeting to provide more information to supervisors and admins primarily.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Modify existing 'User' decorator test to include tests for new custom date format string.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
