### PR TITLE
[WIP] Update "3. Enter Contact Details" section on Case contact form

### DIFF
--- a/app/helpers/case_contacts_helper.rb
+++ b/app/helpers/case_contacts_helper.rb
@@ -14,7 +14,7 @@ module CaseContactsHelper
 
   def contact_mediums
     CaseContact::CONTACT_MEDIUMS.map { |contact_medium|
-      OpenStruct.new(value: contact_medium, label: contact_medium.titleize)
+      OpenStruct.new(value: contact_medium, label: contact_medium.capitalize)
     }
   end
 

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -130,10 +130,10 @@ class CaseContact < ApplicationRecord
     ]
   )
 
-  IN_PERSON = "in-person".freeze
-  TEXT_EMAIL = "text/email".freeze
+  IN_PERSON = "in person".freeze
+  TEXT_EMAIL = "text or email".freeze
   VIDEO = "video".freeze
-  VOICE_ONLY = "voice-only".freeze
+  VOICE_ONLY = "voice only".freeze
   LETTER = "letter".freeze
   CONTACT_MEDIUMS = [IN_PERSON, TEXT_EMAIL, VIDEO, VOICE_ONLY, LETTER].freeze
 

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -33,7 +33,7 @@
   </div>
 
   <div id="enter-contact-details" class="card-style-1 pl-25 mb-10">
-    <h2 class="mb-3"><label>3. Enter Contact Details</label><span class="red-letter"> *</span></h2>
+    <h4 class="mb-20"><label>3. Record contact details</label><span class="red-letter"> *</span></h4>
     <div class="">
       <h5 classs="mb-3"><label>a. Contact Made</label></h5>
       <div class="form-check radio-style mb-20">

--- a/app/views/case_contacts/_form.html.erb
+++ b/app/views/case_contacts/_form.html.erb
@@ -33,9 +33,9 @@
   </div>
 
   <div id="enter-contact-details" class="card-style-1 pl-25 mb-10">
-    <h4 class="mb-20"><label>3. Record contact details</label><span class="red-letter"> *</span></h4>
+    <h4 class="mb-3"><label>3. Record contact details</label><span class="red-letter"> *</span></h4>
     <div class="">
-      <h5 classs="mb-3"><label>a. Contact Made</label></h5>
+      <h5 classs="mb-3"><label>a. Was contact made?</label></h5>
       <div class="form-check radio-style mb-20">
         <%= form.radio_button :contact_made, true,
                         checked: case_contact.contact_made,
@@ -55,7 +55,7 @@
     </div>
 
     <div class="field contact-medium form-group">
-      <h5 classs="mb-3"><label>b. Contact Medium</label></h5>
+      <h5 classs="mb-3"><label>b. How was contact made?</label></h5>
       <%= form.collection_radio_buttons(:medium_type, contact_mediums, 'value', 'label') do |b| %>
         <div class="form-check radio-style mb-20">
           <%= b.radio_button(class: "form-check-input") %>
@@ -65,7 +65,7 @@
     </div>
 
     <div class="pr-50">
-      <h5 class="mb-3"><%= form.label :occurred_at, "c. Occurred On" %></h5>
+      <h5 class="mb-3"><%= form.label :occurred_at, "c. Date of contact" %></h5>
       <div class="input-style-1">
         <% occurred_at = @case_contact.occurred_at || Time.zone.now %>
         <%= render "layouts/components/ranged_date_picker",
@@ -75,7 +75,7 @@
     </div>
 
     <div class="pr-50 ">
-      <h5 class="mb-3"><label>d. Duration of Meeting</label></h5>
+      <h5 class="mb-3"><label>d. Duration of contact</label></h5>
       <%= render(Form::HourMinuteDurationComponent.new(form: form, hour_value: duration_hours(case_contact), minute_value: duration_minutes(case_contact))) %>
     </div>
   </div>

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe CaseContactDecorator do
       end
     end
 
-    context "when medium type is text/email" do
+    context "when medium type is text or email" do
       it "returns the proper font-awesome classes" do
-        case_contact.update_attribute(:medium_type, "text/email")
+        case_contact.update_attribute(:medium_type, "text or email")
 
         expect(case_contact.decorate.medium_icon_classes).to eql("lni lni-envelope")
       end

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe CaseContactDecorator do
   end
 
   describe "#medium_icon_classes" do
-    context "when medium type is in-person" do
+    context "when medium type is in person" do
       it "returns the proper font-awesome classes" do
-        case_contact.update_attribute(:medium_type, "in-person")
+        case_contact.update_attribute(:medium_type, "in person")
 
         expect(case_contact.decorate.medium_icon_classes).to eql("lni lni-users")
       end
