### PR TITLE
5501 Bug in Case Contacts AfterParty task

### DIFF
--- a/lib/tasks/data_post_processors/case_contact_populator.rb
+++ b/lib/tasks/data_post_processors/case_contact_populator.rb
@@ -1,6 +1,10 @@
 module CaseContactPopulator
   def self.populate
     CaseContact.find_each do |case_contact|
+      # Get rid of drafts
+      unless case_contact.casa_case
+        case_contact.destroy
+      end
       casa_org = case_contact.casa_case.casa_org
       case_contact.contact_types&.each do |contact_type|
         ct_name = contact_type.name

--- a/lib/tasks/deployment/20231125151610_set_case_contacts_as_active.rake
+++ b/lib/tasks/deployment/20231125151610_set_case_contacts_as_active.rake
@@ -3,7 +3,7 @@ namespace :after_party do
   task set_case_contacts_as_active: :environment do
     puts "Running deploy task 'set_case_contacts_as_active'"
 
-    CaseContact.all.each do |cc|
+    CaseContact.where.not(casa_case_id: nil).each do |cc|
       cc.additional_expenses.each do |additional_expense|
         additional_expense.update(other_expenses_describe: "No description given") unless additional_expense.other_expenses_describe
       end

--- a/lib/tasks/deployment/20231125151610_set_case_contacts_as_active.rake
+++ b/lib/tasks/deployment/20231125151610_set_case_contacts_as_active.rake
@@ -4,6 +4,10 @@ namespace :after_party do
     puts "Running deploy task 'set_case_contacts_as_active'"
 
     CaseContact.all.each do |cc|
+      cc.additional_expenses.each do |additional_expense|
+        additional_expense.update(other_expenses_describe: "No description given") unless additional_expense.other_expenses_describe
+      end
+
       cc.update!(status: "active", draft_case_ids: [cc.casa_case_id])
     rescue => e
       begin


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5501 

### What changed, and why?
There are some additional expenses in the database that would no longer be considered valid. The update of the older Case Contacts is causing the validation on these to fail. This is reproducible given the following steps:

1. Reseed your database: `rails db:seed:replant`
2. In `app/models/additional_expense.rb` comment out the validation line
3. Make a new soon-to-be-invalid Additional Expense in the console: `CaseContact.first.additional_expenses.create!`
4. Set the specified CaseContact as a draft: `CaseContact.first.update(status: "started")`
5. Uncomment the validation line from step 2
6. Comment out the fix in this pull request from `lib/tasks/deployment/20231125151610_set_case_contacts_as_active.rake` (lines 7-9)
7. Run AfterParty: `bundle exec rake after_party:run`. It should fail.
8. Uncomment the fix in step 6
9. Run AfterParty: `bundle exec rake after_party:run`. It should pass.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
