### PR TITLE
Remove hearing_type_id and judge_id from casa_cases table

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -3,7 +3,7 @@ class CasaCase < ApplicationRecord
   include DateHelper
   extend FriendlyId
 
-  self.ignored_columns = %w[hearing_type_id judge_id transition_aged_youth court_report_due_date]
+  self.ignored_columns = %w[transition_aged_youth court_report_due_date]
 
   attr_accessor :validate_contact_type
 
@@ -234,8 +234,6 @@ end
 #
 #  index_casa_cases_on_casa_org_id                  (casa_org_id)
 #  index_casa_cases_on_case_number_and_casa_org_id  (case_number,casa_org_id) UNIQUE
-#  index_casa_cases_on_hearing_type_id              (hearing_type_id)
-#  index_casa_cases_on_judge_id                     (judge_id)
 #  index_casa_cases_on_slug                         (slug)
 #
 # Foreign Keys

--- a/db/migrate/20230729213608_remove_hearing_type_id_and_judge_id_from_casa_cases.rb
+++ b/db/migrate/20230729213608_remove_hearing_type_id_and_judge_id_from_casa_cases.rb
@@ -1,0 +1,6 @@
+class RemoveHearingTypeIdAndJudgeIdFromCasaCases < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :casa_cases, :hearing_type_id }
+    safety_assured { remove_column :casa_cases, :judge_id }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_29_145419) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_29_213608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -125,17 +125,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_29_145419) do
     t.bigint "casa_org_id", null: false
     t.datetime "birth_month_year_youth", precision: nil
     t.datetime "court_report_due_date", precision: nil
-    t.bigint "hearing_type_id"
     t.boolean "active", default: true, null: false
-    t.bigint "judge_id"
     t.datetime "court_report_submitted_at", precision: nil
     t.integer "court_report_status", default: 0
     t.string "slug"
     t.datetime "date_in_care"
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number", "casa_org_id"], name: "index_casa_cases_on_case_number_and_casa_org_id", unique: true
-    t.index ["hearing_type_id"], name: "index_casa_cases_on_hearing_type_id"
-    t.index ["judge_id"], name: "index_casa_cases_on_judge_id"
     t.index ["slug"], name: "index_casa_cases_on_slug"
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5044

### What changed, and why?
Add migration to remove `hearing_type_id` and `judge_id` columns from `casa_cases` table. Remove mentions of these columns from the codebase.


### How will this affect user permissions?
- Volunteer permissions: X
- Supervisor permissions: X
- Admin permissions: X

### How is this tested? (please write tests!) 💖💪
N/A

### Screenshots please :)
![Screenshot from 2023-07-30 00-49-13](https://github.com/rubyforgood/casa/assets/29335101/e8c4e929-fe4f-4d70-a5cd-8a294fa6f74c)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/

### Feedback please? (optional)
