### PR TITLE
Updates logic for supervisors to view reimbursements in queue

### DIFF
--- a/app/policies/reimbursement_policy.rb
+++ b/app/policies/reimbursement_policy.rb
@@ -7,11 +7,11 @@ class ReimbursementPolicy < ApplicationPolicy
   end
 
   def index?
-    is_admin? && reimbursement_enabled?
+    (is_admin? || is_supervisor?) && reimbursement_enabled?
   end
 
   def datatable?
-    is_admin? && reimbursement_enabled?
+    (is_admin? || is_supervisor?) && reimbursement_enabled?
   end
 
   def change_complete_status?

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe ReimbursementPolicy do
   context "when org reimbursement is enabled" do
     permissions :index?, :change_complete_status? do
       it { is_expected.to permit(casa_admin) }
-      it { is_expected.to_not permit(supervisor) }
+      it { is_expected.to permit(supervisor) }
       it { is_expected.to_not permit(volunteer) }
     end
 
     permissions :datatable? do
       it { is_expected.to permit(casa_admin) }
-      it { is_expected.to_not permit(supervisor) }
+      it { is_expected.to permit(supervisor) }
       it { is_expected.to_not permit(volunteer) }
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4759 

### What changed, and why?

- `app/policies/reimbursement_policy.rb` includes logic to check if user is a supervisor for `def datatable?` and `def index?`
- corresponding spec file is also updated with a `unit test` for this change

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions: `Can view reimbursements queue`
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

-unit test in `spec/policies/reimbursement_policy_spec.rb` updated to expect supervisor permissions for reimbursements enabling.

### Screenshots please :)
<img width="1411" alt="Screen Shot 2023-05-30 at 4 29 21 PM" src="https://github.com/rubyforgood/casa/assets/103534307/2f79bb13-da45-4699-980a-5a5cd9648081">


