### PR TITLE
Remove nvm use from bin/update file, not necessary

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -18,9 +18,6 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  puts 'Using correct node version'
-  system('nvm use') || abort("install correct node version using 'nvm install' and try again")
-
   puts 'Updating yarn'
   system('yarn install') || abort("install yarn and try again")
 


### PR DESCRIPTION
nvm is not necessarily required if you are using a different package manager. Remove from `bin/update` so it can run successfully by developers who are not using nvm.