### PR TITLE
Modify options for Chrome driver in Docker

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -22,6 +22,7 @@ options.add_preference(:browser, set_download_behavior: {behavior: "allow"})
 Capybara.register_driver :selenium_chrome_headless_in_container do |app|
   options.add_argument("--headless")
   options.add_preference(:download, prompt_for_download: false, default_directory: "/home/seluser/Downloads")
+  options.add_argument("--disable-dev-shm-usage")
 
   Capybara::Selenium::Driver.new app,
     browser: :remote,


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5124

### What changed, and why?
Modified options for Chrome driver used in Docker by adding `--disable-dev-shm-usage` flag.

System tests were massively failing during some runs in a Docker environment. [Chrome documentation](https://developer.chrome.com/docs/puppeteer/troubleshooting/#tips) mentions that memory allocated by Docker is usually too small and can cause Chrome to crash.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Ran `docker-compose exec web rspec spec` until I identified a seed that replicated the mass test failure.
Implemented the fix and re-ran tests with the same seed to check that tests now pass.

### Screenshots please :)
n/a