### PR TITLE
Remove restrictions for running CI on PRs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "doc/**"
-      - "**/*.md"
 
 jobs:
   rspec:


### PR DESCRIPTION
It is confusing for people why CI is not
running when making documentation changes.
