### PR TITLE
5051 page.body would do an immediate call vs page have_content would be implicit wait

### DIFF
--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "casa_cases/new", type: :system do
             click_on "Create CASA Case"
           end
 
-          expect(page.body).to have_content(case_number)
+          expect(page).to have_content(case_number)
           expect(page).to have_content(I18n.l(court_date, format: :day_and_date))
           expect(page).to have_content("CASA case was successfully created.")
           expect(page).not_to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time


### PR DESCRIPTION

### What github issue is this PR for, if any?
Resolves #5051

### What changed, and why?

flake fixing
