### PR TITLE
Edit organization manage learning hours

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -2,6 +2,7 @@ channels/application_cable/channel.rb
 channels/application_cable/connection.rb
 controllers/banners_controller.rb
 controllers/followup_reports_controller.rb
+controllers/learning_hour_types_controller.rb
 controllers/mileage_reports_controller.rb
 controllers/placements_controller.rb
 controllers/users/sessions_controller.rb
@@ -30,6 +31,7 @@ notifications/followup_resolved_notification.rb
 notifications/youth_birthday_notification.rb
 policies/fund_request_policy.rb
 policies/learning_hour_policy.rb
+policies/learning_hour_type_policy.rb
 policies/note_policy.rb
 presenters/base_presenter.rb
 presenters/case_contact_presenter.rb

--- a/app/controllers/casa_org_controller.rb
+++ b/app/controllers/casa_org_controller.rb
@@ -3,6 +3,7 @@ class CasaOrgController < ApplicationController
   before_action :set_contact_type_data, only: %i[edit update]
   before_action :set_hearing_types, only: %i[edit update]
   before_action :set_judges, only: %i[edit update]
+  before_action :set_learning_hour_types, only: %i[edit update]
   before_action :set_sent_emails, only: %i[edit update]
   before_action :require_organization!
   after_action :verify_authorized
@@ -66,6 +67,10 @@ class CasaOrgController < ApplicationController
 
   def set_judges
     @judges = Judge.for_organization(@casa_org)
+  end
+
+  def set_learning_hour_types
+    @learning_hour_types = LearningHourType.for_organization(@casa_org)
   end
 
   def set_sent_emails

--- a/app/controllers/learning_hour_types_controller.rb
+++ b/app/controllers/learning_hour_types_controller.rb
@@ -1,0 +1,46 @@
+class LearningHourTypesController < ApplicationController
+  before_action :set_learning_hour_type, only: %i[edit update]
+  after_action :verify_authorized
+
+  def new
+    authorize LearningHourType
+    @learning_hour_type = LearningHourType.new
+  end
+
+  def edit
+    authorize @learning_hour_type
+  end
+
+  def create
+    authorize LearningHourType
+    @learning_hour_type = LearningHourType.new(learning_hour_type_params)
+
+    if @learning_hour_type.save
+      redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully created."
+    else
+      render :new
+    end
+  end
+
+  def update
+    authorize @learning_hour_type
+
+    if @learning_hour_type.update(learning_hour_type_params)
+      redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_learning_hour_type
+    @learning_hour_type = LearningHourType.find(params[:id])
+  end
+
+  def learning_hour_type_params
+    params.require(:learning_hour_type).permit(:name, :active).merge(
+      casa_org: current_organization
+    )
+  end
+end

--- a/app/controllers/learning_hours_controller.rb
+++ b/app/controllers/learning_hours_controller.rb
@@ -57,10 +57,12 @@ class LearningHoursController < ApplicationController
   end
 
   def learning_hours_params
-    params.require(:learning_hour).permit(:occurred_at, :duration_minutes, :duration_hours, :name, :user_id, :learning_type)
+    params.require(:learning_hour).permit(:occurred_at, :duration_minutes, :duration_hours, :name, :user_id,
+      :learning_hour_type_id)
   end
 
   def update_learning_hours_params
-    params.require(:learning_hour).permit(:occurred_at, :duration_minutes, :duration_hours, :name, :learning_type)
+    params.require(:learning_hour).permit(:occurred_at, :duration_minutes, :duration_hours, :name,
+      :learning_hour_type_id)
   end
 end

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -21,6 +21,7 @@ class CasaOrg < ApplicationRecord
   has_many :languages, dependent: :destroy
   has_many :placements, through: :casa_cases
   has_many :banners, dependent: :destroy
+  has_many :learning_hour_types, dependent: :destroy
   has_one_attached :logo
   has_one_attached :court_report_template
 

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -1,6 +1,7 @@
 class LearningHour < ApplicationRecord
   belongs_to :user
-  belongs_to :learning_hour_type
+  # Set to optional to change validation message. See validates_presence_of :learning_hour_type below
+  belongs_to :learning_hour_type, optional: true
 
   # Deprecated with Issue 5028
   # Delete with Issue 5039 but only AFTER 5028 has been released to prod
