### PR TITLE
Create a new CSS class and use it to wrap CASA cases list for scrolling

### DIFF
--- a/app/assets/stylesheets/shared/layout.scss
+++ b/app/assets/stylesheets/shared/layout.scss
@@ -17,6 +17,12 @@ label {
   font-weight: 900;
 }
 
+.casa-case-scroll {
+  width: 225px;
+  height: 350px;
+  overflow-y: auto;
+}
+
 // This may effect other pages than the case contact form!!!
 h5 label {
   font-weight: 500;
@@ -77,29 +83,36 @@ div.row.volunteer-filters {
   .login-header {
     font-size: 0.75em !important;
   }
+
   .content {
     padding: 3rem 0;
     margin-left: 0;
   }
+
   .card-body {
     padding: 0.5rem;
   }
+
   table.table {
     thead {
       display: none;
     }
+
     tr {
       display: table;
       width: 100%;
       border-bottom: 1px solid #efefef;
-      > * {
+
+      >* {
         display: block;
       }
     }
+
     th,
     td {
       border-top: none;
       font-size: 1.25rem;
+
       span.mobile-label {
         color: #757575;
         display: block;

--- a/app/assets/stylesheets/shared/layout.scss
+++ b/app/assets/stylesheets/shared/layout.scss
@@ -18,8 +18,8 @@ label {
 }
 
 .casa-case-scroll {
-  width: 225px;
-  height: 350px;
+  width: 13rem;
+  height: 22rem;
   overflow-y: auto;
 }
 
@@ -83,36 +83,29 @@ div.row.volunteer-filters {
   .login-header {
     font-size: 0.75em !important;
   }
-
   .content {
     padding: 3rem 0;
     margin-left: 0;
   }
-
   .card-body {
     padding: 0.5rem;
   }
-
   table.table {
     thead {
       display: none;
     }
-
     tr {
       display: table;
       width: 100%;
       border-bottom: 1px solid #efefef;
-
-      >* {
+      > * {
         display: block;
       }
     }
-
     th,
     td {
       border-top: none;
       font-size: 1.25rem;
-
       span.mobile-label {
         color: #757575;
         display: block;

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -8,19 +8,19 @@
       <h2><label for="case_contact_casa_case">1. Select relevant CASA case<span class="red-letter"> *</span></label></h2>
     <% end %>
     <div class="casa-case-scroll">
-    <% casa_cases.each_with_index do |casa_case, index| %>
-      <div class="form-check checkbox-style mb-10 ml-5">
-        <%= check_box_tag "case_contact[casa_case_id][]",
-                          casa_case.id,
-                          @selected_cases.include?(casa_case),
-                          id: "case_contact_casa_case_id_#{index}",
-                          class: ["form-check-input", "casa-case-id"],
-                          disabled: case_contact.persisted? %>
-        <label class="form-check-label" for="case_contact_casa_case_id_<%= index %>">
-          <%= casa_case.case_number %>
-        </label>
-      </div>
-    <% end %>
+      <% casa_cases.each_with_index do |casa_case, index| %>
+        <div class="form-check checkbox-style mb-10 ml-5">
+          <%= check_box_tag "case_contact[casa_case_id][]",
+                            casa_case.id,
+                            @selected_cases.include?(casa_case),
+                            id: "case_contact_casa_case_id_#{index}",
+                            class: ["form-check-input", "casa-case-id"],
+                            disabled: case_contact.persisted? %>
+          <label class="form-check-label" for="case_contact_casa_case_id_<%= index %>">
+            <%= casa_case.case_number %>
+          </label>
+        </div>
+      <% end %>
     </div>
   </div>
   <div class="card-style-1 pl-25 mb-10">

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -7,6 +7,7 @@
     <% else %>
       <h2><label for="case_contact_casa_case">1. Select relevant CASA case<span class="red-letter"> *</span></label></h2>
     <% end %>
+    <div class="casa-case-scroll">
     <% casa_cases.each_with_index do |casa_case, index| %>
       <div class="form-check checkbox-style mb-10 ml-5">
         <%= check_box_tag "case_contact[casa_case_id][]",
@@ -20,6 +21,7 @@
         </label>
       </div>
     <% end %>
+    </div>
   </div>
   <div class="card-style-1 pl-25 mb-10">
     <%= render "contact_types",


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4869 

### What changed, and why?
When creating a new case contact, the first section "Select all relevant CASA cases" card can be very large when a supervisor or admin views it (when they are not impersonating a volunteer). To make for a smoother feeling workflow, I housed the selectable cases in a Scroll box 

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Have not written a test so far. It is a CSS feature change to one layout file. I can write a `requests` test if needed.

### Screenshots please :)

https://github.com/rubyforgood/casa/assets/74928397/7bcd15b9-3d92-40a8-ad93-3df8f19851b5



### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![Yes!](https://media.giphy.com/media/3o6UB3VhArvomJHtdK/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
