### PR TITLE
make bin/setup run without error

### DIFF
--- a/db/migrate/20230729145310_add_reference_learning_hour_types.rb
+++ b/db/migrate/20230729145310_add_reference_learning_hour_types.rb
@@ -2,6 +2,7 @@ class AddReferenceLearningHourTypes < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_reference :learning_hours, :learning_hour_type, validate: false, index: {algorithm: :concurrently}
+    # add_reference :learning_hours, :learning_hour_type, validate: false, index: {algorithm: :concurrently}
+    add_reference :learning_hours, :learning_hour_type, index: {algorithm: :concurrently}
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_25_150721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -395,7 +395,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
 
   create_table "learning_hours", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "learning_type", default: 5
     t.string "name", null: false
     t.integer "duration_minutes", null: false
     t.integer "duration_hours", null: false
@@ -648,7 +647,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_150721) do
   add_foreign_key "patch_notes", "patch_note_groups"
   add_foreign_key "patch_notes", "patch_note_types"
   add_foreign_key "placement_types", "casa_orgs"
-  add_foreign_key "placements", "casa_cases"
+  add_foreign_key "placements", "casa_cases", validate: false
   add_foreign_key "placements", "placement_types"
   add_foreign_key "placements", "users", column: "creator_id"
   add_foreign_key "preference_sets", "users"


### PR DESCRIPTION
<img width="825" alt="Screenshot 2024-02-05 at 11 35 34 PM" src="https://github.com/rubyforgood/casa/assets/578159/d9ecf3c1-509c-4f07-9c06-e5ee96fca623">


Fix error:
```

== 20230729145310 AddReferenceLearningHourTypes: migrating ====================
-- add_reference(:learning_hours, :learning_hour_type, {:validate=>false, :index=>{:algorithm=>:concurrently}})
bin/rails aborted!
StandardError: An error has occurred, all later migrations canceled: (StandardError)

Unknown key: :validate. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :array, :using, :cast_as, :as, :type, :enum_type, :stored
/Users/compiledwrong/repositories/casa/db/migrate/20230729145310_add_reference_learning_hour_types.rb:5:in `change'

Caused by:
ArgumentError: Unknown key: :validate. Valid keys are: :limit, :precision, :scale, :default, :null, :collation, :comment, :primary_key, :if_exists, :if_not_exists, :array, :using, :cast_as, :as, :type, :enum_type, :stored (ArgumentError)

        raise ArgumentError.new("Unknown key: #{k.inspect}. Valid keys are: #{valid_keys.map(&:inspect).join(', ')}")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/compiledwrong/repositories/casa/db/migrate/20230729145310_add_reference_learning_hour_types.rb:5:in `change'
Tasks: TOP => db:prepare
(See full trace by running task with --trace)
bin/setup:8:in `system': Command failed with exit 1: bin/rails (RuntimeError)
	from bin/setup:8:in `system!'
	from bin/setup:31:in `block in <main>'
	from /Users/compiledwrong/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/fileutils.rb:244:in `chdir'
	from /Users/compiledwrong/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/fileutils.rb:244:in `cd'
	from bin/setup:11:in `<main>'
```