### PR TITLE
Separate case contacts into separate "tabs" by case

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -215,6 +215,7 @@ class CaseContactsController < ApplicationController
 
   def current_organization_groups
     current_organization.contact_type_groups
+      .includes(:contact_types)
       .joins(:contact_types)
       .where(contact_types: {active: true})
       .uniq

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -221,7 +221,11 @@ class CaseContactsController < ApplicationController
   end
 
   def all_case_contacts
-    policy_scope(current_organization.case_contacts).includes(:creator, contact_types: :contact_type_group)
+    query = policy_scope(current_organization.case_contacts).includes(:creator, contact_types: :contact_type_group)
+    if params[:casa_case_id].present?
+      query = query.where(casa_case_id: params[:casa_case_id])
+    end
+    query
   end
 
   def additional_expense_params

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -131,7 +131,7 @@
   </div>
 <% end %>
 
-<% unless @presenter.case_contacts.any? %>
+<% if @presenter.case_contacts.empty? %>
   <% if params.key?(:casa_case_id) %>
     <div class="card-style-1 mb-5">
       <div class="card-content">

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -132,12 +132,24 @@
 <% end %>
 
 <% unless @presenter.case_contacts.any? %>
-  <div class="card-style-1">
-    <div class="card-content">
-      <%= params[:filterrific] ?
-        "No case contacts have been found." :
-        "You have no case contacts for this case. \
+  <% if params.key?(:casa_case_id) %>
+    <div class="card-style-1 mb-5">
+      <div class="card-content">
+        <h3 class="mb-10"><%= @presenter.display_case_number(params[:casa_case_id].to_i) %></h3>
+        <%= params[:filterrific] ?
+              "No case contacts have been found." :
+              "You have no case contacts for this case. \
         Please click New Case Contact button above to create a case contact for your youth!" %>
+      </div>
     </div>
-  </div>
+  <% else %>
+    <div class="card-style-1">
+      <div class="card-content">
+        <%= params[:filterrific] ?
+              "No case contacts have been found." :
+              "You have no case contacts for this case. \
+        Please click New Case Contact button above to create a case contact for your youth!" %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -15,7 +15,9 @@
   </div>
 </div>
 
-<%= form_for_filterrific @filterrific do |f| %>
+<%= form_for_filterrific @filterrific, url: case_contacts_path do |f| %>
+  <%= hidden_field_tag 'casa_case_id', params[:casa_case_id] %>
+
   <div class="card-style my-4">
     <div class="card-content d-flex justify-content-between align-items-end">
       <div class="h4 btn-lg">Filter by</div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -69,11 +69,29 @@
           </li>
         <% end %>
         <% if current_user.volunteer? %>
-          <li class="<%= active_class(case_contacts_path) %> nav-item">
-            <%= link_to case_contacts_path do %>
-              <i class="lni lni-users mr-10"></i>
-              Case Contacts
-            <% end %>
+          <li class="nav-item nav-item-has-children">
+            <a
+              href="#0"
+              class=""
+              data-bs-toggle="collapse"
+              data-bs-target="#ddmenu_case_contacts"
+              aria-controls="ddmenu_case_contacts"
+              aria-expanded="true"
+              aria-label="Toggle navigation">
+                <span class="icon">
+                  <i class="lni lni-users mr-10"></i>
+                </span>
+              <span class="text">Case Contacts</span>
+            </a>
+            <ul id="ddmenu_case_contacts" class="collapse dropdown-nav">
+              <% current_user.case_contacts.map(&:casa_case).uniq.each do |casa_case| %>
+                <li>
+                  <%= link_to case_contacts_path(casa_case_id: casa_case.id) do %>
+                    <%= casa_case.case_number %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
           </li>
           <li class="<%= active_class(volunteer_learning_hours_path(volunteer_id: current_user.id || 0)) %> nav-item">
             <%= link_to volunteer_learning_hours_path(volunteer_id: current_user.id || 0) do %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -84,7 +84,10 @@
               <span class="text">Case Contacts</span>
             </a>
             <ul id="ddmenu_case_contacts" class="collapse dropdown-nav">
-              <% current_user.case_contacts.map(&:casa_case).uniq.each do |casa_case| %>
+              <li>
+                <%= link_to 'All', case_contacts_path %>
+              </li>
+              <% current_user.casa_cases.each do |casa_case| %>
                 <li>
                   <%= link_to case_contacts_path(casa_case_id: casa_case.id) do %>
                     <%= casa_case.case_number %>

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -102,28 +102,28 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
 
     it "can show only case contacts for one case" do
       travel_to Date.new(2021, 1, 2) do
-        create(:case_contact, creator: volunteer, casa_case: casa_case, notes: 'Case 1 Notes', occurred_at: Time.zone.yesterday - 1)
+        create(:case_contact, creator: volunteer, casa_case: casa_case, notes: "Case 1 Notes", occurred_at: Time.zone.yesterday - 1)
 
         another_case_number = "CINA-2"
         another_case = create(:casa_case, casa_org: organization, case_number: another_case_number)
         create(:case_assignment, volunteer: volunteer, casa_case: another_case)
