### PR TITLE
Add link to Help in user dropdown menu

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -86,6 +86,12 @@
                 </li>
               <% end %>
               <li>
+                <%= link_to "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa", target: :_blank do %>
+                  <i class="lni lni-question-circle"></i>
+                  Help
+                <% end %>
+              </li>
+              <li>
                 <%= link_to destroy_user_session_path do %>
                   <i class="lni lni-exit"></i>
                   Sign Out

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -86,7 +86,7 @@
                 </li>
               <% end %>
               <li>
-                <%= link_to "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa", target: :_blank do %>
+                <%= link_to help_url, target: :_blank do %>
                   <i class="lni lni-question-circle"></i>
                   Help
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,6 +192,10 @@ Rails.application.routes.draw do
     delete :remove_from_volunteer
   end
 
+  direct :help do
+    "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa"
+  end
+
   get "/error", to: "error#index"
 
   namespace :api do

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe "layout/header", type: :view do
       expect(rendered).to match CGI.escapeHTML user.display_name
       expect(rendered).to match CGI.escapeHTML user.email
     end
+
+    it "renders help issue link on the header" do
+      render partial: "layouts/header"
+      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
+    end
   end
 
   context "when logged in as a supervisor" do
@@ -43,6 +48,11 @@ RSpec.describe "layout/header", type: :view do
       expect(rendered).to match "<strong>Role: Supervisor</strong>"
       expect(rendered).to match CGI.escapeHTML user.display_name
       expect(rendered).to match CGI.escapeHTML user.email
+    end
+
+    it "renders help issue link on the header" do
+      render partial: "layouts/header"
+      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
     end
   end
 
@@ -65,6 +75,11 @@ RSpec.describe "layout/header", type: :view do
       render partial: "layouts/header"
 
       expect(rendered).to_not have_link("Edit Organization")
+    end
+
+    it "renders help issue link on the header" do
+      render partial: "layouts/header"
+      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5339 

### What changed, and why?
Added the Help link in user menu as per requirement.

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Added test to check if help link is rendered as expected

### Screenshots please :)
![CASA-Volunteer-Tracking-help-link](https://github.com/rubyforgood/casa/assets/514363/5beecbb5-8940-4b7c-9247-c2574539e2ce)

### Feelings gif (optional)
![Easy Peasy](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3Jhd3VvcjJzeG90MXIxd3NucGRiMG01dXh3OWtiNzlzeDA3OTk2MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/1b29CydpT3IPsikPmN/giphy.gif)

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
