### PR TITLE
fix: Flaky Test Did not Recieve Confirmation Text After Changing Supervisor to Admin

### DIFF
--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -125,7 +125,9 @@ RSpec.describe "supervisors/edit", type: :system do
 
       sign_in user
 
+      visit supervisors_path
       visit edit_supervisor_path(supervisor)
+
       click_on "Change to Admin"
 
       expect(page).to have_text("Supervisor was changed to Admin.")


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5129 

### What changed, and why?

Add visit supervisors_path to load supervisors list before visiting supervisors edit page and click on Change to Admin button

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
