### PR TITLE
volunteer's learning hours page

### DIFF
--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -52,7 +52,6 @@ end
 #  id                     :bigint           not null, primary key
 #  duration_hours         :integer          not null
 #  duration_minutes       :integer          not null
-#  learning_type          :integer          default(5)
 #  name                   :string           not null
 #  occurred_at            :datetime         not null
 #  created_at             :datetime         not null

--- a/app/policies/learning_hour_policy.rb
+++ b/app/policies/learning_hour_policy.rb
@@ -4,7 +4,7 @@ class LearningHourPolicy < ApplicationPolicy
   end
 
   def show?
-    record.user_id == @user.id
+    @user.casa_admin? || @user.supervisor? || record.user_id == @user.id
   end
 
   def new?

--- a/app/views/learning_hours/_supervisor_admin_learning_hours.html.erb
+++ b/app/views/learning_hours/_supervisor_admin_learning_hours.html.erb
@@ -25,7 +25,7 @@
             <tbody>
             <% @learning_hours.each do |learning_hour| %>
               <tr>
-                <td><%= link_to(learning_hour.display_name, volunteer_path(learning_hour.user_id)) %></td>
+                <td><%= link_to(learning_hour.display_name, learning_hour_path(learning_hour.user_id)) %></td>
                 <td><%= format_time(learning_hour.total_time_spent) %></td>
               </tr>
             <% end %>

--- a/app/views/learning_hours/index.html.erb
+++ b/app/views/learning_hours/index.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.volunteer? %>
   <%= render "volunteer_learning_hours", learning_hours: @learning_hours %>
 <% else %>
-  <%= render "supervisor_admin_learning_hours" %>
+  <%= render "supervisor_admin_learning_hours", learning_hours: @learning_hours %>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -395,7 +395,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
 
   create_table "learning_hours", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "learning_type", default: 5
     t.string "name", null: false
     t.integer "duration_minutes", null: false
     t.integer "duration_hours", null: false


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5474

### What changed, and why?
when a supervisor or admin clicks on a volunteer on the learning hours features it will route to the volunteer's learning page


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
log in as a supervisor or as an admin, click on the learning hours feature on the side, then click on a volunteer

### Screenshots please :)
![shot](https://github.com/rubyforgood/casa/assets/29228800/f200d211-ca0d-4fe5-a258-d425d62b03a5)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
