### PR TITLE
Fill Out Notification Tests, and add missing notification Factories

### DIFF
--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe NotificationComponent, type: :component do
   let(:emancipation_checklist_reminder) { create(:notification, :emancipation_checklist_reminder) }
   let(:youth_birthday) { create(:notification, :youth_birthday) }
 
-
   it "renders a followup with note" do
     component = described_class.new(notification: followup_with_note.to_notification)
 

--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe NotificationComponent, type: :component do
   let(:followup_no_note) { create(:notification, :followup_without_note) }
   let(:followup_read) { create(:notification, :followup_read) }
   let(:emancipation_checklist_reminder) { create(:notification, :emancipation_checklist_reminder) }
+  let(:youth_birthday) { create(:notification, :youth_birthday) }
 
 
   it "renders a followup with note" do
@@ -49,5 +50,13 @@ RSpec.describe NotificationComponent, type: :component do
     render_inline(component)
     expect(page).to have_text("Emancipation Checklist Reminder")
     expect(page).to have_text(emancipation_checklist_reminder.to_notification.message)
+  end
+
+  it "renders a youth birthday notification" do
+    component = described_class.new(notification: youth_birthday.to_notification)
+
+    render_inline(component)
+    expect(page).to have_text("Youth Birthday")
+    expect(page).to have_text(youth_birthday.to_notification.message)
   end
 end

--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe NotificationComponent, type: :component do
   let(:followup_with_note) { create(:notification, :followup_with_note) }
   let(:followup_no_note) { create(:notification, :followup_without_note) }
   let(:followup_read) { create(:notification, :followup_read) }
+  let(:emancipation_checklist_reminder) { create(:notification, :emancipation_checklist_reminder) }
+
 
   it "renders a followup with note" do
     component = described_class.new(notification: followup_with_note.to_notification)
@@ -39,5 +41,13 @@ RSpec.describe NotificationComponent, type: :component do
     render_inline(component)
     expect(page).to have_css("a.bg-light.text-muted")
     expect(page).not_to have_css("i.fas.fa-bell")
+  end
+
+  it "renders an emancipation checklist reminder" do
+    component = described_class.new(notification: emancipation_checklist_reminder.to_notification)
+
+    render_inline(component)
+    expect(page).to have_text("Emancipation Checklist Reminder")
+    expect(page).to have_text(emancipation_checklist_reminder.to_notification.message)
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -61,10 +61,18 @@ FactoryBot.define do
       initialize_with { new(params: params) }
     end
 
-    # trait :youth_birthday do
-    #   transient do
-    #     creator { build(:user) }
-    #   end
-    # end
+    trait :youth_birthday do
+      transient do
+        creator { create(:user) }
+      end
+      type { "YouthBirthdayNotification" }
+      params {
+        {
+          casa_case: create(:casa_case),
+          created_by: creator
+        }
+      }
+      initialize_with { new(params: params) }
+    end
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -48,28 +48,20 @@ FactoryBot.define do
     end
 
     trait :emancipation_checklist_reminder do
-      transient do
-        creator { create(:user) }
-      end
       type { "EmancipationChecklistReminderNotification" }
       params {
         {
-          casa_case: create(:casa_case),
-          created_by: creator
+          casa_case: create(:casa_case)
         }
       }
       initialize_with { new(params: params) }
     end
 
     trait :youth_birthday do
-      transient do
-        creator { create(:user) }
-      end
       type { "YouthBirthdayNotification" }
       params {
         {
-          casa_case: create(:casa_case),
-          created_by: creator
+          casa_case: create(:casa_case)
         }
       }
       initialize_with { new(params: params) }

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -54,7 +54,7 @@ FactoryBot.define do
       type { "EmancipationChecklistReminderNotification" }
       params {
         {
-          casa_case: create(:casa_case, :with_one_case_assignment),
+          casa_case: create(:casa_case),
           created_by: creator
         }
       }

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :recipient, factory: :volunteer
     recipient_type { "User" }
     type { "Notification" }
-    
+
     trait :followup_with_note do
       transient do
         creator { build(:user) }

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :recipient, factory: :volunteer
     recipient_type { "User" }
     type { "Notification" }
-
+    
     trait :followup_with_note do
       transient do
         creator { build(:user) }
@@ -46,5 +46,25 @@ FactoryBot.define do
       }
       initialize_with { new(params: params) }
     end