@@ -17,6 +18,7 @@ class LearningHour < ApplicationRecord
   validates :duration_minutes, numericality: {greater_than: 0}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
+  validates_presence_of :learning_hour_type, message: "cannot be blank"
   validate :occurred_at_not_in_future
 
   private

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -1,7 +1,6 @@
 class LearningHour < ApplicationRecord
   belongs_to :user
-  # Set to optional to change validation message. See validates_presence_of :learning_hour_type below
-  belongs_to :learning_hour_type, optional: true
+  belongs_to :learning_hour_type
 
   # Deprecated with Issue 5028
   # Delete with Issue 5039 but only AFTER 5028 has been released to prod
@@ -18,7 +17,6 @@ class LearningHour < ApplicationRecord
   validates :duration_minutes, numericality: {greater_than: 0}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
-  validates_presence_of :learning_hour_type, message: "cannot be blank"
   validate :occurred_at_not_in_future
 
   private

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -1,6 +1,9 @@
 class LearningHour < ApplicationRecord
   belongs_to :user
+  belongs_to :learning_hour_type
 
+  # Deprecated with Issue 5028
+  # Delete with Issue 5039 but only AFTER 5028 has been released to prod
   enum learning_type: {
     book: 1,
     movie: 2,
@@ -8,8 +11,8 @@ class LearningHour < ApplicationRecord
     conference: 4,
     other: 5
   }
+  # End delete
 
-  validates :learning_type, presence: true
   validates :duration_minutes, presence: true
   validates :duration_minutes, numericality: {greater_than: 0}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
@@ -35,21 +38,24 @@ end
 #
 # Table name: learning_hours
 #
-#  id               :bigint           not null, primary key
-#  duration_hours   :integer          not null
-#  duration_minutes :integer          not null
-#  learning_type    :integer          default("other")
-#  name             :string           not null
-#  occurred_at      :datetime         not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  user_id          :bigint           not null
+#  id                    :bigint           not null, primary key
+#  duration_hours        :integer          not null
+#  duration_minutes      :integer          not null
+#  learning_type         :integer          default("other")
+#  name                  :string           not null
+#  occurred_at           :datetime         not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  learning_hour_type_id :bigint
+#  user_id               :bigint           not null
 #
 # Indexes
 #
-#  index_learning_hours_on_user_id  (user_id)
+#  index_learning_hours_on_learning_hour_type_id  (learning_hour_type_id)
+#  index_learning_hours_on_user_id                (user_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (learning_hour_type_id => learning_hour_types.id)
 #  fk_rails_...  (user_id => users.id)
 #

--- a/app/models/learning_hour_type.rb
+++ b/app/models/learning_hour_type.rb
@@ -1,0 +1,29 @@
+class LearningHourType < ApplicationRecord
+  belongs_to :casa_org
+
+  validates :name, presence: true, uniqueness: {scope: %i[casa_org]}
+  default_scope { order(position: :asc, name: :asc) }
+  scope :for_organization, ->(org) { where(casa_org: org).order(:name) }
+  scope :active, -> { where(active: true) }
+end
+
+# == Schema Information
+#
+# Table name: learning_hour_types
+#
+#  id          :bigint           not null, primary key
+#  active      :boolean          default(TRUE)
+#  name        :string
+#  position    :integer          default(1)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  casa_org_id :bigint           not null
+#
+# Indexes
+#
+#  index_learning_hour_types_on_casa_org_id  (casa_org_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (casa_org_id => casa_orgs.id)
+#

--- a/app/policies/learning_hour_type_policy.rb
+++ b/app/policies/learning_hour_type_policy.rb
@@ -1,0 +1,2 @@
+class LearningHourTypePolicy < ApplicationPolicy
+end

--- a/app/services/learning_hours_export_csv_service.rb
+++ b/app/services/learning_hours_export_csv_service.rb
@@ -27,7 +27,7 @@ class LearningHoursExportCsvService
     {
       volunteer_name: learning_hour&.user&.display_name,
       learning_hours_title: learning_hour&.name,
-      learning_hours_type: learning_hour&.learning_type,
+      learning_hours_type: learning_hour&.learning_hour_type&.name,
       duration: get_duration(learning_hour),
       date_of_learning: learning_hour&.occurred_at&.strftime("%F")
     }

