### PR TITLE
Line Chart: MAU (Monthly Active Users) and WAU (Weekly Active Users) by User type

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -38,4 +38,23 @@ class HealthController < ApplicationController
 
     render json: monthly_line_graph_combined_data
   end
+
+  def monthly_unique_users_graph_data
+    first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month }
+
+    monthly_counts_of_volunteers = User.where(type: "Volunteer").group_by_month(:current_sign_in_at, format: "%b %Y").count
+    monthly_counts_of_supervisors = User.where(type: "Supervisor").group_by_month(:current_sign_in_at, format: "%b %Y").count
+    monthly_counts_of_casa_admins = User.where(type: "CasaAdmin").group_by_month(:current_sign_in_at, format: "%b %Y").count
+
+    monthly_line_graph_combined_data = first_day_of_last_12_months.map do |month|
+      [
+        month.strftime("%b %Y"),
+        monthly_counts_of_volunteers[month.strftime("%b %Y")] || 0,
+        monthly_counts_of_supervisors[month.strftime("%b %Y")] || 0,
+        monthly_counts_of_casa_admins[month.strftime("%b %Y")] || 0
+      ]
+    end
+
+    render json: monthly_line_graph_combined_data
+  end
 end

--- a/app/javascript/src/display_app_metric.js
+++ b/app/javascript/src/display_app_metric.js
@@ -26,14 +26,14 @@ $(() => { // JQuery's callback for the DOM loading
   if (monthLineChart) {
     fetchDataAndCreateChart('/health/monthly_line_graph_data', monthLineChart, function (data) {
       console.log(data)
-      createLineChart(monthLineChart, data)
+      createLineChartForCaseContacts(monthLineChart, data)
     })
   }
 
   if (uniqueUsersMonthLineChart) {
     fetchDataAndCreateChart('/health/monthly_unique_users_graph_data', uniqueUsersMonthLineChart, function (data) {
       console.log(data)
-      createUniqueUsersMonthLineChart(uniqueUsersMonthLineChart, data)
+      createLineChartForUniqueUsersMonthly(uniqueUsersMonthLineChart, data)
     })
   }
 
@@ -164,47 +164,36 @@ function getTooltipLabelCallback (context) {
   return `${Math.round(caseContactCountSqrt * caseContactCountSqrt)} case contacts created on ${days[bubbleData.y]} at ${bubbleData.x}:00`
 }
 
-function createLineChart (chartElement, dataset) {
-  const ctx = chartElement.getContext('2d')
-
-  const allMonths = extractChartData(dataset, 0)
-  const allCaseContactsCount = extractChartData(dataset, 1)
-  const allCaseContactNotesCount = extractChartData(dataset, 2)
-  const allUsersCount = extractChartData(dataset, 3)
-
-  return new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: allMonths,
-      datasets: [
-        createLineChartDataset('Total Case Contacts', allCaseContactsCount, '#308af3', '#308af3'),
-        createLineChartDataset('Total Case Contacts with Notes', allCaseContactNotesCount, '#48ba16', '#48ba16'),
-        createLineChartDataset('Total Case Contact Users', allUsersCount, '#FF0000', '#FF0000')
-      ]
-    },
-    options: createChartOptions()
-  })
+function createLineChartForCaseContacts (chartElement, dataset) {
+  const datasetLabels = ['Total Case Contacts', 'Total Case Contacts with Notes', 'Total Case Contact Users']
+  return createLineChart(chartElement, dataset, 'Case Contact Creation', datasetLabels)
 }
 
-function createUniqueUsersMonthLineChart(chartElement, dataset) {
-  const ctx = chartElement.getContext('2d')
+function createLineChartForUniqueUsersMonthly (chartElement, dataset) {
+  const datasetLabels = ['Total Volunteers', 'Total Supervisors', 'Total Admins']
+  return createLineChart(chartElement, dataset, 'Monthly Active Users', datasetLabels)
+}
 
+function createLineChart (chartElement, dataset, chartTitle, datasetLabels) {
+  const ctx = chartElement.getContext('2d')
   const allMonths = extractChartData(dataset, 0)
-  const monthlyCountOfVolunteers = extractChartData(dataset, 1)
-  const monthlyCountOfSupervisors = extractChartData(dataset, 2)
-  const monthlyCountOfAdmins = extractChartData(dataset, 3)
+  const datasets = []
+  const colors = ['#308af3', '#48ba16', '#FF0000']
+
+  for (let i = 1; i < dataset[0].length; i++) {
+    const data = extractChartData(dataset, i)
+    const label = datasetLabels[i - 1]
+    const color = colors[i - 1]
+    datasets.push(createLineChartDataset(label, data, color, color))
+  }
 
   return new Chart(ctx, {
     type: 'line',
     data: {
       labels: allMonths,
-      datasets: [
-        createLineChartDataset('Total Volunteers', monthlyCountOfVolunteers, '#308af3', '#308af3'),
-        createLineChartDataset('Total Supervisors', monthlyCountOfSupervisors, '#48ba16', '#48ba16'),
-        createLineChartDataset('Total Admins', monthlyCountOfAdmins, '#FF0000', '#FF0000')
-      ]
+      datasets
     },
-    options: createChartOptions()
+    options: createChartOptions(chartTitle)
   })
 }
 
@@ -226,7 +215,7 @@ function createLineChartDataset (label, data, borderColor, pointBackgroundColor)
   }
 }
 
