### PR TITLE
Add notifications for volunteer birthdays (#5316)

### DIFF
--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -135,7 +135,7 @@ class CasaAdminsController < ApplicationController
   end
 
   def update_casa_admin_params
-    CasaAdminParameters.new(params).with_only(:email, :display_name, :phone_number, :monthly_learning_hours_report)
+    CasaAdminParameters.new(params).with_only(:email, :display_name, :phone_number, :date_of_birth, :monthly_learning_hours_report)
   end
 
   def learning_hours_checked?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -125,9 +125,9 @@ class UsersController < ApplicationController
 
   def user_params
     if !current_user.casa_admin?
-      params.require(:user).permit(:display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
+      params.require(:user).permit(:display_name, :phone_number, :date_of_birth, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
     else
-      params.require(:user).permit(:email, :display_name, :phone_number, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
+      params.require(:user).permit(:email, :display_name, :phone_number, :date_of_birth, :receive_sms_notifications, :receive_email_notifications, sms_notification_event_ids: [], address_attributes: [:id, :content])
     end
   end
 

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -44,4 +44,16 @@ class UserDecorator < Draper::Decorator
   def formatted_invitation_sent_at
     formatted_timestamp(:invitation_sent_at)
   end
+
+  def formatted_birthday
+    return "" unless object.date_of_birth.respond_to?(:strftime)
+
+    object.date_of_birth.to_date.to_fs(:short_ordinal)
+  end
+
+  def formatted_date_of_birth
+    return "" unless object.date_of_birth.respond_to?(:strftime)
+
+    object.date_of_birth.to_date.to_fs(:slashes)
+  end
 end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,4 +1,8 @@
 module NotificationsHelper
+  def read_when_seen_notifications
+    ["YouthBirthdayNotification", "VolunteerBirthdayNotification", "EmancipationChecklistReminderNotification"]
+  end
+
   def notifications_after_and_including_deploy(notifications)
     latest_deploy_time = Health.instance.latest_deploy_time
 

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -27,6 +27,7 @@ end
 #  confirmed_at                  :datetime
 #  current_sign_in_at            :datetime
 #  current_sign_in_ip            :string
+#  date_of_birth                 :datetime
 #  display_name                  :string           default(""), not null
 #  email                         :string           default(""), not null
 #  encrypted_password            :string           default(""), not null

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -36,6 +36,7 @@ end
 #  id                     :bigint           not null, primary key
 #  duration_hours         :integer          not null
 #  duration_minutes       :integer          not null
+#  learning_type          :integer          default(5)
 #  name                   :string           not null
 #  occurred_at            :datetime         not null
 #  created_at             :datetime         not null

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -54,6 +54,7 @@ end
 #  confirmed_at                  :datetime
 #  current_sign_in_at            :datetime
 #  current_sign_in_ip            :string
+#  date_of_birth                 :datetime
 #  display_name                  :string           default(""), not null
 #  email                         :string           default(""), not null
 #  encrypted_password            :string           default(""), not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,7 @@ end
 #  confirmed_at                  :datetime
 #  current_sign_in_at            :datetime
 #  current_sign_in_ip            :string
+#  date_of_birth                 :datetime
 #  display_name                  :string           default(""), not null
 #  email                         :string           default(""), not null
 #  encrypted_password            :string           default(""), not null

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -147,6 +147,7 @@ end
 #  confirmed_at                  :datetime
 #  current_sign_in_at            :datetime
 #  current_sign_in_ip            :string
+#  date_of_birth                 :datetime
 #  display_name                  :string           default(""), not null
 #  email                         :string           default(""), not null
 #  encrypted_password            :string           default(""), not null

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -41,6 +41,10 @@ class Volunteer < User
       .active
   }
 
+  scope :with_supervisor, -> {
+    joins(:supervisor_volunteer)
+  }
+
   scope :with_assigned_cases, -> {
     joins(:case_assignments)
       .where("case_assignments.active is true")
@@ -56,6 +60,10 @@ class Volunteer < User
                                      .distinct
                                      .order(:display_name)
                                  }
+
+  scope :birthday_next_month, -> {
+    where("EXTRACT(month from date_of_birth) = ?", DateTime.current.next_month.month)
+  }
 
   def self.send_court_report_reminder
     active.includes(:case_assignments).where.not(case_assignments: nil).find_each do |volunteer|

--- a/app/notifications/volunteer_birthday_notification.rb
+++ b/app/notifications/volunteer_birthday_notification.rb
@@ -16,7 +16,7 @@ class VolunteerBirthdayNotification < BaseNotification
 
   # Define helper methods to make rendering easier.
   def message
-    "🎉 🎂  #{params[:volunteer].display_name}'s birthday is on #{params[:volunteer].date_of_birth.to_date.to_fs(:short_ordinal)}!"
+    "🎉 🎂  #{params[:volunteer].display_name}'s birthday is on #{params[:volunteer].decorate.formatted_birthday}!"
   end
 
   def title

--- a/app/notifications/volunteer_birthday_notification.rb
+++ b/app/notifications/volunteer_birthday_notification.rb
@@ -1,0 +1,29 @@
+# To deliver this notification:
+#
+# VolunteerBirthdayNotification.with(post: @post).deliver_later(current_user)
+# VolunteerBirthdayNotification.with(post: @post).deliver(current_user)
+
+class VolunteerBirthdayNotification < BaseNotification
+  # Add your delivery methods
+  #
+  deliver_by :database
+  # deliver_by :email, mailer: "UserMailer"
+  # deliver_by :slack
+  # deliver_by :custom, class: "MyDeliveryMethod"
+
+  # Add required params
+  param :volunteer
+
+  # Define helper methods to make rendering easier.
+  def message
+    "🎉 🎂  #{params[:volunteer].display_name}'s birthday is on #{params[:volunteer].date_of_birth.to_date.to_fs(:short_ordinal)}!"
+  end
+
+  def title
+    "Volunteer Birthday Notification"
+  end
+
+  def url
+    ""
+  end
+end

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -6,6 +6,7 @@ class UserValidator < ActiveModel::Validator
     validate_presence(:display_name, record)
     at_least_one_communication_preference_selected(record)
     valid_phone_number_if_receive_sms_notifications(record)
+    valid_date_of_birth(record.date_of_birth, record)
   end
 
   private
@@ -35,5 +36,11 @@ class UserValidator < ActiveModel::Validator
     if record.receive_sms_notifications && record.phone_number.blank?
       record.errors.add(:base, " Must add a valid phone number to receive SMS notifications.")
     end
+  end
+
+  def valid_date_of_birth(date_of_birth, record)
+    return unless date_of_birth.present?
+
+    record.errors.add(:base, " Date of birth must be in the past.") unless date_of_birth.past?
   end
 end

--- a/app/values/user_parameters.rb
+++ b/app/values/user_parameters.rb
@@ -6,6 +6,7 @@ class UserParameters < SimpleDelegator
         :casa_org_id,
         :display_name,
         :phone_number,
+        :date_of_birth,
         :password,
         :active,
         :receive_reimbursement_email,

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% @notifications.each do |notification| %>
-  <% if ["YouthBirthdayNotification", "VolunteerBirthdayNotification", "EmancipationChecklistReminderNotification"].include? notification.type %>
+  <% if read_when_seen_notifications.include? notification.type %>
     <% notification.mark_as_read! %>
   <% end %>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% @notifications.each do |notification| %>
-  <% if ["YouthBirthdayNotification", "EmancipationChecklistReminderNotification"].include? notification.type %>
+  <% if ["YouthBirthdayNotification", "VolunteerBirthdayNotification", "EmancipationChecklistReminderNotification"].include? notification.type %>
     <% notification.mark_as_read! %>
   <% end %>
 <% end %>

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -32,11 +32,11 @@
   <%= f.label :date_of_birth, "Date of birth" %>
   <% if policy(resource).update_user_setting? %>
     <%= f.text_field :date_of_birth,
-                     value: resource.date_of_birth&.strftime("%Y/%m/%d"),
+                     value: resource.decorate.formatted_date_of_birth,
                      data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                      class: "form-control label-font-weight" %>
-    <% else %>
-    <input type="text" placeholder="<%= resource.date_of_birth&.strftime("%Y/%m/%d") %>" autocomplete="off" readonly>
+  <% else %>
+    <input type="text" placeholder="<%= resource.decorate.formatted_date_of_birth %>" autocomplete="off" readonly>
   <% end %>
 </div>
 

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -28,6 +28,18 @@
   <% end %>
 </div>
 
+<div class="input-style-1">
+  <%= f.label :date_of_birth, "Date of birth" %>
+  <% if policy(resource).update_user_setting? %>
+    <%= f.text_field :date_of_birth,
+                     value: resource.date_of_birth&.strftime("%Y/%m/%d"),
+                     data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+                     class: "form-control label-font-weight" %>
+    <% else %>
+    <input type="text" placeholder="<%= resource.date_of_birth&.strftime("%Y/%m/%d") %>" autocomplete="off" readonly>
+  <% end %>
+</div>
+
 <div class="form-check checkbox-style mb-20">
   <%= f.check_box :receive_reimbursement_email, class: "form-check-input" %>
   <%= f.label :receive_reimbursement_email, "Email Reimbursement Requests", class: "form-check-label" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,6 +23,14 @@
               <%= form.text_field :phone_number, class: "form-control" %>
             </div>
 
+            <div class="input-style-1">
+              <%= form.label :date_of_birth, "Date of birth" %>
+              <%= form.text_field :date_of_birth,
+                                  value: @user.date_of_birth&.strftime("%Y/%m/%d"),
+                                  data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+                                  class: "form-control label-font-weight" %>
+            </div>
+
             <% if current_user.address %>
               <% address = current_user.address %>
             <% else %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,7 +26,7 @@
             <div class="input-style-1">
               <%= form.label :date_of_birth, "Date of birth" %>
               <%= form.text_field :date_of_birth,
-                                  value: @user.date_of_birth&.strftime("%Y/%m/%d"),
+                                  value: @user.decorate.formatted_date_of_birth,
                                   data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                                   class: "form-control label-font-weight" %>
             </div>

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -16,6 +16,14 @@
     <%= form.telephone_field :phone_number, placeholder: "Phone Number", class: "form-control" %>
   </div>
 
+  <div class="input-style-1">
+    <%= form.label :date_of_birth, "Date of birth" %>
+    <%= form.text_field :date_of_birth,
+                        value: @volunteer.date_of_birth&.strftime("%Y/%m/%d"),
+                        data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+                        class: "form-control label-font-weight" %>
+  </div>
+
   <div class="actions">
     <%= button_tag(
       type: "submit",

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,2 @@
 Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
+Date::DATE_FORMATS[:slashes] = "%Y/%m/%d"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }

--- a/db/migrate/20231102181027_add_birthdays_to_users.rb
+++ b/db/migrate/20231102181027_add_birthdays_to_users.rb
@@ -1,0 +1,5 @@
+class AddBirthdaysToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :date_of_birth, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_03_182657) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_181027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -599,6 +599,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_03_182657) do
     t.boolean "receive_reimbursement_email", default: false
     t.string "token"
     t.boolean "monthly_learning_hours_report", default: false, null: false
+    t.datetime "date_of_birth"
     t.index ["casa_org_id"], name: "index_users_on_casa_org_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/lib/tasks/volunteer_birthday_reminder.rake
+++ b/lib/tasks/volunteer_birthday_reminder.rake
@@ -1,0 +1,8 @@
+desc "Create a notification for supervisors when a volunteer has a birthday coming in the next month, scheduled for the 15th of each month in Heroku Scheduler"
+task volunteer_birthday_reminder: :environment do
+  Volunteer.active.with_supervisor.birthday_next_month.each do |volunteer|
+    VolunteerBirthdayNotification
+      .with(volunteer: volunteer)
+      .deliver(volunteer.supervisor)
+  end
+end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -123,4 +123,32 @@ RSpec.describe UserDecorator do
       expect(decorated_user.formatted_invitation_sent_at).to eq expected_date
     end
   end
+
+  describe "#formatted_birthday" do
+    context "when a user has no date of birth set"
+    it "returns a blank string" do
+      user.update(date_of_birth: nil)
+      expect(decorated_user.formatted_birthday).to eq ""
+    end
+
+    context "when a user has a valid date of birth"
+    it "returns the month and ordinal of their birthday" do
+      user.update(date_of_birth: Date.new(1991, 7, 8))
+      expect(decorated_user.formatted_birthday).to eq "July 8th"
+    end
+  end
+
+  describe "#formatted_date_of_birth" do
+    context "when a user has no date of birth set"
+    it "returns a blank string" do
+      user.update(date_of_birth: nil)
+      expect(decorated_user.formatted_date_of_birth).to eq ""
+    end
+
+    context "when a user has a valid date of birth"
+    it "returns the YYYY/MM/DD of their date of birth" do
+      user.update(date_of_birth: Date.new(1991, 7, 8))
+      expect(decorated_user.formatted_date_of_birth).to eq "1991/07/08"
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:display_name) { |n| "User #{n}" }
     password { "12345678" }
     password_confirmation { "12345678" }
