### PR TITLE
fix emancipation download btn positioning

### DIFF
--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -1,4 +1,4 @@
-<div class="row justify-content-between pt-30 mb-30">
+<div class="row justify-content-between align-items-center pt-30 mb-30">
   <div class="col-sm-auto dashboard-table-header">
     <h1>Emancipation Checklist</h1>
     <%= link_to @current_case.case_number, casa_case_path(@current_case) %>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -1,8 +1,10 @@
-<div class="row pt-30 mb-30">
-  <div class="col-sm-12 dashboard-table-header">
+<div class="row justify-content-between pt-30 mb-30">
+  <div class="col-sm-auto dashboard-table-header">
     <h1>Emancipation Checklist</h1>
     <%= link_to @current_case.case_number, casa_case_path(@current_case) %>
-    <span class="d-block float-md-right my-2 mt-md-0 text-center">
+  </div>
+  <div class="col-sm-auto">
+    <span class="mt-md-0 text-center">
       <%= link_to casa_case_emancipation_path(@current_case, format: :docx), class: "main-btn primary-btn btn-sm btn-hover" do %>
         <i class="lni lni-download mr-10"></i>
             Download Checklist


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What changed, and why?
Fixed wonky emancipation checklist download button positioning

### How will this affect user permissions?
- Volunteer permissions: ❌ 
- Supervisor permissions: ❌ 
- Admin permissions: ❌ 

### How is this tested? (please write tests!) 💖💪
manual testing

### Screenshots please :)
Before:

![image](https://github.com/rubyforgood/casa/assets/44326005/fea37136-a0a8-4156-8b13-d217cec99093)

After:

![image](https://github.com/rubyforgood/casa/assets/44326005/cfdd3780-99fd-43a9-9997-765c6e1b7659)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? 
![straighten picture](https://media.giphy.com/media/gfswDfGrHK0ipUICgf/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
