### PR TITLE
Learning hours duration inputs

### DIFF
--- a/app/components/form/hour_minute_duration_component.rb
+++ b/app/components/form/hour_minute_duration_component.rb
@@ -16,7 +16,9 @@ class Form::HourMinuteDurationComponent < ViewComponent::Base
       raise RangeError.new("Parameter hour_value must be positive")
     end
 
-    if hour_value.nil? || hour_value.is_a?(Integer)
+    if hour_value.nil?
+      @hour_value = 0
+    elsif hour_value.is_a?(Integer)
       @hour_value = hour_value
     else
       raise TypeError.new("Parameter hour_value must be an integer")
@@ -34,7 +36,9 @@ class Form::HourMinuteDurationComponent < ViewComponent::Base
       raise RangeError.new("Parameter minute_value must be positive")
     end
 
-    if minute_value.nil? || minute_value.is_a?(Integer)
+    if minute_value.nil?
+      @minute_value = 0
+    elsif minute_value.is_a?(Integer)
       @minute_value = minute_value
     else
       raise TypeError.new("Parameter minute_value must be an integer")

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -4,7 +4,7 @@ class LearningHour < ApplicationRecord
   belongs_to :learning_hour_topic, optional: true
 
   validates :duration_minutes, presence: true
-  validates :duration_minutes, numericality: {greater_than: 0, message: " and hours (total duration) must be greater than 0"}, if: :zero_duration_hours?
+  validates :duration_minutes, numericality: {greater_than: 0, message: "and hours (total duration) must be greater than 0"}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -4,7 +4,7 @@ class LearningHour < ApplicationRecord
   belongs_to :learning_hour_topic, optional: true
 
   validates :duration_minutes, presence: true
-  validates :duration_minutes, numericality: {greater_than: 0}, if: :zero_duration_hours?
+  validates :duration_minutes, numericality: {greater_than: 0, message: " and hours (total duration) must be greater than 0"}, if: :zero_duration_hours?
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LearningHour, type: :model do
     it "has a duration in minutes that is greater than 0" do
       learning_hour = build_stubbed(:learning_hour, duration_hours: 0, duration_minutes: 0)
       expect(learning_hour).to_not be_valid
-      expect(learning_hour.errors[:duration_minutes]).to eq(["must be greater than 0"])
+      expect(learning_hour.errors[:duration_minutes]).to eq(["and hours (total duration) must be greater than 0"])
     end
   end
 

--- a/spec/system/learning_hours/new_spec.rb
+++ b/spec/system/learning_hours/new_spec.rb
@@ -30,4 +30,30 @@ RSpec.describe "learning_hours/new", type: :system do
 
     expect(page).to have_text("New entry was successfully created.")
   end
+
+  it "creates learning hours entry without minutes duration" do
+    fill_in "Learning Hours Title", with: "Test title"
+    select "Book", from: "Type of Learning"
+    fill_in "Hour(s)", with: "3"
+    click_on "Create New Learning Hours Entry"
+
+    expect(page).to have_text("New entry was successfully created.")
+  end
+
+  it "creates learning hours entry without hours duration" do
+    fill_in "Learning Hours Title", with: "Test title"
+    select "Book", from: "Type of Learning"
+    fill_in "Minute(s)", with: "30"
+    click_on "Create New Learning Hours Entry"
+
+    expect(page).to have_text("New entry was successfully created.")
+  end
+
+  it "errors without hours and minutes duration" do
+    fill_in "Learning Hours Title", with: "Test title"
+    select "Book", from: "Type of Learning"
+    click_on "Create New Learning Hours Entry"
+
+    expect(page).to have_text("Duration minutes and hours (total duration) must be greater than 0")
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5383 

### What changed, and why?
- Changed hour/minute form to handle null values to have a default value of 0 (zero).
This behaviour plus the required constraint of the form, will automatically send 0 if not changed and will force the user to input a value, if deleted by mistake before attempting to send.

- Changed the error message when triggering the validation of the minutes not being greater than zero.
  The previous message was not accurate since the minutes can be zero, as long as the hours are not zero. The new message points out that the total duration cannot be zero.

### How is this tested?

Added three new system tests and modified one model test to the learning hour component.
Below are the three new tests failing when the form component is changed back to its original state (not handling the null values separately):
![Screen Shot 2023-12-10 at 10 05 01 AM](https://github.com/rubyforgood/casa/assets/79976550/172f27e8-091d-4118-a291-2e536eb7151e)
![Screen Shot 2023-12-10 at 10 05 40 AM](https://github.com/rubyforgood/casa/assets/79976550/80abb23d-1883-4129-b901-1b683eafa6b4)
 

### Screenshots
![Screen Shot 2023-12-10 at 10 32 38 AM](https://github.com/rubyforgood/casa/assets/79976550/294286ac-38ba-446b-b3a8-b67cf0fed921)
![Screen Shot 2023-12-10 at 10 33 16 AM](https://github.com/rubyforgood/casa/assets/79976550/8b4c7bfc-fbb8-4d63-87e2-56a6ddf5510c)
![Screen Shot 2023-12-10 at 10 34 03 AM](https://github.com/rubyforgood/casa/assets/79976550/ad907292-4de9-4756-98b1-5de60100cc6e)