@@ -104,7 +104,7 @@ RSpec.describe CaseContactDecorator do
 
     context "when medium type is voice-only" do
       it "returns the proper font-awesome classes" do
-        case_contact.update_attribute(:medium_type, "voice-only")
+        case_contact.update_attribute(:medium_type, "voice only")
 
         expect(case_contact.decorate.medium_icon_classes).to eql("lni lni-phone")
       end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -253,13 +253,13 @@ RSpec.describe CaseContact, type: :model do
 
       let!(:case_contacts) do
         [
-          create(:case_contact, medium_type: "in-person"),
+          create(:case_contact, medium_type: "in person"),
           create(:case_contact, medium_type: "letter")
         ]
       end
 
       describe "with specified medium parameter" do
-        let(:medium_type) { "in-person" }
+        let(:medium_type) { "in person" }
 
         it { is_expected.to contain_exactly case_contacts.first }
       end
@@ -348,8 +348,8 @@ RSpec.describe CaseContact, type: :model do
 
           let!(:case_contacts) do
             [
-              create(:case_contact, medium_type: "in-person"),
-              create(:case_contact, medium_type: "text/email"),
+              create(:case_contact, medium_type: "in person"),
+              create(:case_contact, medium_type: "text or email"),
               create(:case_contact, medium_type: "letter")
             ]
           end

--- a/spec/services/case_contacts_contact_dates_spec.rb
+++ b/spec/services/case_contacts_contact_dates_spec.rb
@@ -41,15 +41,15 @@ RSpec.describe CaseContactsContactDates do
       it "returns formatted data" do
         expect(subject).to eq([
           {dates: "6/01*",
-           dates_by_medium_type: {"in-person" => "6/01*"},
+           dates_by_medium_type: {"in person" => "6/01*"},
            name: "Names of persons involved, starting with the child's name",
            type: "Mental therapist"},
           {dates: "4/01*, 5/01*, 6/01*",
-           dates_by_medium_type: {"in-person" => "5/01*, 6/01*", "text or email" => "4/01*"},
+           dates_by_medium_type: {"in person" => "5/01*, 6/01*", "text or email" => "4/01*"},
            name: "Names of persons involved, starting with the child's name",
            type: "Physical therapist"},
           {dates: "4/01*",
-           dates_by_medium_type: {"in-person" => "4/01*"},
+           dates_by_medium_type: {"in person" => "4/01*"},
            name: "Names of persons involved, starting with the child's name",
            type: "Aunt"}
         ])