--- a/app/views/casa_org/_learning_hour_types.html.erb
+++ b/app/views/casa_org/_learning_hour_types.html.erb
@@ -3,7 +3,7 @@
     <div class="card-style mb-30">
       <div class="row align-items-center">
         <div class="col-md-6">
-          <h3>Learning Type</h3>
+          <h3>Type of Learning</h3>
         </div>
         <div class="col-md-6">
           <div class="breadcrumb-wrapper">

--- a/app/views/casa_org/_learning_hour_types.html.erb
+++ b/app/views/casa_org/_learning_hour_types.html.erb
@@ -1,0 +1,53 @@
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card-style mb-30">
+      <div class="row align-items-center">
+        <div class="col-md-6">
+          <h3>Learning Type</h3>
+        </div>
+        <div class="col-md-6">
+          <div class="breadcrumb-wrapper">
+            <span class="ml-5">
+              <%= link_to new_learning_hour_type_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
+                <i class="lni lni-plus mr-10"></i>
+                New Learning Type
+              <% end %>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="table-wrapper table-responsive">
+        <table class="table striped-table">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>Active?</th>
+            <th>Actions</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% @learning_hour_types.each do |learning_hour_type| %>
+            <tr id="learning_hour_type-<%= learning_hour_type.id %>">
+              <td scope="row" class="min-width">
+                <%= learning_hour_type.name %>
+              </td>
+              <td scope="row" class="min-width">
+                <%= learning_hour_type.active ? "Yes" : "No" %>
+              </td>
+              <td>
+                <%= link_to edit_learning_hour_type_path(learning_hour_type) do %>
+                  <div class="action">
+                    <button class="text-danger">
+                      <i class="lni lni-pencil-alt"></i> Edit
+                    </button>
+                  </div>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/casa_org/_learning_hour_types.html.erb
+++ b/app/views/casa_org/_learning_hour_types.html.erb
@@ -10,7 +10,7 @@
             <span class="ml-5">
               <%= link_to new_learning_hour_type_path, class: "btn-sm main-btn primary-btn btn-hover" do %>
                 <i class="lni lni-plus mr-10"></i>
-                New Learning Type
+                New Type of Learning
               <% end %>
             </span>
           </div>

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -128,7 +128,7 @@
     <div class="col-md-6">
       <div class="title mb-30">
         <h2>
-          Manage Learning Types
+          Manage Learning Hours
         </h2>
       </div>
     </div>

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -123,3 +123,17 @@
   <%= render "judges" %>
   <%= render "sent_emails" %>
 </div>
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h2>
+          Manage Learning Types
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="tables-wrapper">
+  <%= render "learning_hour_types" %>
+</div>

--- a/app/views/learning_hour_types/_form.html.erb
+++ b/app/views/learning_hour_types/_form.html.erb
@@ -1,0 +1,36 @@
+<div class="title-wrapper pt-30">
+  <div class="row align-items-center">
+    <div class="col-md-6">
+      <div class="title mb-30">
+        <h1>
+          <%= title %>
+        </h1>
+      </div>
+    </div>
+  </div>
+</div><!-- ==== end title ==== -->
+
+<!-- ========== card start ========== -->
+<div class="card-style mb-30">
+  <%= form_with(model: learning_hour_type, local: true) do |form| %>
+    <div class="alert-box danger-alert">
+      <%= render "/shared/error_messages", resource: learning_hour_type %>
+    </div>
+    <div class="input-style-1">
+      <%= form.label :name, "Name" %>
+      <%= form.text_field :name, class: "form-control", required: true %>
+    </div>
+
+    <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :active, class: 'form-check-input' %>
+      <%= form.label :active, "Active?", class: 'form-check-label' %>
+    </div>
+
+    <div class="actions mb-10">
+      <%= button_tag(type: "submit", class: "btn-sm main-btn primary-btn btn-hover") do %>
+        <i class="lni lni-checkmark-circle mr-5"></i> Submit
+      <% end %>
+    </div>
+  <% end %>
+</div>
+<!-- card end -->

--- a/app/views/learning_hour_types/edit.html.erb
+++ b/app/views/learning_hour_types/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: {title: "Learning Type", learning_hour_type: @learning_hour_type} %>

--- a/app/views/learning_hour_types/edit.html.erb
+++ b/app/views/learning_hour_types/edit.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "form", locals: {title: "Learning Type", learning_hour_type: @learning_hour_type} %>
+<%= render partial: "form", locals: {title: "Type of Learning", learning_hour_type: @learning_hour_type} %>

