### PR TITLE
update text color status on volunteers edit page

### DIFF
--- a/app/views/volunteers/_manage_cases.erb
+++ b/app/views/volunteers/_manage_cases.erb
@@ -22,9 +22,9 @@
                   <td><%= assignment.casa_case.decorate.transition_aged_youth %></td>
                   <td>
                     <% if @volunteer.active? && assignment.casa_case.active? && assignment.active? %>
-                      Volunteer is <span class="badge badge-success text-uppercase display-1 text-dark">Active</span>
+                      Volunteer is <span class="badge bg-success text-uppercase display-1">Active</span>
                     <% elsif @volunteer.active? && assignment.casa_case.active? && !assignment.active? %>
-                      Volunteer is <span class="badge badge-danger text-uppercase text-dark">Unassigned</span>
+                      Volunteer is <span class="badge bg-danger text-uppercase">Unassigned</span>
                     <% elsif @volunteer.active? %>
                       Case was deactivated
                       on: <%= I18n.l(assignment.casa_case.updated_at, format: :standard, default: nil) %>

--- a/app/views/volunteers/_manage_cases.erb
+++ b/app/views/volunteers/_manage_cases.erb
@@ -22,9 +22,9 @@
                   <td><%= assignment.casa_case.decorate.transition_aged_youth %></td>
                   <td>
                     <% if @volunteer.active? && assignment.casa_case.active? && assignment.active? %>
-                      Volunteer is <span class="badge badge-success text-uppercase display-1">Active</span>
+                      Volunteer is <span class="badge badge-success text-uppercase display-1 text-dark">Active</span>
                     <% elsif @volunteer.active? && assignment.casa_case.active? && !assignment.active? %>
-                      Volunteer is <span class="badge badge-danger text-uppercase">Unassigned</span>
+                      Volunteer is <span class="badge badge-danger text-uppercase text-dark">Unassigned</span>
                     <% elsif @volunteer.active? %>
                       Case was deactivated
                       on: <%= I18n.l(assignment.casa_case.updated_at, format: :standard, default: nil) %>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5378

### What changed, and why?
The assignment status color was update to a visible color.

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: not affected
- Admin permissions: not affected

### How is this tested? (please write tests!) 💖💪
Navigate to volunters/id/edit and go to manage cases now the active and unassigned status will be black.

### Screenshots please :)

![Screenshot from 2023-11-19 07-54-41](https://github.com/rubyforgood/casa/assets/11881479/384996ac-3da8-4aa0-bf79-77e58f4a42bc)