-function createChartOptions () {
+function createChartOptions (label) {
   return {
     legend: { display: true },
     plugins: {
@@ -234,7 +223,7 @@ function createChartOptions () {
       title: {
         display: true,
         font: { size: 18 },
-        text: 'Case Contact Creation'
+        text: label
       },
       tooltips: {
         callbacks: {

--- a/app/javascript/src/display_app_metric.js
+++ b/app/javascript/src/display_app_metric.js
@@ -10,6 +10,7 @@ const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 
 $(() => { // JQuery's callback for the DOM loading
   const caseContactCreationTimesBubbleChart = document.getElementById('caseContactCreationTimeBubbleChart')
   const monthLineChart = document.getElementById('monthLineChart')
+  const uniqueUsersMonthLineChart = document.getElementById('uniqueUsersMonthLineChart')
 
   const notificationsElement = $('#notifications')
   const pageNotifier = notificationsElement.length ? new Notifier(notificationsElement) : null
@@ -26,6 +27,13 @@ $(() => { // JQuery's callback for the DOM loading
     fetchDataAndCreateChart('/health/monthly_line_graph_data', monthLineChart, function (data) {
       console.log(data)
       createLineChart(monthLineChart, data)
+    })
+  }
+
+  if (uniqueUsersMonthLineChart) {
+    fetchDataAndCreateChart('/health/monthly_unique_users_graph_data', uniqueUsersMonthLineChart, function (data) {
+      console.log(data)
+      createUniqueUsersMonthLineChart(uniqueUsersMonthLineChart, data)
     })
   }
 
@@ -172,6 +180,28 @@ function createLineChart (chartElement, dataset) {
         createLineChartDataset('Total Case Contacts', allCaseContactsCount, '#308af3', '#308af3'),
         createLineChartDataset('Total Case Contacts with Notes', allCaseContactNotesCount, '#48ba16', '#48ba16'),
         createLineChartDataset('Total Case Contact Users', allUsersCount, '#FF0000', '#FF0000')
+      ]
+    },
+    options: createChartOptions()
+  })
+}
+
+function createUniqueUsersMonthLineChart(chartElement, dataset) {
+  const ctx = chartElement.getContext('2d')
+
+  const allMonths = extractChartData(dataset, 0)
+  const monthlyCountOfVolunteers = extractChartData(dataset, 1)
+  const monthlyCountOfSupervisors = extractChartData(dataset, 2)
+  const monthlyCountOfAdmins = extractChartData(dataset, 3)
+
+  return new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: allMonths,
+      datasets: [
+        createLineChartDataset('Total Volunteers', monthlyCountOfVolunteers, '#308af3', '#308af3'),
+        createLineChartDataset('Total Supervisors', monthlyCountOfSupervisors, '#48ba16', '#48ba16'),
+        createLineChartDataset('Total Admins', monthlyCountOfAdmins, '#FF0000', '#FF0000')
       ]
     },
     options: createChartOptions()

--- a/app/views/health/index.html.erb
+++ b/app/views/health/index.html.erb
@@ -1,4 +1,5 @@
 <div id="health">
   <canvas id="caseContactCreationTimeBubbleChart"></canvas>
   <canvas id="monthLineChart" class="mt-5"></canvas>
+  <canvas id="uniqueUsersMonthLineChart" class="mt-5"></canvas>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     collection do
       get :case_contacts_creation_times_in_last_week
       get :monthly_line_graph_data
+      get :monthly_unique_users_graph_data
     end
   end
 

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -68,4 +68,30 @@ RSpec.describe "Health", type: :request do
       expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
     end
   end
+
+  describe "GET #monthly_unique_users_graph_data" do
+    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year" do
+      create(:user, type: "Volunteer", current_sign_in_at: 11.months.ago)
+      create(:user, type: "Volunteer", current_sign_in_at: 11.months.ago)
+      create(:user, type: "Supervisor", current_sign_in_at: 11.months.ago)
+      create(:user, type: "CasaAdmin", current_sign_in_at: 11.months.ago)
+      create(:user, type: "Volunteer", current_sign_in_at: 10.months.ago)
+      create(:user, type: "Volunteer", current_sign_in_at: 9.months.ago)
+      create(:user, type: "Supervisor", current_sign_in_at: 9.months.ago)
+      create(:user, type: "CasaAdmin", current_sign_in_at: 9.months.ago)
+
+      get monthly_unique_users_graph_data_health_index_path
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("application/json")
+
+      chart_data = JSON.parse(response.body)
+      expect(chart_data).to be_an(Array)
+      expect(chart_data.length).to eq(12)
+
+      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 1])
+      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 0])
+      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
+      expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5530 

### What changed, and why?
New functionality to display active users chart

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Need to add

### Screenshots please :)

![CASA-Monthly-Active-Users](https://github.com/rubyforgood/casa/assets/514363/c6f7f947-46ee-4d7f-a7f9-9d9032b718f6)
