### PR TITLE
Fix Address Field Name Discrepency

### DIFF
--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -40,12 +40,7 @@
   <% end %>
 </div>
 
-<div class="form-check checkbox-style mb-20">
-  <%= f.check_box :receive_reimbursement_email, class: "form-check-input" %>
-  <%= f.label :receive_reimbursement_email, "Email Reimbursement Requests", class: "form-check-label" %>
-</div>
-
-<% if current_organization.show_driving_reimbursement && resource.role == "Volunteer" %>
+<% if resource.role == "Volunteer" %>
   <div class="input-style-1">
     <%= f.label :address_attributes_content, "Mailing address" %>
     <% if policy(resource).update_user_setting? %>
@@ -59,3 +54,8 @@
     <% end %>
   </div>
 <% end %>
+
+<div class="form-check checkbox-style mb-20">
+  <%= f.check_box :receive_reimbursement_email, class: "form-check-input" %>
+  <%= f.label :receive_reimbursement_email, "Email Reimbursement Requests", class: "form-check-label" %>
+</div>

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -740,18 +740,5 @@ RSpec.describe "volunteers/edit", type: :system do
       end
     end
 
-    context "with mileage reimbursement turned off" do
-      it "won't show 'Mailing address' label" do
-        organization = create(:casa_org, show_driving_reimbursement: false)
-        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
-        admin = create(:casa_admin, casa_org_id: organization.id)
-
-        sign_in admin
-        visit edit_volunteer_path(volunteer)
-
-        expect(page).not_to have_text "Mailing address"
-        expect(page).not_to have_selector "input[type=text][id=volunteer_address_attributes_content]"
-      end
-    end
   end
 end

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -739,6 +739,5 @@ RSpec.describe "volunteers/edit", type: :system do
         expect(page).to have_selector("input[value='123 Main St']")
       end
     end
-
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5362

### What changed, and why?
This PR fixes the issue as suggest below, [ref](https://github.com/rubyforgood/casa/issues/5362#issuecomment-1820235394):
> I think the issue is that the address only shows up if `current_organization.show_driving_reimbursement` is true, but the organizations that aren’t giving reimbursements still want the volunteer’s address for other reasons (like to mail holiday cards). So I think the fix is actually just to move the address field up to be underneath the Date of Birth field, and don’t wrap it in the `if current_organization.show_driving_reimbursement` conditional. I also think it’s better to just leave the label as “Mailing Address” than to change it to “Address” as it’s clear that it is the address to which they can receive mail.


### How will this affect user permissions?
- Supervisor/Admin permissions:
  - They will view the mailing address field beneath the date of birth field

### How is this tested? (please write tests!) 💖💪

- Respective test cases have been updated

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/59338032/57b6f3f7-a833-4895-b539-44218986d0ee)

