### PR TITLE
fix: last contact display time based on occurred date, not created date

### DIFF
--- a/app/helpers/contact_types_helper.rb
+++ b/app/helpers/contact_types_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Helper methods for new/edit contact type form
 module ContactTypesHelper
   def set_group_options
@@ -9,7 +11,7 @@ module ContactTypesHelper
 
     return "never" if contact.nil?
 
-    "#{time_ago_in_words(contact.created_at)} ago"
+    "#{time_ago_in_words(contact.occurred_at)} ago"
   end
 
   def last_contact_made_of(contact_type_name, casa_case)
@@ -19,7 +21,7 @@ module ContactTypesHelper
       .case_contacts
       .joins(:contact_types)
       .where(contact_types: {name: contact_type_name})
-      .order(created_at: :desc)
+      .order(occurred_at: :desc)
       .first
   end
 end

--- a/spec/helpers/contact_types_helper_spec.rb
+++ b/spec/helpers/contact_types_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContactTypesHelper, type: :helper do
 
     context "when contact was made" do
       before do
-        contact = build_stubbed(:case_contact, casa_case: casa_case, created_at: 1.day.ago)
+        contact = build_stubbed(:case_contact, casa_case:, created_at: 2.days.ago, occurred_at: 1.day.ago)
         allow(helper).to receive(:last_contact_made_of).and_return(contact)
       end
 
@@ -29,15 +29,18 @@ RSpec.describe ContactTypesHelper, type: :helper do
     let(:casa_case) { create(:casa_case) }
     let(:contact_type) { create(:contact_type) }
 
-    let!(:contact_1) { create(:case_contact, casa_case: casa_case, contact_types: [contact_type]) }
+    let!(:contact1) do
+      create(:case_contact, casa_case:, contact_types: [contact_type],
+        created_at: 2.days.ago, occurred_at: 1.day.ago)
+    end
 
-    let!(:contact_2) do
-      create(:case_contact, casa_case: casa_case, contact_types: [contact_type],
-        created_at: 1.day.ago)
+    let!(:contact2) do
+      create(:case_contact, casa_case:, contact_types: [contact_type],
+        created_at: 1.day.ago, occurred_at: 2.days.ago)
     end
 
     it "returns the last contact made of the given type" do
-      expect(subject).to eq(contact_1)
+      expect(subject).to eq(contact1)
     end
 
     context "when casa_case is nil" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5426 

### What changed, and why?
Last case contact is now based on the date the contact occurred, not the date the contact was entered into the system.

### How will this affect user permissions?
n/a

### How is this tested? (please write tests!) 💖💪
Tests were updated.

### Screenshots please :)
n/a
