### PR TITLE
 Bug: Supervisor Weekly Mailer Lists Too Many Inactive Volunteers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,9 @@ class User < ApplicationRecord
     where(casa_org_id: org.id)
   }
 
-  scope :no_recent_sign_in, -> { active.where("last_sign_in_at <= ?", 30.days.ago).or(User.active.where(last_sign_in_at: nil)) }
+  scope :no_recent_sign_in, -> {
+    active.where("last_sign_in_at <= ? or last_sign_in_at is null", 30.days.ago)
+  }
 
   def casa_admin?
     is_a?(CasaAdmin)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -264,11 +264,15 @@ RSpec.describe User, type: :model do
   end
 
   describe ".no_recent_sign_in" do
-    let!(:old_sign_in_user) { create(:user, last_sign_in_at: 39.days.ago) }
-    let!(:recently_signed_in_user) { create(:user, last_sign_in_at: 5.days.ago) }
-
     it "returns users who haven't signed in in 30 days" do
+      old_sign_in_user = create(:user, last_sign_in_at: 39.days.ago)
+      create(:user, last_sign_in_at: 5.days.ago)
       expect(User.no_recent_sign_in).to contain_exactly(old_sign_in_user)
+    end
+
+    it "returns users who haven't signed in ever" do
+      user = create(:user, last_sign_in_at: nil)
+      expect(User.no_recent_sign_in).to contain_exactly(user)
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5511

### What changed, and why?

In the supervisor weekly digest email, the "inactive volunteers" list included users who were not related to the supervisor.

This was due to a bug in `User#no_recent_sign_in`

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪

See unit tests.

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
