### PR TITLE
Get login duration from backend

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -73,7 +73,7 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
-          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
+          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec spec/system/application/timeout_warning_spec.rb
           ./cc-test-reporter after-build --exit-code $?
 
       - name: Archive selenium screenshots

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -73,7 +73,7 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
-          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec spec/system/application/timeout_warning_spec.rb
+          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
           ./cc-test-reporter after-build --exit-code $?
 
       - name: Archive selenium screenshots

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,4 +126,3 @@ class ApplicationController < ActionController::Base
     notice
   end
 end
- 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,9 +102,9 @@ class ApplicationController < ActionController::Base
     RequestStore.store[:current_user] = current_user
   end
 
-  def set_timeout_duration
-    @timeout_duration = current_user.timeout_in
-  end
+  # def set_timeout_duration
+  #   @timeout_duration = current_user.timeout_in
+  # end
 
   def set_current_organization
     RequestStore.store[:current_organization] = current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    # @timeout_duration = current_user.timeout_in
+    @timeout_duration = current_user.timeout_in
   end
 
   def set_current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    # this is now in miliseconds 
     @timeout_duration = current_user.timeout_in
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,3 +126,4 @@ class ApplicationController < ActionController::Base
     notice
   end
 end
+ 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
+    # this is now second th
     @timeout_duration = current_user.timeout_in
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,9 +102,9 @@ class ApplicationController < ActionController::Base
     RequestStore.store[:current_user] = current_user
   end
 
-  # def set_timeout_duration
-  #   @timeout_duration = current_user.timeout_in
-  # end
+  def set_timeout_duration
+    @timeout_duration = current_user.timeout_in
+  end
 
   def set_current_organization
     RequestStore.store[:current_organization] = current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,9 +103,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    return unless current_user
-
-    @timeout_duration = current_user.timeout_in
+    if current_user
+      @timeout_duration = current_user.timeout_in
+    end
   end
 
   def set_current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
   before_action :set_current_user
+  before_action :set_timeout_duration
   before_action :set_current_organization
   after_action :verify_authorized, except: :index, unless: :devise_controller?
   # after_action :verify_policy_scoped, only: :index
@@ -99,6 +100,10 @@ class ApplicationController < ActionController::Base
 
   def set_current_user
     RequestStore.store[:current_user] = current_user
+  end
+
+  def set_timeout_duration
+    @timeout_duration = current_user.timeout_in
   end
 
   def set_current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    # this is now second th
+    # this is now in miliseconds 
     @timeout_duration = current_user.timeout_in
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,9 +103,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    if current_user
-      @timeout_duration = current_user&.timeout_in
-    end
+    return unless current_user
+
+    @timeout_duration = current_user.timeout_in
   end
 
   def set_current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
-    @timeout_duration = current_user.timeout_in
+    # @timeout_duration = current_user.timeout_in
   end
 
   def set_current_organization

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,7 +104,7 @@ class ApplicationController < ActionController::Base
 
   def set_timeout_duration
     if current_user
-      @timeout_duration = current_user.timeout_in
+      @timeout_duration = current_user&.timeout_in
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,6 +103,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_timeout_duration
+    return unless current_user
+
     @timeout_duration = current_user.timeout_in
   end
 

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -8,7 +8,6 @@ let currentTime
 let timeElapsed
 
 function warningBoxAndReload () {
-  $('body').prepend('<p>############################</p>')
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')
   window.location.reload()
 }

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -8,6 +8,7 @@ let currentTime
 let timeElapsed
 
 function warningBoxAndReload () {
+  $( "body" ).prepend( "<p>############################</p>" );
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')
   window.location.reload()
 }

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,5 +1,5 @@
 const deviseTimeoutInMinutes = 180
-const timeoutDuration = 180;
+// const timeoutDuration = 180
 const twoMinuteWarning = deviseTimeoutInMinutes - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000
@@ -7,7 +7,7 @@ const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
 let currentTime
 let timeElapsed
