### PR TITLE
Email preview uncaught exception

### DIFF
--- a/app/mailers/fund_request_mailer.rb
+++ b/app/mailers/fund_request_mailer.rb
@@ -1,11 +1,13 @@
 class FundRequestMailer < ApplicationMailer
   layout "fund_layout"
 
-  def send_request(_user, fund_request)
+  def send_request(_user, fund_request, bugsnag_active = true)
     to_recipient_email = ENV["FUND_REQUEST_RECIPIENT_EMAIL"]
 
     submitter_email = fund_request.submitter_email
-    Bugsnag.notify("No user for FUND_REQUEST_RECIPIENT_EMAIL for fund request from: #{submitter_email}") unless to_recipient_email
+    if bugsnag_active && !to_recipient_email
+      Bugsnag.notify("No user for FUND_REQUEST_RECIPIENT_EMAIL for fund request from: #{submitter_email}")
+    end
     @inputs = fund_request.as_json
     submitter_name = fund_request.submitter_email&.split("@")&.first
     begin
@@ -16,7 +18,7 @@ class FundRequestMailer < ApplicationMailer
       ).write_to_file.read
       attachments.inline["fund-request-#{Date.today}-#{submitter_name}.pdf"] = pdf_attachment
     rescue => e
-      Bugsnag.notify(e)
+      Bugsnag.notify(e) if bugsnag_active
     end
     mail(layout: nil, to: [to_recipient_email, submitter_email], subject: "Fund request from #{submitter_email}")
   end

--- a/lib/mailers/previews/fund_request_mailer_preview.rb
+++ b/lib/mailers/previews/fund_request_mailer_preview.rb
@@ -20,6 +20,6 @@ class FundRequestMailerPreview < ActionMailer::Preview
       extra_information: "Sample Extra Information"
     )
 
-    FundRequestMailer.send_request(nil, fund_request)
+    FundRequestMailer.send_request(nil, fund_request, false)
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5396 

### What changed, and why?
Added the extra parameter `bugsnag_active` to `FundRequestMailer` to confirm the Bugsnag notifications will be active.
Set the parameter default value to `true`, in order to change only the calls that are triggering the exception to be overridden.
Set FundRequestMailerPreview call of `FundRequestMailer` to `false`.