### PR TITLE
Banner Dismissed Forever Bug fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :set_timeout_duration
   before_action :set_current_organization
+  before_action :set_active_banner
   after_action :verify_authorized, except: :index, unless: :devise_controller?
   # after_action :verify_policy_scoped, only: :index
 
@@ -28,6 +29,13 @@ class ApplicationController < ActionController::Base
     else
       root_path
     end
+  end
+
+  def set_active_banner
+    return nil unless current_organization
+
+    @active_banner = current_organization.banners.active.first
+    @active_banner = nil if session[:dismissed_banner] == @active_banner&.id
   end
 
   protected

--- a/app/javascript/controllers/dismiss_controller.js
+++ b/app/javascript/controllers/dismiss_controller.js
@@ -2,12 +2,19 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['element']
+  static values = {
+    url: String
+  }
 
   dismiss (event) {
     event.preventDefault()
 
-    const { id } = event.params
-    document.cookie = `dismiss_${id}=true`
-    this.elementTarget.classList.add('d-none')
+    fetch(this.urlValue)
+      .then(response => response.json())
+      .then(data => {
+        if (data.status === 'ok') {
+          this.elementTarget.classList.add('d-none')
+        }
+      })
   }
 }

--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,14 +1,10 @@
-<% banner = current_organization.banners.active.first %>
-<% if banner %>
-  <% cookie_id = "banner_#{banner.id}" %>
-  <% if !cookies["dismiss_#{cookie_id}"] %>
-    <div class="bg-secondary-100 text-xl p-5 d-flex" data-controller="dismiss" data-dismiss-target="element">
-      <div class="">
-        <%= banner.content %>
-      </div>
-      <div class="ms-auto">
-        <a href="#" data-action="click->dismiss#dismiss" data-dismiss-id-param="<%= cookie_id %>">Dismiss</a>
-      </div>
+<% if @active_banner %>
+  <div class="bg-secondary-100 text-xl p-5 d-flex" data-controller="dismiss" data-dismiss-target="element" data-dismiss-url-value="<%= dismiss_banner_path(@active_banner) %>">
+    <div class="">
+      <%= @active_banner.content %>
     </div>
-  <% end %>
+    <div class="ms-auto">
+      <a href="#" data-action="click->dismiss#dismiss">Dismiss</a>
+    </div>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,11 @@ Rails.application.routes.draw do
   resources :learning_hour_topics, only: %i[new create edit update]
   resources :followup_reports, only: :index
   resources :placement_reports, only: :index
-  resources :banners, only: %i[index new edit create update destroy]
+  resources :banners, except: %i[show] do
+    member do
+      get :dismiss
+    end
+  end
   resources :bulk_court_dates, only: %i[new create]
   resources :case_groups, only: %i[index new edit create update destroy]
   resources :learning_hours, only: %i[index show new create edit update destroy]

--- a/spec/requests/banners_spec.rb
+++ b/spec/requests/banners_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Banners", type: :request do
+  let!(:casa_org) { create(:casa_org) }
+  let!(:active_banner) { create(:banner, casa_org: casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: casa_org) }
+
+  context "when user dismisses a banner" do
+    subject do
+      get dismiss_banner_path(active_banner)
+    end
+
+    it "sets session variable" do
+      sign_in volunteer
+      subject
+      expect(session[:dismissed_banner]).to eq active_banner.id
+    end
+
+    it "does not display banner on page reloads" do
+      sign_in volunteer
+      get casa_cases_path
+      expect(response.body).to include "Please fill out this survey"
+
+      subject
+      get casa_cases_path
+      expect(response.body).not_to include "Please fill out this survey"
+    end
+
+    context "when user logs out and back in" do
+      it "nils out session variable" do
+        sign_in volunteer
+        subject
+        get destroy_user_session_path
+        sign_in volunteer
+
+        expect(session[:dismissed_banner]).to be_nil
+      end
+
+      it "displays banner" do
+        sign_in volunteer
+        subject
+        get destroy_user_session_path
+        sign_in volunteer
+
+        get casa_cases_path
+        expect(response.body).to include "Please fill out this survey"
+      end
+    end
+  end
+end

--- a/spec/system/banners/dismiss_spec.rb
+++ b/spec/system/banners/dismiss_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "banners/dismiss", type: :system, js: true do
+  let!(:casa_org) { create(:casa_org) }
+  let!(:active_banner) { create(:banner, casa_org: casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: casa_org) }
+
+  context "when user dismisses a banner" do
+    it "hides banner" do
+      sign_in volunteer
+
+      visit root_path
+      expect(page).to have_text("Please fill out this survey")
+
+      click_on "Dismiss"
+      expect(page).not_to have_text("Please fill out this survey")
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5428 

This is an alternate PR to #5452. It makes use of session variables so they are cleared automatically when a user logs out.

### What changed, and why?

1. The original implementation made use of a cookie, which persists past user sessions. This switches to use session storage, which is destroyed when a user logs out.
2. A few minor code changes to clean up original code.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
- spec/system/banners/dismiss_spec.rb
- spec/requests/banners_spec.rb

### Screenshots please :)
![Screenshot 2024-01-06 at 10 04 31 AM](https://github.com/rubyforgood/casa/assets/50247514/6c2e10cb-d313-4dd3-8ffb-65c33dee05d0)
![Screenshot 2024-01-06 at 10 04 25 AM](https://github.com/rubyforgood/casa/assets/50247514/51273963-09bb-41c8-aed8-493349129c3e)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