--- a/app/views/learning_hour_types/new.html.erb
+++ b/app/views/learning_hour_types/new.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "form", locals: {title: "Type of Learning", learning_hour_type: @learning_hour_type} %>
+<%= render partial: "form", locals: {title: "New Type of Learning", learning_hour_type: @learning_hour_type} %>

--- a/app/views/learning_hour_types/new.html.erb
+++ b/app/views/learning_hour_types/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: {title: "New Learning Type", learning_hour_type: @learning_hour_type} %>

--- a/app/views/learning_hour_types/new.html.erb
+++ b/app/views/learning_hour_types/new.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "form", locals: {title: "New Learning Type", learning_hour_type: @learning_hour_type} %>
+<%= render partial: "form", locals: {title: "Type of Learning", learning_hour_type: @learning_hour_type} %>

--- a/app/views/learning_hours/_form.html.erb
+++ b/app/views/learning_hours/_form.html.erb
@@ -20,7 +20,7 @@ id: "learning-hours-form" do |form| %>
       <%= form.label :learning_hour_type_id, "Type of Learning" %>
       <div class="select-position">
         <%= form.collection_select :learning_hour_type_id,
-          LearningHourType.for_organization(current_user.casa_org),
+          LearningHourType.for_organization(current_user.casa_org).active,
                                    :id,
                                    :name,
                                    prompt: "Select learning type",

--- a/app/views/learning_hours/_form.html.erb
+++ b/app/views/learning_hours/_form.html.erb
@@ -17,13 +17,14 @@ id: "learning-hours-form" do |form| %>
                           class:"mr-5" %>
     </div>
     <div class="select-style-1">
-      <%= form.label :learning_type, "Type of Learning" %>
+      <%= form.label :learning_hour_type_id, "Type of Learning" %>
       <div class="select-position">
-        <%= form.select :learning_type,
-                        LearningHour.learning_types&.map {|learning| [learning.first.humanize, learning.first]},
-                        prompt:"Select learning type",
-                        value: @learning_hour.learning_type,
-                        selected: @learning_hour.learning_type %>
+        <%= form.collection_select :learning_hour_type_id,
+          LearningHourType.for_organization(current_user.casa_org),
+                                   :id,
+                                   :name,
+                                   prompt: "Select learning type",
+                                   value: @learning_hour.learning_hour_type_id %>
       </div>
     </div>
   </div>

--- a/app/views/learning_hours/_update_form.html.erb
+++ b/app/views/learning_hours/_update_form.html.erb
@@ -19,7 +19,7 @@
       <%= form.label :learning_hour_type_id, "Type of Learning" %>
       <div class="select-position">
         <%= form.collection_select :learning_hour_type_id,
-                                   LearningHourType.for_organization(current_user.casa_org),
+                                   LearningHourType.for_organization(current_user.casa_org).active,
                                    :id,
                                    :name,
                                    prompt: "Select learning type",

--- a/app/views/learning_hours/_update_form.html.erb
+++ b/app/views/learning_hours/_update_form.html.erb
@@ -16,13 +16,14 @@
                           value: @learning_hour.name %>
     </div>
     <div class="select-style-1">
-      <%= form.label :learning_type, "Type of Learning" %>
+      <%= form.label :learning_hour_type_id, "Type of Learning" %>
       <div class="select-position">
-        <%= form.select :learning_type,
-                        LearningHour.learning_types&.map {|learning| [learning.first.humanize, learning.first]},
-                        prompt:"Select learning type",
-                        value: @learning_hour.learning_type,
-                        selected: @learning_hour.learning_type %>
+        <%= form.collection_select :learning_hour_type_id,
+                                   LearningHourType.for_organization(current_user.casa_org),
+                                   :id,
+                                   :name,
+                                   prompt: "Select learning type",
+                                   value: @learning_hour.learning_hour_type_id %>
       </div>
     </div>
   </div>

--- a/app/views/learning_hours/index.html.erb
+++ b/app/views/learning_hours/index.html.erb
@@ -25,7 +25,7 @@
               <td>
                 <%= link_to learning_hour.name, volunteer_learning_hour_path(id: learning_hour.id) %>
               </td>
