### PR TITLE
Remove the unnecessary use of Selenium for the timedout test

### DIFF
--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "view all volunteers", type: :system do
     end
 
     context "when timed out" do
-      it "prompts login", js: true do
+      it "prompts login" do
         sign_in admin
         visit volunteers_path
         click_on "Supervisor"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4924

### What changed, and why?
Removed the unnecessary `js: true` flag on the system test. This test doesn't need JavaScript enabled to run.
