### PR TITLE
removed extra margin below additional expense

### DIFF
--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -176,12 +176,12 @@ readonly: true %>
                 <div class="col input-style-1">
                   <%= ff.number_field :other_expense_amount,
                   placeholder: "Enter amount",
-                  class: "cc-italic cc-field other-expense-amount w-25 input-style-1 co",
+                  class: "cc-italic cc-field other-expense-amount w-25 co",
                   min: "0", max: 1000, step: 0.01 %>
                 </div>
                 <div class="col input-style-1">
                   <%= ff.text_field :other_expenses_describe, placeholder: "Describe the expense",
-                  class: "cc-italic cc-field other-expenses-describe input-style-1" %>
+                  class: "cc-italic cc-field other-expenses-describe" %>
                 </div>
               </div>
             </li>


### PR DESCRIPTION
### What changed, and why?
Before:
![image](https://github.com/rubyforgood/casa/assets/8918762/4a50ac4a-a22b-4a58-bcff-8f0a62ddc456)

After:
![image](https://github.com/rubyforgood/casa/assets/8918762/256c6f88-f0fc-4eaa-b066-5ffcc60887ac)

### How is this tested? (please write tests!) 💖💪
CI