### PR TITLE
add random date_in_care to CasaCase seeds

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -198,7 +198,8 @@ class DbPopulator
         case_number: case_number,
         court_report_submitted_at: court_report_submitted ? Date.today : nil,
         court_report_status: court_report_submitted ? :submitted : :not_submitted,
-        birth_month_year_youth: birth_month_year_youth
+        birth_month_year_youth: birth_month_year_youth,
+        date_in_care: Date.today - (rand * 1500)
       )
       new_court_date = CourtDate.find_or_create_by!(
         casa_case: new_casa_case,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4999

### What changed, and why?
The seeds have been updated to show a `date_in_care` on each `CasaCase`

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
This PR only touches seeds, so no tests are needed.

To verify that this has worked, run the following commands in your Terminal and make sure the last one returns a date:
- [ ] `rails db:seed:replant`
- [ ] `rails c`
- [ ] `CasaCase.all.sample.date_in_care`

### Screenshots please :)

![Screenshot 2023-07-26 at 09 37 49](https://github.com/rubyforgood/casa/assets/22390758/70ccde5f-7294-4c33-b75b-f0ef851649fe)
