### PR TITLE
Bug Fix: Properly hide and show additional expenses

### DIFF
--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -93,11 +93,7 @@ legend {
         }
     }
  }
-
- .hide-field {
-  display: none;
-}
-
+ 
 .other-expenses li {
     margin-bottom: .2rem;
 }

--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -48,10 +48,6 @@ legend {
     padding-right: 1.5rem !important;
 }
 
-.hide-field {
-    display: none;
-}
-
 .red-letter {
     color: #ff2229;
     font-weight: 900;
@@ -97,6 +93,10 @@ legend {
         }
     }
  }
+
+ .hide-field {
+  display: none;
+}
 
 .other-expenses li {
     margin-bottom: .2rem;

--- a/app/javascript/__tests__/add_additional_expense.test.js
+++ b/app/javascript/__tests__/add_additional_expense.test.js
@@ -5,13 +5,10 @@ require('jest')
 beforeEach(() => {
   const $ = require('jquery')
   document.body.innerHTML =
-  '<style>' +
-  '  #case_contact_additional_expenses_attributes_1_other_expense_amount { display: none; }' +
-  '</style>' +
   '<div>' +
   ' <a href="#" class="add-another-expense" id="add-another-expense">Add another expense</a>' +
-  '<div class="expense-container>' +
-  ' <input placeholder="Describe the expense" class="form-control other-expenses-describe hide-field" type="text" name="case_contact[additional_expenses_attributes][1][other_expenses_describe]" id="case_contact_additional_expenses_attributes_1_other_expense_amount" style="display: inline-block;">' +
+  '<div class="expense-container id="expense2" style="display:none">' +
+  ' <input placeholder="Enter amount" class="form-control other-expenses-describe hide-field" type="text" name="case_contact[additional_expenses_attributes][1][other_expenses_describe]" id="case_contact_additional_expenses_attributes_1_other_expense_amount" style="display: inline-block;">' +
   ' <input placeholder="Describe the expense" class="form-control other-expenses-describe hide-field" type="text" name="case_contact[additional_expenses_attributes][1][other_expenses_describe]" id="case_contact_additional_expenses_attributes_1_other_expenses_describe" style="display: inline-block;" >' +
   '</div>' +
   '</div>'
@@ -24,17 +21,14 @@ describe('Add Additional Expense tests', () => {
   test('Test link to add expenses is present', () => {
     expect($('#add-another-expense').text()).toEqual('Add another expense')
   })
-  test('Test that initial expense amount field is hidden', () => {
-    expect($('#case_contact_additional_expenses_attributes_1_other_expense_amount').is(':hidden')).toBe(true)
+  test('Test that initial additional expense is hidden', () => {
+    expect($('#expense2').css('display: none'))
   })
-  test('Test that initial expense describe field is hidden', () => {
-    expect($('#case_contact_additional_expenses_attributes_1_other_expenses_describe').is(':hidden')).toBe(true)
-  })
-  test('Displays a new set of fields after a click', () => {
+  test('Displays the first additional expense after a click', () => {
     require('../src/add_additional_expense')
 
     $('#add-additional-expense').trigger('click')
 
-    expect($('#case_contact_additional_expenses_attributes_1_other_expense_amount').css('display: inline-block'))
+    expect($('#expense2').css('display: flex'))
   })
 })

--- a/app/javascript/src/add_additional_expense.js
+++ b/app/javascript/src/add_additional_expense.js
@@ -4,7 +4,7 @@ function showAdditionalExpense () {
   for (let i = 1; i < 10; i++) {
     if ($(`#expense${i + 1}`).is(':hidden')) {
       $(`#expense${i + 1}`).wrap('<li></li>')
-      $(`#expense${i + 1}`).removeClass('hide-field')
+      $(`#expense${i + 1}`).removeClass('d-none')
       break
     }
   }

--- a/app/javascript/src/add_additional_expense.js
+++ b/app/javascript/src/add_additional_expense.js
@@ -2,10 +2,9 @@
 
 function showAdditionalExpense () {
   for (let i = 1; i < 10; i++) {
-    if ($(`#case_contact_additional_expenses_attributes_${i}_other_expense_amount`).is(':hidden')) {
+    if ($(`#expense${i + 1}`).is(':hidden')) {
       $(`#expense${i + 1}`).wrap('<li></li>')
-      $(`#case_contact_additional_expenses_attributes_${i}_other_expense_amount`).show()
-      $(`#case_contact_additional_expenses_attributes_${i}_other_expenses_describe`).show()
+      $(`#expense${i + 1}`).removeClass('hide-field')
       break
     }
   }

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -207,20 +207,20 @@ readonly: true %>
           <% end %>
           <% (9 - @case_contact.decorate.additional_expenses_count).times do |i| %>
             <%= form.fields_for :additional_expenses, AdditionalExpense.new do |ff| %>
-            <div class="expense-container row" id="<%= if @case_contact.decorate.additional_expenses_count === 0
+            <div class="expense-container row hide-field" id="<%= if @case_contact.decorate.additional_expenses_count === 0
             then "expense" + (i + 2).to_s
             else "expense" + ((@case_contact.decorate.additional_expenses_count) + (i + 2)).to_s
             end %>">
               <div class="input-style-1 col-sm-3">
                 <%= ff.number_field :other_expense_amount,
                     placeholder: "Enter amount",
-                    class: "cc-italic cc-field other-expense-amount hide-field",
+                    class: "cc-italic cc-field other-expense-amount",
                   min: "0", max: 1000, step: 0.01 %>
               </div>
               <div class="input-style-1 col">
                 <%= ff.text_field :other_expenses_describe,
                     placeholder: "Describe the expense",
-                    class: "cc-italic cc-field other-expenses-describe hide-field" %>
+                    class: "cc-italic cc-field other-expenses-describe" %>
               </div>
             </div>
             <% end %>

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -207,7 +207,7 @@ readonly: true %>
           <% end %>
           <% (9 - @case_contact.decorate.additional_expenses_count).times do |i| %>
             <%= form.fields_for :additional_expenses, AdditionalExpense.new do |ff| %>
-            <div class="expense-container row hide-field" id="<%= if @case_contact.decorate.additional_expenses_count === 0
+            <div class="expense-container row d-none" id="<%= if @case_contact.decorate.additional_expenses_count === 0
             then "expense" + (i + 2).to_s
             else "expense" + ((@case_contact.decorate.additional_expenses_count) + (i + 2)).to_s
             end %>">


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4837

### What changed, and why?
Updated the "Other Expenses" field on a new contact form to not have additional space at the bottom.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Updated tests in `add_additional_expense.test.js` to reflect hiding the entire row of the additional expense

### Screenshots please :)
The screen recording below demonstrates three things:
1. On initial load, there is no white space below the "Other expenses" field
2. User can add additional expense, which un-hides the hidden fields
3. New changes maintain feature that the user is only able to add up to 10 fields. Clicking more than 10 times doesn't show more fields


https://github.com/rubyforgood/casa/assets/24727140/cc20cd83-c291-4fed-85c2-8755f833f490


