### PR TITLE
Admins and supervisors can add a banner to the top of the screen

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -1,5 +1,6 @@
 channels/application_cable/channel.rb
 channels/application_cable/connection.rb
+controllers/banners_controller.rb
 controllers/followup_reports_controller.rb
 controllers/mileage_reports_controller.rb
 controllers/placements_controller.rb

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,0 +1,31 @@
+/*
+ * Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+ * the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+ * inclusion directly in any other asset bundle and remove this file.
+ *
+ *= require trix
+*/
+
+/*
+ * We need to override trix.css’s image gallery styles to accommodate the
+ * <action-text-attachment> element we wrap around attachments. Otherwise,
+ * images in galleries will be squished by the max-width: 33%; rule.
+*/
+.trix-content .attachment-gallery > action-text-attachment,
+.trix-content .attachment-gallery > .attachment {
+  flex: 1 0 33%;
+  padding: 0 0.5em;
+  max-width: 33%;
+}
+
+.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+
+.trix-content action-text-attachment .attachment {
+  padding: 0 !important;
+  max-width: 100% !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,3 +37,6 @@
 @use "pages/reimbursements";
 @use "pages/supervisors";
 @use "pages/volunteers";
+
+@use 'trix/dist/trix.css';
+@use "actiontext";

--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -1,0 +1,56 @@
+class BannersController < ApplicationController
+  after_action :verify_authorized
+
+  def index
+    authorize :application, :admin_or_supervisor?
+
+    @banners = current_organization.banners.includes(:user)
+  end
+
+  def new
+    authorize :application, :admin_or_supervisor?
+
+    @banner = Banner.new
+  end
+
+  def edit
+    authorize :application, :admin_or_supervisor?
+
+    @banner = current_organization.banners.find(params[:id])
+  end
+
+  def create
+    authorize :application, :admin_or_supervisor?
+
+    @banner = current_organization.banners.build(banner_params)
+    if @banner.save
+      redirect_to banners_path
+    else
+      render :new
+    end
+  end
+
+  def update
+    authorize :application, :admin_or_supervisor?
+
+    @banner = current_organization.banners.find(params[:id])
+    if @banner.update(banner_params)
+      redirect_to banners_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    authorize :application, :admin_or_supervisor?
+
+    current_organization.banners.find(params[:id]).destroy
+    redirect_to banners_path
+  end
+
+  private
+
+  def banner_params
+    params.require(:banner).permit(:active, :content, :name).merge(user: current_user)
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,8 +4,8 @@ import 'bootstrap'
 import 'bootstrap-select'
 import './sweet-alert-confirm.js'
 import './controllers'
-import "trix"
-import "@rails/actiontext"
+import 'trix'
+import '@rails/actiontext'
 
 require('datatables.net-dt')(null, window.jQuery) // First parameter is the global object. Defaults to window if null
 require('select2')(window.jQuery)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -34,3 +34,5 @@ require('./src/session_timeout_poller.js')
 require('./src/display_app_metric.js')
 require('./src/casa_org')
 require('./src/sms_reactivation_toggle')
+import "trix"
+import "@rails/actiontext"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,8 @@ import 'bootstrap'
 import 'bootstrap-select'
 import './sweet-alert-confirm.js'
 import './controllers'
+import "trix"
+import "@rails/actiontext"
 
 require('datatables.net-dt')(null, window.jQuery) // First parameter is the global object. Defaults to window if null
 require('select2')(window.jQuery)
@@ -34,5 +36,3 @@ require('./src/session_timeout_poller.js')
 require('./src/display_app_metric.js')
 require('./src/casa_org')
 require('./src/sms_reactivation_toggle')
-import "trix"
-import "@rails/actiontext"

--- a/app/javascript/controllers/dismiss_controller.js
+++ b/app/javascript/controllers/dismiss_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['element'];
+  static targets = ['element']
 
-  dismiss(event) {
+  dismiss (event) {
     event.preventDefault();
 
-    const { id } = event.params;
-    document.cookie = `dismiss_${id}=true`;
-    this.elementTarget.classList.add('d-none');
+    const { id } = event.params
+    document.cookie = `dismiss_${id}=true`
+    this.elementTarget.classList.add('d-none')
   }
 }

--- a/app/javascript/controllers/dismiss_controller.js
+++ b/app/javascript/controllers/dismiss_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ['element']
 
   dismiss (event) {
-    event.preventDefault();
+    event.preventDefault()
 
     const { id } = event.params
     document.cookie = `dismiss_${id}=true`

--- a/app/javascript/controllers/dismiss_controller.js
+++ b/app/javascript/controllers/dismiss_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = [ 'element' ]
+  static targets = ['element'];
 
   dismiss(event) {
     event.preventDefault();

--- a/app/javascript/controllers/dismiss_controller.js
+++ b/app/javascript/controllers/dismiss_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = [ 'element' ]
+
+  dismiss(event) {
+    event.preventDefault();
+
+    const { id } = event.params;
+    document.cookie = `dismiss_${id}=true`;
+    this.elementTarget.classList.add('d-none');
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from './application'
 
+import DismissController from './dismiss_controller'
+application.register('dismiss', DismissController)
+
 import HelloController from './hello_controller'
 application.register('hello', HelloController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,7 +5,7 @@
 import { application } from './application'
 
 import DismissController from './dismiss_controller'
-application.register('dismiss', DismissController)
-
 import HelloController from './hello_controller'
+
+application.register('dismiss', DismissController)
 application.register('hello', HelloController)

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -1,0 +1,43 @@
+class Banner < ApplicationRecord
+  belongs_to :casa_org
+  belongs_to :user
+  has_rich_text :content
+
+  scope :active, -> { where(active: true) }
+
+  validates_presence_of :name
+  validate :only_one_banner_is_active_per_organization
+
+  private
+
+  def only_one_banner_is_active_per_organization
+    is_other_banner_active = casa_org.banners.where.not(id: self.id).any?(&:active?)
+    more_than_one_banner_active = is_other_banner_active && active?
+    if more_than_one_banner_active
+      errors.add(:base, 'Only one banner can be active at a time. Mark the other banners as not active before marking this banner as active.')
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: banners
+#
+#  id          :bigint           not null, primary key
+#  active      :boolean          default(FALSE)
+#  name        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  casa_org_id :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_banners_on_casa_org_id  (casa_org_id)
+#  index_banners_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (casa_org_id => casa_orgs.id)
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -11,10 +11,10 @@ class Banner < ApplicationRecord
   private
 
   def only_one_banner_is_active_per_organization
-    is_other_banner_active = casa_org.banners.where.not(id: self.id).any?(&:active?)
+    is_other_banner_active = casa_org.banners.where.not(id: id).any?(&:active?)
     more_than_one_banner_active = is_other_banner_active && active?
     if more_than_one_banner_active
-      errors.add(:base, 'Only one banner can be active at a time. Mark the other banners as not active before marking this banner as active.')
+      errors.add(:base, "Only one banner can be active at a time. Mark the other banners as not active before marking this banner as active.")
     end
   end
 end

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -20,6 +20,7 @@ class CasaOrg < ApplicationRecord
   has_many :case_assignments, through: :users, source: :casa_cases
   has_many :languages, dependent: :destroy
   has_many :placements, through: :casa_cases
+  has_many :banners, dependent: :destroy
   has_one_attached :logo
   has_one_attached :court_report_template
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -143,4 +143,5 @@ class ApplicationPolicy
 
   alias_method :modify_organization?, :is_admin?
   alias_method :see_import_page?, :is_admin?
+  alias_method :see_banner_page?, :admin_or_supervisor?
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -1,0 +1,38 @@
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>
+          <% if banner.persisted? %>
+            Edit Banner
+          <% else %>
+            New Banner
+          <% end %>
+        </h1>
+      </div>
+    </div>
+  </div>
+</div><!-- ==== end title ==== -->
+<div class="card-style mb-30">
+  <%= form_with model: banner do |form| %>
+    <%= render "shared/error_messages", resource: banner %>
+
+    <div class="input-style-1">
+      <%= form.label :name %>
+      <%= form.text_field :name, required: true %>
+    </div>
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :active, class: 'form-check-input' %>
+      <%= form.label :active, "Active?", class: 'form-check-label' %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :content %>
+      <%= form.rich_text_area :content %>
+    </div>
+    <div class="actions mb-10">
+      <%= button_tag(type: "submit", class: "btn-sm main-btn primary-btn btn-hover") do %>
+        <i class="lni lni-checkmark-circle mr-10"></i> Submit
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/banners/edit.html.erb
+++ b/app/views/banners/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'banners/form', banner: @banner %>

--- a/app/views/banners/index.html.erb
+++ b/app/views/banners/index.html.erb
@@ -1,0 +1,70 @@
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>Banners</h1>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="tables-wrapper">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card-style mb-30">
+        <h3 class="mb-10">Banners</h3>
+        <p class="text-sm mb-20">
+          Banners display at the top of the page and can be used to callout a message to volunteers. One example is displaying a banner with a link to a survey that volunteers can fill out. You can create multiple banners but only one can be active at a time.
+        </p>
+        <%= link_to new_banner_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+          <i class="lni lni-plus mr-10"></i>
+          New Banner
+        <% end %>
+        <div class="table-wrapper table-responsive">
+          <table class="table striped-table" id="banners">
+            <thead>
+            <tr>
+              <th>Name</th>
+              <th>Active?</th>
+              <th>Last Updated By</th>
+              <th>Updated At</th>
+              <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <% @banners.each do |banner| %>
+              <tr>
+                <td class="min-width">
+                  <%= banner.name %>
+                </td>
+                <td class="min-width">
+                  <% if banner.active? %>
+                    Yes
+                  <% else %>
+                    No
+                  <% end %>
+                </td>
+                <td class="min-width">
+                  <%= banner.user.display_name %>
+                </td>
+                <td class="min-width">
+                  <%= time_ago_in_words(banner.updated_at) %> ago
+                </td>
+                <td>
+                  <%= link_to edit_banner_path(banner) do %>
+                    <div class="action">
+                      <button class="text-danger">
+                        <i class="lni lni-pencil-alt"></i> Edit
+                      </button>
+                    </div>
+                  <% end %>
+                  <%= link_to 'Delete', banner_path(banner), class: 'btn btn-danger', method: :delete, data: { confirm: "Are you sure that you want to delete this banner?" } %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/banners/new.html.erb
+++ b/app/views/banners/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'banners/form', banner: @banner %>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,8 +1,14 @@
 <% banner = current_organization.banners.active.first %>
-<% cookie_id = "banner_#{banner.id}" %>
-<% if !cookies["dismiss_#{cookie_id}"] %>
-  <div class="row bg-secondary-100 text-xl p-5" data-controller="dismiss" data-dismiss-target="element">
-    <%= banner.content %>
-    <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
-  </div>
+<% if banner %>
+  <% cookie_id = "banner_#{banner.id}" %>
+  <% if !cookies["dismiss_#{cookie_id}"] %>
+    <div class="bg-secondary-100 text-xl p-5 d-flex" data-controller="dismiss" data-dismiss-target="element">
+      <div class="">
+        <%= banner.content %>
+      </div>
+      <div class="ms-auto">
+        <a href="#" class="float-right" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -7,7 +7,7 @@
         <%= banner.content %>
       </div>
       <div class="ms-auto">
-        <a href="#" class="float-right" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
+        <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,0 +1,8 @@
+<% banner = current_organization.banners.active.first %>
+<% cookie_id = "banner_#{banner.id}" %>
+<% if !cookies["dismiss_#{cookie_id}"] %>
+  <div class="row bg-secondary-100 text-xl p-5" data-controller="dismiss" data-dismiss-target="element">
+    <%= banner.content %>
+    <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
+  </div>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,7 @@
-<header class="header">
-  <div class="container-fluid">
+<header class="header pt-0">
+  <%= render 'layouts/banner' %>
+
+  <div class="container-fluid pt-30">
     <div class="row">
       <div class="col-lg-5 col-md-5 col-6">
         <div class="header-left d-flex align-items-center">

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -158,6 +158,15 @@
                 <% end %>
               </li>
             <% end %>
+
+            <% if policy(:application).see_banner_page? %>
+              <li>
+                <%= link_to banners_path, class: "#{active_class(banners_path)}" do %>
+                  <i class="lni lni-flag mr-10"></i>
+                  Banners
+                <% end %>
+              </li>
+            <% end %>
           </ul>
         </li>
         <li>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,7 @@ Rails.application.routes.draw do
   resources :learning_hours_reports, only: %i[index]
   resources :followup_reports, only: :index
   resources :placement_reports, only: :index
+  resources :banners, only: %i[index new edit create update destroy]
 
   resources :supervisors, except: %i[destroy show], concerns: %i[with_datatable] do
     member do

--- a/db/migrate/20230728135743_create_action_text_tables.action_text.rb
+++ b/db/migrate/20230728135743_create_action_text_tables.action_text.rb
@@ -1,0 +1,26 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20230728135743_create_action_text_tables.action_text.rb
+++ b/db/migrate/20230728135743_create_action_text_tables.action_text.rb
@@ -5,22 +5,23 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
     primary_key_type, foreign_key_type = primary_and_foreign_key_types
 
     create_table :action_text_rich_texts, id: primary_key_type do |t|
-      t.string     :name, null: false
-      t.text       :body, size: :long
+      t.string :name, null: false
+      t.text :body, size: :long
       t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
 
       t.timestamps
 
-      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+      t.index [:record_type, :record_id, :name], name: "index_action_text_rich_texts_uniqueness", unique: true
     end
   end
 
   private
-    def primary_and_foreign_key_types
-      config = Rails.configuration.generators
-      setting = config.options[config.orm][:primary_key_type]
-      primary_key_type = setting || :primary_key
-      foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
-    end
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
 end

--- a/db/migrate/20230728140249_create_banners.rb
+++ b/db/migrate/20230728140249_create_banners.rb
@@ -1,0 +1,12 @@
+class CreateBanners < ActiveRecord::Migration[7.0]
+  def change
+    create_table :banners do |t|
+      t.references :casa_org, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.boolean :active, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_12_080040) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_140249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +86,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_12_080040) do
     t.index ["email"], name: "index_all_casa_admins_on_email", unique: true
     t.index ["invitation_token"], name: "index_all_casa_admins_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_all_casa_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "banners", force: :cascade do |t|
+    t.bigint "casa_org_id", null: false
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.boolean "active", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["casa_org_id"], name: "index_banners_on_casa_org_id"
+    t.index ["user_id"], name: "index_banners_on_user_id"
   end
 
   create_table "casa_case_contact_types", force: :cascade do |t|
@@ -560,6 +581,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_12_080040) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "additional_expenses", "case_contacts"
   add_foreign_key "addresses", "users"
+  add_foreign_key "banners", "casa_orgs"
+  add_foreign_key "banners", "users"
   add_foreign_key "casa_case_emancipation_categories", "casa_cases"
   add_foreign_key "casa_case_emancipation_categories", "emancipation_categories"
   add_foreign_key "casa_cases", "casa_orgs"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@hotwired/stimulus": "^3.2.1",
     "@popperjs/core": "^2.11.8",
     "@rails/actioncable": "^7.0.6",
+    "@rails/actiontext": "^7.0.6",
     "@rails/activestorage": "^7.0.6",
     "@rails/ujs": "^7.0.6",
     "add2calendar": "^1.1.8",
@@ -40,6 +41,7 @@
     "select2-bootstrap-5-theme": "^1.3.0",
     "strftime": "^0.10.2",
     "sweetalert2": "^11.3.5",
+    "trix": "^2.0.5",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/spec/factories/banners.rb
+++ b/spec/factories/banners.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :banner do
+    casa_org
+    association :user, factory: :supervisor
     name { "Volunteer Survey" }
     active { true }
     content { "Please fill out this survey" }

--- a/spec/factories/banners.rb
+++ b/spec/factories/banners.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :banner do
+    name { 'Volunteer Survey' }
+    active { true }
+    content { 'Please fill out this survey' }
+  end
+end

--- a/spec/factories/banners.rb
+++ b/spec/factories/banners.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :banner do
-    name { 'Volunteer Survey' }
+    name { "Volunteer Survey" }
     active { true }
-    content { 'Please fill out this survey' }
+    content { "Please fill out this survey" }
   end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Banner, type: :model do
-  describe '#valid?' do
-    it 'does not allow multiple active banners for same organization' do
+  describe "#valid?" do
+    it "does not allow multiple active banners for same organization" do
       casa_org = create(:casa_org)
       supervisor = create(:supervisor)
       create(:banner, casa_org: casa_org, user: supervisor)
@@ -11,7 +11,7 @@ RSpec.describe Banner, type: :model do
       expect(banner).to_not be_valid
     end
 
-    it 'does allow multiple active banners for different organization' do
+    it "does allow multiple active banners for different organization" do
       casa_org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: casa_org)
       create(:banner, casa_org: casa_org, user: supervisor)

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Banner, type: :model do
+  describe '#valid?' do
+    it 'does not allow multiple active banners for same organization' do
+      casa_org = create(:casa_org)
+      supervisor = create(:supervisor)
+      create(:banner, casa_org: casa_org, user: supervisor)
+
+      banner = build(:banner, casa_org: casa_org, user: supervisor)
+      expect(banner).to_not be_valid
+    end
+
+    it 'does allow multiple active banners for different organization' do
+      casa_org = create(:casa_org)
+      supervisor = create(:supervisor, casa_org: casa_org)
+      create(:banner, casa_org: casa_org, user: supervisor)
+
+      another_org = create(:casa_org)
+      another_supervisor = create(:supervisor, casa_org: another_org)
+      banner = build(:banner, casa_org: another_org, user: another_supervisor)
+      expect(banner).to be_valid
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require "rspec/rails"
 require "pundit/rspec"
 require "view_component/test_helpers"
 require "capybara/rspec"
+require "action_text/system_test_helper"
 
 # Require all support folder files
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
@@ -36,6 +37,7 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include ActionText::SystemTestHelper, type: :system
 
   config.after do
     Warden.test_reset!

--- a/spec/system/banners/banners_spec.rb
+++ b/spec/system/banners/banners_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Banners', type: :system, js: true do
+  let(:admin) { create(:casa_admin) }
+  let(:organization) { admin.casa_org }
+
+  it 'add a banner' do
+    sign_in admin
+
+    visit banners_path
+    click_on 'New Banner'
+    fill_in 'Name', with: 'Volunteer Survey Announcement'
+    check 'Active?'
+    fill_in_rich_text_area 'banner_content', with: 'Please fill out this survey.'
+    click_on 'Submit'
+
+    visit banners_path
+    expect(page).to have_text('Volunteer Survey Announcement')
+
+    visit banners_path
+    within '#banners' do
+      click_on 'Edit', match: :first
+    end
+    fill_in 'Name', with: 'Better Volunteer Survey Announcement'
+    click_on 'Submit'
+
+    visit banners_path
+    expect(page).to have_text('Better Volunteer Survey Announcement')
+
+    visit root_path
+    expect(page).to have_text('Please fill out this survey.')
+  end
+end

--- a/spec/system/banners/banners_spec.rb
+++ b/spec/system/banners/banners_spec.rb
@@ -1,33 +1,33 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Banners', type: :system, js: true do
+RSpec.describe "Banners", type: :system, js: true do
   let(:admin) { create(:casa_admin) }
   let(:organization) { admin.casa_org }
 
-  it 'add a banner' do
+  it "add a banner" do
     sign_in admin
 
     visit banners_path
-    click_on 'New Banner'
-    fill_in 'Name', with: 'Volunteer Survey Announcement'
-    check 'Active?'
-    fill_in_rich_text_area 'banner_content', with: 'Please fill out this survey.'
-    click_on 'Submit'
+    click_on "New Banner"
+    fill_in "Name", with: "Volunteer Survey Announcement"
+    check "Active?"
+    fill_in_rich_text_area "banner_content", with: "Please fill out this survey."
+    click_on "Submit"
 
     visit banners_path
-    expect(page).to have_text('Volunteer Survey Announcement')
+    expect(page).to have_text("Volunteer Survey Announcement")
 
     visit banners_path
-    within '#banners' do
-      click_on 'Edit', match: :first
+    within "#banners" do
+      click_on "Edit", match: :first
     end
-    fill_in 'Name', with: 'Better Volunteer Survey Announcement'
-    click_on 'Submit'
+    fill_in "Name", with: "Better Volunteer Survey Announcement"
+    click_on "Submit"
 
     visit banners_path
-    expect(page).to have_text('Better Volunteer Survey Announcement')
+    expect(page).to have_text("Better Volunteer Survey Announcement")
 
     visit root_path
-    expect(page).to have_text('Please fill out this survey.')
+    expect(page).to have_text("Please fill out this survey.")
   end
 end

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -12,8 +12,10 @@ RSpec.describe "layout/header", type: :view do
     enable_pundit(view, user)
     allow(view).to receive(:true_user).and_return(user)
     allow(view).to receive(:current_user).and_return(user)
-    allow(view).to receive(:current_organization).and_return(1)
     allow(view).to receive(:current_role).and_return(user.role)
+
+    casa_org = build_stubbed :casa_org
+    allow(view).to receive(:current_organization).and_return(casa_org)
   end
 
   context "when logged in as a casa admin" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,7 +1602,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.6.tgz#60765c8e9c357a0ba0840fb1e409caedc233ea0d"
   integrity sha512-ybBsUrIsu5geM8BtqnpM7ZA9D8uzSz+e1B4JR57NaCmasHKWap6AX5DT7NHIbp21opVet1qqoVSdsoLDqXeB2A==
 
-"@rails/activestorage@^7.0.6":
+"@rails/actiontext@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-7.0.6.tgz#42b2b275ce6b24031242c731828de9c02d58b53f"
+  integrity sha512-WHHkYmypUjlo6fvNxfKRluuHmIxZCEoK+g/hBsufoxvjvWSBx61qu0Xq0tCrGUYd4mUZ/kk8OqP96/UBI3vS/w==
+  dependencies:
+    "@rails/activestorage" ">= 7.0.0-alpha1"
+
+"@rails/activestorage@>= 7.0.0-alpha1", "@rails/activestorage@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-7.0.6.tgz#8b762e7142eb8332541dffa0f841d7a5026f64fd"
   integrity sha512-sLr5Uj8cnWkX9lLV7wk8mIVFt6XFOJR7mAXm0QmDnrR/YGMF4Ho5tcVRUHzlyAisRQcHp6D0zHSVgOUukF8OHg==
@@ -5414,6 +5421,11 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+trix@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-2.0.5.tgz#f54880ab38e24d47829a04e04afaf03a8607f772"
+  integrity sha512-OiCbDf17F7JahEwhyL1MvK9DxAAT1vkaW5sn+zpwfemZAcc4RfQB4ku18/1mKP58LRwBhjcy+6TBho7ciXz52Q==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4996

### What changed, and why?

Added an optional banner that is customized by admins/supervisors and varies between organizations.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

System spec plus manual testing locally

### Screenshots please :)

<img width="1785" alt="Screen Shot 2023-07-28 at 2 50 57 PM" src="https://github.com/rubyforgood/casa/assets/982306/f68b9627-c4b9-447d-b347-2e3711ed13cd">

<img width="1611" alt="Screen Shot 2023-07-28 at 3 16 15 PM" src="https://github.com/rubyforgood/casa/assets/982306/9eb3041c-4026-49b7-92ae-979ed29f7c7f">


### Feelings gif (optional)
What gif best describes your feeling working on this issue?

![the office](https://media.giphy.com/media/IwAZ6dvvvaTtdI8SD5/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
