### PR TITLE
Validations/4773 phone numbers

### DIFF
--- a/app/helpers/phone_number_helper.rb
+++ b/app/helpers/phone_number_helper.rb
@@ -1,23 +1,27 @@
 module PhoneNumberHelper
-  VALID_PHONE_NUMBER_LENGTH = 12
+  VALID_PHONE_NUMBER_LENGTHS = [10, 12]
   VALID_COUNTRY_CODE = "+1"
 
   def valid_phone_number(number)
-    message = "must be 12 digits including country code (+1)"
+    message = "must be 10 digits or 12 digits including country code (+1)"
 
     if number.nil? || number.empty?
       return true, nil
     end
 
-    if number.length != VALID_PHONE_NUMBER_LENGTH
+    if !VALID_PHONE_NUMBER_LENGTHS.include?(number.length)
       return false, message
     end
 
-    country_code = number[0..1]
-    phone_number = number[2..number.length]
+    if number.length == 12
+      country_code = number[0..1]
+      phone_number = number[2..number.length]
 
-    if country_code != VALID_COUNTRY_CODE
-      return false, message
+      if country_code != VALID_COUNTRY_CODE
+        return false, message
+      end
+    else
+      phone_number = number
     end
 
     if !phone_number.scan(/\D/).empty?

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -4,6 +4,7 @@ class CasaOrg < ApplicationRecord
 
   before_create :set_slug
   before_update :sanitize_svg
+  before_save :normalize_phone_number
 
   validates :name, presence: true, uniqueness: true
   validates_with CasaOrgValidator
@@ -101,6 +102,12 @@ class CasaOrg < ApplicationRecord
       client.messages.list(limit: 1)
     rescue Twilio::REST::RestError
       errors.add(:base, "Your Twilio credentials are incorrect, kindly check and try again.")
+    end
+  end
+
+  def normalize_phone_number
+    if self.twilio_phone_number&.length == 10
+      self.twilio_phone_number = "+1#{self.twilio_phone_number}"
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
 
   before_update :record_previous_email
   after_create :skip_email_confirmation_upon_creation
+  before_save :normalize_phone_number
 
   validates_with UserValidator
 
@@ -170,6 +171,14 @@ class User < ApplicationRecord
 
   def after_confirmation
     send_email_changed_notification
+  end
+
+  private
+
+  def normalize_phone_number
+    if self.phone_number&.length == 10
+      self.phone_number = "+1#{self.phone_number}"
+    end
   end
 end
 # == Schema Information

--- a/spec/helpers/phone_number_helper_spec.rb
+++ b/spec/helpers/phone_number_helper_spec.rb
@@ -5,8 +5,20 @@ RSpec.describe PhoneNumberHelper do
     include PhoneNumberHelper
 
     context "valid phone number" do
+      it 'with empty string' do
+        valid, error = valid_phone_number("")
+        expect(valid).to be(true)
+        expect(error).to be_nil
+      end
+
       it "with correct country code and 12 digits" do
         valid, error = valid_phone_number("+12223334444")
+        expect(valid).to be(true)
+        expect(error).to be_nil
+      end
+
+      it "with 10 digits" do
+        valid, error = valid_phone_number("2223334444")
         expect(valid).to be(true)
         expect(error).to be_nil
       end
@@ -16,19 +28,19 @@ RSpec.describe PhoneNumberHelper do
       it "with incorrect country code" do
         valid, error = valid_phone_number("+22223334444")
         expect(valid).to be(false)
-        expect(error).to have_text("must be 12 digits including country code (+1)")
+        expect(error).to have_text("must be 10 digits or 12 digits including country code (+1)")
       end
 
       it "with short phone number" do
         valid, error = valid_phone_number("+122")
         expect(valid).to be(false)
-        expect(error).to have_text("must be 12 digits including country code (+1)")
+        expect(error).to have_text("must be 10 digits or 12 digits including country code (+1)")
       end
 
       it "with long phone number" do
         valid, error = valid_phone_number("+12223334444555")
         expect(valid).to be(false)
