### PR TITLE
Fix order of learning_hours in report

### DIFF
--- a/app/models/learning_hours_report.rb
+++ b/app/models/learning_hours_report.rb
@@ -4,6 +4,7 @@ class LearningHoursReport
   def initialize(casa_org_id)
     @learning_hours = LearningHour.includes(:user)
       .where(user: {casa_org_id: casa_org_id})
+      .order(:id)
   end
 
   def to_csv

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe "view all volunteers", type: :system do
     end
 
     context "when timed out" do
-      it "prompts login", js: true do
+      it "prompts login" do
         sign_in supervisor
         visit volunteers_path
         click_on "Supervisor"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5034

### What changed, and why?
The learning hours were not always getting returned in a consistent order.
