### PR TITLE
Display active banner after new user session

### DIFF
--- a/app/helpers/banner_helper.rb
+++ b/app/helpers/banner_helper.rb
@@ -4,4 +4,26 @@ module BannerHelper
       "d-none"
     end
   end
+
+  def active_banner
+    @active_banner ||= current_organization.banners.active.first
+  end
+
+  def active_banner?
+    active_banner.present?
+  end
+
+  def display_active_banner?
+    active_banner? && cookies[dismiss_banner_cookie_name].nil?
+  end
+
+  def banner_cookie_name
+    raise StandardError, "No active banner" unless active_banner?
+
+    "banner_#{active_banner.id}"
+  end
+
+  def dismiss_banner_cookie_name
+    "dismiss_#{banner_cookie_name}"
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -17,6 +17,9 @@ import NavbarController from './navbar_controller'
 import SidebarController from './sidebar_controller'
 
 import SidebarGroupController from './sidebar_group_controller'
+
+import SignoutCleanupController from './signout_cleanup_controller'
+
 application.register('dismiss', DismissController)
 application.register('extended-nested-form', ExtendedNestedFormController)
 application.register('hello', HelloController)
@@ -24,3 +27,4 @@ application.register('multiple-select', MultipleSelectController)
 application.register('navbar', NavbarController)
 application.register('sidebar', SidebarController)
 application.register('sidebar-group', SidebarGroupController)
+application.register('signout-cleanup', SignoutCleanupController)

--- a/app/javascript/controllers/signout_cleanup_controller.js
+++ b/app/javascript/controllers/signout_cleanup_controller.js
@@ -1,0 +1,11 @@
+import Cookies from 'js-cookie'
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  cookies (event) {
+    event.preventDefault()
+    const { cookies } = event.params
+    cookies.forEach(cookie => Cookies.remove(cookie))
+    window.location.href = event.target.href
+  }
+}

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,14 +1,10 @@
-<% banner = current_organization.banners.active.first %>
-<% if banner %>
-  <% cookie_id = "banner_#{banner.id}" %>
-  <% if !cookies["dismiss_#{cookie_id}"] %>
-    <div class="bg-secondary-100 text-xl p-5 d-flex" data-controller="dismiss" data-dismiss-target="element">
-      <div class="">
-        <%= banner.content %>
-      </div>
-      <div class="ms-auto">
-        <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
-      </div>
+<% if display_active_banner? %>
+  <div class="bg-secondary-100 text-xl p-5 d-flex" data-controller="dismiss" data-dismiss-target="element">
+    <div class="">
+      <%= active_banner.content %>
     </div>
-  <% end %>
+    <div class="ms-auto">
+      <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= banner_cookie_name %>">Dismiss</a>
+    </div>
+  </div>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -91,8 +91,12 @@
                   Help
                 <% end %>
               </li>
-              <li>
-                <%= link_to destroy_user_session_path do %>
+              <li data-controller="signout-cleanup">
+                <%= link_to destroy_user_session_path,
+                            data: {
+                              action: 'click->signout-cleanup#cookies',
+                              'signout-cleanup-cookies-param' => active_banner? ? [dismiss_banner_cookie_name] : []
+                            } do %>
                   <i class="lni lni-exit"></i>
                   Sign Out
                 <% end %>

--- a/spec/helpers/banner_helper_spec.rb
+++ b/spec/helpers/banner_helper_spec.rb
@@ -35,4 +35,97 @@ RSpec.describe BannerHelper do
       expect(helper.conditionally_add_hidden_class(true)).to eq(nil)
     end
   end
+
+  describe "#active_banner" do
+    let(:current_organization) { double }
+    let(:banner) { double(id: 1) }
+
+    before do
+      allow(helper).to receive(:current_organization).and_return(current_organization)
+      allow(current_organization).to receive(:banners).and_return(OpenStruct.new(active: []))
+    end
+
+    it "returns active banner if there is one" do
+      allow(current_organization.banners).to receive(:active).and_return([banner])
+
+      expect(helper.active_banner).to eq(banner)
+    end
+
+    it "returns nil if there is not active banners" do
+      allow(current_organization.banners).to receive(:active).and_return([])
+
+      expect(helper.active_banner).to eq(nil)
+    end
+  end
+
+  describe "#active_banner?" do
+    it "returns true if there is active banner" do
+      allow(helper).to receive(:active_banner).and_return("foo")
+      expect(helper.active_banner?).to eq(true)
+    end
+
+    it "returns false if there is no active banner" do
+      allow(helper).to receive(:active_banner).and_return(nil)
+      expect(helper.active_banner?).to eq(false)
+    end
+  end
+
+  describe "#display_active_banner?" do
+    it "returns true if banner message should be displayed" do
+      cookies = double
+
+      allow(helper).to receive(:active_banner?).and_return(true)
+      allow(helper).to receive(:dismiss_banner_cookie_name).and_return("dismiss_banner_1")
+      allow(cookies).to receive(:[]).with("dismiss_banner_1").and_return(nil)
+      allow(helper).to receive(:cookies).and_return(cookies)
+
+      expect(helper.display_active_banner?).to eq(true)
+    end
+
+    it "returns false if there is no active banner" do
+      allow(helper).to receive(:active_banner?).and_return(false)
+
+      expect(helper.display_active_banner?).to eq(false)
+    end
+
+    it "returns false if there active banner but no cookie set" do
+      allow(helper).to receive(:active_banner?).and_return(true)
+      allow(helper).to receive(:dismiss_banner_cookie_name).and_return("dismiss_banner_1")
+      allow(cookies).to receive(:[]).with("dismiss_banner_1").and_return("true")
+      allow(helper).to receive(:cookies).and_return(cookies)
+
+      expect(helper.display_active_banner?).to eq(false)
+    end
+  end
+
+  describe "#banner_cookie_name" do
+    it "returns cookie name for the banner" do
+      banner = double(id: 1)
+      allow(helper).to receive(:active_banner).and_return(banner)
+      expect(helper.banner_cookie_name).to eq("banner_1")
+    end
+
+    it "raises a StandardError if there is no active banner" do
+      allow(helper).to receive(:active_banner?).and_return(false)
+
+      expect {
+        helper.banner_cookie_name
+      }.to raise_error(StandardError, "No active banner")
+    end
+  end
+
+  describe "#dismiss_banner_cookie_name" do
+    it "returns the value of the dismiss banner cookie" do
+      allow(helper).to receive(:banner_cookie_name).and_return("banner_1")
+      expect(helper.dismiss_banner_cookie_name).to eq("dismiss_banner_1")
+    end
+
+    it "raises an error if there is no active banner" do
+      allow(helper).to receive(:banner_cookie_name).and_raise(StandardError, "No active banner")
+
+      expect {
+        helper.dismiss_banner_cookie_name
+      }.to raise_error(StandardError, "No active banner")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5428

### What changed, and why?
How it works: After clicking dismiss banner, cookie is set, meaning that banner should not be displayed. After signout, cookie persisted, thus on next login banner is still hidden.

How it should work after this PR: After clicking dismiss banner, cookie is set. Clicking signout will wipe out the cookie resulting in displaying the banner on next login.

### How will this affect user permissions?
Not related to user permissions

### How is this tested? (please write tests!) 💖💪
Tests included (spec/helpers/banner_helper_spec.rb)

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
