### PR TITLE
[4964] make the templates mirror each other to start

### DIFF
--- a/app/views/notifications/_patch_notes.html.erb
+++ b/app/views/notifications/_patch_notes.html.erb
@@ -1,19 +1,23 @@
 <div id="patch-note-notification" class="list-group-item">
   <div class="d-flex flex-row">
+    <div class="d-flex-shrink-0">
+      <i class='fas fa-bell'></i>
+    </div>
     <div class="ml-2 flex-grow-1">
       <div class="d-flex justify-content-between">
-        <h3 class="mb-1">Patch Notes for <%= deploy_time.strftime("%B %e") %></h3>
+        <h4 class="mb-1">Patch Notes</h4>
+        <small><%= time_ago_in_words(deploy_time) %> ago</small>
       </div>
-      <div class="my-1">
-        <% patch_notes.each do |type, notes_per_type| %>
-          <h5 class="ml-4"><%= type %></h5>
+      <% patch_notes.each do |type, notes_per_type| %>
+        <div class="my-1">
+          <h5 class="ml-4 fw-bold"><%= type %></h5>
           <ul>
             <% notes_per_type.each do |note_text| %>
-              <li><%= note_text %></li>
+              <li><%= simple_format note_text %></li>
             <% end %>
           </ul>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe "/notifications", type: :request do
       let(:patch_note_group_no_volunteers) { create(:patch_note_group, :only_supervisors_and_admins) }
       let(:patch_note_type_a) { create(:patch_note_type, name: "patch_note_type_a") }
       let(:patch_note_type_b) { create(:patch_note_type, name: "patch_note_type_b") }
-      let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7", patch_note_type: patch_note_type_a) }
-      let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}", patch_note_type: patch_note_type_b) }
+      let(:patch_note_1) { create(:patch_note, note: "Patch Note 1", patch_note_type: patch_note_type_a) }
+      let(:patch_note_2) { create(:patch_note, note: "Patch Note B", patch_note_type: patch_note_type_b) }
 
       before do
         patch_note_1.update(created_at: Date.new(2020, 12, 31), patch_note_group: patch_note_group_all_users)

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe "notifications/index", type: :view do
       let(:patch_note_group_no_volunteers) { create(:patch_note_group, :only_supervisors_and_admins) }
       let(:patch_note_type_a) { create(:patch_note_type, name: "patch_note_type_a") }
       let(:patch_note_type_b) { create(:patch_note_type, name: "patch_note_type_b") }
-      let(:patch_note_1) { create(:patch_note, note: "*Sy@\\<iiF>(\\\"Q7", patch_note_type: patch_note_type_a) }
-      let(:patch_note_2) { create(:patch_note, note: "(W!;Ros>cIWNKX}", patch_note_type: patch_note_type_b) }
+      let(:patch_note_1) { create(:patch_note, note: "Patch Note 1", patch_note_type: patch_note_type_a) }
+      let(:patch_note_2) { create(:patch_note, note: "Patch Note B", patch_note_type: patch_note_type_b) }
 
       before do
         Health.instance.update_attribute(:latest_deploy_time, Date.today)
@@ -68,28 +68,17 @@ RSpec.describe "notifications/index", type: :view do
 
         queryable_html = Nokogiri.HTML5(rendered)
 
-        patch_note_notification_information_container = queryable_html.css("#patch-note-notification div.my-1").first
+        patch_note_notification_information_container = queryable_html.css("#patch-note-notification .flex-row").first
+
 
         patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_a.name}')]]").first
-        patch_note_type_a_header_index = patch_note_notification_information_container.children.index(patch_note_type_a_header)
         patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_b.name}')]]").first
-        patch_note_type_b_header_index = patch_note_notification_information_container.children.index(patch_note_type_b_header)
 
-        patch_note_1_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_1.note}')]]").first
-        patch_note_1_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_1_list_item.parent)
-        patch_note_2_list_item = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_2.note}')]]").first
-        patch_note_2_unordered_list_index = patch_note_notification_information_container.children.index(patch_note_2_list_item.parent)
+        patch_note_a_data = patch_note_type_a_header.parent.css("ul").first
+        expect(patch_note_a_data.text).to include(patch_note_1.note)
 
-        expect(patch_note_type_a_header_index).to be < patch_note_1_unordered_list_index
-        expect(patch_note_type_b_header_index).to be < patch_note_2_unordered_list_index
-
-        if patch_note_type_a_header_index < patch_note_type_b_header_index
-          expect(patch_note_type_b_header_index).to be > patch_note_1_unordered_list_index
-        end
-
-        if patch_note_type_b_header_index < patch_note_type_a_header_index
-          expect(patch_note_type_a_header_index).to be > patch_note_2_unordered_list_index
-        end
+        patch_note_b_data = patch_note_type_b_header.parent.css("ul").first
+        expect(patch_note_b_data.text).to include(patch_note_2.note)
       end
     end
   end

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -68,9 +68,6 @@ RSpec.describe "notifications/index", type: :view do
 
         queryable_html = Nokogiri.HTML5(rendered)
 
-        patch_note_notification_information_container = queryable_html.css("#patch-note-notification .flex-row").first
-
-
         patch_note_type_a_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_a.name}')]]").first
         patch_note_type_b_header = queryable_html.xpath("//*[text()[contains(.,'#{patch_note_type_b.name}')]]").first
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4964 

### What changed, and why?

The two different models render on the same list, and cause lining-up differences that were asked to be rectified.

If this is desirable behavior, let me know and I can do some follow up refactoring to make this better.

Thoughts on making this more maintainable:

1) shared component between Notification and PatchNote
2) refactor PatchNote to instead deliver a Notification

happy to hear where I should take this.

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪

UI 
### Screenshots please :)
<img width="899" alt="Screen Shot 2023-07-29 at 10 53 25 AM" src="https://github.com/rubyforgood/casa/assets/5641692/e6d17077-5233-448e-8286-e8cd2b12b819">
