### PR TITLE
Update modal close btn according to latest Bootstrap

### DIFF
--- a/app/views/case_contacts/_confirm_note_content_dialog.html.erb
+++ b/app/views/case_contacts/_confirm_note_content_dialog.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <div class="modal-footer justify-content-between">
-        <button type="button" class="main-btn btn-sm secondary-btn-outline btn-hover mr-10" data-dismiss="modal" id="modal-case-contact-cancel">
+        <button type="button" class="main-btn btn-sm secondary-btn-outline btn-hover mr-10" data-bs-dismiss="modal" id="modal-case-contact-cancel">
           Go Back to Form
         </button>
         <%= form.submit "Continue Submitting", class: "btn-sm main-btn primary-btn btn-hover", id: "modal-case-contact-submit" %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5153

### What changed, and why?
 Update the modal close button according to Bootstrap 5.3

### How will this affect user permissions?
- Volunteer permissions: No
- Supervisor permissions: No
- Admin permissions: No

### How is this tested? (please write tests!) 💖💪
  Doesn't apply.

### Screenshots please :)
https://github.com/rubyforgood/casa/assets/51321005/b840e029-36c9-48b3-84d4-a7431d935926