-        expect(error).to have_text("must be 12 digits including country code (+1)")
+        expect(error).to have_text("must be 10 digits or 12 digits including country code (+1)")
       end
     end
   end

--- a/spec/lib/importers/supervisor_importer_spec.rb
+++ b/spec/lib/importers/supervisor_importer_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe SupervisorImporter do
 
       expect(alert[:type]).to eq(:error)
       expect(alert[:message]).to eq("Not all rows were imported.")
-      expect(alert[:exported_rows]).to include("Phone number must be 12 digits including country code (+1)")
+      expect(alert[:exported_rows]).to include("Phone number must be 10 digits or 12 digits including country code (+1)")
     end
   end
 

--- a/spec/lib/importers/volunteer_importer_spec.rb
+++ b/spec/lib/importers/volunteer_importer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe VolunteerImporter do
 
       expect(alert[:type]).to eq(:error)
       expect(alert[:message]).to eq("Not all rows were imported.")
-      expect(alert[:exported_rows]).to include("Phone number must be 12 digits including country code (+1)")
+      expect(alert[:exported_rows]).to include("Phone number must be 10 digits or 12 digits including country code (+1)")
     end
   end
 end

--- a/spec/support/shared_examples/shows_error_for_invalid_phone_numbers.rb
+++ b/spec/support/shared_examples/shows_error_for_invalid_phone_numbers.rb
@@ -2,24 +2,24 @@ shared_examples_for "shows error for invalid phone numbers" do
   it "shows error message for phone number < 12 digits" do
     role == "admin" || role == "user" ? fill_in("Phone number", with: "+141632489") : fill_in("#{role}_phone_number", with: "+141632489")
     role == "user" ? click_on("Update Profile") : click_on("Submit")
-    expect(page).to have_text "Phone number must be 12 digits including country code (+1)"
+    expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
   end
 
   it "shows error message for phone number > 12 digits" do
     role == "admin" || role == "user" ? fill_in("Phone number", with: "+141632180923") : fill_in("#{role}_phone_number", with: "+141632180923")
     role == "user" ? click_on("Update Profile") : click_on("Submit")
-    expect(page).to have_text "Phone number must be 12 digits including country code (+1)"
+    expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
   end
 
   it "shows error message for bad phone number" do
     role == "admin" || role == "user" ? fill_in("Phone number", with: "+141632u809o") : fill_in("#{role}_phone_number", with: "+141632u809o")
     role == "user" ? click_on("Update Profile") : click_on("Submit")
-    expect(page).to have_text "Phone number must be 12 digits including country code (+1)"
+    expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
   end
 
   it "shows error message for phone number without country code" do
     role == "admin" || role == "user" ? fill_in("Phone number", with: "+24163218092") : fill_in("#{role}_phone_number", with: "+24163218092")
     role == "user" ? click_on("Update Profile") : click_on("Submit")
-    expect(page).to have_text "Phone number must be 12 digits including country code (+1)"
+    expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
   end
 end

--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "users/passwords/new", type: :system do
 
     click_on "Send me reset password instructions"
     expect(page).to have_content "1 error prohibited this User from being saved:"
-    expect(page).to have_text("Phone number must be 12 digits including country code (+1)")
+    expect(page).to have_text("Phone number must be 10 digits or 12 digits including country code (+1)")
   end
 
   it "displays error if user tries to submit empty form" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4773 

### What changed, and why
Phone number fields do not insist on 12 digit phone numbers - allows user to provide 10 digits. '+1' country code added for the user before it is stored in the database. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Adds a test for the 10 digit case in PhoneNumberHelper spec

### Screenshots please :)
![Screenshot 2023-05-12 at 4 19 13 PM](https://github.com/rubyforgood/casa/assets/33361274/7a6a410d-1ab9-4d5b-aae9-71e90b40f92a)
![Screenshot 2023-05-12 at 4 19 44 PM](https://github.com/rubyforgood/casa/assets/33361274/d7f0e509-a51d-47d5-97f4-6dd57a0de682)