+    date_of_birth { nil }
     case_assignments { [] }
     phone_number { "" }
     confirmed_at { Time.now }

--- a/spec/lib/tasks/volunteer_birthday_reminder_spec.rb
+++ b/spec/lib/tasks/volunteer_birthday_reminder_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+require "rake"
+Rake.application.rake_require "tasks/volunteer_birthday_reminder"
+
+RSpec.describe "lib/tasks/volunteer_birthday_reminder.rake" do
+  let(:rake_task) { Rake::Task["volunteer_birthday_reminder"].invoke }
+
+  before do
+    Rake::Task.clear
+    Casa::Application.load_tasks
+
+    travel_to Date.new(2022, 10, 1)
+  end
+
+  after do
+    travel_back
+  end
+
+  context "there is a volunteer with a birthday next month" do
+    let!(:volunteer) do
+      create(:volunteer, :with_assigned_supervisor, date_of_birth: Date.new(1988, 11, 30))
+    end
+
+    it "creates a notification" do
+      expect { rake_task }.to change { volunteer.supervisor.notifications.count }.by(1)
+    end
+  end
+
+  context "there are many volunteers with birthdays next month" do
+    volunteer_count = 10
+    let!(:volunteer) do
+      create_list(:volunteer, volunteer_count, :with_assigned_supervisor, date_of_birth: Date.new(1988, 11, 30))
+    end
+
+    it "creates many notifications" do
+      expect { rake_task }.to change { Notification.count }.by(volunteer_count)
+    end
+  end
+
+  context "there is an unsupervised volunteer with a birthday next month" do
+    let!(:volunteer) do
+      create(:volunteer, date_of_birth: Date.new(1988, 11, 30))
+    end
+
+    it "does not create a notification" do
+      expect { rake_task }.to change { Notification.count }.by(0)
+    end
+  end
+
+  context "there is a volunteer with no date_of_birth" do
+    let!(:volunteer) do
+      create(:volunteer, :with_assigned_supervisor, date_of_birth: nil)
+    end
+
+    it "does not create a notification" do
+      expect { rake_task }.to change { volunteer.supervisor.notifications.count }.by(0)
+    end
+  end
+
+  context "there is a volunteer with a birthday that is not next month" do
+    let!(:volunteer) do
+      create(:volunteer, :with_assigned_supervisor, date_of_birth: Date.new(1998, 7, 16))
+    end
+
+    it "does not create a notification" do
+      expect { rake_task }.to change { volunteer.supervisor.notifications.count }.by(0)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe User, type: :model do
       expect(user.valid?).to be false
     end
 
