### PR TITLE
Disable 15 minutes validation for New Case Contact Form

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -5,7 +5,6 @@ class CaseContact < ApplicationRecord
   attr_accessor :duration_hours
 
   validate :contact_made_chosen
-  validates :duration_minutes, numericality: {greater_than_or_equal_to: 15, message: "Minimum case contact duration should be 15 minutes."}
   validates :miles_driven, numericality: {greater_than_or_equal_to: 0, less_than: 10000}
   validates :medium_type, presence: true
   validates :occurred_at, presence: true

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -27,16 +27,14 @@ RSpec.describe CaseContact, type: :model do
     expect(case_contact.errors[:occurred_at]).to eq(["can't be blank"])
   end
 
-  it "validates duration_minutes is only numeric values" do
+  it "validates duration_minutes to allow nil value" do
     case_contact = build_stubbed(:case_contact, duration_minutes: nil)
-    expect(case_contact).to_not be_valid
-    expect(case_contact.errors[:duration_minutes]).to eq(["Minimum case contact duration should be 15 minutes."])
+    expect(case_contact).to be_valid
   end
 
-  it "validates duration_minutes cannot be less than 15 minutes." do
+  it "validates duration_minutes can be less than 15 minutes." do
     case_contact = build_stubbed(:case_contact, duration_minutes: 10)
-    expect(case_contact).to_not be_valid
-    expect(case_contact.errors[:duration_minutes]).to eq(["Minimum case contact duration should be 15 minutes."])
+    expect(case_contact).to be_valid
   end
 
   it "verifies occurred at is not in the future" do

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe "/case_contacts", type: :request do
 
     context "with invalid parameters" do
       let!(:other_casa_case) { create(:casa_case, casa_org: organization) }
-      let(:invalid_attributes) { {creator: "volunteer", casa_case_id: [other_casa_case.id], occurred_at: Time.now + 1.week} }
+      let(:invalid_attributes) { {creator: volunteer, casa_case_id: [other_casa_case.id], occurred_at: Time.now + 1.week} }
       let(:params) { {case_contact: invalid_attributes} }
 
       it { is_expected.to have_http_status(:success) }

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe "/case_contacts", type: :request do
 
     context "with invalid parameters" do
       let!(:other_casa_case) { create(:casa_case, casa_org: organization) }
-      let(:invalid_attributes) { {creator: volunteer, casa_case_id: [other_casa_case.id]} }
+      let(:invalid_attributes) { {creator: "volunteer", casa_case_id: [other_casa_case.id], occurred_at: Time.now + 1.week} }
       let(:params) { {case_contact: invalid_attributes} }
 
       it { is_expected.to have_http_status(:success) }

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -155,7 +155,6 @@ RSpec.describe "case_contacts/new", type: :system do
         within "#enter-contact-details" do
           choose "Yes"
         end
-        choose "Video"
         fill_in "case_contact_occurred_at", with: "04/04/2020"
         fill_in "case-contact-duration-hours-display", with: "0"
         fill_in "case-contact-duration-minutes-display", with: "5"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5287 

### What changed, and why?
Removed the duration validation from New Case Contact form so that form can be submitted even if minutes is set to 0 instead of earlier validation of minimum 15mins

### How will this affect user permissions?
- Volunteer permissions: Not Effected
- Supervisor permissions: Not Effected
- Admin permissions: Not Effected

### How is this tested? (please write tests!) 💖💪
Modified the existing tests checking for 15mins duration validation.

### Screenshots please :)

Duration validation is not triggered now.

![CASA-Volunteer-Tracking-new-contact-form](https://github.com/rubyforgood/casa/assets/514363/eac0df1e-c5cc-4c1f-b6c6-b5f313a78c51)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
