### PR TITLE
remove unused stylesheet import

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,6 @@
 @use "@fortawesome/fontawesome-free/scss/fontawesome";
 @use "@fortawesome/fontawesome-free/scss/solid";
 @use "select2/dist/css/select2";
-@use "select2-bootstrap-5-theme/dist/select2-bootstrap-5-theme";
 
 // custom css for the app
 @use "base/breakpoints";


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5008 

### What changed, and why?
Removed unused stylesheet import that `yarn build:css:dev` was complaining about.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
No tests required, as this is just a CSS import

### Screenshots please :)
_Terminal error before_
![terminal-before](https://github.com/rubyforgood/casa/assets/22390758/e2f89c82-e8d5-4302-a2d5-82f9cd0a6b7b)


_Terminal after_
![terminal-after](https://github.com/rubyforgood/casa/assets/22390758/f91602b3-66e7-49d5-b03b-1d37105afa19)


_Browser error before_
![browser-before](https://github.com/rubyforgood/casa/assets/22390758/c86c5d54-d4e5-4f59-9e02-648314153afd)


_Browser after_
![browser-after](https://github.com/rubyforgood/casa/assets/22390758/9656399e-5edb-488d-85f6-73a69bbfcf43)
