### PR TITLE
After creating casa contact redirect back to all

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,6 +87,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def store_referring_location
+    session[:return_to] = request.referer
+  end
+
+  def redirect_back_to_referer(fallback_location:)
+    redirect_to(session[:return_to] || fallback_location)
+  end
+
   private
 
   def store_user_location!

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -81,7 +81,7 @@ class CaseContactsController < ApplicationController
       @casa_cases = [@case_contact.casa_case]
       render :new
     else
-      redirect_to case_contacts_path(success: true), notice: "Case #{'contact'.pluralize(@selected_cases.count)} successfully created"
+      redirect_to case_contacts_path(success: true), notice: "Case #{"contact".pluralize(@selected_cases.count)} successfully created"
     end
   end
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -81,8 +81,7 @@ class CaseContactsController < ApplicationController
       @casa_cases = [@case_contact.casa_case]
       render :new
     else
-      contact_msg = @selected_cases.count > 1 ? "contants" : "contant"
-      redirect_to case_contacts_path(success: true), notice: "Case #{contact_msg} successfully created"
+      redirect_to case_contacts_path(success: true), notice: "Case #{pluralize(@selected_cases.count, "contact")} successfully created"
     end
   end
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -80,10 +80,9 @@ class CaseContactsController < ApplicationController
       @case_contact = case_contacts.first
       @casa_cases = [@case_contact.casa_case]
       render :new
-    elsif @selected_cases.count > 1
-      redirect_to case_contacts_path(success: true), notice: "Case contacts successfully created"
     else
-      redirect_to casa_case_path(CaseContact.last.casa_case, success: true), notice: "Case contact successfully created"
+      contact_msg = @selected_cases.count > 1 ? 'contants' : 'contant'
+      redirect_to case_contacts_path(success: true), notice: "Case #{contact_msg} successfully created"
     end
   end
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -25,6 +25,7 @@ class CaseContactsController < ApplicationController
   end
 
   def new
+    store_referring_location
     authorize CaseContact
     @casa_cases = policy_scope(current_organization.casa_cases)
 
@@ -81,7 +82,8 @@ class CaseContactsController < ApplicationController
       @casa_cases = [@case_contact.casa_case]
       render :new
     else
-      redirect_to case_contacts_path(success: true), notice: "Case #{"contact".pluralize(@selected_cases.count)} successfully created"
+      flash[:notice] = "Case #{"contact".pluralize(@selected_cases.count)} successfully created"
+      redirect_back_to_referer(fallback_location: case_contacts_path(success: true))
     end
   end
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -81,7 +81,7 @@ class CaseContactsController < ApplicationController
       @casa_cases = [@case_contact.casa_case]
       render :new
     else
-      redirect_to case_contacts_path(success: true), notice: "Case #{pluralize(@selected_cases.count, "contact")} successfully created"
+      redirect_to case_contacts_path(success: true), notice: "Case #{'contact'.pluralize(@selected_cases.count)} successfully created"
     end
   end
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -81,7 +81,7 @@ class CaseContactsController < ApplicationController
       @casa_cases = [@case_contact.casa_case]
       render :new
     else
-      contact_msg = @selected_cases.count > 1 ? 'contants' : 'contant'
+      contact_msg = @selected_cases.count > 1 ? "contants" : "contant"
       redirect_to case_contacts_path(success: true), notice: "Case #{contact_msg} successfully created"
     end
   end

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe "/case_contacts", type: :request do
         expect(case_contact.want_driving_reimbursement).to eq(true)
       end
 
-      it "redirects to casa_case#show" do
-        expect(request).to redirect_to(casa_case_url(casa_case, success: true))
+      it "redirects to case_contacts#index as fallback" do
+        expect(request).to redirect_to(case_contacts_path(success: true))
       end
 
       context "when multiple casa cases were selected" do

--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "case_contacts/create", type: :system do
+  let(:volunteer) { create(:volunteer, :with_cases_and_contacts, :with_assigned_supervisor) }
+  let(:casa_case) { volunteer.casa_cases.first }
+
+  context "redirects to where new case contact started from" do
+    before do
+      sign_in volunteer
+    end
+
+    it "when /case_contacts" do
+      visit case_contacts_path
+
+      click_on "New Case Contact"
+      complete_form(casa_case)
+      click_on "Submit"
+
+      expect(page.current_url).to eq case_contacts_url
+    end
+
+    it "when /case_contacts?casa_case_id=ID" do
+      visit case_contacts_path(casa_case_id: casa_case.id)
+
+      click_on "New Case Contact"
+      complete_form(casa_case)
+      click_on "Submit"
+
+      expect(page.current_url).to eq case_contacts_url(casa_case_id: casa_case.id)
+    end
+
+    it "when /casa_cases/CASE_NUMBER" do
+      visit casa_case_path(casa_case)
+
+      click_on "New Case Contact"
+      complete_form(casa_case)
+      click_on "Submit"
+
+      expect(page.current_url).to eq casa_case_url(casa_case)
+    end
+  end
+end
+
+def complete_form(casa_case)
+  within ".casa-case-scroll" do
+    check casa_case.case_number
+  end
+
+  within "#contact-type-form" do
+    check casa_case.casa_org.contact_type_groups.first.contact_types.first.name
+  end
+
+  within "#enter-contact-details" do
+    choose "Yes"
+  end
+
+  choose "In Person"
+  fill_in "case-contact-duration-hours-display", with: "1"
+  fill_in "case-contact-duration-minutes-display", with: "45"
+end

--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "case_contacts/create", type: :system do
       complete_form(casa_case)
       click_on "Submit"
 
-      expect(page.current_url).to eq case_contacts_url
+      expect(page).to have_current_path(case_contacts_path)
     end
 
     it "when /case_contacts?casa_case_id=ID" do
@@ -26,7 +26,7 @@ RSpec.describe "case_contacts/create", type: :system do
       complete_form(casa_case)
       click_on "Submit"
 
-      expect(page.current_url).to eq case_contacts_url(casa_case_id: casa_case.id)
+      expect(page).to have_current_path(case_contacts_path(casa_case_id: casa_case.id))
     end
 
     it "when /casa_cases/CASE_NUMBER" do
@@ -36,7 +36,7 @@ RSpec.describe "case_contacts/create", type: :system do
       complete_form(casa_case)
       click_on "Submit"
 
-      expect(page.current_url).to eq casa_case_url(casa_case)
+      expect(page).to have_current_path(casa_case_path(casa_case))
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5154

### What changed, and why?
According to requirement, redirect back to All Casa Contact after creation.

### How will this affect user permissions?
- Volunteer permissions: No
- Supervisor permissions: No
- Admin permissions: No

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
<img width="1440" alt="image" src="https://github.com/rubyforgood/casa/assets/51321005/c48259c7-e9f9-4f47-9fb4-254a2ff247f5">



