### PR TITLE
fix typo error

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -129,7 +129,7 @@ class CaseContactsController < ApplicationController
     authorize CasaAdmin
 
     case_contact = authorize(current_organization.case_contacts.with_deleted.find(params[:id]))
-    case_contact.restore(recrusive: true)
+    case_contact.restore(recursive: true)
     flash[:notice] = "Contact is successfully restored."
     redirect_to request.referer
   end

--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -10,7 +10,7 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.save
     flash_message = "#{volunteer.display_name} successfully assigned to #{supervisor.display_name}."
 
-    redirect_to request.referrer, notice: flash_message
+    redirect_to request.referer, notice: flash_message
   end
 
   def unassign
@@ -22,7 +22,7 @@ class SupervisorVolunteersController < ApplicationController
     supervisor_volunteer.save!
     flash_message = "#{volunteer.display_name} was unassigned from #{supervisor.display_name}."
 
-    redirect_to request.referrer, notice: flash_message
+    redirect_to request.referer, notice: flash_message
   end
 
   private


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/5056

### What changed, and why?

This PR corrects a typo in the codebase that was affecting the proper functioning of the application. 
The issue was related to the misspelling of 'referrer' in the code. The correct spelling 'referer' has been applied throughout the affected file. 
Additionally, fixes the 'recrusive' typo, replacing it with 'recursive', ensuring the correct behavior in the application.

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
