### PR TITLE
Allow supervisors to see youths birth month/date in form

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -27,7 +27,6 @@
         </div>
       <% end %>
       <h2><%= form.label :court_details, "Court Details" %></h2>
-      <% if policy(casa_case).update_birth_month_year_youth? %>
         <div class="form-group my-3">
           <%= form.label :birth_month_year_youth, "Youth's Birth Month & Year", class: 'my-2' %>
           <br>
@@ -38,11 +37,11 @@
                                    start_year: Date.current.year,
                                    end_year: 1989,
                                    prompt: {month: "Month", year: "Year"},
-                                   discard_day: true
+                                   discard_day: true,
+                                   disabled: !policy(casa_case).update_birth_month_year_youth?
                                  }, class: "form-control select-style-2" %>
           </span>
         </div>
-      <% end %>
       <% if policy(casa_case).update_date_in_care_youth? %>
         <div class="field form-group">
           <%= form.label :date_in_care, "Youth's Date in Care", class: 'my-2' %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5312 

### What changed, and why?
Instead of being hidden the youth's birth month/year field are disabled on the form for users who can't edit it. @bcastillo32 confirmed with stakeholders this is what they wanted.


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