+    it "requires date of birth to be in the past" do
+      user = build(:user, date_of_birth: 10.days.from_now)
+      expect(user.valid?).to be false
+    end
+
     it "has an empty old_emails array when initialized" do
       user = build(:user)
       expect(user.old_emails).to eq([])

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -288,6 +288,63 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
+  describe ".with_supervisor" do
+    subject { Volunteer.with_supervisor }
+
+    context "no volunteers" do
+      it { is_expected.to be_empty }
+    end
+
+    context "volunteers" do
+      let!(:unassigned1) { create(:volunteer, display_name: "aaa") }
+      let!(:unassigned2) { create(:volunteer, display_name: "bbb") }
+
+      let!(:supervisor1) { create(:supervisor, display_name: "supe1") }
+      let!(:assigned1) { create(:volunteer, display_name: "ccc") }
+      let!(:assignment1) { create(:supervisor_volunteer, volunteer: assigned1, supervisor: supervisor1) }
+
+      let!(:supervisor2) { create(:supervisor, display_name: "supe2") }
+      let!(:assigned2) { create(:volunteer, display_name: "ddd") }
+      let!(:assignment2) { create(:supervisor_volunteer, volunteer: assigned2, supervisor: supervisor2) }
+
+      let!(:assigned3) { create(:volunteer, display_name: "eee") }
+      let!(:assignment3) { create(:supervisor_volunteer, volunteer: assigned3, supervisor: supervisor2) }
+
+      it { is_expected.to contain_exactly(assigned1, assigned2, assigned3) }
+    end
+  end
+
+  describe ".birthday_next_month" do
+    subject { Volunteer.birthday_next_month }
+    before do
+      travel_to Date.new(2022, 10, 1)
+    end
+
+    after do
+      travel_back
+    end
+
+    context "there are volunteers whose birthdays are not next month" do
+      let!(:volunteer1) { create(:volunteer, date_of_birth: Date.new(1990, 9, 1)) }
+      let!(:volunteer2) { create(:volunteer, date_of_birth: Date.new(1998, 10, 15)) }
+      let!(:volunteer3) { create(:volunteer, date_of_birth: Date.new(1919, 12, 1)) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "there are volunteers whose birthdays are next month" do
+      let!(:volunteer1) { create(:volunteer, date_of_birth: Date.new(2001, 11, 1)) }
+      let!(:volunteer2) { create(:volunteer, date_of_birth: Date.new(1920, 11, 15)) }
+      let!(:volunteer3) { create(:volunteer, date_of_birth: Date.new(1989, 11, 30)) }
+
+      let!(:volunteer4) { create(:volunteer, date_of_birth: Date.new(2001, 6, 1)) }
+      let!(:volunteer5) { create(:volunteer, date_of_birth: Date.new(1920, 1, 15)) }
+      let!(:volunteer6) { create(:volunteer, date_of_birth: Date.new(1967, 2, 21)) }
+
+      it { is_expected.to contain_exactly(volunteer1, volunteer2, volunteer3) }
+    end
+  end
+
   describe "#with_assigned_cases" do
     let!(:volunteers) { create_list(:volunteer, 3) }
     let!(:volunteer_with_cases) { create_list(:volunteer, 3, :with_casa_cases) }

--- a/spec/notifications/volunteer_birthday_notification_spec.rb
+++ b/spec/notifications/volunteer_birthday_notification_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe VolunteerBirthdayNotification, type: :model do
+  describe "message" do
+    let(:volunteer) do
+      build(:volunteer, display_name: "Biday Sewn", date_of_birth: Date.new(1968, 2, 8))
+    end
+
+    let(:volunteer_notification) { VolunteerBirthdayNotification.with(volunteer: volunteer) }
+
+    it "contains a short ordinal form of the volunteer's date of birth" do
+      expect(volunteer_notification.message).to include "February 8th"
+    end
+
+    it "contains the volunteer's name" do
+      expect(volunteer_notification.message).to include "Biday Sewn"
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -33,11 +33,12 @@ RSpec.describe "/users", type: :request do
       volunteer = build(:volunteer)
       sign_in volunteer
 
-      patch users_path, params: {user: {display_name: "New Name", address_attributes: {content: "some address"}, phone_number: "+12223334444", sms_notification_event_ids: [SmsNotificationEvent.first.id]}}
+      patch users_path, params: {user: {display_name: "New Name", address_attributes: {content: "some address"}, phone_number: "+12223334444", date_of_birth: Date.new(1958, 12, 1), sms_notification_event_ids: [SmsNotificationEvent.first.id]}}
 
       expect(volunteer.address.content).to eq "some address"
       expect(volunteer.display_name).to eq "New Name"
       expect(volunteer.phone_number).to eq "+12223334444"
+      expect(volunteer.date_of_birth).to eq Date.new(1958, 12, 1)
       expect(volunteer.sms_notification_event_ids).to include SmsNotificationEvent.first.id
       expect(UserSmsNotificationEvent.count).to eq 1
     end

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe "casa_admins/edit", type: :system do
     it "can successfully edit user display name and phone number" do
       expected_display_name = "Root Admin"
       expected_phone_number = "+14398761234"
+      expected_date_of_birth = "1997/04/16"
 
       visit edit_casa_admin_path(admin)
 
       fill_in "Display name", with: expected_display_name
       fill_in "Phone number", with: expected_phone_number
+      fill_in "Date of birth", with: expected_date_of_birth
       check "Receive Monthly Learning Hours Report"
 
       click_on "Submit"
@@ -24,6 +26,7 @@ RSpec.describe "casa_admins/edit", type: :system do
 
       expect(admin.display_name).to eq expected_display_name
       expect(admin.phone_number).to eq expected_phone_number
+      expect(admin.date_of_birth.strftime("%Y/%m/%d")).to eq expected_date_of_birth
       expect(admin.monthly_learning_hours_report).to be_truthy
     end
   end
@@ -68,6 +71,13 @@ RSpec.describe "casa_admins/edit", type: :system do
     end
 
     it_should_behave_like "shows error for invalid phone numbers"
+
+    it "shows error message for invalid date" do
+      fill_in "Date of birth", with: 8.days.from_now.strftime("%Y/%m/%d")
+      click_on "Submit"
+
+      expect(page).to have_text "Date of birth must be in the past."
+    end
 
     it "shows error message for empty email" do
       fill_in "Email", with: ""

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "supervisors/edit", type: :system do
         visit edit_supervisor_path(supervisor)
       end
       it_should_behave_like "shows error for invalid phone numbers"
+
+      it "shows error for invalid date of birth" do
+        fill_in "Date of birth", with: 5.days.from_now.strftime("%Y/%m/%d")
+      end
     end
 
     it "can go to the supervisor edit page and see red message when there are no active volunteers" do
@@ -164,12 +168,14 @@ RSpec.describe "supervisors/edit", type: :system do
         @old_email = @supervisor.email
         visit edit_supervisor_path(@supervisor)
         fill_in "supervisor_email", with: "new_supervisor_email@example.com"
+        fill_in "supervisor_phone_number", with: "+14155556876"
+        fill_in "supervisor_date_of_birth", with: "2003/05/06"
 
         click_on "Submit"
         @supervisor.reload
       end
 
-      it "sends a confirmaton email to the supervisor and displays current email" do
+      it "sends a confirmation email to the supervisor and displays current email" do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
@@ -187,6 +193,25 @@ RSpec.describe "supervisors/edit", type: :system do
 
         expect(page).to have_field("Email", with: "new_supervisor_email@example.com")
         expect(@supervisor.old_emails).to match([@old_email])
+      end
+    end
+
+    context "when entering invalid information" do
+      before do
+        sign_in user
+        @supervisor = create(:supervisor)
+        visit edit_supervisor_path(@supervisor)
+      end
+
+      it "shows error message for invalid phone number" do
+        fill_in "supervisor_phone_number", with: "+1415555676"
+        click_on "Submit"
+        expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+      end
+      it "shows error message for invalid date of birth" do
+        fill_in "supervisor_date_of_birth", with: 5.days.from_now.strftime("%Y/%m/%d")
+        click_on "Submit"
+        expect(page).to have_text "Date of birth must be in the past."
       end
     end
 

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -330,6 +330,19 @@ RSpec.describe "users/edit", type: :system do
       expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
       expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
     end
+
+    it "displays Supervisor error message if invalid date of birth" do
+      org = create(:casa_org)
+      supervisor = create(:supervisor, casa_org: org)
+
+      sign_in supervisor
+      visit edit_users_path
+
+      fill_in "Date of birth", with: 8.days.from_now.strftime("%Y/%m/%d")
+      click_on "Update Profile"
+      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
+      expect(page).to have_text("Date of birth must be in the past.")
+    end
   end
 
   context "when admin" do
@@ -537,6 +550,18 @@ RSpec.describe "users/edit", type: :system do
       click_on "Save Preferences"
       expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
       expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
+    end
+
+    it "displays admin error message if invalid date of birth" do
+      org = create(:casa_org)
+      admin = create(:casa_admin, casa_org: org)
+
+      sign_in admin
+      visit edit_users_path
+
+      fill_in "Date of birth", with: 8.days.from_now.strftime("%Y/%m/%d")
+      click_on "Update Profile"
+      expect(page).to have_text("Date of birth must be in the past.")
     end
   end
 end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "volunteers/edit", type: :system do
         visit edit_volunteer_path(volunteer)
 
         fill_in "volunteer_display_name", with: "Kamisato Ayato"
+        fill_in "volunteer_phone_number", with: "+14163248967"
+        fill_in "volunteer_date_of_birth", with: "1988/07/01"
         click_on "Submit"
 
         expect(page).to have_text "Volunteer was successfully updated."
@@ -73,6 +75,20 @@ RSpec.describe "volunteers/edit", type: :system do
           click_on "Submit"
 
           expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+        end
+
+        it "shows error message for invalid date of birth" do
+          organization = create(:casa_org)
+          admin = create(:casa_admin, casa_org_id: organization.id)
+          volunteer = create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id)
+
+          sign_in admin
+          visit edit_volunteer_path(volunteer)
+
+          fill_in "volunteer_date_of_birth", with: 5.days.from_now.strftime("%Y/%m/%d")
+          click_on "Submit"
+
+          expect(page).to have_text "Date of birth must be in the past."
         end
       end
 

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "volunteers/new", type: :system do
 
       fill_in "Email", with: "new_volunteer@example.com"
       fill_in "Display name", with: "New Volunteer Display Name"
