### PR TITLE
provided the fix for flaky specs

### DIFF
--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -450,12 +450,9 @@ RSpec.describe CaseContact, type: :model do
 
       groups_with_types = case_contact.contact_groups_with_types
 
-      expect(groups_with_types).to eql(
-        {
-          "Family" => ["Parent"],
-          "Health" => ["Medical Professional", "Other Therapist"]
-        }
-      )
+      expect(groups_with_types.keys).to match_array(["Family", "Health"])
+      expect(groups_with_types["Family"]).to match_array(["Parent"])
+      expect(groups_with_types["Health"]).to match_array(["Medical Professional", "Other Therapist"])
     end
   end
 


### PR DESCRIPTION
### What GitHub issue is this PR for, if any?
Resolves [5050](https://github.com/rubyforgood/casa/issues/5050)

### What changed, and why?
- used match_array instead of eql while comparing the array elements in the rspec.
- Fix flaky spec.