### PR TITLE
[DOCUMENTATION] Typo error fixed on Readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ A CASA (Court Appointed Special Advocate) is a role where a volunteer advocates 
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
+**Table of Contents.**
 
   - [Welcome contributors!](#welcome-contributors)
-    - [About this project](#about-this-project)
+    - [About this project.](#about-this-project)
 - [Developing! ✨🛠✨](#developing-)
-  - [How to Contribute](#how-to-contribute)
-  - [Installation](#installation)
-    - [General Setup Instructions](#general-setup-instructions)
-    - [Platform Specific Installation Instructions](#platform-specific-installation-instructions)
-    - [Common issues](#common-issues)
-  - [Running the App / Verifying Installation](#running-the-app--verifying-installation)
-- [Other Documentation](#other-documentation)
-- [Acknowledgements](#acknowledgements)
-- [Communication and Collaboration](#communication-and-collaboration)
-- [Feedback](#feedback)
+  - [How to Contribute.](#how-to-contribute)
+  - [Installation.](#installation)
+    - [General Setup Instructions.](#general-setup-instructions)
+    - [Platform Specific Installation Instructions.](#platform-specific-installation-instructions.)
+    - [Common issues.](#common-issues)
+  - [Running the App / Verifying Installation.](#running-the-app--verifying-installation)
+- [Other Documentation.](#other-documentation)
+- [Acknowledgements.](#acknowledgements)
+- [Communication and Collaboration.](#communication-and-collaboration)
+- [Feedback.](#feedback)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -43,15 +43,15 @@ Issues on the issue board https://github.com/rubyforgood/casa/projects/1 in the 
 
 Pull requests which are not for an issue but which improve the codebase are also welcome! Feel free to make GitHub issues for bugs and improvements. A maintainer will be keeping an eye on issues and PRs every day or three.
 
-### About this project
+### About this project.
 
-CASA is a national organization with many regional chapters. We currently work with [Prince George's County CASA in Maryland](https://pgcasa.org/), [Montgomery CASA Maryland](https://casaspeaks4kids.com), and [Howard County Maryland](https://marylandcasa.org/programs/howard-county/)
+CASA is a national organization with many regional chapters. We currently work with [Prince George's County CASA in Maryland](https://pgcasa.org/), [Montgomery CASA Maryland](https://casaspeaks4kids.com), and [Howard County Maryland.](https://marylandcasa.org/programs/howard-county/)
 
 This system provides value by:
 
-- providing volunteers with a portal for logging activity
-- allow supervisors to oversee volunteer activity
-- generate reports on volunteer activity for admins to use in grant proposals
+- providing volunteers with a portal for logging activity.
+- allow supervisors to oversee volunteer activity.
+- generate reports on volunteer activity for admins to use in grant proposals.
 
 Read about the [product sense](doc/productsense.md) that guides our approach to this work.
 
@@ -61,7 +61,7 @@ Read about the [product sense](doc/productsense.md) that guides our approach to 
 - The **CASA case** is assigned to a **volunteer**.
 - The **volunteer** records their efforts spent on the CASA case as **case contacts**.
 - **Supervisors** oversee CASA **volunteers** by monitoring, tracking, and advising them on **CASA case** activities.
-- At PG CASA, the minimum volunteer commitment is one year (this varies by CASA chapter, in San Francisco the minimum commitment is ~ two years).  A volunteer's  lifecycle is very long, so there's a lot of activity for chapters to organize.
+- At PG CASA, the minimum volunteer commitment is one year (This varies by CASA chapter, in San Francisco the minimum commitment is ~ two years).  A volunteer's  lifecycle is very long, so there's a lot of activity for chapters to organize.
 
 **Project Considerations**
 
@@ -74,7 +74,7 @@ The complete [role description of a CASA volunteer](https://pgcasa.org/volunteer
 
 # Developing! ✨🛠✨
 ## How to Contribute
-  See our [contributing guide](./doc/CONTRIBUTING.md) 💖 ✨
+  See our [contributing guide.](./doc/CONTRIBUTING.md) 💖 ✨
 ## Installation
 ### General Setup Instructions
 **Downloading the Project**
@@ -119,14 +119,14 @@ If you are using Ubuntu on WSL and receive the following message when trying to 
 
 **Database Setup**
 1. `bin/rails db:setup` create schema
-    requires running local postgres, with a role created for whatever user you're running rails as
+    requires running local postgres, with a role created for whatever user you're running rails as.
 1. `bin/rails db:seed:replant` generates test data (can be rerun to regenerate test data)
 
 **Compile Assets**
-1.  `yarn build` compile javascript
-&ensp;&ensp;`yarn build:dev` to auto recompile for when you edit js files
-3.  `yarn build:css` compile css
-&ensp;&ensp;`yarn build:css:dev` to auto recompile for when you edit sass files
+1.  `yarn build` compile javascript.
+&ensp;&ensp;`yarn build:dev` to auto recompile for when you edit js files.
+3.  `yarn build:css` compile css.
+&ensp;&ensp;`yarn build:css:dev` to auto recompile for when you edit sass files.
 
 ### Platform Specific Installation Instructions
  - [Docker](doc/DOCKER.md)
@@ -140,22 +140,22 @@ If you are using Ubuntu on WSL and receive the following message when trying to 
 
 1. If your rails/rake commands hang forever instead of running, try: `rails app:update:bin`
 1. There is currently no option for a user to sign up and create an account through the UI. This is intentional. If you want to log in, use a pre-seeded user account and its credentials.
-1. If you are on windows and see the error "Requirements support for mingw is not implemented yet" then use https://rubyinstaller.org/ instead
+1. If you are on windows and see the error "Requirements support for mingw is not implemented yet" then use https://rubyinstaller.org/ instead.
 1. Install imagemagick to see images locally. Instructions: https://imagemagick.org/script/download.php
 
 ## Running the App / Verifying Installation
-1. `bin/rails server` or `bin/rails s` to start the local webserver
+1. `bin/rails server` or `bin/rails s` to start the local webserver.
 
 **Logging in with seed users**
 
 Login as a regular user at http://localhost:3000/users/sign_in. Some example seed users:
-- volunteer1@example.com    view site as a volunteer
-- supervisor1@example.com   view site as a supervisor
-- casa_admin1@example.com   view site as an admin
-- casa_admin2-1@example.com view site as admin from a different org
+- volunteer1@example.com    view site as a volunteer.
+- supervisor1@example.com   view site as a supervisor.
+- casa_admin1@example.com   view site as an admin.
+- casa_admin2-1@example.com view site as admin from a different org.
 
 Login as an all CASA admin at http://localhost:3000/all_casa_admins/sign_in. An example seed user:
-- allcasaadmin@example.com view site as an all CASA admin
+- allcasaadmin@example.com view site as an all CASA admin.
 
 The password for all seed users is `12345678`
 
@@ -165,20 +165,20 @@ We are using [Letter Opener](https://github.com/ryanb/letter_opener) in
 development to receive mail. All emails sent in development should open in a
 new tab in the browser.
 
-To see local email previews, check out http://localhost:3000/rails/mailers
+To see local email previews, check out, http://localhost:3000/rails/mailers
 
 **Running Tests**
- - run the ruby test suite `bin/rails spec`
- - run the javascript test suite `yarn test`
+ - Run the ruby test suite, `bin/rails spec`
+ - Run the javascript test suite, `yarn test`
 
 If you have trouble running tests, check out CI scripts in [`.github/workflows/`](.github/workflows/) for sample commands.
 Test coverage is run by simplecov on all builds and aggregated by CodeClimate
 
 **Cleaning up before you pull request**
-1. `bundle exec standardrb --fix` auto-fix Ruby linting issues [more linter info](https://github.com/testdouble/standard)
-1. `bundle exec erblint --lint-all --autocorrect` [ERB linter](https://github.com/Shopify/erb-lint)
-1. `yarn lint:fix` to run the [JS linter](https://standardjs.com/index.html) and fix issues
-1. `rake factory_bot:lint` if you have been editing factories and want to find factories and traits which produce invalid objects
+1. `bundle exec standardrb --fix` auto-fix Ruby linting issues [more linter info.](https://github.com/testdouble/standard)
+1. `bundle exec erblint --lint-all --autocorrect` [ERB linter.](https://github.com/Shopify/erb-lint)
+1. `yarn lint:fix` to run the [JS linter](https://standardjs.com/index.html) and fix issues.
+1. `rake factory_bot:lint` if you have been editing factories and want to find factories and traits which produce invalid objects.
 
 If additional work arises from your pull request that is outside the scope of the issue it resolves, please open a new issue.
 
@@ -206,12 +206,12 @@ which will run any database migrations, update gems and yarn packages, and run
 the after party post-deployment tasks.
 
 # Other Documentation
-Check out [the wiki](https://github.com/rubyforgood/casa/wiki)
+Check out [The wiki.](https://github.com/rubyforgood/casa/wiki)
 
 There is a `doc` directory at the top level that includes:
-* an `architecture-decisions` directory containing important architectural decisions and entity relationship diagrams of various models
+* An `architecture-decisions` directory containing important architectural decisions and entity relationship diagrams of various models
   (see the article [Architectural Decision Records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) describing this approach).
-* [Code of Conduct](doc/code-of-conduct.md)
+* [Code of Conduct.](doc/code-of-conduct.md)
 * [productsense.md](doc/productsense.md)(for team leads & product interested contributors)
 * [SECURITY.md](doc/SECURITY.md)
 


### PR DESCRIPTION
### What changed, and why?
A few typo errors were fixed in the README.md file including capitalization of alphabets and adding period and "," after the sentence 

### Feedback, please? (optional)
Yes, I would like to ask why did not anyone install it on Windows till now?
<img width="378" alt="image" src="https://github.com/rubyforgood/casa/assets/108126089/21f5ba56-1ecd-4d8a-9892-83d44375d570">
