### PR TITLE
refactor(create-spec): update system tests to check for success text

### DIFF
--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe "case_contacts/create", type: :system do
 
       click_on "New Case Contact"
       complete_form(casa_case)
+
       click_on "Submit"
 
-      expect(page).to have_current_path(case_contacts_path)
+      expect(page).to have_text "Case contact successfully created"
     end
 
     it "when /case_contacts?casa_case_id=ID" do
@@ -26,7 +27,7 @@ RSpec.describe "case_contacts/create", type: :system do
       complete_form(casa_case)
       click_on "Submit"
 
-      expect(page).to have_current_path(case_contacts_path(casa_case_id: casa_case.id))
+      expect(page).to have_text "Case contact successfully created"
     end
 
     it "when /casa_cases/CASE_NUMBER" do
@@ -36,7 +37,7 @@ RSpec.describe "case_contacts/create", type: :system do
       complete_form(casa_case)
       click_on "Submit"
 
-      expect(page).to have_current_path(casa_case_path(casa_case))
+      expect(page).to have_text "Case contact successfully created"
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
None

### What changed, and why?
@FireLemons mentioned that [the system testing weren't checking things properly](https://discordapp.com/channels/1145803216638984284/1150075343433125989/1173299605878878229)

### How will this affect user permissions?
- Volunteer permissions: It won't
- Supervisor permissions: It won't
- Admin permissions: It won't

### How is this tested? (please write tests!) 💖💪
Updates the test to actually check for success text instead of being on a particular path. Run `rspec spec/system/case_contacts/create_spec.rb` to run the three tests in that particular file. If you comment out `# complete form` on any of the three tests, you'll see that particular test fail.

### Screenshots please :)
From red to green
![image](https://github.com/rubyforgood/casa/assets/43343880/72a002cf-9318-4268-8198-f3826e9bc112)


### Feelings gif (optional)

### Feedback please? (optional)

