### PR TITLE
[4993] add download current template button for admin ui

### DIFF
--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -28,7 +28,16 @@
     </div>
     <div class="input-style-1">
       <%= form.label :court_report_template, "Court report template" %>
-      <%= form.file_field :court_report_template, class: "form-control" %>
+      <div class="row">
+        <div class="col-sm">
+          <%= form.file_field :court_report_template, class: "form-control" %>
+        </div>
+         <div class="col-sm align-middle my-auto">
+          <% if current_organization.court_report_template.attached? %>
+            <%= link_to 'Download Current Template', rails_blob_path(current_organization.court_report_template, only_path: true), class: "btn btn-info"  %>
+          <% end %>
+        </div>
+      </div>
     </div>
     <hr>
     <h3 class="mb-2">Organization Features</h3>

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -34,7 +34,7 @@
         </div>
          <div class="col-sm align-middle my-auto">
           <% if current_organization.court_report_template.attached? %>
-            <%= link_to 'Download Current Template', rails_blob_path(current_organization.court_report_template, only_path: true), class: "btn btn-info"  %>
+            <%= link_to 'Download Current Template', rails_blob_path(current_organization.court_report_template, only_path: true), class: "btn btn-info" %>
           <% end %>
         </div>
       </div>

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe "casa_org/edit", type: :view do
   let(:organization) { create :casa_org }
   let(:admin) { build_stubbed(:all_casa_admin) }
-  let(:contact_type_groups) { [] }
-  let(:contact_types) { [] }
 
   before do
     allow(view).to receive(:current_organization).and_return(organization)
@@ -13,8 +11,6 @@ RSpec.describe "casa_org/edit", type: :view do
     assign(:hearing_types, [])
     assign(:judges, [])
     assign(:sent_emails, [])
-
-
 
     sign_in admin
 

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "casa_org/edit", type: :view do
+  let(:organization) { create :casa_org }
+  let(:admin) { build_stubbed(:all_casa_admin) }
+  let(:contact_type_groups) { [] }
+  let(:contact_types) { [] }
+
+  before do
+    allow(view).to receive(:current_organization).and_return(organization)
+    assign(:contact_type_groups, [])
+    assign(:contact_types, [])
+    assign(:hearing_types, [])
+    assign(:judges, [])
+    assign(:sent_emails, [])
+
+
+
+    sign_in admin
+
+    render template: "casa_org/edit"
+  end
+
+  it "renders and does not show download prompt if new org" do
+    expect(rendered).not_to have_text("Download Current Template")
+  end
+
+  context "with a template uploaded" do
+    before do
+      organization.court_report_template.attach(io: File.open("#{Rails.root}/app/documents/templates/default_report_template.docx"), filename: 'default_report_template
+.docx', content_type: "application/docx")
+    end
+
+    it "renders a prompt to download current template" do
+      expect(rendered).not_to have_text("Download Current Template")
+    end
+  end
+end

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "casa_org/edit", type: :view do
-
   before do
     assign(:contact_type_groups, [])
     assign(:contact_types, [])
@@ -10,7 +9,6 @@ RSpec.describe "casa_org/edit", type: :view do
     assign(:sent_emails, [])
 
     sign_in build_stubbed(:all_casa_admin)
-
   end
 
   it "renders and does not show download prompt if new org" do
@@ -23,7 +21,6 @@ RSpec.describe "casa_org/edit", type: :view do
   end
 
   context "with a template uploaded" do
-
     it "renders a prompt to download current template" do
       organization = create :casa_org
       allow(view).to receive(:current_organization).and_return(organization)

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -1,34 +1,39 @@
 require "rails_helper"
 
 RSpec.describe "casa_org/edit", type: :view do
-  let(:organization) { create :casa_org }
-  let(:admin) { build_stubbed(:all_casa_admin) }
 
   before do
-    allow(view).to receive(:current_organization).and_return(organization)
     assign(:contact_type_groups, [])
     assign(:contact_types, [])
     assign(:hearing_types, [])
     assign(:judges, [])
     assign(:sent_emails, [])
 
-    sign_in admin
+    sign_in build_stubbed(:all_casa_admin)
 
-    render template: "casa_org/edit"
   end
 
   it "renders and does not show download prompt if new org" do
+    organization = create :casa_org
+    allow(view).to receive(:current_organization).and_return(organization)
+
+    render template: "casa_org/edit"
+
     expect(rendered).not_to have_text("Download Current Template")
   end
 
   context "with a template uploaded" do
-    before do
-      organization.court_report_template.attach(io: File.open("#{Rails.root}/app/documents/templates/default_report_template.docx"), filename: 'default_report_template
-.docx', content_type: "application/docx")
-    end
 
     it "renders a prompt to download current template" do
-      expect(rendered).not_to have_text("Download Current Template")
+      organization = create :casa_org
+      allow(view).to receive(:current_organization).and_return(organization)
+
+      organization.court_report_template.attach(io: File.open("#{Rails.root}/app/documents/templates/default_report_template.docx"), filename: 'default_report_template
+.docx', content_type: "application/docx")
+
+      render template: "casa_org/edit"
+
+      expect(rendered).to have_text("Download Current Template")
     end
   end
 end

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe "casa_org/edit", type: :view do
     assign(:judges, [])
     assign(:sent_emails, [])
 
-    sign_in build_stubbed(:all_casa_admin)
+    sign_in build_stubbed(:casa_admin)
   end
 
-  it "renders and does not show download prompt if new org" do
+  it "does not show download prompt with no custom template" do
     organization = create :casa_org
     allow(view).to receive(:current_organization).and_return(organization)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4993 

### What changed, and why?

Added download button prompt



### How will this affect user permissions?
No changes

### How is this tested? (please write tests!) 💖💪
Bench test + View specs

### Screenshots please :)
<img width="837" alt="Screen Shot 2023-07-28 at 8 17 46 AM" src="https://github.com/rubyforgood/casa/assets/5641692/e37b566d-541d-4be7-a058-dd51f630552c">

### Feelings gif (optional)
What gif best describes your feeling working on this issue?
😹 
### Feedback please? (optional)
Might've been worth specifying desired behavior if there was no court template to grab from. I made an assumption that "blank" is best, but could have been otherwise!