-              <td> <%= (learning_hour.learning_type).humanize %> </td>
+              <td> <%= learning_hour.learning_hour_type.name %> </td>
               <td> <%= learning_hour.occurred_at.strftime("%B %d, %Y") %> </td>
               <td>
               <% if (learning_hour.duration_hours > 0) %>

--- a/app/views/learning_hours/show.html.erb
+++ b/app/views/learning_hours/show.html.erb
@@ -20,7 +20,7 @@
         <tbody>
           <tr>
             <td><%= @learning_hour.name %></td>
-            <td><%= (@learning_hour.learning_type).humanize %></td>
+            <td><%= @learning_hour.learning_hour_type.name %></td>
             <td><%= @learning_hour.occurred_at.strftime("%B %d, %Y") %></td>
             <td>
               <% if (@learning_hour.duration_hours > 0) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,10 @@
 
 en:
   hello: "Hello world"
+  activerecord:
+    attributes:
+      learning_hour:
+        learning_hour_type: "Type of Learning"
   pundit:
     default: "Sorry, you are not authorized to perform this action."
     casa_case_policy:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -239,7 +239,7 @@ en:
       title: Learning Hours
     form:
       learning_hours_title: Learning Hours Title
-      learning_type: Type of Learning
+      learning_hour_type_id: Type of Learning
       duration: Learning Duration
       occurred_on: Occurred On
       create_button: Create New Learning Hours Entry

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
   resources :other_duties, only: %i[new create edit index update]
   resources :missing_data_reports, only: %i[index]
   resources :learning_hours_reports, only: %i[index]
+  resources :learning_hour_types, only: %i[new create edit update]
   resources :followup_reports, only: :index
   resources :placement_reports, only: :index
   resources :banners, only: %i[index new edit create update destroy]

--- a/db/migrate/20230729143126_create_learning_hour_types.rb
+++ b/db/migrate/20230729143126_create_learning_hour_types.rb
@@ -1,0 +1,12 @@
+class CreateLearningHourTypes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :learning_hour_types do |t|
+      t.references :casa_org, null: false, foreign_key: true
+      t.string :name
+      t.boolean :active, default: true
+      t.integer :position, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230729145310_add_reference_learning_hour_types.rb
+++ b/db/migrate/20230729145310_add_reference_learning_hour_types.rb
@@ -1,0 +1,7 @@
+class AddReferenceLearningHourTypes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :learning_hours, :learning_hour_type, validate: false, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20230729145351_add_foreign_key_learning_hour_types.rb
+++ b/db/migrate/20230729145351_add_foreign_key_learning_hour_types.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyLearningHourTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :learning_hours, :learning_hour_types, validate: false
+  end
+end

--- a/db/migrate/20230729145419_validate_foreign_key_learning_hour_types.rb
+++ b/db/migrate/20230729145419_validate_foreign_key_learning_hour_types.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyLearningHourTypes < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :learning_hours, :learning_hour_types
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_140249) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_29_145419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -364,6 +364,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_140249) do
     t.index ["user_id"], name: "index_languages_users_on_user_id"
   end
 
+  create_table "learning_hour_types", force: :cascade do |t|
+    t.bigint "casa_org_id", null: false
+    t.string "name"
+    t.boolean "active", default: true
+    t.integer "position", default: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["casa_org_id"], name: "index_learning_hour_types_on_casa_org_id"
+  end
+
   create_table "learning_hours", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "learning_type", default: 5
@@ -373,6 +383,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_140249) do
     t.datetime "occurred_at", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "learning_hour_type_id"
+    t.index ["learning_hour_type_id"], name: "index_learning_hours_on_learning_hour_type_id"
     t.index ["user_id"], name: "index_learning_hours_on_user_id"
   end
 
@@ -598,6 +610,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_140249) do
   add_foreign_key "followups", "users", column: "creator_id"
   add_foreign_key "judges", "casa_orgs"
   add_foreign_key "languages", "casa_orgs"
+  add_foreign_key "learning_hour_types", "casa_orgs"
+  add_foreign_key "learning_hours", "learning_hour_types"
   add_foreign_key "learning_hours", "users"
   add_foreign_key "mileage_rates", "casa_orgs"
   add_foreign_key "mileage_rates", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,6 +62,7 @@ class SeederMain
       HearingType,
       Judge,
       Language,
