### PR TITLE
[4992] fix form not being able to save by toggling required fields immediately

### DIFF
--- a/app/javascript/src/casa_org.js
+++ b/app/javascript/src/casa_org.js
@@ -43,5 +43,5 @@ $('document').ready(() => {
   }
 
   ($('.accordionTwilio').on('click', twilioToggle))
-  twilioToggle();
+  twilioToggle()
 })

--- a/app/javascript/src/casa_org.js
+++ b/app/javascript/src/casa_org.js
@@ -19,15 +19,15 @@ function twilioToggle () {
 
 function addCheckedAttr (el) {
   el.attr('required', true)
-  el.setAttribute('aria-disabled', false)
-  el.setAttribute('aria-required', true)
+  el.attr('aria-disabled', false)
+  el.attr('aria-required', true)
   el.removeAttr('disabled')
 }
 
 function removeCheckedAttr (el) {
   el.removeAttr('required')
-  el.setAttribute('aria-required', false)
-  el.setAttribute('aria-disabled', true)
+  el.attr('aria-required', false)
+  el.attr('aria-disabled', true)
   el.attr('disabled', true)
 }
 
@@ -43,4 +43,5 @@ $('document').ready(() => {
   }
 
   ($('.accordionTwilio').on('click', twilioToggle))
+  twilioToggle();
 })

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "casa_org/edit", type: :system do
     )
   end
 
-  it "can update show_driving_reimbursement flag" do
+  it "can update show_driving_reimbursement flag", js: true do
     check "Show driving reimbursement"
     click_on "Submit"
     has_no_checked_field? "Show driving reimbursement"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4992

### What changed, and why?
the hidden fields of the twilio dropdown are causing the form to not be able to save. this solves this by leaning on the toggle code already written.


### How will this affect user permissions?
nope

### How is this tested? (please write tests!) 💖💪
manually. i tried to run system tests, but got into a very sad place. Hail mary switched js on in one of the form tests as a proxy. 

### Screenshots please :)
I guess I could screenshot "errors gone" but probably fine withotu?

### Feelings gif (optional)
😡  (because capybara system tests spent wayy too much time trying to unscrew that)

### Feedback please? (optional)
Praying that R4G other devs help me unstick my capybara problems.