### PR TITLE
Add error notification for preferences saving

### DIFF
--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -1,5 +1,7 @@
 /* global alert */
 /* global $ */
+const AsyncNotifier = require("../src/async_notifier");
+let pageNotifier;
 
 const defineCaseContactsTable = function () {
   $('table#case_contacts').DataTable(
@@ -12,6 +14,13 @@ const defineCaseContactsTable = function () {
 }
 
 $('document').ready(() => {
+  try {
+    const asyncNotificationsElement = $("#async-notifications");
+    pageNotifier = new AsyncNotifier(asyncNotificationsElement);
+  } catch (err) {
+    console.error(err);
+  }
+
   $.fn.dataTable.ext.search.push(
     function (settings, data, dataIndex) {
       if (settings.nTable.id !== 'casa-cases') {
@@ -106,7 +115,12 @@ $('document').ready(() => {
         },
         dataType: 'json',
         type: 'POST',
-        success: function (response) { }
+        success: function (response) {
+          if (response.error) {
+            pageNotifier.notify("Error while saving preferences", "error");
+            console.error(response.error);
+          }
+        },
       })
     },
     stateSaveParams: function (settings, data) {

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -1,7 +1,7 @@
 /* global alert */
 /* global $ */
-const AsyncNotifier = require("../src/async_notifier");
-let pageNotifier;
+const AsyncNotifier = require('../src/async_notifier')
+let pageNotifier
 
 const defineCaseContactsTable = function () {
   $('table#case_contacts').DataTable(
@@ -15,10 +15,10 @@ const defineCaseContactsTable = function () {
 
 $('document').ready(() => {
   try {
-    const asyncNotificationsElement = $("#async-notifications");
-    pageNotifier = new AsyncNotifier(asyncNotificationsElement);
+    const asyncNotificationsElement = $('#async-notifications')
+    pageNotifier = new AsyncNotifier(asyncNotificationsElement)
   } catch (err) {
-    console.error(err);
+    console.error(err)
   }
 
   $.fn.dataTable.ext.search.push(
@@ -117,10 +117,10 @@ $('document').ready(() => {
         type: 'POST',
         success: function (response) {
           if (response.error) {
-            pageNotifier.notify("Error while saving preferences", "error");
-            console.error(response.error);
+            pageNotifier.notify('Error while saving preferences', 'error')
+            console.error(response.error)
           }
-        },
+        }
       })
     },
     stateSaveParams: function (settings, data) {

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -191,3 +191,5 @@
   </div>
 </div>
 </div>
+
+<%= render "shared/async_notifier" %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves https://github.com/rubyforgood/casa/issues/4980

### What changed, and why?

This PR adds an error notification to the preferences saving process. If there's an error while saving preferences, a notification is displayed to the user, and the error message is logged to the console for debugging purposes. 

### How will this affect user permissions?
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

I tested the changes by simulating user interactions on the frontend. Specifically, I tested the preferences saving process by triggering the saving action and intentionally causing errors. I confirmed that the error notification is shown to the user when an error occurs during preferences saving.

### Screenshots please :)

![image](https://github.com/rubyforgood/casa/assets/88126195/d3543761-d029-4695-b623-c75efa155a70)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
