### PR TITLE
Pr2 for Issue #2698 - Adds a task to backfill user preference sets. 

### DIFF
--- a/lib/tasks/deployment/20230419224330_backfill_user_prefernce_sets.rake
+++ b/lib/tasks/deployment/20230419224330_backfill_user_prefernce_sets.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc "Deployment task: This will create a PreferenceSet for all users that are missing one"
+  task backfill_user_prefernce_sets: :environment do
+    puts "Running deploy task 'backfill_user_prefernce_sets'"
+
+    # Put your task implementation HERE.
+    User.includes(:preference_set).where(preference_sets: {id: nil}).find_in_batches(batch_size: 500) do |users|
+      # NOTE: This should ideally be run in a background job.
+      users.each(&:create_preference_set)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
This is the second Pr out of three to fix issue #2698     -Pr1: [https://github.com/rubyforgood/casa/pull/4769](url)

In this second Pr I am Adding an after party task to backfill the preferences_sets. This is needed because in Pr1 I added a migration to add a new column to this table. 

### What github issue is this PR for, if any?
Ref #2698 

### What changed, and why?
This Pr Adds an after party task to backfill the preference_sets. This is needed because in Pr1 I added a migration to add a new column "table_state" to preference_set

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions:n/a
- Admin permissions:n/a

### How is this tested? (please write tests!) 💖💪

N/a ... I think?
### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
