### PR TITLE
Update Slack expired links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,4 +43,4 @@ password for all users: 12345678
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -6,4 +6,4 @@
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -6,4 +6,4 @@
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,4 +31,4 @@ password for all users: 12345678
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -16,4 +16,4 @@ rspec or rspec in docker?
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/problem_validation.md
+++ b/.github/ISSUE_TEMPLATE/problem_validation.md
@@ -15,4 +15,4 @@ Please use this template to document problems mentioned by CASA stakeholders so 
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A CASA (Court Appointed Special Advocate) is a role where a volunteer advocates 
 
 We are very happy to have you! CASA and Ruby for Good are committed to welcoming new contributors of all skill levels.
 
-We highly recommend that you join us in [slack](http://bit.ly/3Quxc1Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
 
 Issues on the issue board https://github.com/rubyforgood/casa/projects/1 in the TODO column are fair game. An issue can be claimed by commenting on it.
 
@@ -222,7 +222,7 @@ Thank you to [Scout](https://ter.li/h8k29r) for letting us use their dashboard f
 
 # Communication and Collaboration
 
-Most conversation happens in the #casa channel of the Ruby For Good slack. Get access here: http://bit.ly/3Quxc1Q
+Most conversation happens in the #casa channel of the Ruby For Good slack. Get access [here](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA).
 
 You can also open an issue or comment on an issue on GitHub and a maintainer will reply to you.
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing  
 We ♥ contributors! By participating in this project, you agree to abide by the Ruby for Good [code of conduct](https://github.com/rubyforgood/code-of-conduct).
 
-If you have any questions about an issue, comment on the issue, open a new issue or ask in [the RubyForGood slack](http://bit.ly/3Quxc1Q). CASA has a `#casa` channel in the Slack. Our channel in slack also contains a zoom link for office hours every day office hours are held.
+If you have any questions about an issue, comment on the issue, open a new issue or ask in [the RubyForGood slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-21pyz2ab8-H6JgQfGGI0Ab6MfNOZRIQA). CASA has a `#casa` channel in the Slack. Our channel in slack also contains a zoom link for office hours every day office hours are held.
 
 You won't be yelled at for giving your best effort. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contributions, and don't want a wall of rules to get in the way of that.
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
None.

### What changed, and why?
- The Slack links expired.
- Links were update to match the invite link present on the website: https://rubyforgood.org/join-us
- @mattzollinhofer updated this last month on [this commit](https://github.com/rubyforgood/casa/commit/3be583491380ccfea46440171151b03460efd2f7)

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
- Click the link in the an incognito / private browsing window if you're already a member of Slack.

### Screenshots please :)
Before:
![image](https://github.com/rubyforgood/casa/assets/13178700/4cf649c1-d293-4abc-be6a-5e8235e1e21e)

### Feelings gif (optional)
What gif best describes your feeling working on this issue?
![meticulous](https://media4.giphy.com/media/3o7TKCHmvPRGCZzvaw/giphy.gif)
