### PR TITLE
Add "YTD" to "Time Completed" Learning Hours Table Column

### DIFF
--- a/app/views/learning_hours/_supervisor_admin_learning_hours.html.erb
+++ b/app/views/learning_hours/_supervisor_admin_learning_hours.html.erb
@@ -18,7 +18,7 @@
             <thead>
             <tr>
               <th><h6>Volunteer</h6></th>
-              <th><h6>Time Completed</h6></th>
+              <th><h6>Time Completed YTD</h6></th>
             </tr>
             <!-- end table row-->
             </thead>

--- a/spec/requests/learning_hours_spec.rb
+++ b/spec/requests/learning_hours_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "LearningHours", type: :request do
 
       it "displays the time completed column" do
         get learning_hours_path
-        expect(response.body).to include("Time Completed")
+        expect(response.body).to include("Time Completed YTD")
       end
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe "LearningHours", type: :request do
 
       it "displays the time completed column" do
         get learning_hours_path
-        expect(response.body).to include("Time Completed")
+        expect(response.body).to include("Time Completed YTD")
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5486

### What changed, and why?
Update "Time Completed" column to "Time Completed YTD" On Learning Hours Table for supervisors and admins

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
modify existing test to test new requirement 

### Screenshots please :)
<img width="1663" alt="image" src="https://github.com/rubyforgood/casa/assets/79267974/a29ee923-98ca-4718-9a4b-041588f28a3f">


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