+      LearningHourType,
       MileageRate,
       Supervisor,
       SupervisorVolunteer,

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -50,6 +50,7 @@ class DbPopulator
     create_judges(casa_org)
     create_languages(casa_org)
     create_mileage_rates(casa_org)
+    create_learning_hour_types(casa_org)
     casa_org
   end
 
@@ -363,6 +364,16 @@ class DbPopulator
       end
 
       i += 1
+    end
+  end
+
+  def create_learning_hour_types(casa_org)
+    learning_types = %w[book movie webinar conference other]
+
+    learning_types.each do |learning_type|
+      learning_hour_type = casa_org.learning_hour_types.new(name: learning_type.capitalize)
+      learning_hour_type.position = 99 if learning_type == "other"
+      learning_hour_type.save
     end
   end
 

--- a/lib/tasks/deployment/20230729145858_convert_learning_hour_types.rake
+++ b/lib/tasks/deployment/20230729145858_convert_learning_hour_types.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc "Deployment task: converts_learning_type_enum_to_learning_hour_types_for_casa_orgs"
+  task convert_learning_hour_types: :environment do
+    puts "Running deploy task 'convert_learning_hour_types'"
+
+    learning_types = %w[book movie webinar conference other]
+    CasaOrg.all.each do |casa_org|
+      user_ids = casa_org.users.pluck(:id)
+      learning_hours = LearningHour.where(user_id: user_ids)
+
+      learning_types.each do |learning_type|
+        learning_hour_type = casa_org.learning_hour_types.new(name: learning_type.capitalize)
+        learning_hour_type.position = 99 if learning_type == "other"
+        learning_hour_type.save
+
+        learning_hours.where(learning_type: learning_type).update_all(learning_hour_type_id: learning_hour_type.id)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20230729145858_convert_learning_hour_types.rake
+++ b/lib/tasks/deployment/20230729145858_convert_learning_hour_types.rake
@@ -9,9 +9,14 @@ namespace :after_party do
       learning_hours = LearningHour.where(user_id: user_ids)
 
       learning_types.each do |learning_type|
-        learning_hour_type = casa_org.learning_hour_types.new(name: learning_type.capitalize)
-        learning_hour_type.position = 99 if learning_type == "other"
-        learning_hour_type.save
+        learning_hour_type = if learning_type == "other"
+          casa_org.learning_hour_types.find_or_create_by!(
+            name: learning_type.capitalize,
+            position: 99
+          )
+        else
+          casa_org.learning_hour_types.find_or_create_by!(name: learning_type.capitalize)
+        end
 
         learning_hours.where(learning_type: learning_type).update_all(learning_hour_type_id: learning_hour_type.id)
       end

--- a/spec/factories/learning_hour_types.rb
+++ b/spec/factories/learning_hour_types.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :learning_hour_type do
+    casa_org { CasaOrg.first || create(:casa_org) }
+    name { Faker::Book.genre }
+    active { false }
+    position { 1 }
+  end
+end

--- a/spec/factories/learning_hour_types.rb
+++ b/spec/factories/learning_hour_types.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :learning_hour_type do
     casa_org { CasaOrg.first || create(:casa_org) }
-    name { Faker::Book.genre }
-    active { false }
+    sequence(:name) { |n| "Learning Hour Type #{n}" }
+    active { true }
     position { 1 }
   end
 end

--- a/spec/factories/learning_hours.rb
+++ b/spec/factories/learning_hours.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     duration_minutes { 25 }
     duration_hours { 1 }
     occurred_at { 2.days.ago }
+    learning_hour_type { LearningHourType.first || create(:learning_hour_type) }
   end
 end

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe LearningHour, type: :model do
     expect(learning_hour.errors[:name]).to eq(["/ Title cannot be blank"])
   end
 
-  it "has a learning_type" do
-    learning_hour = build_stubbed(:learning_hour, learning_type: nil)
+  it "has a learning_hour_type" do
+    learning_hour = build_stubbed(:learning_hour, learning_hour_type: nil)
     expect(learning_hour).to_not be_valid
-    expect(learning_hour.errors[:learning_type]).to eq(["can't be blank"])
+    expect(learning_hour.errors[:learning_hour_type]).to eq(["must exist"])
   end
 
   context "duration_hours is zero" do

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LearningHour, type: :model do
   it "has a learning_hour_type" do
     learning_hour = build_stubbed(:learning_hour, learning_hour_type: nil)
     expect(learning_hour).to_not be_valid
