### PR TITLE
Make Case Group Names Unique Per Org

### DIFF
--- a/app/models/case_group.rb
+++ b/app/models/case_group.rb
@@ -2,6 +2,7 @@ class CaseGroup < ApplicationRecord
   belongs_to :casa_org
   has_many :case_group_memberships
   has_many :casa_cases, through: :case_group_memberships
+  before_validation :strip_name
 
   validates_presence_of :case_group_memberships
 

--- a/app/models/case_group.rb
+++ b/app/models/case_group.rb
@@ -3,7 +3,7 @@ class CaseGroup < ApplicationRecord
   has_many :case_group_memberships
   has_many :casa_cases, through: :case_group_memberships
 
-  validates :name, uniqueness: {scope: :casa_org}
+  validates :name, presence: true, uniqueness: {scope: :casa_org}
   validates_presence_of :case_group_memberships
 end
 

--- a/app/models/case_group.rb
+++ b/app/models/case_group.rb
@@ -3,8 +3,15 @@ class CaseGroup < ApplicationRecord
   has_many :case_group_memberships
   has_many :casa_cases, through: :case_group_memberships
 
-  validates :name, presence: true, uniqueness: {scope: :casa_org}
   validates_presence_of :case_group_memberships
+
+  validates :name, presence: true, uniqueness: {scope: :casa_org, case_sensitive: false}
+
+  private
+
+  def strip_name
+    self.name = name.strip if name
+  end
 end
 
 # == Schema Information

--- a/app/models/case_group.rb
+++ b/app/models/case_group.rb
@@ -3,7 +3,7 @@ class CaseGroup < ApplicationRecord
   has_many :case_group_memberships
   has_many :casa_cases, through: :case_group_memberships
 
-  validates :name, uniqueness: { scope: :casa_org }
+  validates :name, uniqueness: {scope: :casa_org}
   validates_presence_of :case_group_memberships
 end
 

--- a/app/models/case_group.rb
+++ b/app/models/case_group.rb
@@ -3,7 +3,8 @@ class CaseGroup < ApplicationRecord
   has_many :case_group_memberships
   has_many :casa_cases, through: :case_group_memberships
 
-  validates_presence_of :name, :case_group_memberships
+  validates :name, uniqueness: { scope: :casa_org }
+  validates_presence_of :case_group_memberships
 end
 
 # == Schema Information

--- a/spec/factories/case_groups.rb
+++ b/spec/factories/case_groups.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :case_group do
     casa_org { CasaOrg.first || create(:casa_org) }
-    name { "A family" }
+    sequence(:name) { |n| "Family #{n}" }
 
     after(:build) do |case_group, _|
       if case_group.case_group_memberships.empty?

--- a/spec/models/case_group_spec.rb
+++ b/spec/models/case_group_spec.rb
@@ -8,9 +8,15 @@ RSpec.describe CaseGroup, type: :model do
       casa_org = create(:casa_org)
       create(:case_group, casa_org: casa_org, name: "The Johnson Family")
       non_uniq_case_group = build(:case_group, casa_org: casa_org, name: "The Johnson Family")
+      non_uniq_case_group_whitespace = build(:case_group, casa_org: casa_org, name: "The Johnson Family   ")
+      non_uniq_case_group_case_sensitive = build(:case_group, casa_org: casa_org, name: "The Johnson family")
 
       expect(non_uniq_case_group).to_not be_valid
+      expect(non_uniq_case_group_case_sensitive).to_not be_valid
+      expect(non_uniq_case_group_whitespace).to_not be_valid
       expect(non_uniq_case_group.errors[:name]).to include("has already been taken")
+      expect(non_uniq_case_group_case_sensitive.errors[:name]).to include("has already been taken")
+      expect(non_uniq_case_group_whitespace.errors[:name]).to include("has already been taken")
     end
   end
 

--- a/spec/models/case_group_spec.rb
+++ b/spec/models/case_group_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 RSpec.describe CaseGroup, type: :model do
+
+  describe 'validations' do
+    it { should validate_presence_of(:case_group_memberships) }
+
+    it 'validates uniqueness of name scoped to casa_org' do
+      casa_org = create(:casa_org)
+      create(:case_group, casa_org: casa_org, name: 'The Johnson Family')
+      non_uniq_case_group = build(:case_group, casa_org: casa_org, name: 'The Johnson Family')
+  
+      expect(non_uniq_case_group).to_not be_valid
+      expect(non_uniq_case_group.errors[:name]).to include('has already been taken')
+    end  
+  end
+
+  describe 'relationships' do
+    it { should have_many(:case_group_memberships) }
+    it { should have_many(:casa_cases).through(:case_group_memberships) }
+  end
+
   it "has a valid factory" do
     case_group = build(:case_group)
 

