### PR TITLE
Delete unused languages_users table from db

### DIFF
--- a/db/migrate/20230809002819_drop_languages_users.rb
+++ b/db/migrate/20230809002819_drop_languages_users.rb
@@ -1,0 +1,9 @@
+class DropLanguagesUsers < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :languages_users
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_30_103110) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_002819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -368,13 +368,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_30_103110) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["casa_org_id"], name: "index_languages_on_casa_org_id"
-  end
-
-  create_table "languages_users", id: false, force: :cascade do |t|
-    t.bigint "language_id", null: false
-    t.bigint "user_id", null: false
-    t.index ["language_id"], name: "index_languages_users_on_language_id"
-    t.index ["user_id"], name: "index_languages_users_on_user_id"
   end
 
   create_table "learning_hour_types", force: :cascade do |t|


### PR DESCRIPTION
### What changed, and why?
Deleted `languages_users` table from db because I suspect `user_languages` is used instead.

### How is this tested? (please write tests!) 💖💪
Adding a language to a user only makes a row in the latter table
![image](https://github.com/rubyforgood/casa/assets/8918762/11e01b15-61d4-4a0f-9aad-73adbc861728)
 ![image](https://github.com/rubyforgood/casa/assets/8918762/88c439c5-2657-4908-9d3a-1b414d86730c)

Do not merge until we can confirm the prod version of `languages_users` has no rows