### PR TITLE
fix autosave overriding values on inputs where the value shouldn't be changed

### DIFF
--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -30,7 +30,7 @@ $(() => { // JQuery's callback for the DOM loading
         formData.forEach(({ id, value, checked }) => {
           const input = document.querySelector(`#${id}`)
 
-          if (input) {
+          if (input && !(/checkbox|hidden|image|radio|reset|submit/.test(input.type))) {
             input.value = value
           }
 


### PR DESCRIPTION
### What changed, and why?
Some inputs contain values set by the backend. The user is not normally able to modify those values like in the case of input type=hidden. I have removed the ability for the case contact autosave to override the values for inputs like these.

Inputs ignored for value override include: 
 - checkbox
 - hidden
 - image(like a submit)
 - radio
 - reset(a button that clears the form)
 - submit

### How is this tested? (please write tests!) 💖💪
Manually for now. The plan is to later convert the case contact autosaver into a class so it can be unit tested
### Screenshots please :)

autosave data in localstorage: 
Notice the row with id `case_contact_casa_case_id_1` and value `8`
![Screenshot from 2023-11-14 06-53-12](https://github.com/rubyforgood/casa/assets/8918762/99a1df0a-e955-4e09-ab1e-6685449d5943)

Without the fix. The value of the checkbox has been changed to 8 from localstorage
![Screenshot from 2023-11-14 06-42-57](https://github.com/rubyforgood/casa/assets/8918762/5c50dff3-20f5-4b48-891a-b8a37662c04e)

After the fix. The true value is preserved.
![Screenshot from 2023-11-14 06-43-09](https://github.com/rubyforgood/casa/assets/8918762/2511a91a-ae4d-41de-9bd2-993431bac097)
