### PR TITLE
created past mileage data for test data

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -356,7 +356,7 @@ class DbPopulator
       begin
         MileageRate.create!({
           amount: Faker::Number.between(from: 0.0, to: 1.0).round(2),
-          effective_date: Faker::Date.forward(days: 700),
+          effective_date: Faker::Date.backward(days: 700),
           is_active: true,
           casa_org_id: casa_org.id
         })


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5244 

### What changed, and why?
The seed data for mileage rates had their effective dates in the future, with this fix they will be in the past

### How will this affect user permissions?
- Volunteer permissions: Not effected
- Supervisor permissions: Not effected
- Admin permissions: Not effected

### How is this tested? (please write tests!) 💖💪
You can try this command in the dev or testing environment rails console after running db:seed and check whether the dates are in the past
`MileageRate.pluck(:effective_date)`

### Screenshots please :)

Before change
![image](https://github.com/rubyforgood/casa/assets/63001461/8b9fa963-170b-4d44-a971-0abde0045464)


After change
![image](https://github.com/rubyforgood/casa/assets/63001461/2822e75b-8198-42e8-afdf-e6e3291de3d9)