--- a/spec/models/case_group_spec.rb
+++ b/spec/models/case_group_spec.rb
@@ -1,21 +1,20 @@
 require "rails_helper"
 
 RSpec.describe CaseGroup, type: :model do
-
-  describe 'validations' do
+  describe "validations" do
     it { should validate_presence_of(:case_group_memberships) }
 
-    it 'validates uniqueness of name scoped to casa_org' do
+    it "validates uniqueness of name scoped to casa_org" do
       casa_org = create(:casa_org)
-      create(:case_group, casa_org: casa_org, name: 'The Johnson Family')
-      non_uniq_case_group = build(:case_group, casa_org: casa_org, name: 'The Johnson Family')
-  
+      create(:case_group, casa_org: casa_org, name: "The Johnson Family")
+      non_uniq_case_group = build(:case_group, casa_org: casa_org, name: "The Johnson Family")
+
       expect(non_uniq_case_group).to_not be_valid
-      expect(non_uniq_case_group.errors[:name]).to include('has already been taken')
-    end  
+      expect(non_uniq_case_group.errors[:name]).to include("has already been taken")
+    end
   end
 
-  describe 'relationships' do
+  describe "relationships" do
     it { should have_many(:case_group_memberships) }
     it { should have_many(:casa_cases).through(:case_group_memberships) }
   end

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Case Groups", type: :system, js: true do
 
     visit case_groups_path
     click_on "New Case Group"
-    fill_in "Name", with: "A family"
+    fill_in "Name", with: "A Family "
     select casa_case.case_number, from: "Cases"
     click_on "Submit"
 

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -27,4 +27,26 @@ RSpec.describe "Case Groups", type: :system, js: true do
     visit case_groups_path
     expect(page).to have_text("Another family")
   end
+
+  it "will not create a case group if the name is not unique" do
+    casa_case = create(:casa_case)
+
+    sign_in admin
+
+    visit case_groups_path
+    click_on "New Case Group"
+    fill_in "Name", with: "A family"
+    select casa_case.case_number, from: "Cases"
+    click_on "Submit"
+
+    visit case_groups_path
+    click_on "New Case Group"
+    fill_in "Name", with: "A family"
+    select casa_case.case_number, from: "Cases"
+    click_on "Submit"
+
+    visit case_groups_path
+    expect(page).to have_text("A family").once
+    expect(flash[:notice]).to include("Group name must be unique.")
+  end
 end

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -44,9 +44,10 @@ RSpec.describe "Case Groups", type: :system, js: true do
     fill_in "Name", with: "A family"
     select casa_case.case_number, from: "Cases"
     click_on "Submit"
+   
+    expect(page).to have_text("Name has already been taken")
 
     visit case_groups_path
     expect(page).to have_text("A family").once
-    expect(flash[:notice]).to include("Group name must be unique.")
   end
 end

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Case Groups", type: :system, js: true do
     fill_in "Name", with: "A family"
     select casa_case.case_number, from: "Cases"
     click_on "Submit"
-   
+
     expect(page).to have_text("Name has already been taken")
 
     visit case_groups_path


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5105 

### What changed, and why?
Added a uniqueness constraint for case groups scoped to the casa org they belong to. 

In other words, you now cannot have a case group with the same name within the same casa org. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

Model Validation Spec:

<img width="714" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/d62a6997-07d7-4654-a092-7a58370a5f51">

System Spec:

<img width="490" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/df24cc8f-e94b-496f-8105-9aae2c512a60">



### Screenshots please :)
<img width="642" alt="image" src="https://github.com/rubyforgood/casa/assets/80081206/71b7bdc7-da20-4d90-8dc7-bc885e24949e">


<img width="442" alt="Screenshot 2023-08-09 at 1 02 16 PM" src="https://github.com/rubyforgood/casa/assets/80081206/dd08ebae-7de5-45ec-b73e-6583ea2efa0a">

![image](https://github.com/rubyforgood/casa/assets/80081206/de882b90-48e3-4af3-a284-0c42be8ab29a)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
