### PR TITLE
rake CI check uses project's version of rake

### DIFF
--- a/.github/workflows/rake-after_party.yml
+++ b/.github/workflows/rake-after_party.yml
@@ -58,6 +58,6 @@ jobs:
           PGUSER: postgres
           RAILS_ENV: test
         run: |
-          rake db:create
-          rake db:schema:load
-          rake after_party:run
+          bundle exec rake db:create
+          bundle exec rake db:schema:load
+          bundle exec rake after_party:run


### PR DESCRIPTION
### What changed, and why?
A rake upgrade pr is unable to get the "rake after_party" CI check to pass because it uses the wrong version of rake
Tested by CI