### PR TITLE
Update Rswag initializers

### DIFF
--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -3,7 +3,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + "/swagger"
+  c.openapi_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -7,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+  c.openapi_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,15 +6,15 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join("swagger").to_s
+  config.openapi_root = Rails.root.join("swagger").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  config.openapi_specs = {
     "v1/swagger.yaml" => {
       openapi: "3.0.1",
       info: {
@@ -58,5 +58,5 @@ RSpec.configure do |config|
   # The swagger_docs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end


### PR DESCRIPTION
### What GitHub issue is this PR for?
[Resolves #5467](https://github.com/rubyforgood/casa/issues/5467)

### What changed, and why?
Update Rswag gem syntax, swapping out instances of `swagger_*` with `openapi_*`, due to below warning message when resetting the database:
`DEPRECATION WARNING: swagger_root= is deprecated and will be removed from rswag-api 3.0 (use openapi_root= instead) (called from block in <top (required)> at .../casa/config/initializers/rswag_api.rb:6)`

### How will this affect user permissions?
N/A

### How is this tested? (please write tests!) 💖💪
RSpec passed for `spec/requests/api/v1/users/sessions_spec.rb` and `spec/swagger_helper.rb`.

_I'm still a beginner in open source PR and junior with Rails, so apologies if it's wildly incorrect!_