### PR TITLE
Bring local time component to original specification

### DIFF
--- a/app/components/local_time_component.html.erb
+++ b/app/components/local_time_component.html.erb
@@ -1,1 +1,1 @@
-<div title="<%= specific_time %>"><%= local_time %></div>
+<span title="<%= specific_time %>"><%= local_time %></span>

--- a/app/components/local_time_component.html.erb
+++ b/app/components/local_time_component.html.erb
@@ -1,1 +1,1 @@
-<div><%= local_time %></div>
+<div title="<%= specific_time %>"><%= local_time %></div>

--- a/app/components/local_time_component.rb
+++ b/app/components/local_time_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class LocalTimeComponent < ViewComponent::Base
-  include ActionController::Cookies
-  attr_reader :format, :unix_timestamp
+  attr_reader :format, :unix_timestamp, :time_zone
 
-  def initialize(format:, unix_timestamp:)
+  def initialize(format:, unix_timestamp:, time_zone:)
     @format = format
+    @time_zone = time_zone
     @unix_timestamp = unix_timestamp
   end
 
@@ -14,12 +14,7 @@ class LocalTimeComponent < ViewComponent::Base
     time.strftime(@format)
   end
 
-  private
-
-  def before_render
-    browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies[:browser_time_zone])
-    ActiveSupport::TimeZone.all.find { |zone| zone.tzinfo == browser_tz } || Time.zone
-  rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
-    @time_zone = Time.zone
+  def specific_time
+    Time.at(unix_timestamp).strftime("%b %d, %Y, %l:%M %p %Z")
   end
 end

--- a/app/components/local_time_component.rb
+++ b/app/components/local_time_component.rb
@@ -10,17 +10,8 @@ class LocalTimeComponent < ViewComponent::Base
   end
 
   def local_time
-    # Time format should be passed as 12 or 24 only
-    unless [12, 24].include?(format)
-      raise ArgumentError, "Invalid time format argument"
-    end
-
     time = Time.at(unix_timestamp).in_time_zone(@time_zone)
-    time_format = format == 12 ? "%I:%M %p" : "%H:%M"
-    formatted_date = time.strftime("%B %d, %Y")
-    time_of_day = time.strftime(time_format)
-    time_zone = time.zone
-    formatted_date + " at " + time_of_day + " " + time_zone
+    time.strftime(@format)
   end
 
   private

--- a/app/components/local_time_component.rb
+++ b/app/components/local_time_component.rb
@@ -15,6 +15,6 @@ class LocalTimeComponent < ViewComponent::Base
   end
 
   def specific_time
-    Time.at(unix_timestamp).strftime("%b %d, %Y, %l:%M %p %Z")
+    Time.at(unix_timestamp).in_time_zone(@time_zone).strftime("%b %d, %Y, %l:%M %p %Z")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,6 +63,7 @@
   </section>
 
   <%= render "layouts/notifier" %>
+  <%= render (LocalTimeComponent.new(format: "A date: %b %d, %Y", unix_timestamp: 1694349775, time_zone: current_user&.decorate&.local_time_zone)) %>
 
   <footer class="footer">
     <div class="container-fluid">

--- a/spec/components/local_time_component_spec.rb
+++ b/spec/components/local_time_component_spec.rb
@@ -3,15 +3,33 @@
 require "rails_helper"
 
 RSpec.describe LocalTimeComponent, type: :component do
-  it "render correct date from user local time" do
-    component = described_class.new(format: 12, unix_timestamp: 1693825843)
+  it "formats the date using strftime" do
+    component = described_class.new(format: "%b %d, %Y", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Eastern Time (US & Canada)"))
     render_inline(component)
-    expect(page).to have_text("September 04, 2023")
+    expect(page).to have_text("Sep 04, 2023")
   end
 
-  it "does not render correct date from user local time" do
-    component = described_class.new(format: 12, unix_timestamp: 1693825843)
+  it "uses the time zone passed to it to format the time" do
+    component = described_class.new(format: "%l:%M %p %Z", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Eastern Time (US & Canada)"))
     render_inline(component)
-    expect(page).to_not have_text("September 06, 2023")
+    expect(page).to have_text("7:10 AM EDT")
+
+    component = described_class.new(format: "%l:%M %p %Z", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Central Time (US & Canada)"))
+    render_inline(component)
+    expect(page).to have_text("6:10 AM CDT")
+
+    component = described_class.new(format: "%l:%M %p %Z", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Mountain Time (US & Canada)"))
+    render_inline(component)
+    expect(page).to have_text("5:10 AM MDT")
+
+    component = described_class.new(format: "%l:%M %p %Z", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Pacific Time (US & Canada)"))
+    render_inline(component)
+    expect(page).to have_text("4:10 AM PDT")
+  end
+
+  it "has an unambigous detailed date as the title of the element" do
+    component = described_class.new(format: "%l:%M %p %Z", unix_timestamp: 1693825843, time_zone: ActiveSupport::TimeZone.new("Central Time (US & Canada)"))
+    render_inline(component)
+    expect(page.find_css("span").attr("title").value).to have_text("Sep 04, 2023,  6:10 AM CDT")
   end
 end


### PR DESCRIPTION
### What changed, and why?
 - parameter `format` is now the string argument passed to `strftime` for improved versatility
 - a detailed [title](https://www.w3schools.com/TAGS/att_title.asp) showing the exact time has been added to the component which was part of the original design of the component.
 - added a parameter `time_zone` because the previous solution had problems described below.

The previous solution had this `before_render`
```ruby
def before_render
    browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies[:browser_time_zone])
    ActiveSupport::TimeZone.all.find { |zone| zone.tzinfo == browser_tz } || Time.zone
rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
    @time_zone = Time.zone
end
```
which looks identical to this method found as a user decorator in our codebase  
```ruby
def browser_time_zone
      browser_tz = ActiveSupport::TimeZone.find_tzinfo(cookies[:browser_time_zone])
      ActiveSupport::TimeZone.all.find { |zone| zone.tzinfo == browser_tz } || Time.zone
rescue TZInfo::UnknownTimezone, TZInfo::InvalidTimezoneIdentifier
      Time.zone
 end
```

In the existing code, the lines
` ActiveSupport::TimeZone.all.find { |zone| zone.tzinfo == browser_tz } || Time.zone`
` Time.zone`
acted as return values
instead of returning, the `before_render`'s purposed was to set the `@time_zone` variable which was only set if the user's time zone was not found. However the component seemed to function every time. This is because the `cookies` variable was private to the current controller and was inaccessible from the component so `Time.zone` would always be defaulted to.  
  
Having 2 of the same method makes the code not DRY. Most of the dates displayed to users source their time zone from `browser_time_zone` so it would be better to have it as the only source of truth and pass the time zone to the component.

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)
`<%= render (LocalTimeComponent.new(format: "A date: %b %d, %Y", unix_timestamp: 1694349775, time_zone: current_user&.decorate&.local_time_zone)) %>`  
![image](https://github.com/rubyforgood/casa/assets/8918762/54aa6aac-5755-4cad-a925-f13b96aafef4)