### PR TITLE
Remove onHover clickable effect for "Role" and "Email" fields on prof…

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -62,14 +62,14 @@
               class="dropdown-menu dropdown-menu-end"
               aria-labelledby="profile">
               <li>
-                <a href="#0">
+                <span>
                   <strong>Role: <%= current_role %></strong>
-                </a>
+                </span>
               </li>
               <li>
-                <a href="#0">
+                <span>
                   <strong> <%= current_user.email %></strong>
-                </a>
+                </span>
               </li>
               <li>
                 <%= link_to edit_users_path do %>

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1656,11 +1656,15 @@ h6,
           background: rgba(74, 108, 247, 0.05); }
         .header .header-right .dropdown-menu li:last-child {
           border-bottom: none; }
-        .header .header-right .dropdown-menu li a {
+        .header .header-right .dropdown-menu li a,
+        .header .header-right .dropdown-menu li span {
           padding: 8px 12px;
           display: flex;
           color: rgba(0, 0, 0, 0.7);
           border-radius: 6px; }
+        .header .header-right .dropdown-menu li span {
+          font-size: 14px;
+        }
           .header .header-right .dropdown-menu li a .image {
             max-width: 35px;
             width: 100%;


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5137

### What changed, and why?
Changed "Role" and "Email" menu fields to use "span" HTML tag instead of "a".
Provided CSS styles for changed tags.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
![Screenshot from 2023-08-24 00-05-47](https://github.com/rubyforgood/casa/assets/29335101/6aa73e81-2429-46b9-ab02-8067b3796c25)

### Feelings gif (optional)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9

