### PR TITLE
Added extra columns to mileage_export_csv_service

### DIFF
--- a/app/services/mileage_export_csv_service.rb
+++ b/app/services/mileage_export_csv_service.rb
@@ -27,6 +27,7 @@ class MileageExportCsvService
       miles_driven: case_contact&.miles_driven,
       casa_case_number: case_contact&.casa_case&.case_number,
       creator_name: case_contact&.creator&.display_name,
+      supervisor_name: case_contact&.creator&.supervisor&.display_name,
       volunteer_address: case_contact&.creator&.address&.content,
       reimbursed: case_contact&.reimbursement_complete
     }

--- a/spec/models/mileage_report_spec.rb
+++ b/spec/models/mileage_report_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe MileageReport, type: :model do
         "Miles Driven",
         "Casa Case Number",
         "Creator Name",
+        "Supervisor Name",
         "Volunteer Address",
         "Reimbursed"
       ])
@@ -46,6 +47,7 @@ RSpec.describe MileageReport, type: :model do
         "Miles Driven",
         "Casa Case Number",
         "Creator Name",
+        "Supervisor Name",
         "Volunteer Address",
         "Reimbursed"
       ])

--- a/spec/services/mileage_export_csv_service_spec.rb
+++ b/spec/services/mileage_export_csv_service_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe MileageExportCsvService do
       "Miles Driven",
       "Casa Case Number",
       "Creator Name",
+      "Supervisor Name",
       "Volunteer Address",
       "Reimbursed"
     ])
-    expect(results[1].split(",").count).to eq(8)
+    expect(results[1].split(",").count).to eq(9)
   end
 end

--- a/spec/system/reports/export_data_spec.rb
+++ b/spec/system/reports/export_data_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe "case_contact_reports/index", type: :system do
   it "downloads mileage report", js: true do
     sign_in admin
 
-    case_contact_with_mileage = create(:case_contact, want_driving_reimbursement: true, miles_driven: 10)
+    supervisor = create(:supervisor)
+    volunteer = create(:volunteer, supervisor: supervisor)
+    case_contact_with_mileage = create(:case_contact, want_driving_reimbursement: true, miles_driven: 10, creator: volunteer)
     case_contact_without_mileage = create(:case_contact)
 
     visit reports_path
@@ -66,6 +68,7 @@ RSpec.describe "case_contact_reports/index", type: :system do
 
     expect(download_file_name).to match(/mileage-report-\d{4}-\d{2}-\d{2}.csv/)
     expect(download_content).to include(case_contact_with_mileage.creator.display_name)
+    expect(download_content).to include(case_contact_with_mileage.creator.supervisor.display_name)
     expect(download_content).not_to include(case_contact_without_mileage.creator.display_name)
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4870

### What changed, and why?
An extra column to the mileage export csv was added by stakeholder request

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Updated tests related to the export csv

### Screenshots please :)
[mileage-report-2023-06-22.csv](https://github.com/rubyforgood/casa/files/11840773/mileage-report-2023-06-22.csv)

