### PR TITLE
Fix for Case Contact chart for Case Contact with notes calculation

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -24,7 +24,7 @@ class HealthController < ApplicationController
     first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month }
 
     monthly_counts_of_case_contacts_created = CaseContact.group_by_month(:created_at, last: 12).count
-    monthly_counts_of_case_contacts_with_notes_created = CaseContact.where("notes != ''").group_by_month(:created_at, last: 12).count
+    monthly_counts_of_case_contacts_with_notes_created = CaseContact.left_outer_joins(:contact_topic_answers).where("case_contacts.notes != '' OR contact_topic_answers.value != ''").select(:id).distinct.group_by_month(:created_at, last: 12).count
     monthly_counts_of_users_who_have_created_case_contacts = CaseContact.select(:creator_id).distinct.group_by_month(:created_at, last: 12).count
 
     monthly_line_graph_combined_data = first_day_of_last_12_months.map do |month|

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe "Health", type: :request do
       create(:case_contact, created_at: 10.months.ago)
       create(:case_contact, created_at: 9.months.ago)
 
+      # Create associated contact_topic_answers
+      create(:contact_topic_answer, case_contact: CaseContact.first)
+      create(:contact_topic_answer, case_contact: CaseContact.last) 
+
       get monthly_line_graph_data_health_index_path
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to include("application/json")
@@ -64,7 +68,7 @@ RSpec.describe "Health", type: :request do
 
       expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 2])
       expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 1])
-      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 0, 1])
+      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
       expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
     end
   end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Health", type: :request do
 
       # Create associated contact_topic_answers
       create(:contact_topic_answer, case_contact: CaseContact.first)
-      create(:contact_topic_answer, case_contact: CaseContact.last) 
+      create(:contact_topic_answer, case_contact: CaseContact.last)
 
       get monthly_line_graph_data_health_index_path
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5591 

### What changed, and why?
Recently, contact_topic_answers was introduced so calculation for the chart needs to be updated to consider both case contact notes as well as contact_topic_answers values

### How will this affect user permissions?
- Volunteer permissions: NA
- Supervisor permissions: NA
- Admin permissions: NA

### How is this tested? (please write tests!) 💖💪
Added test code to check values

### Screenshots please :)
![CASA-Case-Contact-Chart png](https://github.com/rubyforgood/casa/assets/514363/f2951d0a-df11-4294-94d9-a80563b10701)

### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