-    expect(learning_hour.errors[:learning_hour_type]).to eq(["cannot be blank"])
+    expect(learning_hour.errors[:learning_hour_type]).to eq(["must exist"])
   end
 
   context "duration_hours is zero" do

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LearningHour, type: :model do
   it "has a learning_hour_type" do
     learning_hour = build_stubbed(:learning_hour, learning_hour_type: nil)
     expect(learning_hour).to_not be_valid
-    expect(learning_hour.errors[:learning_hour_type]).to eq(["must exist"])
+    expect(learning_hour.errors[:learning_hour_type]).to eq(["cannot be blank"])
   end
 
   context "duration_hours is zero" do

--- a/spec/models/learning_hour_type_spec.rb
+++ b/spec/models/learning_hour_type_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe LearningHourType, type: :model do
+  it { is_expected.to belong_to(:casa_org) }
+  it { is_expected.to validate_presence_of(:name) }
+
+  it "has a valid factory" do
+    expect(build(:learning_hour_type).valid?).to be true
+  end
+
+  it "has unique names for the specified organization" do
+    casa_org_1 = create(:casa_org)
+    casa_org_2 = create(:casa_org)
+    create(:learning_hour_type, casa_org: casa_org_1, name: "Book")
+    expect {
+      create(:learning_hour_type, casa_org: casa_org_1, name: "Book")
+    }.to raise_error(ActiveRecord::RecordInvalid)
+    expect {
+      create(:learning_hour_type, casa_org: casa_org_2, name: "Book")
+    }.to_not raise_error
+  end
+
+  describe "for_organization" do
+    let!(:casa_org_1) { create(:casa_org) }
+    let!(:casa_org_2) { create(:casa_org) }
+    let!(:record_1) { create(:learning_hour_type, casa_org: casa_org_1) }
+    let!(:record_2) { create(:learning_hour_type, casa_org: casa_org_2) }
+
+    it "returns only records matching the specified organization" do
+      expect(described_class.for_organization(casa_org_1)).to eq([record_1])
+      expect(described_class.for_organization(casa_org_2)).to eq([record_2])
+    end
+  end
+
+  describe "default scope" do
+    let(:casa_org) { create(:casa_org) }
+
+    it "orders alphabetically by position and then name" do
+      create(:learning_hour_type, casa_org: casa_org, name: "Book")
+      create(:learning_hour_type, casa_org: casa_org, name: "Webinar")
+      create(:learning_hour_type, casa_org: casa_org, name: "Other", position: 99)
+      create(:learning_hour_type, casa_org: casa_org, name: "YouTube")
+
+      type_names = %w[Book Webinar YouTube Other]
+      expect(described_class.for_organization(casa_org).map(&:name)).to eq(type_names)
+    end
+  end
+end

--- a/spec/models/learning_hours_report_spec.rb
+++ b/spec/models/learning_hours_report_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe LearningHoursReport, type: :model do
       it "includes all learning hours" do
         casa_org = build(:casa_org)
         users = create_list(:user, 3, casa_org: casa_org)
+        learning_hour_type = create(:learning_hour_type)
         learning_hours =
           [
-            create(:learning_hour, user: users[0]),
-            create(:learning_hour, user: users[1], learning_type: :movie),
-            create(:learning_hour, user: users[2], learning_type: :webinar)
+            create(:learning_hour, user: users[0], learning_hour_type: learning_hour_type),
+            create(:learning_hour, user: users[1], learning_type: :movie, learning_hour_type: learning_hour_type),
+            create(:learning_hour, user: users[2], learning_type: :webinar, learning_hour_type: learning_hour_type)
           ]
         result = CSV.parse(described_class.new(casa_org.id).to_csv)
 
@@ -21,7 +22,7 @@ RSpec.describe LearningHoursReport, type: :model do
           next if index.zero?
           expect(row[0]).to eq learning_hours[index - 1].user.display_name
           expect(row[1]).to eq learning_hours[index - 1].name
-          expect(row[2]).to eq learning_hours[index - 1].learning_type
+          expect(row[2]).to eq learning_hours[index - 1].learning_hour_type.name
           expect(row[3]).to eq "#{learning_hours[index - 1].duration_hours}:#{learning_hours[index - 1].duration_minutes}"
           expect(row[4]).to eq learning_hours[index - 1].occurred_at.strftime("%F")
         end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -341,11 +341,12 @@ RSpec.describe Volunteer, type: :model do
 
   describe "#learning_hours_spent_in_one_year" do
     let(:volunteer) { create :volunteer }