+      fill_in "Date of birth", with: "08/08/2001"
 
       click_on "Create Volunteer"
 
@@ -30,6 +31,7 @@ RSpec.describe "volunteers/new", type: :system do
 
       fill_in "Email", with: "new_volunteer2@example.com"
       fill_in "Display name", with: "New Volunteer Display Name 2"
+      fill_in "Date of birth", with: "01/01/2000"
 
       expect do
         click_on "Create Volunteer"

--- a/spec/views/volunteers/edit.html.erb_spec.rb
+++ b/spec/views/volunteers/edit.html.erb_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe "volunteers/edit", type: :view do
     expect(rendered).to_not have_field("volunteer_email", readonly: true)
   end
 
+  it "allows an administrator to edit a volunteers date of birth" do
+    administrator = build_stubbed :casa_admin
+    enable_pundit(view, administrator)
+    org = create :casa_org
+    volunteer = create :volunteer, casa_org: org
+    allow(view).to receive(:current_user).and_return(administrator)
+    allow(view).to receive(:current_organization).and_return(administrator.casa_org)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field("volunteer_date_of_birth", readonly: true)
+    expect(rendered).to have_field("volunteer_date_of_birth", readonly: false)
+  end
+
   it "allows a supervisor to edit a volunteers email address" do
     supervisor = build_stubbed :supervisor
     enable_pundit(view, supervisor)
