### PR TITLE
Fix browser warnings for volunteer pages

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -26,9 +26,9 @@
           <%= form.text_field :case_number, class: "form-control", :required => 'required' %>
         </div>
       <% end %>
-      <h2><%= form.label :court_details, "Court Details" %></h2>
+      <h2><label>Court Details</label></h2>
         <div class="form-group my-3">
-          <%= form.label :birth_month_year_youth, "Youth's Birth Month & Year", class: 'my-2' %>
+          <label class="my-2">Youth's Birth Month & Year</label>
           <br>
           <span class="datetime-year-month">
             <%= form.date_select :birth_month_year_youth,

--- a/app/views/case_contacts/_contact_types.html.erb
+++ b/app/views/case_contacts/_contact_types.html.erb
@@ -1,5 +1,5 @@
 <div id="contact-type-form">
-  <h2 id="contact-type-label"><%= form.label :contact_types, "2. Select All Contact Types" %><span class="red-letter"> *</span></h2>
+  <h2 id="contact-type-label"><label>2. Select All Contact Types</label><span class="red-letter"> *</span></h2>
   <% if controller.controller_name == 'casa_cases' %>
     <div class="row">
       <div class="col-sm">

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -3,9 +3,9 @@
 
   <div class="card-style-1 pl-25 mb-10">
     <% if casa_cases.length > 1 %>
-      <h2><label for="case_contact_casa_case">1. Select all relevant CASA cases<span class="red-letter"> *</span></label></h2>
+      <h2><label>1. Select all relevant CASA cases<span class="red-letter"> *</span></label></h2>
     <% else %>
-      <h2><label for="case_contact_casa_case">1. Select relevant CASA case<span class="red-letter"> *</span></label></h2>
+      <h2><label>1. Select relevant CASA case<span class="red-letter"> *</span></label></h2>
     <% end %>
     <div class="casa-case-scroll">
       <% casa_cases.each do |casa_case| %>
@@ -33,9 +33,9 @@
   </div>
 
   <div id="enter-contact-details" class="card-style-1 pl-25 mb-10">
-    <h2 class="mb-3"><label for="case_contact_casa_case">3. Enter Contact Details</label><span class="red-letter"> *</span></h2>
+    <h2 class="mb-3"><label>3. Enter Contact Details</label><span class="red-letter"> *</span></h2>
     <div class="">
-      <h5 classs="mb-3"><%= form.label :contact_made, "a. Contact Made" %></h5>
+      <h5 classs="mb-3"><label>a. Contact Made</label></h5>
       <div class="form-check radio-style mb-20">
         <%= form.radio_button :contact_made, true,
                         checked: case_contact.contact_made,
@@ -55,7 +55,7 @@
     </div>
 
     <div class="field contact-medium form-group">
-      <h5 classs="mb-3"><%= form.label :medium_type, "b. Contact Medium" %></h5>
+      <h5 classs="mb-3"><label>b. Contact Medium</label></h5>
       <%= form.collection_radio_buttons(:medium_type, contact_mediums, 'value', 'label') do |b| %>
         <div class="form-check radio-style mb-20">
           <%= b.radio_button(class: "form-check-input") %>
@@ -75,7 +75,7 @@
     </div>
 
     <div class="pr-50 ">
-      <h5 class="mb-3"><label for="case_contact_casa_case">d. Duration of Meeting</label></h5>
+      <h5 class="mb-3"><label>d. Duration of Meeting</label></h5>
       <div class="row align-items-center">
         <div class="input-style-1 col pl-0">
           <%= form.number_field :duration_hours,
@@ -100,7 +100,7 @@
   </div>
 
   <div class="card-style-1 pl-25 mb-10 pr-50">
-    <h2 class="mb-3"><label for="case_contact_casa_case">4. Enter Travel Details</label></h2>
+    <h2 class="mb-3"><label>4. Enter Travel Details</label></h2>
     <div class="field miles-driven form-group">
       <h5 class="mb-3"><%= form.label :miles_driven, "a. Miles Driven" %></h5>
       <div class="input-style-1">
@@ -114,7 +114,7 @@
 
     <% if current_organization.show_driving_reimbursement && show_volunteer_reimbursement(casa_cases) %>
       <div class="field want-driving-reimbursement form-group">
-        <h5 class="mb-3"><%= form.label :want_driving_reimbursement, "b. Want Driving Reimbursement" %></h5>
+        <h5 class="mb-3"><label>b. Want Driving Reimbursement</label></h5>
         <div class="form-check radio-style mb-20">
           <%= form.radio_button :want_driving_reimbursement, true,
                           required: false,
@@ -131,7 +131,7 @@
         </div>
       </div>
       <div class="field volunteer-address form-group">
-        <h5 class="mb-3"><%= form.label :volunteer_address, "c. Volunteer Address" %></h5>
+        <h5 class="mb-3"><label>c. Volunteer Address</label></h5>
         <div class="input-style-1 mb-0">
         <%
           if current_role == "Volunteer"

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -37,12 +37,12 @@
             <h3 class="mt-10"><label>Date of contact</label></h3>
           </div>
           <div class="col-sm-6 input-style-1">
