### PR TITLE
Update sidebar_helper#active_class to fix bug with active menu items

### DIFF
--- a/app/assets/stylesheets/shared/sidebar.scss
+++ b/app/assets/stylesheets/shared/sidebar.scss
@@ -113,6 +113,16 @@
   }
 }
 
+.group-actions {
+  &:hover::before {
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+  &::before {
+    opacity: 0 !important;
+    visibility: hidden !important;
+  }
+}
 // Media Queries
 @media only screen and (max-width: screen-sizes.$mobile) {
   .sidebar-wrapper {

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -18,7 +18,7 @@ module SidebarHelper
   private # private doesn't work in modules. It's here for semantic purposes
 
   def active_class(link_path)
-    if request_path_active?
+    if request_path_active?(link_path)
       "active"
     else
       ""
@@ -27,7 +27,7 @@ module SidebarHelper
     ""
   end
 
-  def request_path_active?
+  def request_path_active?(link_path)
     # The second check is needed because Sidebar menu item 'Emancipation
     # Checklist(s)' contains a redirect if any @casa_transitioning_cases are
     # found

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -18,14 +18,20 @@ module SidebarHelper
   private # private doesn't work in modules. It's here for semantic purposes
 
   def active_class(link_path)
-    # The second check is needed because Sidebar menu item 'Emancipation Checklist(s)'
-    # contains a redirect if any @casa_transitioning_cases are found
-    if (request.path == link_path) || (link_path == "/emancipation_checklists" && request.path.match("emancipation"))
+    if request_path_active?
       "active"
     else
       ""
     end
   rescue ActionController::UrlGenerationError
     ""
+  end
+
+  def request_path_active?
+    # The second check is needed because Sidebar menu item 'Emancipation
+    # Checklist(s)' contains a redirect if any @casa_transitioning_cases are
+    # found
+    (request.path == link_path) ||
+      (link_path == "/emancipation_checklists" && request.path.match("emancipation"))
   end
 end

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -18,10 +18,13 @@ module SidebarHelper
   private # private doesn't work in modules. It's here for semantic purposes
 
   def active_class(link_path)
-    url_route_sections = link_path.split("/")
-    url_route_sections.delete("all_casa_admins")
-    controller_name = url_route_sections.second
-    current_page?({controller: controller_name, action: action_name}) ? "active" : ""
+    # The second check is needed because Sidebar menu item 'Emancipation Checklist(s)'
+    # contains a redirect if any @casa_transitioning_cases are found
+    if (request.path == link_path) || (link_path == "/emancipation_checklists" && request.path.match("emancipation"))
+      "active"
+    else
+      ""
+    end
   rescue ActionController::UrlGenerationError
     ""
   end

--- a/app/views/layouts/_all_casa_admin_sidebar.html.erb
+++ b/app/views/layouts/_all_casa_admin_sidebar.html.erb
@@ -9,14 +9,14 @@
   <nav class="sidebar-nav">
     <nav class="sidebar-nav">
       <ul>
-        <li class="nav-item">
+        <li class="<%= active_class(all_casa_admins_patch_notes_path) %> nav-item">
           <%= link_to all_casa_admins_patch_notes_path do %>
             <i class="lni lni-notepad mr-10"></i>
             Patch Notes
           <% end %>
         </li>
         <li>
-        <li class="nav-item">
+        <li class="<%= active_class(edit_all_casa_admins_path) %> nav-item">
           <%= link_to edit_all_casa_admins_path do %>
             <i class="lni lni-pencil-alt mr-10"></i>
             Edit Profile

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -61,7 +61,7 @@
           </li>
         <% end %>
         <% if all_casa_admin_signed_in? %>
-          <li class="<%= active_class(all_casa_admins_patch_notes_path) %> nav-item">
+          <li class="nav-item">
             <%= link_to all_casa_admins_patch_notes_path do %>
               <i class="lni lni-notepad mr-10"></i>
               Patch Notes
@@ -93,7 +93,7 @@
         <li class="nav-item nav-item-has-children">
           <a
             href="#0"
-            class=""
+            class="group-actions"
             data-bs-toggle="collapse"
             data-bs-target="#ddmenu_55"
             aria-controls="ddmenu_55"

--- a/spec/helpers/sidebar_helper_spec.rb
+++ b/spec/helpers/sidebar_helper_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe SidebarHelper do
 
       context "when accessing an index route" do
         it "renders sidebar menu item as an active link" do
-          # allow(helper).to receive(:action_name).and_return("index")
-          # allow(helper).to receive(:current_page?).with({controller: "supervisors", action: "index"}).and_return(true)
           helper.request.path = "/supervisors"
 
           menu_item = helper.menu_item(label: "Supervisors", path: supervisors_path, visible: true)

--- a/spec/helpers/sidebar_helper_spec.rb
+++ b/spec/helpers/sidebar_helper_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe SidebarHelper do
 
       context "when accessing an index route" do
         it "renders sidebar menu item as an active link" do
-          allow(helper).to receive(:action_name).and_return("index")
-          allow(helper).to receive(:current_page?).with({controller: "supervisors", action: "index"}).and_return(true)
+          # allow(helper).to receive(:action_name).and_return("index")
+          # allow(helper).to receive(:current_page?).with({controller: "supervisors", action: "index"}).and_return(true)
+          helper.request.path = "/supervisors"
 
           menu_item = helper.menu_item(label: "Supervisors", path: supervisors_path, visible: true)
 
@@ -42,10 +43,29 @@ RSpec.describe SidebarHelper do
 
       context "when accessing an all casa admin menu item" do
         it "renders the sidebar menu item as an active link" do
-          allow(helper).to receive(:action_name).and_return("index")
-          allow(helper).to receive(:current_page?).with({controller: "patch_notes", action: "index"}).and_return(true)
+          # allow(helper).to receive(:action_name).and_return("index")
+          # allow(helper).to receive(:current_page?).with({controller: "patch_notes", action: "index"}).and_return(true)
+          helper.request.path = "/all_casa_admins/patch_notes"
 
           menu_item = helper.menu_item(label: "Patch Notes", path: all_casa_admins_patch_notes_path, visible: true)
+
+          expect(menu_item).to match "class=\"list-group-item active\""
+        end
+      end
+
+      context "when accessing an volunteer emancipation checklist" do
+        it "renders the sidebar menu item as an active link with no redirect" do
+          helper.request.path = "/emancipation_checklists"
+
+          menu_item = helper.menu_item(label: "Emancipation Checklist(s)", path: emancipation_checklists_path, visible: true)
+
+          expect(menu_item).to match "class=\"list-group-item active\""
+        end
+
+        it "renders the sidebar menu item as an active link with redirect" do
+          helper.request.path = "/casa_cases/some-case-slug/emancipation"
+
+          menu_item = helper.menu_item(label: "Emancipation Checklist(s)", path: emancipation_checklists_path, visible: true)
 
           expect(menu_item).to match "class=\"list-group-item active\""
         end

--- a/spec/helpers/sidebar_helper_spec.rb
+++ b/spec/helpers/sidebar_helper_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe SidebarHelper do
 
       context "when accessing an all casa admin menu item" do
         it "renders the sidebar menu item as an active link" do
-          # allow(helper).to receive(:action_name).and_return("index")
-          # allow(helper).to receive(:current_page?).with({controller: "patch_notes", action: "index"}).and_return(true)
           helper.request.path = "/all_casa_admins/patch_notes"
 
           menu_item = helper.menu_item(label: "Patch Notes", path: all_casa_admins_patch_notes_path, visible: true)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #[4926](https://github.com/rubyforgood/casa/issues/4926)

### What changed, and why?
Updated the sidebar_helper.rb#active_class and update the styles for Group Action item to not show active along with the menu item that was clicked.

### How will this affect user permissions?
- Volunteer permissions: No change
- Supervisor permissions: No change
- Admin permissions: No change

### How is this tested? (please write tests!) 💖💪
Added test to check if menu item is marked active.

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/14931684/8ef7a6ca-cd2e-413e-b419-b7e0f20f1a32)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
