### PR TITLE
Fix test suite warnings

### DIFF
--- a/app/views/supervisor_mailer/_active_volunteer_info.html.erb
+++ b/app/views/supervisor_mailer/_active_volunteer_info.html.erb
@@ -36,7 +36,7 @@
   <% if recently_unassigned %>
     <br>
     This case was unassigned from <%= volunteer_display_name %> on
-    <%= case_assignment.updated_at.to_date.to_s(:long_ordinal) %>
+    <%= case_assignment.updated_at.to_date.to_fs(:long_ordinal) %>
     <% if successful_contacts + unsuccessful_contacts > 0 %>
       The above activity only describes the part of the week when the case was still assigned to
       <% volunteer_display_name %>

--- a/lib/tasks/deployment/20211023145114_store_deploy_time.rake
+++ b/lib/tasks/deployment/20211023145114_store_deploy_time.rake
@@ -1,7 +1,7 @@
 namespace :after_party do
   desc "Deployment task: stores_the_time_of_the_latest_deploy_as_a_file"
   task store_deploy_time: :environment do
-    puts "Running deploy task 'store_deploy_time'"
+    puts "Running deploy task 'store_deploy_time'" unless Rails.env.test?
 
     Health.instance.update_attribute(:latest_deploy_time, Time.now)
   end

--- a/lib/tasks/test_checker.rake
+++ b/lib/tasks/test_checker.rake
@@ -1,11 +1,15 @@
 require "amazing_print"
 
-DENY_FILESPEC = File.join(Rails.root, ".allow_skipping_tests")
-DASHED_LINE = "-" * 80
-
 desc "Check app rb files to verify that there are corresponding spec files."
 task test_checker: :environment do
   # File containing app filespecs that should not be flagged as errors for not having spec files.
+  def deny_filespec
+    File.join(Rails.root, ".allow_skipping_tests")
+  end
+
+  def dashed_line
+    "-" * 80
+  end
   # Lines beginning with '#' are ignored.
 
   # Transform the object into the object's AmazingPrint representation.
@@ -55,7 +59,7 @@ task test_checker: :environment do
 
   def ignore_files
     return @ignore_files if @ignore_files
-    file_lines = File.readlines(DENY_FILESPEC).map(&:chomp)
+    file_lines = File.readlines(deny_filespec).map(&:chomp)
     @ignore_files = file_lines.reject { |line| /\s*#/.match(line) } # exclude comment lines
   end
 
@@ -76,9 +80,9 @@ task test_checker: :environment do
     percent = (100 * missing_but_denied_files.size.to_f / app_files.size)
     puts <<~TEXT
 
-      #{DASHED_LINE}
+      #{dashed_line}
       #{missing_but_denied_files.size} of #{app_files.size} app files (#{percent.round(1)}%) did not have a corresponding spec file
-      but were listed in the deny file (#{DENY_FILESPEC}):
+      but were listed in the deny file (#{deny_filespec}):
 
       #{amazing_printize(missing_but_denied_files)}
     TEXT
@@ -88,7 +92,7 @@ task test_checker: :environment do
     percent = (100 * missing_and_not_denied_spec_files.size.to_f / app_files.size)
     puts <<~ERROR_TXT
 
-      #{DASHED_LINE}
+      #{dashed_line}
       #{missing_and_not_denied_spec_files.size} of #{app_files.size} app files (#{percent.round(1)}%) did not have a corresponding spec file
       and are not in the deny list:
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
References #5037

### What changed, and why?

The test suite is currently outputting a lot of noise relating to some deprecation warnings and changed autoloading behavior. I have addressed the 2 main culprits:

- In the `_active_volunteer_info.html.erb` partial, there was a call to a deprecated method from ActiveSupport that allowed passing an argument to the `to_s` method on various objects. In the Rails 7 release this method was moved to `to_fs` and the overridden `to_s` method was deprecated.
- In the `test_checker.rake` task there were 2 constants defined at the top level of the task. Due to the way the autoloader works, these were causing a ton of warnings due to this file being autoloaded and redefining the constant (rake files aren't namespaced in a traditional way so technically that constant is available more globally than might be apparent). To fix this I changed the constant definitions to method definition inside of the task block. I would have kept them as regular variables, however the linter considered them to be "unnecessary" as they were only called inside of other inline methods in this task block. Realistically I think a better solution would be to move the body of this rake task into a class and then just instantiate and call methods on the class inside the task, but that seemed out of the scope of this issue.

Separately I switched another rake task that is called in the test suite to only print to the screen when the environment is not the test environment as has been done elsewhere in the app.

### How will this affect user permissions?
- N/A

### How is this tested? (please write tests!) 💖💪
- Neither of these changes are covered by the current test suite. 
- I can probably add a test to ensure the output of the `to_fs` is as expected if you would like, but I might need some help to make sure I fully understand the context of that particular partial. 
- The rake task itself is currently not actually tested, but if you would like testing around it, I think moving the logic to an actual class and testing that would be the best option. If you would like me to go ahead and do that larger refactor so as to decouple the logic from the rake environment I can do that as well as part of this PR or a separate one. 

### Screenshots please :)
Before:
![image](https://github.com/rubyforgood/casa/assets/90267290/1ea09eda-07e2-4989-94b1-ac4e5abbf551)
![image](https://github.com/rubyforgood/casa/assets/90267290/c8d7468c-2fa5-42ee-966e-9179ac78dce8)

After: 
![image](https://github.com/rubyforgood/casa/assets/90267290/99b61fcb-d226-421b-aa7a-155e7cba0eb3)
