### PR TITLE
Remove “+ Highlight” button from New Case Contact form

### DIFF
--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -133,21 +133,3 @@ legend {
 .cc-italic {
     font-style: italic;
 }
-
-.notes-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.5em;
-
-  h2 {
-    margin-bottom: 0;
-  }
-}
-
-.highlight-button {
-  background: none;
-  border: none;
-  color: var(--blue);
-  font-size: 1.1em;
-}

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -66,11 +66,6 @@ async function fireSwalFollowupAlert () {
   })
 }
 
-function displayHighlightModal (event) {
-  event.preventDefault()
-  $('#caseContactHighlight').modal('show')
-}
-
 $(() => { // JQuery's callback for the DOM loading
   const milesDriven = $('#case_contact_miles_driven')
   const durationHoursElement = $('#case-contact-duration-hours-display')
@@ -170,7 +165,6 @@ $(() => { // JQuery's callback for the DOM loading
 
   $('[data-toggle="tooltip"]').tooltip()
   $('.followup-button').on('click', displayFollowupAlert)
-  $('#open-highlight-modal').on('click', displayHighlightModal)
 
   if (/\/case_contacts\/*.*\?.*success=true/.test(window.location.href)) {
     $('#thank_you').modal()

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -236,12 +236,7 @@ readonly: true %>
   </div>
 
   <div class="card-style-1 pl-25 mb-10">
-    <div class="notes-header pr-25">
-      <h2 class="mb-3"><%= form.label :notes, "5. Enter Notes" %></h2>
-
-      <button id="open-highlight-modal" class="mb-3 btn-sm main-btn secondary-btn-outline btn-hover" data-bs-toggle="modal" data-target="#visibleColumns">+ Highlight</button>
-
-    </div>
+    <h2 class="mb-3"><%= form.label :notes, "5. Enter Notes" %></h2>
     <div class="cc-italic mb-3">
       Please refer to individuals by their roles instead of by their names. Ex: My supervisor joined me for a call with the social worker to discuss my youth.
     </div>
@@ -257,34 +252,3 @@ readonly: true %>
   </div>
   <%= render 'confirm_note_content_dialog', form: form %>
   <% end %>
-
-<div class="warning-modal">
-  <div class="modal fade" id="caseContactHighlight" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content card-style">
-        <div class="modal-header px-0 border-0">
-          <h5 class="text-bold">Highlight</h5>
-          <button
-            class="border-0 bg-transparent h1"
-            data-bs-dismiss="modal">
-            <i class="lni lni-cross-circle"></i>
-          </button>
-        </div>
-        <div class="modal-body px-0">
-          <div class="mb-30">
-            <h6 class="mb-20">
-              Coming Soon.
-            </h6>
-          </div>
-          <div class="action d-flex flex-wrap justify-content-end">
-            <button
-              data-bs-dismiss="modal"
-              class="main-btn danger-btn-outline btn-hover m-1"><i class="lni lni-ban mr-10"></i>
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5285

### What changed, and why?
The `+ Highlight' button was removed from the "New Case Contact" Form. Related JavaScript and CSS files were modified to reflect the change.

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: not affected
- Admin permissions: not affected

### How is this tested? (please write tests!) 💖💪
Navigated to page and confirmed that the button was removed.
Re-ran test suite locally to ensure existing tests still pass.

### Screenshots please :)
<img width="1765" alt="Screenshot 2023-10-19 at 12 14 43" src="https://github.com/rubyforgood/casa/assets/85654561/d90dba0d-f506-4c6f-83f9-08762508e244">
