### PR TITLE
fixed the notifier toast from always showing in progress in the patch…

### DIFF
--- a/app/javascript/src/all_casa_admin/patch_notes.js
+++ b/app/javascript/src/all_casa_admin/patch_notes.js
@@ -6,12 +6,6 @@ const patchNoteFunctions = {} // A hack to be able to alphabetize functions
 
 let pageNotifier
 
-jQuery.ajaxSetup({
-  beforeSend: function () {
-    pageNotifier.startAsyncOperation()
-  }
-})
-
 // Inserts a patch note display after the create patch note form in the patch note list and styles it as new
 //  @param    {number} patchNoteGroupId  The id of the group allowed to view the patch note
 //  @param    {jQuery} patchNoteList     A jQuery object representing the patch note list
@@ -69,10 +63,22 @@ patchNoteFunctions.createPatchNote = function (patchNoteGroupId, patchNoteText, 
   TypeChecker.checkString(patchNoteText, 'patchNoteText')
 
   // Post request
-  return $.post(patchNotePath, {
-    note: patchNoteText,
-    patch_note_group_id: patchNoteGroupId,
-    patch_note_type_id: patchNoteTypeId
+  // return $.post(patchNotePath, {
+  //   note: patchNoteText,
+  //   patch_note_group_id: patchNoteGroupId,
+  //   patch_note_type_id: patchNoteTypeId
+  // })
+  return $.ajax({
+    url: patchNotePath,
+    type: 'POST',
+    data: {
+      note: patchNoteText,
+      patch_note_group_id: patchNoteGroupId,
+      patch_note_type_id: patchNoteTypeId
+    },
+    beforeSend: function () {
+      pageNotifier.startAsyncOperation()
+    }
   })
     .then(function (response, textStatus, jqXHR) {
       if (response.errors) {
@@ -100,7 +106,10 @@ patchNoteFunctions.deletePatchNote = function (patchNoteId) {
 
   return $.ajax({
     url: `${patchNotePath}/${patchNoteId}`,
-    type: 'DELETE'
+    type: 'DELETE',
+    beforeSend: function () {
+      pageNotifier.startAsyncOperation()
+    }
   })
     .then(function (response, textStatus, jqXHR) {
       if (response.errors) {
@@ -464,6 +473,9 @@ patchNoteFunctions.savePatchNote = function (patchNoteGroupId, patchNoteId, patc
       note: patchNoteText,
       patch_note_group_id: patchNoteGroupId,
       patch_note_type_id: patchNoteTypeId
+    },
+    beforeSend: function () {
+      pageNotifier.startAsyncOperation()
     }
   })
     .then(function (response, textStatus, jqXHR) {

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -42,6 +42,7 @@ end
 #  old_emails                  :string           default([]), is an Array
 #  phone_number                :string           default("")
 #  receive_email_notifications :boolean          default(TRUE)
+#  receive_reimbursement_email :boolean          default(FALSE)
 #  receive_sms_notifications   :boolean          default(FALSE), not null
 #  reset_password_sent_at      :datetime
 #  reset_password_token        :string

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -69,6 +69,7 @@ end
 #  old_emails                  :string           default([]), is an Array
 #  phone_number                :string           default("")
 #  receive_email_notifications :boolean          default(TRUE)
+#  receive_reimbursement_email :boolean          default(FALSE)
 #  receive_sms_notifications   :boolean          default(FALSE), not null
 #  reset_password_sent_at      :datetime
 #  reset_password_token        :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,6 +207,7 @@ end
 #  old_emails                  :string           default([]), is an Array
 #  phone_number                :string           default("")
 #  receive_email_notifications :boolean          default(TRUE)
+#  receive_reimbursement_email :boolean          default(FALSE)
 #  receive_sms_notifications   :boolean          default(FALSE), not null
 #  reset_password_sent_at      :datetime
 #  reset_password_token        :string

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -162,6 +162,7 @@ end
 #  old_emails                  :string           default([]), is an Array
 #  phone_number                :string           default("")
 #  receive_email_notifications :boolean          default(TRUE)
+#  receive_reimbursement_email :boolean          default(FALSE)
 #  receive_sms_notifications   :boolean          default(FALSE), not null
 #  reset_password_sent_at      :datetime
 #  reset_password_token        :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -543,6 +543,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_155223) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "old_emails", default: [], array: true
+    t.boolean "receive_reimbursement_email", default: false
     t.index ["casa_org_id"], name: "index_users_on_casa_org_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
…_notes.js

### What github issue is this PR for, if any?
Resolves #[4896](https://github.com/rubyforgood/casa/issues/4896)

### What changed, and why?
Updated patch_notes.js to fix the bug of the notifier toast always showing in progress. Had to move the beforesend callback into the actual ajax call instead of setting it globally in Jquery.ajaxsetup.

### How will this affect user permissions?
- Volunteer permissions: No change
- Supervisor permissions: No change
- Admin permissions: No change
- All Casa Admin: all_casa_admin1@example.com will only see the notifier when an ajax call is made.

### How is this tested? (please write tests!) 💖💪
Reused the same test.

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/14931684/3781a337-26dc-42ec-8bb8-2ffa161d69fe)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![struggle but victory](https://media.giphy.com/media/245nc6KzmWf541JzCN/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