-            <%= f.label "Starting from", for: :occurred_starting_at %>
+            <%= f.label "Starting from", for: "filterrific_occurred_starting_at" %>
             <%= f.text_field(:occurred_starting_at, data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                                                   class: "") %>
           </div>
           <div class="col-sm-6 input-style-1">
-            <%= f.label "Ending at", for: :occurred_until %>
+            <%= f.label "Ending at", for: "filterrific_occurred_ending_at" %>
             <%= f.text_field(:occurred_ending_at, data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                                                   class: "") %>
           </div>

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -17,7 +17,7 @@
         </p>
         <%= form_with url: generate_case_court_reports_path, local: false do |form| %>
           <div class="input-style-1">
-            <%= form.label :case_number, "Case Number:" %>
+            <%= form.label :case_selection, "Case Number:" %>
             <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
 
             <% show_search = !current_user.volunteer? %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,7 +16,7 @@
       </div>
         <div class="col-12">
           <div class="input-style-1" id="email-input">
-            <%= f.label "Email" %>
+            <%= f.label "Email", for: "email" %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email", class: "form-control", required: true, id:"email" %>
           </div>
         </div>

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -51,6 +51,8 @@
           <label><%= option.name %></label>
         </div>
       <% end %>
+      <!-- The labels here intentionally do not have for attributes matching the inputs -->
+      <!-- This is because javascript sets the state of the checkbox depending on whether the ajax based saving was successful -->
     </div>
   <% end %>
 </div>

--- a/app/views/learning_hours/_form.html.erb
+++ b/app/views/learning_hours/_form.html.erb
@@ -11,10 +11,10 @@ id: "learning-hours-form" do |form| %>
     <div class="input-style-1">
       <%= form.label :name, "Learning Hours Title" %>
       <%= form.text_field :name,
-                          id: "title",
                           placeholder: "-- Enter a title --",
                           value: @learning_hour.name,
-                          class:"mr-5" %>
+                          class:"mr-5",
+                          required: true %>
     </div>
     <div class="select-style-1">
       <%= form.label :learning_hour_type_id, "Type of Learning" %>
@@ -46,7 +46,6 @@ id: "learning-hours-form" do |form| %>
       <div class="input-style-1 duration-hours">
         <%= form.label :duration_hours, "Hour(s)" %>
         <%= form.number_field :duration_hours,
-                            id: "learning-hours-duration-hours-display",
                             min: 0,
                             class: "cc-field",
                             size: "10",
@@ -55,9 +54,8 @@ id: "learning-hours-form" do |form| %>
                             required: true %>
       </div>
       <div class="input-style-1 duration-minutes">
-        <%= form.label :duration__minutes, "Minute(s)" %>
+        <%= form.label :duration_minutes, "Minute(s)" %>
         <%= form.number_field :duration_minutes,
-                            id: "learning-minutes-duration-hours-display",
                             min: 0,
                             class: "cc-field",
                             size: "10",
@@ -71,7 +69,6 @@ id: "learning-hours-form" do |form| %>
     <% occurred_at = @learning_hour.occurred_at || Time.zone.now %>
     <div class="input-style-1">
       <%= form.text_field :occurred_at,
-                          id:"learning-occurred-at",
                           value: occurred_at.to_date,
                           data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                           class: "form-control label-font-weight" %>

--- a/app/views/learning_hours/_update_form.html.erb
+++ b/app/views/learning_hours/_update_form.html.erb
@@ -11,7 +11,6 @@
     <div class="input-style-1">
       <%= form.label :name, "Learning Hours Title" %>
       <%= form.text_field :name,
-                          id: "title",
                           placeholder: "-- Enter a title --",
                           value: @learning_hour.name %>
     </div>
@@ -45,7 +44,6 @@
     <div class="input-style-1 duration-hours">
       <%= form.label :duration_hours, "Hour(s)" %>
       <%= form.number_field :duration_hours,
-                          id: "learning-hours-duration-hours-display",
                           min: 0,
                           class: "cc-field",
                           size: "10",
@@ -54,9 +52,8 @@
                           required: true %>
     </div>
     <div class="input-style-1 duration-minutes">
-      <%= form.label :duration__minutes, "Minute(s)" %>
+      <%= form.label :duration_minutes, "Minute(s)" %>
       <%= form.number_field :duration_minutes,
-                          id: "learning-minutes-duration-hours-display",
                           min: 0,
                           class: "cc-field",
                           size: "10",
@@ -70,7 +67,6 @@
     <% occurred_at = @learning_hour.occurred_at || Time.zone.now %>
     <div class="input-style-1">
       <%= form.text_field :occurred_at,
-                          id:"learning-occurred-at",
                           value: occurred_at.to_date,
                           data: {provide: "datepicker", date_format: "yyyy/mm/dd"} %>
     </div>

