### PR TITLE
fixed not being able to select multiple cases after failing the case contact form

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -78,7 +78,7 @@ class CaseContactsController < ApplicationController
     case_contacts = create_case_contact_for_every_selected_casa_case(@selected_cases)
     if case_contacts.any?(&:new_record?)
       @case_contact = case_contacts.first
-      @casa_cases = [@case_contact.casa_case]
+
       render :new
     elsif @selected_cases.count > 1
       redirect_to case_contacts_path(success: true), notice: "Case contacts successfully created"


### PR DESCRIPTION
### What changed, and why?
#### First bug
If you go to a new case contact form with get parameters, and if you select multiple cases
![image](https://github.com/rubyforgood/casa/assets/8918762/29ef8d14-e6f1-4089-9fdb-038a367c36ee)

and fail to fill out the case contact form, you can't select multiple cases anymore
![image](https://github.com/rubyforgood/casa/assets/8918762/13ccbff7-0a9e-4656-aded-3c331ddfc050)

#### Second bug
If you navigate to the new case contact form and you have GET parameters and you select cases that don't include the casa case in the GET parameters,
![image](https://github.com/rubyforgood/casa/assets/8918762/c80a4a94-b5f6-4bc9-b1a8-5c2997c3e1df)
it responds as though no cases were selected.
![image](https://github.com/rubyforgood/casa/assets/8918762/3adcf380-b496-42fb-8f6b-701a89cb9665)

### How is this tested? (please write tests!) 💖💪
Only Manually

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/8918762/c5084a5d-fa5e-4a2f-a7cd-468457e96336)