### PR TITLE
Remove www subdomain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include Users::TimeZone
 
   protect_from_forgery
+  before_action :remove_www_subdomain
   before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
   before_action :set_current_user
@@ -140,5 +141,11 @@ class ApplicationController < ActionController::Base
       notice += " Confirmation Email Sent."
     end
     notice
+  end
+
+  def remove_www_subdomain
+    if /^www/.match?(request.host)
+      redirect_to request.url.sub("www.", ""), allow_other_host: true
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
N/A

### What changed, and why?
This would redirect www.casavolunteertracking.org to casavolunteertracking.org (something that Heroku doesn't do). It does require a wildcard SSL certificate, though.

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
