### PR TITLE
Removed action column from learning hours table

### DIFF
--- a/app/views/learning_hours/index.html.erb
+++ b/app/views/learning_hours/index.html.erb
@@ -17,13 +17,14 @@
             <th>Learning Type</th>
             <th>Date</th>
             <th>Time Spent</th>
-            <th>Action></th>
           </tr>
         </thead>
         <tbody>
           <% @learning_hours.order(occurred_at: :desc).each do |learning_hour| %>
             <tr>
-              <td> <%= learning_hour.name %> </td>
+              <td>
+                <%= link_to learning_hour.name, volunteer_learning_hour_path(id: learning_hour.id) %>
+              </td>
               <td> <%= (learning_hour.learning_type).humanize %> </td>
               <td> <%= learning_hour.occurred_at.strftime("%B %d, %Y") %> </td>
               <td>
@@ -32,7 +33,6 @@
               <% end %>
               <%= learning_hour.duration_minutes %> min
               </td>
-              <td><%= link_to 'See More', volunteer_learning_hour_path(id: learning_hour.id) %> </td>
             </tr>
           <% end %>
         </tbody>

--- a/spec/requests/learning_hours_spec.rb
+++ b/spec/requests/learning_hours_spec.rb
@@ -1,7 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "LearningHours", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:volunteer) { create(:volunteer) }
+
+  context "as a volunteer user" do
+    before { sign_in volunteer }
+
+    describe "GET /index" do
+      it "succeeds" do
+        get volunteer_learning_hours_path(volunteer_id: volunteer.id)
+        expect(response).to have_http_status(:success)
+      end
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/4963

### What changed, and why?
Removed Action column from the learning hours table. Made Title field adopt the functionality of the removed column. Added a simple test for the learning_hours index request.

### How will this affect user permissions?
- Volunteer permissions:   X
- Supervisor permissions: X
- Admin permissions:        X

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
![Screenshot from 2023-07-07 01-20-38](https://github.com/rubyforgood/casa/assets/29335101/e85d301f-9a12-44bb-ac0e-93460d460b29)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
