### PR TITLE
CasaCase accepts date_in_care

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -151,6 +151,7 @@ class CasaCasesController < ApplicationController
     params.require(:casa_case).permit(
       :case_number,
       :birth_month_year_youth,
+      :date_in_care,
       :court_report_due_date,
       :empty_court_date,
       casa_case_contact_types_attributes: [:contact_type_id],

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "/casa_cases", type: :request do
+  let(:date_in_care) { Date.today }
   let(:organization) { build(:casa_org) }
   let(:group) { build(:contact_type_group) }
   let(:type1) { create(:contact_type, contact_type_group: group) }
@@ -8,6 +9,9 @@ RSpec.describe "/casa_cases", type: :request do
     {
       case_number: "1234",
       birth_month_year_youth: pre_transition_aged_youth_age,
+      "date_in_care(3i)": date_in_care.day,
+      "date_in_care(2i)": date_in_care.month,
+      "date_in_care(1i)": date_in_care.year,
       casa_org_id: organization.id,
       casa_case_contact_types_attributes: [{contact_type_id: type1.id}]
     }
@@ -158,6 +162,7 @@ RSpec.describe "/casa_cases", type: :request do
           casa_case = CasaCase.last
           expect(casa_case.casa_org).to eq organization
           expect(casa_case.birth_month_year_youth).to eq pre_transition_aged_youth_age
+          expect(casa_case.date_in_care.to_date).to eq date_in_care
         end
 
         it "also responds as json", :aggregate_failures do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5291

### What changed, and why?
The date in care was not a permitted param so it was not being included
in the attributes during CasaCase creation. Added it to the list of
permitted params.


### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Added an expectation to the casa_case_spec.rb

### Screenshots please :)
#### Before
![image](https://github.com/rubyforgood/casa/assets/444766/7e2a5c0e-7e0a-4ab8-ab85-8a59611fa127)
![Z-2023-10-21 at 21 25 22](https://github.com/rubyforgood/casa/assets/444766/c3371198-612d-4087-91bc-5995f0be974b)

#### After
![Z-2023-10-21 at 21 21 48](https://github.com/rubyforgood/casa/assets/444766/1a70f5a4-7f06-48f2-841d-fdec0a9ae4fe)
![Z-2023-10-21 at 21 22 41](https://github.com/rubyforgood/casa/assets/444766/2fd1bf8b-746f-4b4f-a6f6-29ea304a3fac)
![Z-2023-10-21 at 21 34 55](https://github.com/rubyforgood/casa/assets/444766/2d645d32-a3cf-4134-93e6-448672fc1230)


### Feelings gif (optional)
![mmmm happy](https://media.giphy.com/media/VIPdgcooFJHtC/giphy.gif)
