### PR TITLE
Only require the bundler/audit/task in dev environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-require "bundler/audit/task"
-
-Bundler::Audit::Task.new
+if Rails.env.development?
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
+end


### PR DESCRIPTION
Gem is only installed in dev

Should fix build errors on Heroku:

```
-----> Detecting rake tasks

 !
 !     Could not detect rake tasks
 !     ensure you can run `$ bundle exec rake -P` against your app
 !     and using the production group of your Gemfile.
 !     rake aborted!
 !     LoadError: cannot load such file -- bundler/audit/task
 !     <internal:/tmp/build_7d353d22/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
 !     <internal:/tmp/build_7d353d22/vendor/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
 !     /tmp/build_7d353d22/Rakefile:8:in `<top (required)>'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load_rakefile'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:710:in `raw_load_rakefile'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:104:in `block in load_rakefile'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:103:in `load_rakefile'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:82:in `block in run'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
 !     /tmp/build_7d353d22/vendor/bundle/ruby/3.2.0/gems/rake-13.0.6/lib/rake/application.rb:80:in `run'
 !     /tmp/build_7d353d22/bin/rake:4:in `<main>'
 !
/tmp/codon/tmp/buildpacks/50d5eddf222a9b7326028041d4e6509f915ccf2c/lib/language_pack/helpers/rake_runner.rb:100:in `load_rake_tasks!': Could not detect rake tasks (LanguagePack::Helpers::RakeRunner::CannotLoadRakefileError)
ensure you can run `$ bundle exec rake -P` against your app
and using the production group of your Gemfile.
rake aborted!
LoadError: cannot load such file -- bundler/audit/task
```