--- a/spec/services/case_contacts_contact_dates_spec.rb
+++ b/spec/services/case_contacts_contact_dates_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CaseContactsContactDates do
            name: "Names of persons involved, starting with the child's name",
            type: "Mental therapist"},
           {dates: "4/01*, 5/01*, 6/01*",
-           dates_by_medium_type: {"in-person" => "5/01*, 6/01*", "text/email" => "4/01*"},
+           dates_by_medium_type: {"in-person" => "5/01*, 6/01*", "text or email" => "4/01*"},
            name: "Names of persons involved, starting with the child's name",
            type: "Physical therapist"},
           {dates: "4/01*",

--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -55,7 +55,7 @@ def complete_form(casa_case)
     choose "Yes"
   end
 
-  choose "In Person"
+  choose "In person"
   fill_in "case_contact_duration_hours", with: "1"
   fill_in "case_contact_duration_minutes", with: "45"
 end

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "case_contacts/edit", type: :system do
       expect(case_contact.casa_case.volunteers[0].address.content).to eq "123 str"
       expect(case_contact.casa_case_id).to eq casa_case.id
       expect(case_contact.duration_minutes).to eq 105
-      expect(case_contact.medium_type).to eq "in-person"
+      expect(case_contact.medium_type).to eq "in person"
       expect(case_contact.contact_made).to eq true
     end
 
@@ -139,7 +139,7 @@ you are trying to set the address for both of them. This is not currently possib
       expect(volunteer.address.content).to eq "123 str"
       expect(case_contact.casa_case_id).to eq casa_case.id
       expect(case_contact.duration_minutes).to eq 105
-      expect(case_contact.medium_type).to eq "in-person"
+      expect(case_contact.medium_type).to eq "in person"
       expect(case_contact.contact_made).to eq true
     end
 

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "case_contacts/edit", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -64,7 +64,7 @@ RSpec.describe "case_contacts/edit", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -122,7 +122,7 @@ you are trying to set the address for both of them. This is not currently possib
         choose "Yes"
       end
 
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "case_contacts/edit", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "10"
       choose "case_contact_want_driving_reimbursement_true"
       expect(page).to have_selector("#case_contact_casa_case_attributes_volunteers_attributes_0_address_attributes_content")
@@ -67,7 +67,7 @@ RSpec.describe "case_contacts/edit", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "10"
       choose "case_contact_want_driving_reimbursement_true"
       expect(page).not_to have_selector("#case_contact_casa_case_attributes_volunteers_attributes_0_address_attributes_content")
@@ -125,7 +125,7 @@ you are trying to set the address for both of them. This is not currently possib
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "10"
       choose "case_contact_want_driving_reimbursement_true"
       expect(page).to have_selector("#case_contact_casa_case_attributes_volunteers_attributes_0_address_attributes_content")

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -297,7 +297,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "2020/4/4"
@@ -321,7 +321,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(page).to have_checked_field("School")
       expect(page).to have_checked_field("Therapist")
       expect(page).to have_checked_field("Yes")
-      expect(page).to have_checked_field("In Person")
+      expect(page).to have_checked_field("In person")
       expect(page).to have_field("case_contact_duration_hours", with: "1")
       expect(page).to have_field("case_contact_duration_minutes", with: "45")
       expect(page).to have_field("c. Date of contact", with: "2020-04-04")
@@ -345,7 +345,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "a. Miles Driven", with: "30"
@@ -379,7 +379,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -410,7 +410,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -443,7 +443,7 @@ RSpec.describe "case_contacts/new", type: :system do
       within "#enter-contact-details" do
         choose "Yes"
       end
-      choose "In Person"
+      choose "In person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
       fill_in "c. Date of contact", with: "04/04/2020"
@@ -492,7 +492,7 @@ RSpec.describe "case_contacts/new", type: :system do
 
           fill_out_minimum_required_fields_for_case_contact_form
 
-          choose "Voice Only"
+          choose "Voice only"
           fill_in "a. Miles Driven", with: "5"
           find("body").click
 
@@ -525,7 +525,7 @@ RSpec.describe "case_contacts/new", type: :system do
         within "#enter-contact-details" do
           choose "Yes"
         end
-        choose "In Person"
+        choose "In person"
         fill_in "case_contact_duration_hours", with: "1"
         fill_in "case_contact_duration_minutes", with: "45"
         fill_in "c. Date of contact", with: 2.days.ago.strftime("%Y/%m/%d\n")
@@ -546,7 +546,7 @@ RSpec.describe "case_contacts/new", type: :system do
         expect(page).to have_checked_field("School")
         expect(page).to have_checked_field("Therapist")
         expect(page).to have_checked_field("Yes")
-        expect(page).to have_checked_field("In Person")
+        expect(page).to have_checked_field("In person")
         expect(page).to have_field("case_contact_duration_hours", with: "1")
         expect(page).to have_field("case_contact_duration_minutes", with: "45")
         expect(page).to have_field("c. Date of contact", with: 2.days.ago.strftime("%Y-%m-%d"))

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       choose "case_contact_want_driving_reimbursement_false"
 
       fill_in "Notes", with: "Hello world"
@@ -300,7 +300,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "2020/4/4"
+      fill_in "c. Date of contact", with: "2020/4/4"
       fill_in "a. Miles Driven", with: "30"
       choose "case_contact_want_driving_reimbursement_false"
       fill_in "Notes", with: "Hello world"
@@ -324,7 +324,7 @@ RSpec.describe "case_contacts/new", type: :system do
       expect(page).to have_checked_field("In Person")
       expect(page).to have_field("case_contact_duration_hours", with: "1")
       expect(page).to have_field("case_contact_duration_minutes", with: "45")
-      expect(page).to have_field("c. Occurred On", with: "2020-04-04")
+      expect(page).to have_field("c. Date of contact", with: "2020-04-04")
       expect(page).to have_field("a. Miles Driven", with: "30")
       expect(page).to have_checked_field("case_contact_want_driving_reimbursement_false")
       expect(page).not_to have_checked_field("case_contact_want_driving_reimbursement_true")
@@ -382,7 +382,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "30"
       choose "case_contact_want_driving_reimbursement_false"
       fill_in "Notes", with: ""
@@ -413,7 +413,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "30"
       choose "case_contact_want_driving_reimbursement_false"
       fill_in "Notes", with: "This is the note"
@@ -446,7 +446,7 @@ RSpec.describe "case_contacts/new", type: :system do
       choose "In Person"
       fill_in "case_contact_duration_hours", with: "1"
       fill_in "case_contact_duration_minutes", with: "45"
-      fill_in "c. Occurred On", with: "04/04/2020"
+      fill_in "c. Date of contact", with: "04/04/2020"
       fill_in "a. Miles Driven", with: "30"
       choose "case_contact_want_driving_reimbursement_false"
       fill_in "Notes", with: "This is the note"
@@ -528,7 +528,7 @@ RSpec.describe "case_contacts/new", type: :system do
         choose "In Person"
         fill_in "case_contact_duration_hours", with: "1"
         fill_in "case_contact_duration_minutes", with: "45"
-        fill_in "c. Occurred On", with: 2.days.ago.strftime("%Y/%m/%d\n")
+        fill_in "c. Date of contact", with: 2.days.ago.strftime("%Y/%m/%d\n")
         fill_in "a. Miles Driven", with: "0"
         choose "case_contact_want_driving_reimbursement_true"
         fill_in "case_contact_casa_case_attributes_volunteers_attributes_0_address_attributes_content",	with: "123 str"
@@ -549,7 +549,7 @@ RSpec.describe "case_contacts/new", type: :system do
         expect(page).to have_checked_field("In Person")
         expect(page).to have_field("case_contact_duration_hours", with: "1")
         expect(page).to have_field("case_contact_duration_minutes", with: "45")
-        expect(page).to have_field("c. Occurred On", with: 2.days.ago.strftime("%Y-%m-%d"))
+        expect(page).to have_field("c. Date of contact", with: 2.days.ago.strftime("%Y-%m-%d"))
         expect(page).to have_field("a. Miles Driven", with: "0")
         expect(page).to have_checked_field("case_contact_want_driving_reimbursement_true")
         expect(page).not_to have_checked_field("case_contact_want_driving_reimbursement_false")

--- a/spec/views/case_contacts/edit.html.erb_spec.rb
+++ b/spec/views/case_contacts/edit.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "case_contacts/edit", type: :view do
 
   it "is listing all the contact methods from the model" do
     case_contact = build_stubbed(:case_contact)
-    contact_type = build_stubbed(:contact_type, name: "In Person")
+    contact_type = build_stubbed(:contact_type, name: "In person")
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
     assign :selected_cases, [case_contact.casa_case]
@@ -26,7 +26,7 @@ RSpec.describe "case_contacts/edit", type: :view do
   it "displays occurred time in the occurred at form field" do
     case_contact = build_stubbed(:case_contact)
     case_contact.occurred_at = Time.zone.now - (3600 * 24)
-    contact_type = build_stubbed(:contact_type, name: "In Person")
+    contact_type = build_stubbed(:contact_type, name: "In person")
     assign :case_contact, case_contact
     assign :casa_cases, [case_contact.casa_case]
     assign :selected_cases, [case_contact.casa_case]

--- a/spec/views/case_contacts/new.html.erb_spec.rb
+++ b/spec/views/case_contacts/new.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "case_contacts/new", type: :view do
       sign_in_as_volunteer
     end
 
-    it { is_expected.to have_field("c. Occurred On", with: current_time) }
+    it { is_expected.to have_field("c. Date of contact", with: current_time) }
     it { is_expected.to have_selector("textarea", id: "case_contact_notes") }
   end
 
@@ -36,7 +36,7 @@ RSpec.describe "case_contacts/new", type: :view do
     end
 
     context "when the case has no volunteers" do
-      it { is_expected.to have_field("c. Occurred On", with: current_time) }
+      it { is_expected.to have_field("c. Date of contact", with: current_time) }
       it { is_expected.to have_selector("textarea", id: "case_contact_notes") }
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5348 

This PR is a work-in progress (waiting on some style changes: `bold <> light labels and asterisk on next line <> same line` from #5366)

### What changed, and why?
Updated UI changes for "3. Enter Contact Details" section as per [Figma file](https://www.figma.com/file/QHOE6wHBESpsbxQmlnAZ2L/Case-Contact-Reporting-Process?type=design&node-id=196-19512&mode=design) and some other styles need to be applied.

<details>
 
- Update `3. Enter Contact Details` to `3. Record contact details` and it's style
- Update `a. Contact Made` to  `a. Was contact made?`
- Update `b. Contact Medium` to `b. How was contact made?`
- Update `c. Occurred On` to `c. Date of contact`
- Update `d. Duration of Meeting` to `d. Duration of contact`
- Update date format for `c. Date of contact` from `yyyy/mm/dd` to `mm/dd/yyyy`, and include a placeholder for the same.
- Remove explicit hours and minutes text from `d. Duration of contact`'s hour and minute field to have placeholder as `0 hour(s)` and `0 minute(s)`
- Update contact medium texts and change formatting from `titleize` to  `capitalize`

</details>


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)