### PR TITLE
Fixes bugsnag console message

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,11 +1,15 @@
-Bugsnag.configure do |config|
-  config.api_key = ENV["BUGSNAG_API_KEY"]
-  config.ignore_classes << ActiveRecord::RecordNotFound
-  config.release_stage = ENV["HEROKU_APP_NAME"] || ENV["APP_ENVIRONMENT"]
+if ENV["BUGSNAG_API_KEY"].present?
+  Bugsnag.configure do |config|
+    config.api_key = ENV["BUGSNAG_API_KEY"]
+    config.ignore_classes << ActiveRecord::RecordNotFound
+    config.release_stage = ENV["HEROKU_APP_NAME"] || ENV["APP_ENVIRONMENT"]
 
-  callback = proc do |event|
-    event.set_user(current_user&.id, current_user&.email)
+    callback = proc do |event|
+      event.set_user(current_user&.id, current_user&.email)
+    end
+
+    config.add_on_error(callback)
   end
-
-  config.add_on_error(callback)
+else
+  Bugsnag.configuration.logger = ::Logger.new("/dev/null")
 end


### PR DESCRIPTION
Without an API key bugsnag displays the following warning: 
```sh
Not delivering sessions due to an invalid api_key
```

It is something that new people often get worried about and is very annoying when using irb for debugging. This PR sends that warning to `dev/null` if an API key is not provided.

Solution take from [here](https://github.com/chaskiq/chaskiq/issues/251#issuecomment-1813804184)
