### PR TITLE
make uncaught exception impossible

### DIFF
--- a/app/javascript/src/case_contact_autosave.js
+++ b/app/javascript/src/case_contact_autosave.js
@@ -34,7 +34,7 @@ $(() => { // JQuery's callback for the DOM loading
             input.value = value
           }
 
-          if (!input.checked) {
+          if (input && !input.checked) {
             input.checked = checked
           }
         })


### PR DESCRIPTION
### What changed, and why?
Fixed an uncaught exception caused by a null reference
![image](https://github.com/rubyforgood/casa/assets/8918762/a0cadae2-8f56-4eca-96da-2f78de5134bb)
