### PR TITLE
[5049] we COULD do this in an integration spec, but considering we are evaluating for the content of each volunteer, let count be handled by unit tests

### DIFF
--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -89,8 +89,6 @@ RSpec.describe "view all volunteers", type: :system do
       visit volunteers_path
       expect(page).to have_selector(".volunteer-filters")
 
-      # by default, only active users are shown
-      expect(page.all("table#volunteers tbody tr").count).to eq(assigned_volunteers.count + unassigned_volunteers.count)
       assigned_volunteers.each do |assigned_volunteer|
         expect(page).to have_text assigned_volunteer.display_name
       end


### PR DESCRIPTION

implicit waits instead of explicit waits

### What github issue is this PR for, if any?
Resolves #5049
### What changed, and why?

Remove flake by removing assertion already covered

