### PR TITLE
fix: fixes the list of "no_recent_sign_in" on supervisor weekly_digest

### DIFF
--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -10,6 +10,7 @@ class SupervisorMailer < UserMailer
     @supervisor = supervisor
     @casa_organization = supervisor.casa_org
     @inactive_messages = InactiveMessagesService.new(supervisor).inactive_messages
+    @inactive_volunteers = supervisor.inactive_volunteers
     if supervisor.receive_reimbursement_email
       mileage_report_attachment = MileageReport.new(@casa_organization.id).to_csv
       attachments["mileage-report-#{Time.current.strftime("%Y-%m-%d")}.csv"] = mileage_report_attachment

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -37,6 +37,14 @@ class Supervisor < User
     ).where(invitation_accepted_at: nil).where.not(invitation_created_at: nil)
   end
 
+  def not_signed_in_nor_have_case_contacts_volunteers
+    recent_case_contact_volunteer_ids = volunteers.joins(:case_contacts).where(
+      case_contacts: {occurred_at: 30.days.ago..}
+    ).pluck(:id)
+
+    volunteers.no_recent_sign_in.where.not(id: recent_case_contact_volunteer_ids)
+  end
+
   def recently_unassigned_volunteers
     unassigned_supervisor_volunteers.joins(:volunteer).includes(:volunteer)
       .where(updated_at: 1.week.ago..Time.zone.now).map(&:volunteer)

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -37,9 +37,9 @@ class Supervisor < User
     ).where(invitation_accepted_at: nil).where.not(invitation_created_at: nil)
   end
 
-  def not_signed_in_nor_have_case_contacts_volunteers
+  def inactive_volunteers
     recent_case_contact_volunteer_ids = volunteers.joins(:case_contacts).where(
-      case_contacts: {occurred_at: 30.days.ago..}
+      case_contacts: {created_at: 30.days.ago..}
     ).pluck(:id)
 
     volunteers.no_recent_sign_in.where.not(id: recent_case_contact_volunteer_ids)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
     where(casa_org_id: org.id)
   }
 
-  scope :no_recent_sign_in, -> { active.where("last_sign_in_at <= ?", 30.days.ago) }
+  scope :no_recent_sign_in, -> { active.where("last_sign_in_at <= ?", 30.days.ago).or(User.active.where(last_sign_in_at: nil)) }
 
   def casa_admin?
     is_a?(CasaAdmin)

--- a/app/views/supervisor_mailer/_no_recent_sign_in.html.erb
+++ b/app/views/supervisor_mailer/_no_recent_sign_in.html.erb
@@ -1,11 +1,10 @@
-<% volunteer_list = supervisor.not_signed_in_nor_have_case_contacts_volunteers %>
-<% if volunteer_list.any? %>
+<% if inactive_volunteers.any? %>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      <b><%= "The following volunteers have not signed nor had case contacts in the last 30 days" %></b>
+      <b><%= "The following volunteers have not signed in or created case contacts in the last 30 days" %></b>
       <br>
 
-      <% volunteer_list.each do |volunteer| %>
+      <% inactive_volunteers.each do |volunteer| %>
         - <%= volunteer.display_name %>
         <br>
       <% end %>

--- a/app/views/supervisor_mailer/_no_recent_sign_in.html.erb
+++ b/app/views/supervisor_mailer/_no_recent_sign_in.html.erb
@@ -1,10 +1,11 @@
-<% if supervisor.volunteers.no_recent_sign_in.any? %>
+<% volunteer_list = supervisor.not_signed_in_nor_have_case_contacts_volunteers %>
+<% if volunteer_list.any? %>
   <tr style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0; text-align: left;">
     <td class="content-block" style="font-family: Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-      <b><%= "The following volunteers have not recently signed in, within 30 days" %></b>
+      <b><%= "The following volunteers have not signed nor had case contacts in the last 30 days" %></b>
       <br>
 
-      <% supervisor.volunteers.no_recent_sign_in.each do |volunteer| %>
+      <% volunteer_list.each do |volunteer| %>
         - <%= volunteer.display_name %>
         <br>
       <% end %>

--- a/app/views/supervisor_mailer/weekly_digest.html.erb
+++ b/app/views/supervisor_mailer/weekly_digest.html.erb
@@ -6,5 +6,5 @@
   <%= render("recently_unassigned_volunteers", supervisor: @supervisor) %>
   <%= render("additional_notes", inactive_messages: @inactive_messages) %>
   <%= render("pending_volunteers", supervisor: @supervisor) %>
-  <%= render("no_recent_sign_in", supervisor: @supervisor) %>
+  <%= render("no_recent_sign_in", supervisor: @supervisor, inactive_volunteers: @inactive_volunteers) %>
 </table>

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
     end
 
     it "does not display no_recent_sign_in section" do
