### PR TITLE
Update image height to match casa logo aspect ratio

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <% if current_organization&.logo&.attached? %>
       <%= link_to image_tag(current_organization.logo,
                             width: 200,
-                            height: 100,
+                            height: 171,
                             alt: "CASA Logo"),
                   "/" %>
     <% else %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4925

### What changed, and why?

The logo height in the sidebar partial `_sidebar.html.erb` was updated to match the ratio of the dimensions of the CASA logo provided in the assets folder.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪

Displayed logo was compared to the CASA logo for proper ratio

### Screenshots please :)

<img width="236" alt="Screenshot 2023-07-04 at 10 47 18 PM" src="https://github.com/rubyforgood/casa/assets/108249540/dff5f512-af9c-4b57-8693-7ef12a455b77">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

![alt text](https://media.giphy.com/media/KYElw07kzDspaBOwf9/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