@@ -65,6 +82,23 @@ RSpec.describe "volunteers/edit", type: :view do
     expect(rendered).to have_field("volunteer_phone_number")
   end
 
+  it "allows a supervisor in the same org to edit a volunteers date of birth" do
+    org = create :casa_org
+    supervisor = build_stubbed :supervisor, casa_org: org
+    enable_pundit(view, supervisor)
+    volunteer = create :volunteer, casa_org: org
+    allow(view).to receive(:current_user).and_return(supervisor)
+    allow(view).to receive(:current_organization).and_return(supervisor.casa_org)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field("volunteer_date_of_birth", readonly: true)
+    expect(rendered).to have_field("volunteer_date_of_birth", readonly: false)
+  end
+
   it "does not allow a supervisor from a different org to edit a volunteers phone number" do
     different_supervisor = build_stubbed :supervisor
     enable_pundit(view, different_supervisor)
@@ -79,6 +113,22 @@ RSpec.describe "volunteers/edit", type: :view do
     render template: "volunteers/edit"
 
     expect(rendered).not_to have_field("volunteer_phone_number")
+  end
+
+  it "does not allow a supervisor from a different org to edit a volunteers date of birth" do
+    different_supervisor = build_stubbed :supervisor
+    enable_pundit(view, different_supervisor)
+    org = create :casa_org
+    volunteer = create :volunteer, casa_org: org
+    allow(view).to receive(:current_user).and_return(different_supervisor)
+    allow(view).to receive(:current_organization).and_return(different_supervisor.casa_org)
+
+    assign :volunteer, volunteer
+    assign :supervisors, []
+
+    render template: "volunteers/edit"
+
+    expect(rendered).to_not have_field("volunteer_date_of_birth", readonly: false)
   end
 
   it "shows invite and login info" do


