### PR TITLE
Added white background card to communication preference section

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -116,37 +116,41 @@
 
 <div>
   <%= form_for @user, as: :user, url: users_path do |form| %>
-    <br>
-    <h3>Communication Preferences</h3>
-    <p>Tell us how you'd like to receive notifications.</p>
-    <div class="form-check checkbox-style mb-20">
-      <%= form.check_box :receive_email_notifications, class: "toggle-email-notifications form-check-input" %>
-      <%= form.label :receive_email_notifications, "Email Me", class: "form-check-label" %>
+    <div class="title mb-30">
+      <h2>Communication Preferences</h3>
     </div>
 
-    <% if @user.casa_org.twilio_enabled? %>
+    <div class="card-style">
+      <p>Tell us how you'd like to receive notifications.</p>
       <div class="form-check checkbox-style mb-20">
-          <%= form.check_box :receive_sms_notifications, class: "toggle-sms-notifications form-check-input" %>
-          <%= form.label :receive_sms_notifications, "Text Me", class: "form-check-label" %>
+        <%= form.check_box :receive_email_notifications, class: "toggle-email-notifications form-check-input" %>
+        <%= form.label :receive_email_notifications, "Email Me", class: "form-check-label" %>
       </div>
-      <div class="ps-4 pb-4">
-        <%= form.collection_check_boxes("sms_notification_event_ids", SmsNotificationEvent.where(user_type: @user.type),
-  :id, :name) do |event| %>
-          <div class="form-check checkbox-style mb-20">
-            <%= event.check_box(class: "form-check-input form-check-input", id: "toggle-sms-notification-event") %>
-            <%= event.label(class: "form-check-label") %>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="form-check checkbox-style mb-20">
-          <%= form.check_box :receive_sms_notifications, class: "toggle-sms-notifications form-check-input", disabled: true %>
-          <%= form.label :receive_sms_notifications, "Enable Twilio For Text Messaging", class: "form-check-label" %>
-      </div>
-    <% end %>
 
-    <div class="actions mb-10">
-      <%= form.submit "Save Preferences", class: "main-btn primary-btn btn-hover mb-3 save-preference" %>
+      <% if @user.casa_org.twilio_enabled? %>
+        <div class="form-check checkbox-style mb-20">
+            <%= form.check_box :receive_sms_notifications, class: "toggle-sms-notifications form-check-input" %>
+            <%= form.label :receive_sms_notifications, "Text Me", class: "form-check-label" %>
+        </div>
+        <div class="ps-4 pb-4">
+          <%= form.collection_check_boxes("sms_notification_event_ids", SmsNotificationEvent.where(user_type: @user.type),
+    :id, :name) do |event| %>
+            <div class="form-check checkbox-style mb-20">
+              <%= event.check_box(class: "form-check-input form-check-input", id: "toggle-sms-notification-event") %>
+              <%= event.label(class: "form-check-label") %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="form-check checkbox-style mb-20">
+            <%= form.check_box :receive_sms_notifications, class: "toggle-sms-notifications form-check-input", disabled: true %>
+            <%= form.label :receive_sms_notifications, "Enable Twilio For Text Messaging", class: "form-check-label" %>
+        </div>
+      <% end %>
+
+      <div class="actions mb-10">
+        <%= form.submit "Save Preferences", class: "main-btn primary-btn btn-hover mb-3 save-preference" %>
+      </div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/4952

### What changed, and why?
Added a white background to the card. Modified header to look like other sections.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

### Screenshots please :)
![Screenshot from 2023-07-08 00-24-10](https://github.com/rubyforgood/casa/assets/29335101/c1f37fae-4377-4e35-89b1-d3daa10cfa8d)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