-      expect(mail.body.encoded).not_to match("volunteers have not signed nor had case contacts in the last 30 days")
+      expect(mail.body.encoded).not_to match("volunteers have not signed in or created case contacts in the last 30 days")
     end
 
     context "when supervisor has a volunteer that has not been active for the last 30 days" do
@@ -115,7 +115,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
       end
 
       it "display no_recent_sign_in section" do
-        expect(mail.body.encoded).to match("volunteers have not signed nor had case contacts in the last 30 days")
+        expect(mail.body.encoded).to match("volunteers have not signed in or created case contacts in the last 30 days")
       end
 
       context "but volunteer has a recent case_contact to its name" do
@@ -124,7 +124,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
         end
 
         it "does not display no_recent_sign_in section" do
-          expect(mail.body.encoded).not_to match("volunteers have not signed nor had case contacts in the last 30 days")
+          expect(mail.body.encoded).not_to match("volunteers have not signed in or created case contacts in the last 30 days")
         end
       end
     end

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -101,8 +101,32 @@ RSpec.describe SupervisorMailer, type: :mailer do
       expect(mail.body.encoded).to_not match("There are no additional notes.")
     end
 
-    it "displays no additional notes messsage when there are no additional notes" do
+    it "displays no additional notes message when there are no additional notes" do
       expect(mail.body.encoded).to match("There are no additional notes.")
+    end
+
+    it "does not display no_recent_sign_in section" do
+      expect(mail.body.encoded).not_to match("volunteers have not signed nor had case contacts in the last 30 days")
+    end
+
+    context "when supervisor has a volunteer that has not been active for the last 30 days" do
+      let!(:volunteer) do
+        create(:volunteer, casa_org: supervisor.casa_org, supervisor: supervisor, last_sign_in_at: 31.days.ago)
+      end
+
+      it "display no_recent_sign_in section" do
+        expect(mail.body.encoded).to match("volunteers have not signed nor had case contacts in the last 30 days")
+      end
+
+      context "but volunteer has a recent case_contact to its name" do
+        let!(:recent_case_contact) do
+          create(:case_contact, casa_case: casa_case, occurred_at: 29.days.ago, creator: volunteer)
+        end
+
+        it "does not display no_recent_sign_in section" do
+          expect(mail.body.encoded).not_to match("volunteers have not signed nor had case contacts in the last 30 days")
+        end
+      end
     end
   end
 

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -43,6 +43,28 @@ RSpec.describe Supervisor, type: :model do
     end
   end
 
