### PR TITLE
Implements contact_topics on CasaOrg and CaseContact models (fixes #5500)

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -51,6 +51,7 @@ services/fdf_inputs_service.rb
 validators/casa_org_validator.rb
 validators/court_report_validator.rb
 validators/user_validator.rb
+validators/contact_topics_validator.rb
 values/all_casa_admin_parameters.rb
 values/casa_admin_parameters.rb
 values/supervisor_parameters.rb

--- a/app/controllers/all_casa_admins/casa_orgs_controller.rb
+++ b/app/controllers/all_casa_admins/casa_orgs_controller.rb
@@ -12,7 +12,7 @@ class AllCasaAdmins::CasaOrgsController < AllCasaAdminsController
     @casa_org = CasaOrg.new(casa_org_params)
 
     if @casa_org.save
-      @casa_org.generate_contact_types_and_hearing_types
+      @casa_org.generate_defaults
       respond_to do |format|
         format.html do
           redirect_to all_casa_admins_casa_org_path(@casa_org),

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -13,6 +13,7 @@ class CaseContact < ApplicationRecord
   validate :reimbursement_only_when_miles_driven, if: :active_or_expenses?
   validate :volunteer_address_when_reimbursement_wanted, if: :active_or_expenses?
   validate :volunteer_address_is_valid, if: :active_or_expenses?
+  validates_with ContactTopicsValidator
 
   belongs_to :creator, class_name: "User"
   has_one :supervisor_volunteer, -> {
@@ -257,6 +258,11 @@ class CaseContact < ApplicationRecord
     end
   end
 
+  def contact_topics_from(source)
+    self.contact_topics = source.contact_topics
+    save!
+  end
+
   def self.options_for_sorted_by
     sorted_by_params.each.map { |option_pair| option_pair.reverse }
   end
@@ -290,6 +296,7 @@ end
 #
 #  id                         :bigint           not null, primary key
 #  contact_made               :boolean          default(FALSE)
+#  contact_topics             :jsonb
 #  deleted_at                 :datetime
 #  draft_case_ids             :integer          default([]), is an Array
 #  duration_minutes           :integer

--- a/app/models/contact_topics.rb
+++ b/app/models/contact_topics.rb
@@ -1,0 +1,16 @@
+class ContactTopics
+  CASA_DEFAULT_COURT_TOPICS = Rails.root.join("data", "default_contact_topics.yml")
+
+  class << self
+    def generate_for_org!(casa_org)
+      casa_org.contact_topics = default_contact_topics
+      casa_org.save!
+    end
+
+    private
+
+    def default_contact_topics
+      YAML.load_file(CASA_DEFAULT_COURT_TOPICS)
+    end
+  end
+end

--- a/app/validators/contact_topics_validator.rb
+++ b/app/validators/contact_topics_validator.rb
@@ -1,0 +1,16 @@
+class ContactTopicsValidator < ActiveModel::Validator
+  PERMITTED_ATTRIBUTES = %w[title details active].freeze
+
+  def validate(source)
+    contact_topics = Array.wrap(source.contact_topics)
+
+    contact_topics.each do |topic|
+      if !topic.is_a?(Hash)
+        source.errors.add(:contact_topics, "must be a hash or array of hashes")
+      elsif (topic.keys - PERMITTED_ATTRIBUTES).any?
+        source.errors.add(:contact_topics,
+          "expected keys: #{PERMITTED_ATTRIBUTES.join(", ")} got keys: #{topic.keys}")
+      end
+    end
+  end
+end

--- a/data/default_contact_topics.yml
+++ b/data/default_contact_topics.yml
@@ -1,0 +1,32 @@
+- title: "Background information"
+  details:
+    - "When did the family first come into contact with the Department of Social Services or Department of Juvenile Justice – how many times?"
+    - "Tell the history of their involvement with the department and any facts about their life that could help determine the need for placement and/or services."
+    - "Discuss the child’s history – behavior problems, educational history, medical history, psychological history (any hospitalizations, previous counseling, etc.)"
+    - "If child has been placed previously give a history of the child’s placements (placed with different parents, relatives, DSS, etc)."
+- title: "Current situation"
+  details:
+    - "Where is the child placed?"
+    - "How is the child adjusting to the placement?"
+    - "Are there any issues or concerns about the placement? If so, describe these concerns and specify the actions being taken to address them."
+- title: "Education, vocation, or daycare"
+  details:
+    - "Where is the child placed for education (daycare, public school, non-public school, GED, Job Corps, etc)?"
+    - "How is the child adjusting to the educational placement? Are there any education-related concerns at this point? If yes, detail them and mention the steps taken to address them."
+    - "Does the child have an IEP? If not, is there a need for one?"
+    - "Is the child employed? If not, are they looking for a job?"
+    - "Does the child have vocational/life skills? Are they attending life skill classes?"
+    - "Are there any other life skill needs? (Driver’s education, state ID, transportation assistance, etc.)"
+    - "What is the feedback from professionals providing these services about the child's progress? Include strengths and not just needs."
+- title: "Health and mental health"
+  details:
+    - "Is the child up to date with medical exams?"
+    - "Are there any other medical concerns?"
+    - "Is the child receiving therapy, medication monitoring, mentoring, or other services? If so, specify with whom these services are being received."
+- title: "Family and community connections"
+  details:
+    - "Is this child seeing parents, siblings, other relatives? If so, who is the child visiting, and how often? Does the child desire a different arrangement?"
+    - "Detail the steps parents have taken to address court orders. Address any barriers and highlight positive steps."
+- title: "Child’s strengths"
+  details:
+    - "Describe the child’s strengths, interests, and hobbies to provide a well-rounded perspective."

--- a/db/migrate/20240131210129_add_contact_topics_json_to_casa_org_and_case_contact.rb
+++ b/db/migrate/20240131210129_add_contact_topics_json_to_casa_org_and_case_contact.rb
@@ -1,0 +1,6 @@
+class AddContactTopicsJsonToCasaOrgAndCaseContact < ActiveRecord::Migration[7.0]
+  def change
+    add_column :casa_orgs, :contact_topics, :jsonb, default: []
+    add_column :case_contacts, :contact_topics, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_31_210129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -160,6 +160,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
     t.boolean "twilio_enabled", default: false
     t.boolean "additional_expenses_enabled", default: false
     t.boolean "learning_topic_active", default: false
+    t.jsonb "contact_topics", default: []
     t.index ["slug"], name: "index_casa_orgs_on_slug", unique: true
   end
 
@@ -201,6 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
     t.string "status", default: "started"
     t.integer "draft_case_ids", default: [], array: true
     t.string "volunteer_address"
+    t.jsonb "contact_topics", default: []
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"
     t.index ["deleted_at"], name: "index_case_contacts_on_deleted_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,7 @@ require_relative "seeds/db_populator"
 require_relative "../lib/tasks/data_post_processors/case_contact_populator"
 require_relative "../lib/tasks/data_post_processors/contact_type_populator"
 require_relative "../lib/tasks/data_post_processors/sms_notification_event_populator"
+require_relative "../lib/tasks/data_post_processors/contact_topic_populator"
 
 class SeederMain
   attr_reader :db_populator, :rng
@@ -76,6 +77,7 @@ class SeederMain
   def post_process_data
     ContactTypePopulator.populate
     CaseContactPopulator.populate
+    ContactTopicPopulator.populate
   end
 
   def get_seed_specification

--- a/lib/tasks/data_post_processors/contact_topic_populator.rb
+++ b/lib/tasks/data_post_processors/contact_topic_populator.rb
@@ -1,0 +1,7 @@
+module ContactTopicPopulator
+  def self.populate
+    CasaOrg.all.each do |casa_org|
+      ContactTopics.generate_for_org!(casa_org)
+    end
+  end
+end

--- a/spec/factories/casa_orgs.rb
+++ b/spec/factories/casa_orgs.rb
@@ -12,5 +12,13 @@ FactoryBot.define do
     trait :with_logo do
       logo { Rack::Test::UploadedFile.new(Rails.root.join("spec", "fixtures", "org_logo.jpeg")) }
     end
+
+    trait :no_twilio do
+      twilio_account_sid { nil }
+      twilio_api_key_secret { nil }
+      twilio_api_key_sid { nil }
+      twilio_phone_number { nil }
+      twilio_enabled { false }
+    end
   end
 end

--- a/spec/models/contact_topics_spec.rb
+++ b/spec/models/contact_topics_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ContactTopics, type: :model do
+  let(:casa_org) { build(:casa_org) }
+  let(:contact_topics) { [{"test" => "test"}] }
+  let(:permitted_attributes) { %w[test] }
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(contact_topics)
+
+    stub_const("ContactTopicsValidator::PERMITTED_ATTRIBUTES", permitted_attributes)
+  end
+
+  describe "sets the default topics for organization" do
+    let(:casa_org) { create(:casa_org, :no_twilio) }
+
+    it "sets the default topics for organization" do
+      expect(casa_org.contact_topics).to eq([])
+      ContactTopics.generate_for_org!(casa_org)
+      expect(casa_org.reload.contact_topics).to eq(contact_topics)
+    end
+  end
+end


### PR DESCRIPTION
This adds the model level behavior needed for contact topics. I thought this was a big enough PR to not want include request related stuff here.

### General Implementation

Topics are implements as a jsonb field on Organizations and CaseContacts in the form:
```
case_contact.contact_topics = 
[
    {"title" => "Main question", "details" =>["followup question", "followup question 2"], "active" => "true or false" },
    {...}, 
    ...
]
```

The allowed keys are set as `ContactTopicsValidator::PERMITTED_ATTRIBUTES`.

I created a Validator class for validations and ContactTopics for the main behavior itself. These could be combined but I was unsure if the behavior might grow so I separated them.

I was considering bringing in a gem to validate the json: https://github.com/voxpupuli/json-schema. I am not sure if that is too much for this case. Currently validations check the names of keys only.

#### Defaults

Defaults for topics are set during Organization creation, this is done in the controller. 

The values for defaults are set in `data/default_contact_topics.yml`. I don't know if this is the best place for this data or if it should by a .yml file.

### Tests

I created model tests. I wanted to create them as shared examples but the behavior differences were too large between CaseContacts and Orgs. 

I can't get the docker tests to pass even on main locally.

### Why JSON?

I initially wanted to use a polymorphic relationship the belongs_to org or case_contact. However, issues arose during the wizard that creates case_contacts:

![image](https://github.com/rubyforgood/casa/assets/14540596/f7104990-73ae-44c0-91a2-2188870cec47)

For the duration of the wizard the CaseContact is built but it is not saved to database till the end. That means that if I create CaseContactTopics I don't have a way to persist them, since CaseContact does not have an id to reference. 

Thus, I decided that I had to store the values of topics on the object directly, same as the `notes` field.

### What github issue is this PR for, if any?
Resolves #5500 partially