+
+    trait :emancipation_checklist_reminder do
+      transient do
+        creator { create(:user) }
+      end
+      type { "EmancipationChecklistReminderNotification" }
+      params {
+        {
+          casa_case: create(:casa_case, :with_one_case_assignment),
+          created_by: creator
+        }
+      }
+      initialize_with { new(params: params) }
+    end
+
+    # trait :youth_birthday do
+    #   transient do
+    #     creator { build(:user) }
+    #   end
+    # end
   end
 end

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "notifications/index", type: :system do
   let(:volunteer) { build(:volunteer) }
   let(:case_contact) { create(:case_contact, creator: volunteer) }
   let(:casa_case) { case_contact.casa_case }
-  let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
-  let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
+  let(:next_month) { Time.now.month == 12 ? 1 : Time.now.month + 1 }
+  let(:year) { Time.now.month == 12 ? Time.now.year + 1 : Time.now.year }
 
   before { casa_case.assigned_volunteers << volunteer }
 
@@ -177,11 +177,11 @@ RSpec.describe "notifications/index", type: :system do
       end
     end
 
-    context "youth is not of transition age" do 
-      let(:casa_case) {build(:casa_case, :pre_transition)}
+    context "youth is not of transition age" do
+      let(:casa_case) { build(:casa_case, :pre_transition) }
       let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
       before { casa_case.assigned_volunteers << volunteer }
-      
+
       before do
         travel_to Time.zone.local(year, next_month, 1) do
           sign_in volunteer
@@ -202,9 +202,9 @@ RSpec.describe "notifications/index", type: :system do
 
   context "YouthBirthdayNotification" do
     context "when youth has birthday in the next calendar month" do
-      let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
+      let(:the_15th_of_next_month) { Time.zone.local(year, next_month, 15) }
       let(:youth_birthday) { the_15th_of_next_month - 16.years + 1.month }
-      let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}
+      let(:casa_case) { build(:casa_case, birth_month_year_youth: youth_birthday) }
       let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
       before { casa_case.assigned_volunteers << volunteer }
 
@@ -219,7 +219,7 @@ RSpec.describe "notifications/index", type: :system do
         end
       end
 
-      it 'should display a notification on the notifications page' do
+      it "should display a notification on the notifications page" do
         expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
         expect(page).to have_content("Youth Birthday Notification")
         expect(page).to have_content("Your youth, case number: #{casa_case.case_number} has a birthday next month.")
@@ -227,9 +227,9 @@ RSpec.describe "notifications/index", type: :system do
     end
 
     context "the youth has a birthday not in the next month" do
-      let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
+      let(:the_15th_of_next_month) { Time.zone.local(year, next_month, 15) }
       let(:youth_birthday) { the_15th_of_next_month - 16.years + 2.month }
-      let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}
+      let(:casa_case) { build(:casa_case, birth_month_year_youth: youth_birthday) }
       let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
       before { casa_case.assigned_volunteers << volunteer }
 
@@ -244,7 +244,7 @@ RSpec.describe "notifications/index", type: :system do
         end
       end
 
-      it 'should not send a notification' do
+      it "should not send a notification" do
         expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
         expect(page).to_not have_content("Youth Birthday Notification")
         expect(page).to_not have_content("Your youth, case number: #{casa_case.case_number} has a birthday next month.")

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 require "rake"
 Rake.application.rake_require "tasks/emancipation_checklist_reminder"
+Rake.application.rake_require "tasks/youth_birthday_reminder"
 
 RSpec.describe "notifications/index", type: :system do
   let(:admin) { create(:casa_admin) }
@@ -199,6 +200,62 @@ RSpec.describe "notifications/index", type: :system do
         expect(page).to_not have_content("Emancipation Checklist Reminder")
         expect(page).to_not have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
         expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