+  describe "not_signed_in_nor_have_case_contacts_volunteers" do
+    let(:supervisor) { create(:supervisor) }
+    let(:volunteer) { create(:volunteer, last_sign_in_at: 31.days.ago) }
+    let(:other_volunteer) { create(:volunteer, last_sign_in_at: 29.days.ago) }
+
+    subject { supervisor.not_signed_in_nor_have_case_contacts_volunteers }
+
+    before do
+      create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
+      create(:supervisor_volunteer, supervisor: supervisor, volunteer: other_volunteer)
+    end
+
+    it { is_expected.to contain_exactly(volunteer) }
+
+    context "when volunteer has a recent case_contact" do
+      let(:casa_case) { create(:casa_case, casa_org: supervisor.casa_org) }
+      let!(:case_contact) { create(:case_contact, casa_case: casa_case, occurred_at: 29.days.ago, creator: volunteer) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
   describe "change to admin" do
     it "returns true if the change was successful" do
       expect(subject.change_to_admin!).to be_truthy

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Supervisor, type: :model do
+  include Devise::Test::IntegrationHelpers
+
   subject(:supervisor) { create :supervisor }
 
   describe "#role" do
@@ -48,20 +50,48 @@ RSpec.describe Supervisor, type: :model do
     let(:volunteer) { create(:volunteer, last_sign_in_at: 31.days.ago) }
     let(:other_volunteer) { create(:volunteer, last_sign_in_at: 29.days.ago) }
 
-    subject { supervisor.not_signed_in_nor_have_case_contacts_volunteers }
+    subject { supervisor.inactive_volunteers }
 
     before do
       create(:supervisor_volunteer, supervisor: supervisor, volunteer: volunteer)
       create(:supervisor_volunteer, supervisor: supervisor, volunteer: other_volunteer)
     end
 
-    it { is_expected.to contain_exactly(volunteer) }
-
-    context "when volunteer has a recent case_contact" do
-      let(:casa_case) { create(:casa_case, casa_org: supervisor.casa_org) }
-      let!(:case_contact) { create(:case_contact, casa_case: casa_case, occurred_at: 29.days.ago, creator: volunteer) }
+    context "when volunteer has logged in in the last 30 days" do
+      let(:volunteer) { create(:volunteer, last_sign_in_at: 29.days.ago) }
 
       it { is_expected.to be_empty }
+
+      context "when volunteer then logged out" do
+        it "is empty" do
+          sign_out volunteer
+
+          is_expected.to be_empty
+        end
+      end
+    end
+
+    context "when volunteer hasn't logged in in the last 30 days" do
+      it { is_expected.to contain_exactly(volunteer) }
+
+      context "when volunteer is inactive" do
+        let(:volunteer) { create(:volunteer, last_sign_in_at: 31.days.ago, active: false) }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "when volunteer has never logged in" do
+        let(:volunteer) { create(:volunteer, last_sign_in_at: nil) }
+
+        it { is_expected.to contain_exactly(volunteer) }
+      end
+
+      context "when volunteer has a recent case_contact" do
+        let(:casa_case) { create(:casa_case, casa_org: supervisor.casa_org) }
+        let!(:case_contact) { create(:case_contact, casa_case: casa_case, occurred_at: 31.days.ago, creator: volunteer, created_at: 29.days.ago) }
+
+        it { is_expected.to be_empty }
+      end
     end
   end
 

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       create_list :case_contact, 2, creator: volunteer, casa_case: casa_case, contact_made: false, occurred_at: Time.current - 6.days
       @case_contact = create :case_contact, creator: volunteer, casa_case: casa_case, contact_made: true, occurred_at: Time.current - 6.days
       assign :supervisor, supervisor
+      assign :inactive_volunteers, []
       sign_in supervisor
       @inactive_messages = InactiveMessagesService.new(supervisor).inactive_messages
       render template: "supervisor_mailer/weekly_digest"
@@ -40,6 +41,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
     before(:each) do
       sign_in supervisor
       assign :supervisor, supervisor
+      assign :inactive_volunteers, []
       @inactive_messages = InactiveMessagesService.new(supervisor).inactive_messages
       render template: "supervisor_mailer/weekly_digest"
     end
@@ -55,6 +57,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       volunteer.casa_cases << casa_case
       sign_in supervisor
       assign :supervisor, supervisor
+      assign :inactive_volunteers, []
       @inactive_messages = InactiveMessagesService.new(supervisor).inactive_messages
       render template: "supervisor_mailer/weekly_digest"
     end
@@ -74,6 +77,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
 
       sign_in supervisor
       assign :supervisor, supervisor
+      assign :inactive_volunteers, []
       render template: "supervisor_mailer/weekly_digest"
     end
 
@@ -91,7 +95,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       new_supervisor.volunteers << volunteer
       volunteer.supervisor_volunteer.update(is_active: true)
       assign :supervisor, supervisor
-      @inactive_messages = []
+      assign :inactive_volunteers, []
 
       render template: "supervisor_mailer/weekly_digest"
     end
@@ -107,6 +111,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       supervisor.volunteers << volunteer
       sign_in supervisor
       assign :supervisor, supervisor
+      assign :inactive_volunteers, []
       volunteer.supervisor_volunteer.update(is_active: false)
       @inactive_messages = []
       render template: "supervisor_mailer/weekly_digest"
@@ -123,10 +128,11 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       supervisor.volunteers << volunteer
       sign_in supervisor
       assign :supervisor, supervisor
+      assign :inactive_volunteers, supervisor.inactive_volunteers
       render template: "supervisor_mailer/weekly_digest"
     end
 
-    it { expect(rendered).to have_text("The following volunteers have not signed nor had case contacts in the last 30 days") }
+    it { expect(rendered).to have_text("The following volunteers have not signed in or created case contacts in the last 30 days") }
     it { expect(rendered).to have_text("- #{volunteer.display_name}") }
   end
 end

--- a/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
+++ b/spec/views/supervisor_mailer/weekly_digest.html.erb_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "supervisor_mailer/weekly_digest", type: :view do
       render template: "supervisor_mailer/weekly_digest"
     end
 
-    it { expect(rendered).to have_text("The following volunteers have not recently signed in, within 30 days") }
+    it { expect(rendered).to have_text("The following volunteers have not signed nor had case contacts in the last 30 days") }
     it { expect(rendered).to have_text("- #{volunteer.display_name}") }
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #4672 

### What changed, and why?
 - Changes the list of Volunteers the `weekly digest` supervisor email shows in the section `no_recent_sign_in`:
   - It was pointed out here https://github.com/rubyforgood/casa/issues/4672#issuecomment-1636244266 that the list should use the more recent of `last_sign_in_at` or last case_contact created. My understanding of it is that even if a volunteer has not logged in in the last 30 days, but he has a "recent" case_contact associated, the email section should not list that volunteer.
   - I used the case_contact's `occurred_at` field. Please verify and let me know that this is the field we want instead of using one of the other regular timestamps.
   - I changed the text in the email to let the supervisor know of that new behaviour.
   - I chose to maintain `User.no_recent_sign_in` as a scope even though this was the only place where it was used, so I just created a new call for supervisors to get that exact list. I feel like this situation should have its own name, but I'll leave that for you guys to figure out, in the meantime I used a big explanatory one just in case... let me know...

### How will this affect user permissions?
- No change

### How is this tested? (please write tests!) 💖💪
 - Added specs making sure all 3 scenarios are included and verified

### Screenshots please :)
 - does not apply
