### PR TITLE
add error to Bugsnag for StandardError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   after_action :verify_authorized, except: :index, unless: :devise_controller?
   # after_action :verify_policy_scoped, only: :index
 
+  KNOWN_ERRORS = [Pundit::NotAuthorizedError, Organizational::UnknownOrganization]
   rescue_from StandardError, with: :log_and_reraise
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
@@ -138,7 +139,9 @@ class ApplicationController < ActionController::Base
   end
 
   def log_and_reraise(error)
-    Bugsnag.notify(error)
+    unless KNOWN_ERRORS.include?(error.class)
+      Bugsnag.notify(error)
+    end
     raise
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,9 +13,9 @@ class ApplicationController < ActionController::Base
   after_action :verify_authorized, except: :index, unless: :devise_controller?
   # after_action :verify_policy_scoped, only: :index
 
+  rescue_from StandardError, with: :log_and_reraise
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
-  rescue_from StandardError, with: :log_and_reraise
 
   impersonates :user
 
@@ -139,7 +139,7 @@ class ApplicationController < ActionController::Base
 
   def log_and_reraise(error)
     Bugsnag.notify(error)
-    raise error
+    raise
   end
 
   def check_unconfirmed_email_notice(user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
   rescue_from Organizational::UnknownOrganization, with: :not_authorized
+  rescue_from StandardError, with: :log_and_reraise
 
   impersonates :user
 
@@ -134,6 +135,11 @@ class ApplicationController < ActionController::Base
     session[:user_return_to] = nil
     flash[:notice] = "Sorry, you are not authorized to perform this action."
     redirect_to(root_url)
+  end
+
+  def log_and_reraise(error)
+    Bugsnag.notify(error)
+    raise error
   end
 
   def check_unconfirmed_email_notice(user)

--- a/public/403.html
+++ b/public/403.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>We're sorry, but something went wrong (403)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {


### PR DESCRIPTION
Fix 403 error page to say 403, and add error to Bugsnag for StandardError

Currently bugsnag errors are visible in discord https://discord.gg/87Afg5fZ
<img width="131" alt="Screenshot 2024-04-14 at 10 12 52 PM" src="https://github.com/rubyforgood/casa/assets/578159/288a25a3-9023-4bb0-a014-c1709127a188">

