### PR TITLE
Add Previews for the Fund Request Mailer

### DIFF
--- a/lib/mailers/previews/fund_request_mailer_preview.rb
+++ b/lib/mailers/previews/fund_request_mailer_preview.rb
@@ -6,20 +6,20 @@ class FundRequestMailerPreview < ActionMailer::Preview
   def send_request
     # Set the FUND_REQUEST_RECIPIENT_EMAIL environment variable for testing
     ENV["FUND_REQUEST_RECIPIENT_EMAIL"] = "recipient@example.com"
-    
+
     fund_request = FundRequest.new(
-      submitter_email: 'casa@example.cmo',
-      youth_name: 'The youth Name',
+      submitter_email: "casa@example.cmo",
+      youth_name: "The youth Name",
       payment_amount: "$123.45",
       deadline: Date.today + 7.days,
-      request_purpose: 'shoes',
-      payee_name: 'payee_name',
-      requested_by_and_relationship: 'Sample Requester',
-      other_funding_source_sought: 'Sample Funding Source',
-      impact: 'Sample Impact',
-      extra_information: 'Sample Extra Information'
+      request_purpose: "shoes",
+      payee_name: "payee_name",
+      requested_by_and_relationship: "Sample Requester",
+      other_funding_source_sought: "Sample Funding Source",
+      impact: "Sample Impact",
+      extra_information: "Sample Extra Information"
     )
 
-   FundRequestMailer.send_request(nil, fund_request)
+    FundRequestMailer.send_request(nil, fund_request)
   end
 end

--- a/lib/mailers/previews/fund_request_mailer_preview.rb
+++ b/lib/mailers/previews/fund_request_mailer_preview.rb
@@ -1,0 +1,25 @@
+# Preview all emails at http://localhost:3000/rails/mailers/fund_request_mailer
+# :nocov:
+require_relative "../debug_preview_mailer"
+
+class FundRequestMailerPreview < ActionMailer::Preview
+  def send_request
+    # Set the FUND_REQUEST_RECIPIENT_EMAIL environment variable for testing
+    ENV["FUND_REQUEST_RECIPIENT_EMAIL"] = "recipient@example.com"
+    
+    fund_request = FundRequest.new(
+      submitter_email: 'casa@example.cmo',
+      youth_name: 'The youth Name',
+      payment_amount: "$123.45",
+      deadline: Date.today + 7.days,
+      request_purpose: 'shoes',
+      payee_name: 'payee_name',
+      requested_by_and_relationship: 'Sample Requester',
+      other_funding_source_sought: 'Sample Funding Source',
+      impact: 'Sample Impact',
+      extra_information: 'Sample Extra Information'
+    )
+
+   FundRequestMailer.send_request(nil, fund_request)
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5344 

### What changed, and why?
Added missing preview for FundRequest mail.

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Manually test by running http://localhost:3000/rails/mailers

### Screenshots please :)

**Mail Preview**

![Mailer-Previews](https://github.com/rubyforgood/casa/assets/514363/7e144f82-a171-4bda-90b1-de1a16a3917b)

**Fund Request Mailer**

![Mailer-Preview-for-fund_request_mailer-send_request](https://github.com/rubyforgood/casa/assets/514363/71028365-6407-4e1f-b051-098705214fe6)