-    let!(:leraning_hours) do
+    let(:learning_hour_type) { create :learning_hour_type }
+    let!(:learning_hours) do
       [
-        create(:learning_hour, user: volunteer, duration_hours: 1, duration_minutes: 30),
-        create(:learning_hour, user: volunteer, duration_hours: 3, duration_minutes: 45),
-        create(:learning_hour, user: volunteer, duration_hours: 1, duration_minutes: 30, occurred_at: 2.year.ago)
+        create(:learning_hour, user: volunteer, duration_hours: 1, duration_minutes: 30, learning_hour_type: learning_hour_type),
+        create(:learning_hour, user: volunteer, duration_hours: 3, duration_minutes: 45, learning_hour_type: learning_hour_type),
+        create(:learning_hour, user: volunteer, duration_hours: 1, duration_minutes: 30, occurred_at: 2.year.ago, learning_hour_type: learning_hour_type)
       ]
     end
 

--- a/spec/services/learning_hours_export_csv_service_spec.rb
+++ b/spec/services/learning_hours_export_csv_service_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 RSpec.describe LearningHoursExportCsvService do
   let!(:user) { create(:user) }
-
+  let!(:learning_hour_type) { create(:learning_hour_type) }
   let!(:learning_hour) do
     create(:learning_hour,
       duration_hours: 2,
       duration_minutes: 30,
-      occurred_at: "2022-06-20")
+      occurred_at: "2022-06-20",
+      learning_hour_type: learning_hour_type)
   end
 
   describe "#perform" do
@@ -20,7 +21,8 @@ RSpec.describe LearningHoursExportCsvService do
     end
 
     it "returns a csv as a string ending with the learning hours values" do
-      csv_values = "#{user.display_name},#{learning_hour.name},#{learning_hour.learning_type},2:30,2022-06-20\n"
+      csv_values = "#{user.display_name},#{learning_hour.name},#{learning_hour.learning_hour_type.name}," \
+        "2:30,2022-06-20\n"
 
       if learning_hour.name.include? ","
         csv_values.gsub!(learning_hour.name, '"' + learning_hour.name + '"')

--- a/spec/views/casa_orgs/edit.html.erb_spec.rb
+++ b/spec/views/casa_orgs/edit.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "casa_org/edit", type: :view do
     assign(:contact_types, [])
     assign(:hearing_types, [])
     assign(:judges, [])
+    assign(:learning_hour_types, [])
     assign(:sent_emails, [])
 
     sign_in build_stubbed(:casa_admin)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5028 

### What changed, and why?
- Added a way for CASA admins to edit the types of learning volunteers can select when adding a learning hour
- There is a way to set the order (position field) but it is not available to be changed to the admins through the UI
- Each current CASA org gets the current options added to their org. This is done through an AfterParty task
  - Book
  - Conference
  - Movie
  - Webinar
  - Other (will be displayed last)
- There's a new issue to do some additional clean up after Prod deployment #5039 

### How will this affect user permissions?
- Volunteer permissions: None
- Supervisor permissions: None
- Admin permissions: Can change the Types of Learning a volunteer can select.

### How is this tested? (please write tests!) 💖💪
- Updated tests
- Added tests for LearningHourType model

### Screenshots please :)
<img width="578" alt="Screenshot 2023-07-29 at 3 08 43 PM" src="https://github.com/rubyforgood/casa/assets/50247514/d7daeb73-d2f5-43df-a380-99e308889933">
<img width="1385" alt="Screenshot 2023-07-29 at 3 07 34 PM" src="https://github.com/rubyforgood/casa/assets/50247514/bda92124-3bd5-49b7-825c-304cf17be1d6">
<img width="744" alt="Screenshot 2023-07-29 at 3 07 19 PM" src="https://github.com/rubyforgood/casa/assets/50247514/44aefdf6-1884-4246-9876-54e5a868ded0">
<img width="606" alt="Screenshot 2023-07-29 at 3 05 39 PM" src="https://github.com/rubyforgood/casa/assets/50247514/93e90760-fdc9-4322-bf99-ddc3a72db224">

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
