### PR TITLE
Add Topic Column to Learning Hour Table

### DIFF
--- a/app/views/learning_hours/index.html.erb
+++ b/app/views/learning_hours/index.html.erb
@@ -15,6 +15,9 @@
           <tr>
             <th>Title</th>
             <th>Learning Type</th>
+            <% if current_user.casa_org.learning_topic_active %>
+              <th>Learning Topic</th>
+            <% end %>
             <th>Date</th>
             <th>Time Spent</th>
           </tr>
@@ -26,6 +29,9 @@
                 <%= link_to learning_hour.name, volunteer_learning_hour_path(id: learning_hour.id) %>
               </td>
               <td> <%= learning_hour.learning_hour_type.name %> </td>
+              <% if current_user.casa_org.learning_topic_active %>
+                <td> <%= learning_hour.learning_hour_topic&.name %> </td>
+              <% end %>
               <td> <%= learning_hour.occurred_at.strftime("%B %d, %Y") %> </td>
               <td>
               <% if (learning_hour.duration_hours > 0) %>

--- a/spec/requests/learning_hours_spec.rb
+++ b/spec/requests/learning_hours_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe "LearningHours", type: :request do
         get volunteer_learning_hours_path(volunteer_id: volunteer.id)
         expect(response).to have_http_status(:success)
       end
+
+      it "displays the Learning Topic column if learning_topic_active is true" do
+        volunteer.casa_org.update(learning_topic_active: true)
+        get volunteer_learning_hours_path(volunteer_id: volunteer.id)
+        expect(response.body).to include("Learning Topic")
+      end
+
+      it "does not display the Learning Topic column if learning_topic_active is false" do
+        volunteer.casa_org.update(learning_topic_active: false)
+        get volunteer_learning_hours_path(volunteer_id: volunteer.id)
+        expect(response.body).not_to include("Learning Topic")
+      end
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5245 

### What changed, and why?
Display learning hour topic column to Volunteer learning hour table if learning hour topic feature is enabled for organization

### How will this affect user permissions?
- Volunteer permissions: Not Effected
- Supervisor permissions: Not Effected
- Admin permissions: Not Effected

### How is this tested? (please write tests!) 💖💪
Added test to check column is visible only if learning hour topic feature is enabled for organization

### Screenshots please :)
![volunteer_learning_table_learning_topic](https://github.com/rubyforgood/casa/assets/514363/f1eb7706-3631-40a7-a1a7-3c556239ee3d)


### Feelings gif (optional)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
