### PR TITLE
Modify helpsite link for volunteers

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -86,6 +86,7 @@
                 </li>
               <% end %>
               <li>
+                <% help_url = current_user.volunteer? ? help_volunteers_url : help_admins_supervisors_url %>
                 <%= link_to help_url, target: :_blank do %>
                   <i class="lni lni-question-circle"></i>
                   Help

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,8 +199,12 @@ Rails.application.routes.draw do
     delete :remove_from_volunteer
   end
 
-  direct :help do
+  direct :help_admins_supervisors do
     "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa"
+  end
+
+  direct :help_volunteers do
+    "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-Volunteers-c24d9d2ef8b249bbbda8192191365039?pvs=4"
   end
 
   get "/error", to: "error#index"

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "layout/header", type: :view do
 
     it "renders help issue link on the header" do
       render partial: "layouts/header"
-      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
+      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-Volunteers-c24d9d2ef8b249bbbda8192191365039?pvs=4")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5531.

### What changed, and why?
If a user is a volunteer the link of the helpsite is different. The helpsite for admins and supervisors is unchanged.

### How will this affect user permissions?
- Volunteer permissions: n/a
- Supervisor permissions: n/a
- Admin permissions: n/a

### How is this tested? (please write tests!) 💖💪
Modified `spec/views/layouts/header.html.erb_spec.rb`

### Screenshots please :)
- Volunteer
<img width="975" alt="volunteer" src="https://github.com/rubyforgood/casa/assets/85654561/9ac5cac3-6881-416c-94ce-337e358cadd5">

- Admin
<img width="974" alt="admin" src="https://github.com/rubyforgood/casa/assets/85654561/5cc82393-0d32-4167-bfce-aefa8af05dac">

- Supervisor
<img width="974" alt="supervisor" src="https://github.com/rubyforgood/casa/assets/85654561/4932761e-54f1-4216-a67f-5979194a97ca">

