### PR TITLE
Issue 4810 - add Org Pre

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -32,11 +32,6 @@
       <%= form.label :court_report_template, "Court report template" %>
       <%= form.file_field :court_report_template, class: "form-control" %>
     </div>
-    <div class="form-check checkbox-style mb-20">
-      <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
-      <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label' %>
-    </div>
-    <hr>
     <div class="input-style-1">
       <%= form.label :twilio_phone_number, "Twilio Phone Number" %>
       <%= form.text_field :twilio_phone_number, class: "form-control" %>
@@ -52,6 +47,12 @@
     <div class="input-style-1">
       <%= form.label :twilio_api_key_secret, "Twilio API Key Secret" %>
       <%= form.text_field :twilio_api_key_secret, class: "form-control" %>
+    </div>
+    <hr>
+    <h3 class="mb-2">Organization Features</h3>
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
+      <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label mb-2' %>
     </div>
     <div class="actions mb-10">
       <%= button_tag(


### PR DESCRIPTION
… heading and associated checkbox to just above submit button

### What github issue is this PR for, if any?
Resolves #4810 

### What changed, and why?
Added Organization Features heading for the new on/off reimbursement checkbox, and moved both elements down to just above the submit button, with a thematic break in place.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions: affects org/edit route

### How is this tested? (please write tests!) 💖💪
None required

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/95949082/f6637fd2-0ee9-437d-8047-61581e0fce38)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
