### PR TITLE
Flaky spec fix: Do not use blank padding for hour display

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
       full: "%B %-d, %Y"
       youth_date_of_birth: "%B %Y"
       short_date: "%-m/%d"
-      edit_profile: "%B %d, %Y at %l:%M %p"
+      edit_profile: "%B %d, %Y at %-l:%M %p"
   notifications:
     emancipation_checklist_reminder_notification:
       title: "Emancipation Checklist Reminder"


### PR DESCRIPTION
### What changed, and why?
The test at `/spec/system/users/edit_spec.rb:114` is currently breaking the build

removed space padding for a formatted date. The test fails because the browser automatically truncates consecutive spaces

The `%l` option blank pads numbers less than
10, which is causing the spec to be flaky,
and leaves an extra space in the time
display: "May 17, 2023 at&nbsp;&nbsp;3:21 AM". This
change removes the blank padding.
