### PR TITLE
5370: Learning Hours for the Seeder

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,6 +68,7 @@ class SeederMain
       Supervisor,
       SupervisorVolunteer,
       User,
+      LearningHour,
       Volunteer
     ]
   end

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -52,6 +52,7 @@ class DbPopulator
     create_mileage_rates(casa_org)
     create_learning_hour_types(casa_org)
     create_learning_hour_topics(casa_org)
+    create_learning_hours(casa_org)
     casa_org
   end
 
@@ -383,6 +384,29 @@ class DbPopulator
     learning_topics.each do |learning_topic|
       learning_hour_topic = casa_org.learning_hour_topics.new(name: learning_topic.humanize.capitalize)
       learning_hour_topic.save
+    end
+  end
+
+  def create_learning_hours(casa_org)
+    casa_org.volunteers.each do |user|
+      [1, 2, 3].sample.times do
+        learning_hour_topic = casa_org.learning_hour_topics.sample
+        learning_hour_type = casa_org.learning_hour_types.sample
+        # randomize between 30 to 180 minutes
+        duration_minutes = (2..12).to_a.sample * 15
+        duration_hours = duration_minutes / 60
+        duration_minutes = duration_minutes % 60
+        occurred_at = Time.current - (1..7).to_a.sample.days
+        LearningHour.create(
+          user:,
+          learning_hour_type:,
+          name: "#{learning_hour_type.name} on #{learning_hour_topic.name}",
+          duration_hours:,
+          duration_minutes:,
+          occurred_at:,
+          learning_hour_topic:
+        )
+      end
     end
   end
 

--- a/spec/seeds/seeds_spec.rb
+++ b/spec/seeds/seeds_spec.rb
@@ -15,6 +15,7 @@ def empty_ar_classes
     Supervisor,
     SupervisorVolunteer,
     User,
+    LearningHour,
     HearingType,
     Volunteer,
     CaseCourtOrder


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5370 

### What changed, and why?

Seeder logic has been updated to create LearningHour records, to make it quicker to have a testing environment containing test CasaOrg records including some volunteers with learning hours created.

### How will this affect user permissions?
- Volunteer permissions: not affected
- Supervisor permissions: not affected
- Admin permissions: not affected

### How is this tested? (please write tests!) 💖💪
`spec/seeds/seeds_spec.rb` has been updated to ensure that seeder logic for `LearningHour` creates records (does not come back with empty resultset)

### Screenshots please :)

Screenshot of a volunteer with seeded learning hours:
![Screen Shot 2023-11-21 at 10 52 44 PM](https://github.com/rubyforgood/casa/assets/214966/2f9bbe29-eb40-4cdd-83dc-b70cb3823f5d)

Per #5370 I am attaching proof that seeder runs with `rake db:reset`
![Screen Shot 2023-11-21 at 11 06 04 PM](https://github.com/rubyforgood/casa/assets/214966/f05cf738-7486-494a-be27-e7c6990b3fe6)
