### PR TITLE
Fix: Handle exception thrown when volunteer tries to add same language twice

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,11 +26,15 @@ class UsersController < ApplicationController
       return render "edit"
     end
 
-    current_user.languages << @language
-    if current_user.save
-      redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
+    if current_user.languages.include?(@language)
+      redirect_to edit_users_path, alert: "#{@language.name} is already in your languages list."
     else
-      redirect_to edit_users_path, alert: "Error unable to add #{@language.name} to your languages list!"
+      current_user.languages << @language
+      if current_user.save
+        redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
+      else
+        redirect_to edit_users_path, alert: "Error unable to add #{@language.name} to your languages list!"
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,16 +23,19 @@ class UsersController < ApplicationController
   def add_language
     if @language.nil?
       @user.errors.add(:language_id, "can not be blank. Please select a language before adding.")
-      render :edit
+      return render "edit"
+    end
+
+    if current_user.languages.include?(@language)
+      @user.errors.add(:language_id, "#{@language.name} is already in your languages list.")
+      return render "edit"
+    end
+
+    current_user.languages << @language
+    if current_user.save
+      redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
     else
-      if current_user.languages.include?(@language)
-        flash[:alert] = "#{@language.name} is already in your languages list."
-      elsif current_user.languages << @language && current_user.save
-        flash[:notice] = "#{@language.name} was added to your languages list."
-      else
-        flash[:alert] = "Error unable to add #{@language.name} to your languages list!"
-      end
-      redirect_to edit_users_path
+      redirect_to edit_users_path, alert: "Error unable to add #{@language.name} to your languages list!"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,18 +23,16 @@ class UsersController < ApplicationController
   def add_language
     if @language.nil?
       @user.errors.add(:language_id, "can not be blank. Please select a language before adding.")
-      return render "edit"
-    end
-
-    if current_user.languages.include?(@language)
-      redirect_to edit_users_path, alert: "#{@language.name} is already in your languages list."
+      render :edit
     else
-      current_user.languages << @language
-      if current_user.save
-        redirect_to edit_users_path, notice: "#{@language.name} was added to your languages list."
+      if current_user.languages.include?(@language)
+        flash[:alert] = "#{@language.name} is already in your languages list."
+      elsif current_user.languages << @language && current_user.save
+        flash[:notice] = "#{@language.name} was added to your languages list."
       else
-        redirect_to edit_users_path, alert: "Error unable to add #{@language.name} to your languages list!"
+        flash[:alert] = "Error unable to add #{@language.name} to your languages list!"
       end
+      redirect_to edit_users_path
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -429,6 +429,29 @@ RSpec.describe "/users", type: :request do
         expect(response.body).to include("Please select a language before adding.")
       end
     end
+
+    context "when the user tries to add the same language again" do
+      let(:language) { create(:language) }
+      before do
+        # Add the language once
+        patch add_language_users_path(volunteer), params: {
+          language_id: language.id
+        }
+        # Try to add the same language again
+        patch add_language_users_path(volunteer), params: {
+          language_id: language.id
+        }
+      end
+    
+      it "should not add the language again" do
+        expect(volunteer.languages.count).to eq(1) # Ensure the language count remains the same
+      end
+    
+      it "should notify the user that the language is already in their list" do
+        expect(response).to redirect_to(edit_users_path)
+        expect(flash[:alert]).to eq "#{language.name} is already in your languages list."
+      end
+    end
   end
   describe "DELETE /remove_language" do
     let(:volunteer) { create(:volunteer) }

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -448,8 +448,8 @@ RSpec.describe "/users", type: :request do
       end
 
       it "should notify the user that the language is already in their list" do
-        expect(response).to redirect_to(edit_users_path)
-        expect(flash[:alert]).to eq "#{language.name} is already in your languages list."
+        expect(response).to have_http_status(200)
+        expect(response.body).to include("#{language.name} is already in your languages list.")
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -442,11 +442,11 @@ RSpec.describe "/users", type: :request do
           language_id: language.id
         }
       end
-    
+
       it "should not add the language again" do
         expect(volunteer.languages.count).to eq(1) # Ensure the language count remains the same
       end
-    
+
       it "should notify the user that the language is already in their list" do
         expect(response).to redirect_to(edit_users_path)
         expect(flash[:alert]).to eq "#{language.name} is already in your languages list."


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5132 

### What changed, and why?
This fix will handle exception which is thrown when volunteer tries to add same language twice

### How will this affect user permissions?
I don't think current code changes will effect permissions

### How is this tested? (please write tests!) 💖💪
- Have added test to handle exception and show warning message to user
- Also tested manually by trying to add same language again

### Screenshots please :)
![CASA-Volunteer-Tracking-same-language-exception](https://github.com/rubyforgood/casa/assets/514363/e01c2496-45fb-44ff-bbd2-22d1be6fc556)

