### PR TITLE
build: datatables.net-dt to 1.13.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bootstrap-select": "^1.13.18",
     "chart.js": "^4.3.3",
     "chartjs-adapter-luxon": "^1.3.1",
-    "datatables.net-dt": "^1.13.6",
+    "datatables.net-dt": "^1.13.8",
     "esbuild": "^0.19.2",
     "faker": "^5.5.3",
     "jquery": "^3.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,18 +2339,18 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-datatables.net-dt@^1.13.6:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-1.13.6.tgz#da646d9e288ba690393a8bdf129916a038d14b3c"
-  integrity sha512-0fBsUi8k5e+x5e+xA/Eb5stFr2PIkHgDnbhZs8ZDLvzzL975lCm6sqBAcsTsXKvF7yuBvaDTVBTF4wOMw7PrYw==
+datatables.net-dt@^1.13.8:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/datatables.net-dt/-/datatables.net-dt-1.13.8.tgz#6e875d97407cc605f0dadb3452cf477361000176"
+  integrity sha512-/ZPzr1hQ+domerlg/MbcQHqeeqxK9fsZmpRs1YeKxsdfr+UyHQTUiiOO7RqekppSLc7MPqxGnzKkCX9vAgqm0w==
   dependencies:
-    datatables.net ">=1.13.4"
+    datatables.net "1.13.8"
     jquery ">=1.7"
 
-datatables.net@>=1.13.4:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.13.5.tgz#790a3d70d5e103f5465ed8c52a50eb242e1e2dc4"
-  integrity sha512-XoCQHkUM5MwbC3Wx7WpVvt4i880J8pIFDA9HIKD4GhvtalryBfmdd+bZvrc/rEbraZS7U4eR2k8/wFY0NeHVqQ==
+datatables.net@1.13.8:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.13.8.tgz#05a2fb5a036b0b65b66d1bb1eae0ba018aaea8a3"
+  integrity sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==
   dependencies:
     jquery ">=1.7"
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5337 

### What changed, and why?
Bumped datatables.net-dt to version 1.13.8 instead of 1.13.7
Version 1.13.7 was not uploading the datatables objects properly

### Screenshots
Comparison between dependencies versions from failed to merge previous request and actual request 
![Screen Shot 2023-11-17 at 9 24 16 PM](https://github.com/rubyforgood/casa/assets/79976550/a7cd9ea8-6efb-4dd0-a1fc-d30eb416bee5)