### PR DESCRIPTION
Resolves #5316

This PR adds notifications for volunteer birthdays.

- Adds an optional 'date_of_birth' parameter to the Users model, which is a prerequisite for being able to notify supervisors of upcoming volunteer birthdays.

- Adds a `birthday_next_month` scope to `Volunteer`, volunteer birthday notification, and rake task for creating the notifications.

## Permissions
Volunteers can edit their own DOB, and supervisors and admins from the same org as a volunteer are able to edit the volunteer's DOB.

## Tests
I've added tests for the views, and permissions, and a validation rule for the DOB's (they must be in the past.) and for the notification message, and notification rake task.

![Volunteer birthday notification](https://github.com/rubyforgood/casa/assets/2257631/632659cc-746d-4c30-8eba-4c6d18afdb5a)

![Supervisor editing a volunteer from the shared form](https://github.com/rubyforgood/casa/assets/2257631/b5d06cb0-d32a-4962-84cd-415cdb8cc98b)

![User editing their own profile with datepicker](https://github.com/rubyforgood/casa/assets/2257631/23e00ae6-2888-4ade-99dc-7cf69b33df0a)

![Date of birth validation message](https://github.com/rubyforgood/casa/assets/2257631/05799a22-a87e-4819-8ac2-a456fa80755e)