-        create(:case_contact, creator: volunteer, casa_case: another_case, notes: 'Case 2 Notes', occurred_at: Time.zone.today)
+        create(:case_contact, creator: volunteer, casa_case: another_case, notes: "Case 2 Notes", occurred_at: Time.zone.today)
 
         sign_in volunteer
 
         # showing all cases
         visit root_path
-        click_on 'Case Contacts'
-        within '#ddmenu_case_contacts' do
-          click_on 'All'
+        click_on "Case Contacts"
+        within "#ddmenu_case_contacts" do
+          click_on "All"
         end
         expect(page).to have_text("Case 1 Notes")
         expect(page).to have_text("Case 2 Notes")
 
         # showing case 1
         visit root_path
-        click_on 'Case Contacts'
-        within '#ddmenu_case_contacts' do
+        click_on "Case Contacts"
+        within "#ddmenu_case_contacts" do
           click_on case_number
         end
         expect(page).to have_text("Case 1 Notes")
@@ -131,8 +131,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
 
         # showing case 2
         visit root_path
-        click_on 'Case Contacts'
-        within '#ddmenu_case_contacts' do
+        click_on "Case Contacts"
+        within "#ddmenu_case_contacts" do
           click_on another_case_number
         end
         expect(page).to have_text("Case 2 Notes")
@@ -148,8 +148,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
 
         # no contacts because we're only showing case 1 and that occurred before the filter dates
         visit root_path
-        click_on 'Case Contacts'
-        within '#ddmenu_case_contacts' do
+        click_on "Case Contacts"
+        within "#ddmenu_case_contacts" do
           click_on case_number
         end
         expect(page).to_not have_text("Case 1 Notes")

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
   let(:organization) { create(:casa_org) }
 
   context "with case contacts" do
-    let(:casa_case) { build(:casa_case, casa_org: organization, case_number: "CINA-1") }
+    let(:case_number) { "CINA-1" }
+    let(:casa_case) { build(:casa_case, casa_org: organization, case_number: case_number) }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
     context "without filter" do
@@ -96,6 +97,63 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
             expect(title).to have_content(contact_group_text)
           end
         end
+      end
+    end
+
+    it "can show only case contacts for one case" do
+      travel_to Date.new(2021, 1, 2) do
+        create(:case_contact, creator: volunteer, casa_case: casa_case, notes: 'Case 1 Notes', occurred_at: Time.zone.yesterday - 1)
+
+        another_case_number = "CINA-2"
+        another_case = create(:casa_case, casa_org: organization, case_number: another_case_number)
+        create(:case_assignment, volunteer: volunteer, casa_case: another_case)
+        create(:case_contact, creator: volunteer, casa_case: another_case, notes: 'Case 2 Notes', occurred_at: Time.zone.today)
+
+        sign_in volunteer
+
+        # showing all cases
+        visit root_path
+        click_on 'Case Contacts'
+        within '#ddmenu_case_contacts' do
+          click_on 'All'
+        end
+        expect(page).to have_text("Case 1 Notes")
+        expect(page).to have_text("Case 2 Notes")
+
+        # showing case 1
+        visit root_path
+        click_on 'Case Contacts'
+        within '#ddmenu_case_contacts' do
+          click_on case_number
+        end
+        expect(page).to have_text("Case 1 Notes")
+        expect(page).to_not have_text("Case 2 Notes")
+
+        # showing case 2
+        visit root_path
+        click_on 'Case Contacts'
+        within '#ddmenu_case_contacts' do
+          click_on another_case_number
+        end
+        expect(page).to have_text("Case 2 Notes")
+        expect(page).to_not have_text("Case 1 Notes")
+
+        # filtering to only show case 2
+        click_button "Show / Hide"
+        fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday.to_s
+        fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow.to_s
+        click_button "Filter"
+        expect(page).to have_text("Case 2 Notes")
+        expect(page).to_not have_text("Case 1 Notes")
+
+        # no contacts because we're only showing case 1 and that occurred before the filter dates
+        visit root_path
+        click_on 'Case Contacts'
+        within '#ddmenu_case_contacts' do
+          click_on case_number
+        end
+        expect(page).to_not have_text("Case 1 Notes")
+        expect(page).to_not have_text("Case 2 Notes")
       end
     end
   end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "layout/sidebar", type: :view do
       render partial: "layouts/sidebar"
 
       expect(rendered).to have_link("My Cases", href: "/casa_cases")
-      expect(rendered).to have_link("Case Contacts", href: "/case_contacts")
+      expect(rendered).to have_link("All", href: "/case_contacts")
       expect(rendered).to have_link("Generate Court Report", href: "/case_court_reports")
       expect(rendered).to_not have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Volunteers", href: "/volunteers")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5012

### What changed, and why?

Prior to this PR, all case contacts for a volunteer were on the same page. This PR adds links so you can see a single case's contacts. These single case pages work with the existing filters.

### How will this affect user permissions?
- Volunteer permissions: No impact
- Supervisor permissions: No impact
- Admin permissions: No impact

### How is this tested? (please write tests!) 💖💪

System test and manual local testing


### Screenshots please :)

<img width="217" alt="Screen Shot 2023-07-29 at 10 14 07 AM" src="https://github.com/rubyforgood/casa/assets/982306/33a8cf94-b17b-4f1f-8a21-dd3e8e217527">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
