### PR TITLE
Remove Inbox from Sidebar

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -16,12 +16,6 @@
   <nav class="sidebar-nav">
     <nav class="sidebar-nav">
       <ul>
-        <li class="<%= active_class(notifications_path) %> nav-item">
-          <%= link_to notifications_path do %>
-            <i class="lni lni-envelope mr-10"></i>
-            Inbox
-          <% end %>
-        </li>
         <% if policy(Supervisor).index? %>
           <li class="<%= active_class(supervisors_path) %> nav-item">
             <%= link_to supervisors_path do %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5152

### What changed, and why?
  Removed the inbox from the sidebar.

### How will this affect user permissions?
- Volunteer permissions: No
- Supervisor permissions: No
- Admin permissions: No

### How is this tested? (please write tests!) 💖💪
  Not required.

### Screenshots please :)

<img width="1440" alt="image" src="https://github.com/rubyforgood/casa/assets/51321005/6455dfd2-b61e-45c3-ba53-b95c0ab8f02d">
