### PR TITLE
make additional expense option's visibility depend on feature flag

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -54,10 +54,12 @@
       <%= form.check_box :show_driving_reimbursement, class: 'form-check-input' %>
       <%= form.label :show_driving_reimbursement, "Show driving reimbursement", class: 'form-check-label mb-2' %>
     </div>
-    <div class="form-check checkbox-style mb-20">
-      <%= form.check_box :additional_expenses_enabled, class: 'form-check-input' %>
-      <%= form.label :additional_expenses_enabled, "Volunteers can add Other Expenses", class: 'form-check-label mb-2' %>
-    </div>
+    <% if FeatureFlagService.is_enabled?(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG) %>
+        <div class="form-check checkbox-style mb-20">
+          <%= form.check_box :additional_expenses_enabled, class: 'form-check-input' %>
+          <%= form.label :additional_expenses_enabled, "Volunteers can add Other Expenses", class: 'form-check-label mb-2' %>
+        </div>
+    <% end %>
     <div class="actions mb-10">
       <%= button_tag(
             type: "submit",

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -125,8 +125,28 @@ RSpec.describe "casa_org/edit", type: :system do
     expect(page).to have_text("Twilio Phone Number")
   end
 
-  it "has option to enable additional expenses" do
-    expect(page).to have_text("Volunteers can add Other Expenses")
+  describe "additional expense feature flag" do
+    context "enabled" do
+      before do
+        FeatureFlagService.enable!(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG)
+        visit edit_casa_org_path(organization)
+      end
+
+      it "has option to enable additional expenses" do
+        expect(page).to have_text("Volunteers can add Other Expenses")
+      end
+    end
+
+    context "disabled" do
+      before do
+        FeatureFlagService.disable!(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG)
+        visit edit_casa_org_path(organization)
+      end
+
+      it "has option to enable additional expenses" do
+        expect(page).not_to have_text("Volunteers can add Other Expenses")
+      end
+    end
   end
 
   it "requires name text field" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4915

### What changed, and why?
Show additional expense option only if the related feature flag is enabled
add relevant test

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
added the tests and checked manually 

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/9966978/0627482a-ced9-4acf-8e9c-d886921cca19)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
