### PR TITLE
Removed "Assigned To" column from My Cases table for volunteers

### DIFF
--- a/app/views/casa_cases/index.html.erb
+++ b/app/views/casa_cases/index.html.erb
@@ -68,7 +68,9 @@
               <th>Judge</th>
               <th>Status</th>
               <th>Transition Aged Youth</th>
-              <th>Assigned To</th>
+              <% unless current_user.volunteer? %>
+                <th>Assigned To</th>
+              <% end %>
               <th></th>
             </tr>
           </thead>
@@ -80,20 +82,17 @@
                 <td class="min-width"><%= casa_case.judge_name %></td>
                 <td class="min-width"><%= casa_case.decorate.status %></td>
                 <td class="min-width"><%= casa_case.decorate.transition_aged_youth %></td>
-                <td class="min-width">
-                  <% if casa_case.active? %>
-                    <% if current_user.volunteer? %>
-                      <%= safe_join(casa_case.assigned_volunteers.map { |vol|
-                    vol.display_name }, ", ") %>
-                    <% else %>
+                <% unless current_user.volunteer? %>
+                  <td class="min-width">
+                    <% if casa_case.active? %>
                       <%= safe_join(casa_case.assigned_volunteers.map { |vol|
                     link_to(vol.display_name, edit_volunteer_path(vol)) },
                                 ", ") %>
+                    <% else %>
+                      Case was deactivated on: <%= I18n.l(casa_case.updated_at, format: :standard, default: nil) %>
                     <% end %>
-                  <% else %>
-                    Case was deactivated on: <%= I18n.l(casa_case.updated_at, format: :standard, default: nil) %>
-                  <% end %>
-                </td>
+                  </td>
+                <% end %>
                 <td>
                   <i class="lni lni-pencil-alt text-danger"></i>
                   <%= link_to "Edit", edit_casa_case_path(casa_case), class: 'text-danger' %>

--- a/spec/system/dashboard/show_spec.rb
+++ b/spec/system/dashboard/show_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "dashboard/show", type: :system do
   let(:volunteer) { create(:volunteer, display_name: "Bob Loblaw") }
+  let(:casa_admin) { create(:casa_admin, display_name: "John Doe") }
+
   context "volunteer user" do
     before do
       sign_in volunteer
@@ -21,15 +23,13 @@ RSpec.describe "dashboard/show", type: :system do
       expect(page).not_to have_text(casa_case_3.case_number)
     end
 
-    it "sees volunteer names in Cases table as plain text" do
+    it "volunteer does not see his name in Cases table" do
       casa_case = build(:casa_case, active: true, casa_org: volunteer.casa_org, case_number: "CINA-1")
       create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
 
       visit casa_cases_path
 
-      expect(page).to have_text("Bob Loblaw")
-      expect(page).to have_no_link("Bob Loblaw")
-      expect(page).to have_css("td", text: "Bob Loblaw")
+      expect(page).not_to have_css("td", text: "Bob Loblaw")
     end
 
     it "displays 'No active cases' when they don't have any assignments", js: true do
@@ -37,6 +37,23 @@ RSpec.describe "dashboard/show", type: :system do
       expect(page).to have_text("My Cases")
       expect(page).not_to have_css("td", text: "Bob Loblaw")
       expect(page).not_to have_text("Detail View")
+    end
+  end
+
+  context "admin user" do
+    before do
+      sign_in casa_admin
+    end
+
+    it "sees volunteer names in Cases table as a link" do
+      casa_case = build(:casa_case, active: true, casa_org: volunteer.casa_org, case_number: "CINA-1")
+      create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
+
+      visit casa_cases_path
+
+      expect(page).to have_text("Bob Loblaw")
+      expect(page).to have_link("Bob Loblaw")
+      expect(page).to have_css("td", text: "Bob Loblaw")
     end
   end
 end

--- a/spec/views/casa_cases/index.html.erb_spec.rb
+++ b/spec/views/casa_cases/index.html.erb_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe "casa_cases/index", type: :view do
+  context "when accessed by a volunteer" do
+    it "can not see the Assigned To column" do
+      user = create(:volunteer, display_name: "Bob Loblaw")
+      enable_pundit(view, user)
+      allow(view).to receive(:current_user).and_return(user)
+
+      casa_case = build(:casa_case, active: true, casa_org: user.casa_org, case_number: "CINA-1")
+      create(:case_assignment, volunteer: user, casa_case: casa_case)
+      assign :casa_cases, [casa_case]
+      assign :duties, OtherDuty.none
+
+      render template: "casa_cases/index"
+
+      expect(rendered).not_to have_text "Assigned To"
+      expect(rendered).not_to have_text("Bob Loblaw")
+    end
+  end
+
   context "when accessed by an admin" do
     it "can see the New Case button" do
       organization = create(:casa_org)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5218

### What changed, and why?
Modified "app/views/casa_cases/index.html.erb" template so volunteers can't see "Assigned To" column anymore


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
Modified test cases in "spec/system/dashboard/show_spec.rb" and "spec/views/casa_cases/index.html.erb_spec.rb" files


### Screenshots please :)
![Screenshot from 2023-09-19 16-00-24](https://github.com/rubyforgood/casa/assets/29335101/c101f1a1-b45f-433e-a487-5ac92502ae74)
Volunteer no longer can see a column


![Screenshot from 2023-09-19 16-00-00](https://github.com/rubyforgood/casa/assets/29335101/23068c14-0205-4aa5-aa07-69d152d04a6e)
But Supervisor still does


### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
