### PR TITLE
fix add to calendar button text overflow

### DIFF
--- a/app/assets/stylesheets/pages/casa_cases.scss
+++ b/app/assets/stylesheets/pages/casa_cases.scss
@@ -14,11 +14,12 @@ body.casa_cases {
   }
 
   .a2cldr {
-    width: 175px;
+    width: 190px;
   }
 
   .a2cldr .a2cldr-btn {
-    width: 175px;
+    width: 190px;
+    text-align: center
   }
 
   .a2cldr-list {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4853 

### What changed, and why?
Slightly modified the width and aligned the text in the center

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
just checked visually

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/9966978/5f547549-c749-40b8-b58c-31569f874bb5)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
