### PR TITLE
Fix flaky contact type alphabetization test

### DIFF
--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -40,10 +40,20 @@ RSpec.describe "/case_contacts", type: :request do
   describe "GET /new" do
     let!(:casa_case) { create(:casa_case, casa_org: organization) }
     let!(:contact_type_group_b) { create(:contact_type_group, casa_org: organization, name: "B") }
-    let!(:contact_types_b) { create_list(:contact_type, 2, contact_type_group: contact_type_group_b) }
+    let!(:contact_types_b) do
+      [
+        create(:contact_type, name: "Teacher", contact_type_group: contact_type_group_b),
+        create(:contact_type, name: "Counselor", contact_type_group: contact_type_group_b)
+      ]
+    end
 
     let!(:contact_type_group_a) { create(:contact_type_group, casa_org: organization, name: "A") }
-    let!(:contact_types_a) { create_list(:contact_type, 2, contact_type_group: contact_type_group_a) }
+    let!(:contact_types_a) do
+      [
+        create(:contact_type, name: "Sibling", contact_type_group: contact_type_group_a),
+        create(:contact_type, name: "Parent", contact_type_group: contact_type_group_a)
+      ]
+    end
 
     subject(:request) do
       get new_case_contact_path
@@ -53,9 +63,9 @@ RSpec.describe "/case_contacts", type: :request do
 
     it { is_expected.to have_http_status(:success) }
 
-    it "shows all contact types alphabetically" do
+    it "shows all contact types alphabetically by group" do
       page = request.parsed_body
-      expected_contact_types = [].concat(contact_types_a, contact_types_b).map(&:name)
+      expected_contact_types = ["Parent", "Sibling", "Counselor", "Teacher"]
       expect(page).to match(/#{expected_contact_types.join(".*")}/m)
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5176 

### What changed, and why?
Previous test was relying on factory sequences, but alphabetization of numerical strings can have unexpected results.

For example:
![image](https://github.com/rubyforgood/casa/assets/44326005/dc0f6def-bb6a-4de0-bb0e-726d53f3c5c1)

This PR updates the test to use hard-coded names for the case contacts so that alphabetization will always return the same result.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
The change is a test 🙂 

### Screenshots please :)


### Feelings gif (optional)
![alphabetized](https://media.giphy.com/media/xT5LMR4kfKPRbYfybC/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