--- a/app/views/other_duties/_form.html.erb
+++ b/app/views/other_duties/_form.html.erb
@@ -21,7 +21,7 @@
   </div>
 
     <div class="row input-style-1">
-      <%= form.label :duration_meeting, "Duty Duration" %>
+      <label>Duty Duration</label>
       <div class="col-sm-6">
         <div class="input-style-1 duration-hours">
           <%= form.number_field :duration_hours,

--- a/app/views/shared/_court_order_list.erb
+++ b/app/views/shared/_court_order_list.erb
@@ -1,4 +1,4 @@
-<%= form.label :case_court_orders, "Court Orders - Please check that you didn't enter any youth names" %>
+<label>Court Orders - Please check that you didn't enter any youth names</label>
 <template data-extended-nested-form-target="template">
   <%= form.fields_for :case_court_orders, CaseCourtOrder.new, child_index: "NEW_RECORD" do |ff| %>
     <%= render "shared/court_order_form", f: ff %>

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -47,7 +47,7 @@
 
 <% if current_organization.show_driving_reimbursement && resource.role == "Volunteer" %>
   <div class="input-style-1">
-    <%= f.label :address, "Mailing address" %>
+    <%= f.label :address_attributes_content, "Mailing address" %>
     <% if policy(resource).update_user_setting? %>
       <%= f.fields_for :address, (resource.address ? nil : Address.new) do |a| %>
         <%= a.text_field :content, placeholder: "Mailing Address" %>

--- a/app/views/users/_languages.html.erb
+++ b/app/views/users/_languages.html.erb
@@ -36,7 +36,7 @@
         <%= form_for volunteer, url: add_language_users_path do |form| %>
           <div class="row select-style-1 mt-3">
             <div class="col-lg-12">
-              <label><h5>Add Language</h5></label>
+              <h5><%= form.label :languages, "Add Language" %></h5>
             </div>
             <div class="col-lg-4">
               <div class="select-position">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -39,7 +39,7 @@
 
             <div class="input-style-1">
               <%= form.fields_for :address, address do |f| %>
-                <%= f.label :address, "Address" %>
+                <%= f.label :content, "Address" %>
                 <%= f.text_field :content, class: "form-control" %>
               <% end %>
             </div>
@@ -81,7 +81,7 @@
               <%= form_for(@user, as: :user, url: {action: "update_password"}) do |f| %>
                 <div class="input-style-1">
                   <%= f.label :current_password, "Current Password" %><br>
-                  <%= f.password_field :current_password, autocomplete: "off", class: "form-control", id:"current_password" %>
+                  <%= f.password_field :current_password, autocomplete: "off", class: "form-control" %>
                 </div>
                 <div class="input-style-1">
                   <%= f.label :password, "New Password" %><br>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -39,7 +39,7 @@
                               class: "form-check-input",
                               data: { value: "" },
                               id: "unassigned-vol-filter" %>
-            <%= label_tag "supervisor-option-none", "No supervisor assignment", class: "form-check-label" %>
+            <%= label_tag "supervisor-option-none", "No supervisor assignment", class: "form-check-label", for: "unassigned-vol-filter" %>
           </div>
           <% current_organization.supervisors.where(active: true).each do |supervisor| %>
             <div class="dropdown-item form-check checkbox-style">

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345"
+      fill_in "Current Password", with: "12345"
       fill_in "New Password", with: "123456789"
       fill_in "New Password Confirmation", with: "123456789"
 
@@ -29,7 +29,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123"
       fill_in "New Password Confirmation", with: "1234"
 
@@ -65,7 +65,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123456789"
       fill_in "New Password Confirmation", with: "123456789"
 
@@ -83,7 +83,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123456789"
       fill_in "Password Confirmation", with: "123456789"
 
@@ -235,7 +235,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123456789"
       fill_in "Password Confirmation", with: "123456789"
 
@@ -457,7 +457,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123"
       fill_in "Password Confirmation", with: "1234"
 
@@ -476,7 +476,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123456789"
       fill_in "Password Confirmation", with: "123456789"
 
@@ -511,7 +511,7 @@ RSpec.describe "users/edit", type: :system do
 
       click_on "Change Password"
 
-      fill_in "current_password", with: "12345678"
+      fill_in "Current Password", with: "12345678"
       fill_in "New Password", with: "123456789"
       fill_in "Password Confirmation", with: "123456789"
 

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "casa_cases/new", type: :view do
 
       render template: "casa_cases/new"
 
-      expect(rendered).to include CGI.escapeHTML("Youth's Birth Month & Year")
+      expect(rendered).to include("Youth's Birth Month & Year")
     end
   end
 


### PR DESCRIPTION
### What changed, and why?
The browser gives warnings that a lot of our labels' for attributes don't match anything which is wrong.
![Screenshot from 2023-11-15 06-29-59](https://github.com/rubyforgood/casa/assets/8918762/42c4855f-dbcc-452f-af53-05186e790172)

Gave the learning hours title field the `required` attribute because it's required on the backend.

### How is this tested? (please write tests!) 💖💪
Just manually