### PR TITLE
Sort mileage rates by effective_dates

### DIFF
--- a/app/controllers/mileage_rates_controller.rb
+++ b/app/controllers/mileage_rates_controller.rb
@@ -4,7 +4,7 @@ class MileageRatesController < ApplicationController
 
   def index
     authorize :application, :see_mileage_rate?
-    @mileage_rates = MileageRate.where(casa_org: current_organization)
+    @mileage_rates = MileageRate.where(casa_org: current_organization).order(effective_date: :asc)
   end
 
   def new

--- a/spec/controllers/mileage_rates_controller_spec.rb
+++ b/spec/controllers/mileage_rates_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe MileageRatesController, type: :controller do
+  describe "#index" do
+    it "render the mileage rates by effective date in ascending order" do
+      mileage_rate1 = FactoryBot.create(:mileage_rate, effective_date: Date.new(2023, 3, 1))
+      mileage_rate2 = FactoryBot.create(:mileage_rate, effective_date: Date.new(2023, 1, 1))
+      mileage_rate3 = FactoryBot.create(:mileage_rate, effective_date: Date.new(2023, 2, 1))
+      mileage_rates = MileageRate.order(effective_date: :asc)
+      get :index
+      expect(mileage_rates).to eq([mileage_rate2, mileage_rate3, mileage_rate1])
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5227

### What changed, and why?

Mileage rates are now being rendered in ascending order by effective dates. @mileage_rates.order is added in index axtion to order the mileage rates in ascending order by effective_dates. This helps the mileage rates table to be more user friendly!

### How is this tested? (please write tests!) 💖💪

A test for controller index action is added to test that mileage rates are being rendered in ascending order by effective dates.

### Screenshots please :)

![mileage_rates](https://github.com/rubyforgood/casa/assets/35504149/38c1ddde-dab2-4499-8a40-88f93fb223ec)