-console.log("here", window.timeout)
+console.log('here', window.timeout)
 
 function warningBoxAndReload () {
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,4 +1,7 @@
 const deviseTimeoutInMinutes = 180
+const timeoutDuration = 180;
+// I could do this below if this is preferred
+// const deviseTimeoutInMinutes = timeoutDuration || 180;
 const twoMinuteWarning = deviseTimeoutInMinutes - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,9 +1,5 @@
 const deviseTimeoutInMinutes = 180
-// const timeoutDuration = <%= 3.hours.to_i * 60 %>;
-// const timeoutDuration = <%= @timeout_duration || 180 %>;
 const timeoutDuration = 180;
-// I could do this below if this is preferred
-// const deviseTimeoutInMinutes = timeoutDuration || 180;
 const twoMinuteWarning = deviseTimeoutInMinutes - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000
@@ -11,6 +7,7 @@ const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
 let currentTime
 let timeElapsed
+console.log("here", window.timeout)
 
 function warningBoxAndReload () {
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')
@@ -22,7 +19,6 @@ setInterval(myTimer, 1000)
 function myTimer () {
   timeElapsed = Math.abs(lastTime - startTime)
   currentTime = new Date().getTime()
-  // console.log('Should go up by 1 second', timeElapsed)
   if (timeElapsed > deviseTimeoutInMilliseconds) {
     window.location.reload()
   } else if (timeElapsed > totalTimerAmount) {

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,11 +1,12 @@
 const deviseTimeoutInMinutes = 180
+// const timeoutDuration = <%= 3.hours.to_i * 60 %>;
+// const timeoutDuration = <%= @timeout_duration || 180 %>;
 const timeoutDuration = 180;
 // I could do this below if this is preferred
 // const deviseTimeoutInMinutes = timeoutDuration || 180;
 const twoMinuteWarning = deviseTimeoutInMinutes - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000
-// config.timeout_in = 3.hours
 const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
 let currentTime

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -8,7 +8,7 @@ let currentTime
 let timeElapsed
 
 function warningBoxAndReload () {
-  $( "body" ).prepend( "<p>############################</p>" );
+  $('body').prepend('<p>############################</p>')
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')
   window.location.reload()
 }

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -4,10 +4,8 @@ const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = timeout * 60 * 1000
 const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
-
 let currentTime
 let timeElapsed
-
 
 function warningBoxAndReload () {
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,12 +1,13 @@
-const timeout = 180
+const timeoutInMinutes = window.timeout || 180;
 const twoMinuteWarning = timeout - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = timeout * 60 * 1000
 const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
+
 let currentTime
 let timeElapsed
-console.log('here', window.timeout)
+
 
 function warningBoxAndReload () {
   window.alert('Warning: You will be logged off in 2 minutes due to inactivity.')

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,8 +1,7 @@
-const deviseTimeoutInMinutes = 180
-// const timeoutDuration = 180
-const twoMinuteWarning = deviseTimeoutInMinutes - 2
+const timeout = 180
+const twoMinuteWarning = timeout - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
-const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000
+const deviseTimeoutInMilliseconds = timeout * 60 * 1000
 const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
 let currentTime

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -2,6 +2,7 @@ const deviseTimeoutInMinutes = 180
 const twoMinuteWarning = deviseTimeoutInMinutes - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = deviseTimeoutInMinutes * 60 * 1000
+// config.timeout_in = 3.hours
 const startTime = new Date().getTime()
 let lastTime = new Date().getTime()
 let currentTime

--- a/app/javascript/src/session_timeout_poller.js
+++ b/app/javascript/src/session_timeout_poller.js
@@ -1,4 +1,4 @@
-const timeoutInMinutes = window.timeout || 180;
+const timeout = window.timeout || 180
 const twoMinuteWarning = timeout - 2
 const totalTimerAmount = twoMinuteWarning * 60 * 1000
 const deviseTimeoutInMilliseconds = timeout * 60 * 1000

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,9 @@
 
   <%= render 'shared/favicons' %>
 
-  <%# <script> %>
-    <%# window.timeout = <%= @timeout_duration %> %>
-  <%# </script> %>
+  <script>
+    window.timeout = <%= @timeout_duration %>
+  </script>
 
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,8 @@
  
   
   <script> 
-    var timeout = <%= @timeout_duration %>
-    console.log("here", timeout) 
+    window.timeout = <%= @timeout_duration %>
+ 
   </script>
   
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
+  <% binding.pry %>
   <script>
     var timeout = <%= @timeout_duration %>
   </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,6 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
-
   <script>
     window.timeout = <%= @timeout_duration %>
   </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
 
 </head>
 <body class="<%= body_class %>">
+<p> <%= @timeout_duration %> </p>
 <noscript>
   <div class="noscript alert alert-danger">
     <h2 class="alert-heading">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
-
+  <script> 
+    var timeout = <%= @timeout_duration %> 
+  </script>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 
@@ -29,7 +31,6 @@
 
 </head>
 <body class="<%= body_class %>">
-<p> <%= @timeout_duration %> </p>
 <noscript>
   <div class="noscript alert alert-danger">
     <h2 class="alert-heading">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
 
   <%= render 'shared/favicons' %>
   <script>
-    window.timeout = <%= @timeout_duration %>
+    window.timeout = <%= @timeout_duration.to_json %>
   </script>
 
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,14 +15,11 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
-  
- 
-  
-  <script> 
-    window.timeout = <%= @timeout_duration %>
- 
-  </script>
-  
+
+  <%# <script> %>
+    <%# window.timeout = <%= @timeout_duration %> %>
+  <%# </script> %>
+
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
-  <script> 
-    var timeout = <%= @timeout_duration %> 
+  <script>
+    var timeout = <%= @timeout_duration %>
   </script>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,10 +15,14 @@
   <%= og_tag :image, content: image_url('login.jpg') %>
 
   <%= render 'shared/favicons' %>
-  <% binding.pry %>
-  <script>
+  
+ 
+  
+  <script> 
     var timeout = <%= @timeout_duration %>
+    console.log("here", timeout) 
   </script>
+  
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
 

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "/*", type: :system do
+
+  context "when user is signed in" do
+    let(:user) { create(:volunteer) }
+    before do
+      sign_in user
+    end
+    it "renders the seconds before logout as a javascript variable" do
+      visit "/"
+      parsed_page = Nokogiri::HTML(page.html)
+      expect(parsed_page.at('script').text.strip).to include(user.timeout_in.in_seconds.to_s)
+    end
+  end
+
+  #     travel_to(1.day.ago) do
+  #       visit time_travel_verification_path
+  #       expect(page).to have_content('WOAH Time Travel!')
+end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -12,9 +12,13 @@ RSpec.describe "/*", type: :system do
       parsed_page = Nokogiri::HTML(page.html)
       expect(parsed_page.at('script').text.strip).to include(user.timeout_in.in_seconds.to_s)
     end
-  end
 
-  #     travel_to(1.day.ago) do
-  #       visit time_travel_verification_path
-  #       expect(page).to have_content('WOAH Time Travel!')
+    it "warns the user two mintues before logout" do
+      visit "/"
+      travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
+        sleep 2
+        page.accept_alert
+      end
+    end
+  end
 end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -11,8 +11,5 @@ RSpec.describe "/*", type: :system do
       parsed_page = Nokogiri::HTML(page.html)
       expect(parsed_page.at("script").text.strip).to include(user.timeout_in.in_seconds.to_s)
     end
-
-    xit "warns the user two mintues before logout", js: true do
-    end
   end
 end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -18,11 +18,22 @@ RSpec.describe "/*", type: :system do
       travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
         sleep 2
         Capybara.using_wait_time(5) do
-          expect(page).to have_content('timeout')
+          # expect(page).to have_content('timeout')
+          # expect(page).to have_content('timeout', visible: true)
+          # expect(page).to have_selector("*", text: 'timeout', visible: true)
+          # unless page.has_selector?("*", text: 'timeout', visible: true)
+          #   puts page.html  # Print the page content for debugging
+          #   fail "Expected to find 'timeout', but it was not found"
+          # end
+          begin
+            page.driver.browser.switch_to.alert
+            puts "Alert message is present"
+          rescue Selenium::WebDriver::Error::NoAlertPresentError
+            
         end
         page.accept_alert
         #check that there is an alert
       end
     end
-   end
+  end
 end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "/*", type: :system do
-
   context "when user is signed in" do
     let(:user) { create(:volunteer) }
     before do
@@ -10,25 +9,10 @@ RSpec.describe "/*", type: :system do
     it "renders the seconds before logout as a javascript variable" do
       visit "/"
       parsed_page = Nokogiri::HTML(page.html)
-      expect(parsed_page.at('script').text.strip).to include(user.timeout_in.in_seconds.to_s)
+      expect(parsed_page.at("script").text.strip).to include(user.timeout_in.in_seconds.to_s)
     end
 
     xit "warns the user two mintues before logout", js: true do
-      # visit "/"
-      # travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
-      #   sleep 2
-      #   Capybara.using_wait_time(5) do
-      #     begin
-      #       wait = Selenium::WebDriver::Wait.new(timeout: 5) # Set a timeout limit
-
-      #       expect(page).to have_text("############################")
-      #       # expect(alert.text).to include('known_text') # Replace 'known_text' with expected text
-      #       # alert.accept
-      #     rescue Selenium::WebDriver::Error::TimeoutError
-      #       fail "Alert did not appear in time"
-          end
-        end
-      end
     end
   end
 end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -13,12 +13,16 @@ RSpec.describe "/*", type: :system do
       expect(parsed_page.at('script').text.strip).to include(user.timeout_in.in_seconds.to_s)
     end
 
-    it "warns the user two mintues before logout" do
+    it "warns the user two mintues before logout", js: true do
       visit "/"
       travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
         sleep 2
+        Capybara.using_wait_time(5) do
+          expect(page).to have_content('timeout')
+        end
         page.accept_alert
+        #check that there is an alert
       end
     end
-  end
+   end
 end

--- a/spec/system/application/timeout_warning_spec.rb
+++ b/spec/system/application/timeout_warning_spec.rb
@@ -13,26 +13,21 @@ RSpec.describe "/*", type: :system do
       expect(parsed_page.at('script').text.strip).to include(user.timeout_in.in_seconds.to_s)
     end
 
-    it "warns the user two mintues before logout", js: true do
-      visit "/"
-      travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
-        sleep 2
-        Capybara.using_wait_time(5) do
-          # expect(page).to have_content('timeout')
-          # expect(page).to have_content('timeout', visible: true)
-          # expect(page).to have_selector("*", text: 'timeout', visible: true)
-          # unless page.has_selector?("*", text: 'timeout', visible: true)
-          #   puts page.html  # Print the page content for debugging
-          #   fail "Expected to find 'timeout', but it was not found"
-          # end
-          begin
-            page.driver.browser.switch_to.alert
-            puts "Alert message is present"
-          rescue Selenium::WebDriver::Error::NoAlertPresentError
-            
+    xit "warns the user two mintues before logout", js: true do
+      # visit "/"
+      # travel_to(user.timeout_in.from_now - 2.minutes - 1.seconds) do
+      #   sleep 2
+      #   Capybara.using_wait_time(5) do
+      #     begin
+      #       wait = Selenium::WebDriver::Wait.new(timeout: 5) # Set a timeout limit
+
+      #       expect(page).to have_text("############################")
+      #       # expect(alert.text).to include('known_text') # Replace 'known_text' with expected text
+      #       # alert.accept
+      #     rescue Selenium::WebDriver::Error::TimeoutError
+      #       fail "Alert did not appear in time"
+          end
         end
-        page.accept_alert
-        #check that there is an alert
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #https://github.com/rubyforgood/casa/issues/4725

### What changed, and why?

- the `config.timeout_in = 3.hours ` has been passed into [here](https://github.com/rubyforgood/casa/pull/4693/files#diff-c51b651f39074e2d51508b09f96b6b3d8f49f719589fd6b0a5b6d72d9ec324b1)
- This hardcoded value is now accessible as an instance variable 


### How will this affect user permissions?
- Volunteer permissions: login duration 
- Supervisor permissions: login duration 
- Admin permissions: login duration 

### How is this tested? (please write tests!) 💖💪
[here](https://github.com/rubyforgood/casa/blob/ea0fe12922e1b1662b3c00d686bc29b2836f19cb/spec/system/application/timeout_warning_spec.rb)

I will need to include the Jasmine gem per Shen's guidance to create a test that simulates the passage of time. 
This task has been created as a new issue ticket.
This is why the second test has not yet been completed.

### Screenshots please :)
<img width="1125" alt="Screenshot 2023-08-03 at 11 14 48 AM" src="https://github.com/rubyforgood/casa/assets/20326770/50460d82-a785-4025-a0ad-3d087f68af51">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9

Is it better to list more or fewer reviewers? Not sure what is best practice for Casa 
Thank you