+      end
+    end
+  end
+
+  context "YouthBirthdayNotification" do
+    context "when youth has birthday in the next calendar month" do
+      let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
+      let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
+      let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
+      let(:youth_birthday) { the_15th_of_next_month - 16.years + 1.month }
+      let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}
+      let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+      before { casa_case.assigned_volunteers << volunteer }
+
+      before do
+        travel_to the_15th_of_next_month do
+          create(:case_assignment, casa_case: casa_case, volunteer: volunteer)
+          sign_in volunteer
+          Rake::Task.clear
+          Casa::Application.load_tasks
+          Rake::Task["youth_birthday_reminder"].invoke
+          visit notifications_path
+        end
+      end
+
+      it 'should display a notification on the notifications page' do
+        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
+        expect(page).to have_content("Youth Birthday Notification")
+        expect(page).to have_content("Your youth, case number: #{casa_case.case_number} has a birthday next month.")
+      end
+    end
+
+    context "the youth has a birthday not in the next month" do
+      let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
+      let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
+      let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
+      let(:youth_birthday) { the_15th_of_next_month - 16.years + 2.month }
+      let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}
+      let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
+      before { casa_case.assigned_volunteers << volunteer }
+
+      before do
+        travel_to the_15th_of_next_month do
+          create(:case_assignment, casa_case: casa_case, volunteer: volunteer)
+          sign_in volunteer
+          Rake::Task.clear
+          Casa::Application.load_tasks
+          Rake::Task["youth_birthday_reminder"].invoke
+          visit notifications_path
+        end
+      end
+
+      it 'should not send a notification' do
+        expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
+        expect(page).to_not have_content("Youth Birthday Notification")
+        expect(page).to_not have_content("Your youth, case number: #{casa_case.case_number} has a birthday next month.")
       end
     end
   end

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "notifications/index", type: :system do
   let(:volunteer) { build(:volunteer) }
   let(:case_contact) { create(:case_contact, creator: volunteer) }
   let(:casa_case) { case_contact.casa_case }
+  let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
+  let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
 
   before { casa_case.assigned_volunteers << volunteer }
 
@@ -141,8 +143,6 @@ RSpec.describe "notifications/index", type: :system do
   context "EmancipationChecklistReminder" do
     context "on the first of the month with a transition-aged youth" do
       before do
-        next_month = Time.now.month == 12 ? 1 : Time.now.month + 1
-        year = Time.now.month == 12 ? Time.now.year + 1 : Time.now.year
         travel_to Time.zone.local(year, next_month, 1) do
           sign_in volunteer
           Rake::Task.clear
@@ -161,8 +161,6 @@ RSpec.describe "notifications/index", type: :system do
 
     context "not on the first of the month" do
       before do
-        next_month = Time.now.month == 12 ? 1 : Time.now.month + 1
-        year = Time.now.month == 12 ? Time.now.year + 1 : Time.now.year
         travel_to Time.zone.local(year, next_month, 2) do
           sign_in volunteer
           Rake::Task.clear
@@ -185,8 +183,6 @@ RSpec.describe "notifications/index", type: :system do
       before { casa_case.assigned_volunteers << volunteer }
       
       before do
-        next_month = Time.now.month == 12 ? 1 : Time.now.month + 1
-        year = Time.now.month == 12 ? Time.now.year + 1 : Time.now.year
         travel_to Time.zone.local(year, next_month, 1) do
           sign_in volunteer
           Rake::Task.clear
@@ -206,8 +202,6 @@ RSpec.describe "notifications/index", type: :system do
 
   context "YouthBirthdayNotification" do
     context "when youth has birthday in the next calendar month" do
-      let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
-      let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
       let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
       let(:youth_birthday) { the_15th_of_next_month - 16.years + 1.month }
       let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}
@@ -233,8 +227,6 @@ RSpec.describe "notifications/index", type: :system do
     end
 
     context "the youth has a birthday not in the next month" do
-      let(:next_month) {Time.now.month == 12 ? 1 : Time.now.month + 1}
-      let(:year) {Time.now.month == 12 ? Time.now.year + 1 : Time.now.year}
       let(:the_15th_of_next_month) {Time.zone.local(year, next_month, 15)}
       let(:youth_birthday) { the_15th_of_next_month - 16.years + 2.month }
       let(:casa_case) {build(:casa_case, birth_month_year_youth: youth_birthday)}

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe "notifications/index", type: :system do
   let(:volunteer) { build(:volunteer) }
   let(:case_contact) { create(:case_contact, creator: volunteer) }
   let(:casa_case) { case_contact.casa_case }
-  let(:next_month) { Time.now.month == 12 ? 1 : Time.now.month + 1 }
-  let(:year) { Time.now.month == 12 ? Time.now.year + 1 : Time.now.year }
 
   before { casa_case.assigned_volunteers << volunteer }
 
@@ -144,10 +142,11 @@ RSpec.describe "notifications/index", type: :system do
       visit notifications_path
     end
 
-    it "should display a notification reminder that links to the emancipation checklist for each youth" do
+    it "should display a notification reminder that links to the emancipation checklist" do
+      notification_message = "Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist."
       expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
       expect(page).to have_content("Emancipation Checklist Reminder")
