### PR TITLE
Bug: "Created by" label in Case Contact cards #4962

### DIFF
--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -1,5 +1,5 @@
 <div class="container-fluid mb-1">
-  <div class="card-style-1 mb-15 pt-0 pb-5">
+  <div class="card-style-1 mb-15 pt-0 pb-3 full-card">
     <div class="card-content">
       <div class="col-8">
         <div class="mt-0">
@@ -52,11 +52,8 @@
         <% end %>
         </div>
       </div>
-
     </div>
-  </div>
-  <div>
-    <h6 class="mb-2 text-primary ml-5">
+    <h6 class="mb-1 text-primary ml-30 mt-3">
       Created by:
       <% if policy(contact).edit? %>
         <% if current_user.volunteer? %>

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         case_contacts
         sign_in volunteer
         visit case_contacts_path
-        expect(page).to have_text("Bob Loblaw")
+        within(".full-card", match: :first) do
+          expect(page).to have_text("Bob Loblaw")
+        end
       end
 
       it "can navigate to edit volunteer page" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4962

### What changed, and why?
- updated styling to ensure created by label is included in the card
- added ID to card to ensure robust testing

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
A within block was added to existed testing to ensure the created by label is within the card

### Screenshots please :)
<img width="957" alt="casa screenshot" src="https://github.com/rubyforgood/casa/assets/102825498/5febc736-4d96-4baf-9a09-09a936b4749f">


### Feelings gif (optional)
<img src="https://media2.giphy.com/media/TdfyKrN7HGTIY/giphy.gif"/>

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
