### PR TITLE
Draft Case Contact Filter Fix

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -20,7 +20,7 @@ class CaseContactsController < ApplicationController
     ) || return
 
     case_contacts = CaseContact.case_hash_from_cases(@filterrific.find)
-    case_contacts = case_contacts.select { |k,_v| k == params[:casa_case_id].to_i } if params[:casa_case_id].present?
+    case_contacts = case_contacts.select { |k, _v| k == params[:casa_case_id].to_i } if params[:casa_case_id].present?
 
     @presenter = CaseContactPresenter.new(case_contacts)
   end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -20,6 +20,7 @@ class CaseContactsController < ApplicationController
     ) || return
 
     case_contacts = CaseContact.case_hash_from_cases(@filterrific.find)
+    case_contacts = case_contacts.select { |k,_v| k == params[:casa_case_id].to_i } if params[:casa_case_id].present?
 
     @presenter = CaseContactPresenter.new(case_contacts)
   end
@@ -107,11 +108,7 @@ class CaseContactsController < ApplicationController
   end
 
   def all_case_contacts
-    query = policy_scope(current_organization.case_contacts).includes(:creator, contact_types: :contact_type_group)
-    if params[:casa_case_id].present?
-      query = query.where(casa_case_id: params[:casa_case_id])
-    end
-    query
+    policy_scope(current_organization.case_contacts).includes(:creator, contact_types: :contact_type_group)
   end
 
   def additional_expense_params

--- a/app/views/learning_hours/_form.html.erb
+++ b/app/views/learning_hours/_form.html.erb
@@ -49,7 +49,7 @@
   </div>
   <div class="field-card mt-4">
     <h5 class="mb-3"><%= form.label :occurred_at, "Occurred On" %>:</h5>
-    <% occurred_at = learning_hour.occurred_at || Time.zone.now %>
+    <% occurred_at = learning_hour.occurred_at || Date.today %>
     <div class="input-style-1">
       <%= form.text_field :occurred_at,
                           value: occurred_at.to_date,

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
           end
         end
       end
+
+      describe "by casa_case_id" do
+        let!(:case_contact) { create(:case_contact, :details_status, creator: volunteer, draft_case_ids: [casa_case.id]) }
+        let!(:other_casa_case) { create(:casa_case, casa_org: organization, case_number: "CINA-2") }
+
+        it "displays the draft" do
+          sign_in volunteer
+          visit case_contacts_path(casa_case_id: casa_case.id)
+
+          expect(page).not_to have_content "You have no case contacts for this case."
+          expect(page).to have_content "Draft"
+        end
+
+        it "only displays the filtered case" do
+          sign_in volunteer
+          visit case_contacts_path(casa_case_id: casa_case.id)
+
+          expect(page).not_to have_content other_casa_case.case_number
+          expect(page).to have_content casa_case.case_number
+        end
+      end
     end
 
     describe "case contacts text color" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Did not create an issue

### What changed, and why?
Fixed Drafts not showing when only a single casa case was filtered.
![image (1)](https://github.com/rubyforgood/casa/assets/50247514/e693e654-34b5-425a-89dc-a23e88112d59)
![image](https://github.com/rubyforgood/casa/assets/50247514/4f4caed8-064c-4be2-8420-f298e3ad44f8)


### How will this affect user permissions?
None

### How is this tested? (please write tests!) 💖💪
- spec/system/case_contacts/index_spec.rb

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