-      expect(page).to have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
+      expect(page).to have_link(notification_message, href: casa_case_emancipation_path(casa_case.id))
     end
   end
 
@@ -159,9 +158,10 @@ RSpec.describe "notifications/index", type: :system do
     end
 
     it "should display a notification on the notifications page" do
+      notification_message = "Your youth, case number: #{casa_case.case_number} has a birthday next month."
       expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
       expect(page).to have_content("Youth Birthday Notification")
-      expect(page).to have_content("Your youth, case number: #{casa_case.case_number} has a birthday next month.")
+      expect(page).to have_link(notification_message, href: casa_case_path(casa_case.id))
     end
   end
 

--- a/spec/system/notifications/index_spec.rb
+++ b/spec/system/notifications/index_spec.rb
@@ -141,62 +141,16 @@ RSpec.describe "notifications/index", type: :system do
   end
 
   context "EmancipationChecklistReminder" do
-    context "on the first of the month with a transition-aged youth" do
-      before do
-        travel_to Time.zone.local(year, next_month, 1) do
-          sign_in volunteer
-          Rake::Task.clear
-          Casa::Application.load_tasks
-          Rake::Task["emancipation_checklist_reminder"].invoke
-          visit notifications_path
-        end
-      end
-
-      it "should display a notification reminder that links to the emancipation checklist for each youth" do
-        expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
-        expect(page).to have_content("Emancipation Checklist Reminder")
-        expect(page).to have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
-      end
+    before do
+      volunteer.notifications << create(:notification, :emancipation_checklist_reminder, params: {casa_case: casa_case})
+      sign_in volunteer
+      visit notifications_path
     end
 
-    context "not on the first of the month" do
-      before do
-        travel_to Time.zone.local(year, next_month, 2) do
-          sign_in volunteer
-          Rake::Task.clear
-          Casa::Application.load_tasks
-          Rake::Task["emancipation_checklist_reminder"].invoke
-          visit notifications_path
-        end
-      end
-
-      it "should not display a notification" do
-        expect(page).to_not have_content("Emancipation Checklist Reminder")
-        expect(page).to_not have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
-        expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
-      end
-    end
-
-    context "youth is not of transition age" do
-      let(:casa_case) { build(:casa_case, :pre_transition) }
-      let(:case_contact) { create(:case_contact, creator: volunteer, casa_case: casa_case) }
-      before { casa_case.assigned_volunteers << volunteer }
-
-      before do
-        travel_to Time.zone.local(year, next_month, 1) do
-          sign_in volunteer
-          Rake::Task.clear
-          Casa::Application.load_tasks
-          Rake::Task["emancipation_checklist_reminder"].invoke
-          visit notifications_path
-        end
-      end
-
-      it "should not display a notification" do
-        expect(page).to_not have_content("Emancipation Checklist Reminder")
-        expect(page).to_not have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
-        expect(page).to have_text(I18n.t(".notifications.index.no_notifications"))
-      end
+    it "should display a notification reminder that links to the emancipation checklist for each youth" do
+      expect(page).not_to have_text(I18n.t(".notifications.index.no_notifications"))
+      expect(page).to have_content("Emancipation Checklist Reminder")
+      expect(page).to have_content("Your case #{casa_case.case_number} is a transition aged youth. We want to make sure that along the way, we’re preparing our youth for emancipation. Make sure to check the emancipation checklist.")
     end
   end
 
@@ -237,7 +191,6 @@ RSpec.describe "notifications/index", type: :system do
         travel_to the_15th_of_next_month do
           create(:case_assignment, casa_case: casa_case, volunteer: volunteer)
           sign_in volunteer
-          Rake::Task.clear
           Casa::Application.load_tasks
           Rake::Task["youth_birthday_reminder"].invoke
           visit notifications_path


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4681 

### What changed, and why?
Adds 2 missing traits to notification factory  in spec/factories/notifications.rb (emancipation_checklist_reminder and youth_birthday):

<img width="443" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/ab3deeb2-1a73-4353-9eed-9a863dadde0a">

This also adds 2 corresponding component tests in spec/components/notification_component_spec.rb:

<img width="718" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/909a61b3-bc77-4839-8f00-eeba5f5c52f5">

Finally, I've added some tests in spec/system/notifications/index_spec.rb 

<img width="987" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/3b1fa6ec-04c5-4873-8488-da71360f2563">
