### PR TITLE
reduce space taken up by notifier

### DIFF
--- a/app/assets/stylesheets/shared/notifier.scss
+++ b/app/assets/stylesheets/shared/notifier.scss
@@ -8,6 +8,7 @@
 }
 
 #notifications {
+  align-items: end;
   bottom: 0;
   display: flex;
   flex-direction: column;
@@ -38,6 +39,10 @@
   .messages {
     margin-bottom: 0;
     padding: 0;
+
+    div {
+      width: fit-content;
+    }
   }
 
   .success-notification {
@@ -72,6 +77,7 @@
     border-radius: 10px 10px 0 0;
     color: white;
     padding: 0.25em 1em;
+    width: fit-content;
 
     span {
       display: inline;


### PR DESCRIPTION
### What changed, and why?
 - fixed parts of the notifier taking up too much space

### How is this tested? (please write tests!) 💖💪
Manually

### Screenshots please :)
#### Notifier improvements:
Before
![image](https://github.com/rubyforgood/casa/assets/8918762/05d925f6-7dd0-451e-b810-d40e7a0cca23)
After
![image](https://github.com/rubyforgood/casa/assets/8918762/a3971154-9f7d-42e1-8892-3ad20a27ed63)
