### PR TITLE
Filtered reports generation

### DIFF
--- a/app/assets/stylesheets/base/variables.scss
+++ b/app/assets/stylesheets/base/variables.scss
@@ -5,3 +5,9 @@ $red: #dc3545;
 $sidebar-inactive: #9AA4CA;
 $sidebar-active: #365CF5;
 $sidebar-dark: #1A2142;
+
+:root {
+  --dark: #262d3f; 
+  --gray: #5d657b;
+  --silver: #D9D9D9;
+}

--- a/app/assets/stylesheets/pages/casa_cases.scss
+++ b/app/assets/stylesheets/pages/casa_cases.scss
@@ -113,3 +113,52 @@ body.casa_cases-show {
     display: block;
   }
 }
+
+#generate-docx-report-modal {
+  .dates-container {
+    display: flex;
+  }
+
+  .docx-report__modal-body {
+    display: flex;
+    flex-direction: column;
+    row-gap: 1rem;
+
+  }
+
+  .modal-footer {
+    [data-bs-dismiss="modal"] {
+      padding-block: 11px;
+    }
+  }
+}
+
+.generate-report-button {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  border: solid 1px var(--silver);
+  padding: 1.2rem;
+  column-gap: 1.2rem;
+
+  &:hover {
+    border-color: black;
+  }
+
+  svg {
+    min-inline-size: 40px;
+    width: 40px;
+    height: auto;
+  }
+
+  div {
+    text-align: left;
+    h3 {
+      margin-block-end: .25rem;
+
+    }
+    p {
+
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/typography.scss
+++ b/app/assets/stylesheets/shared/typography.scss
@@ -1,4 +1,5 @@
 // TODO check in css so tests can run without internet
+@use "../base/variables.scss" as globals;
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
 
 body {
@@ -13,12 +14,16 @@ option {
   font-family: Inter;
   font-size: 16px;
   font-weight: 500;
+  line-height: 19px;
+  color: var(--dark);
 }
 
 .content-2 {
   font-family: Inter;
   font-size: 14px;
   font-weight: 500;
+  line-height: 22px;
+  color: var(--gray)
 }
 
 .content-3 {

--- a/app/components/modal/footer_component.html.erb
+++ b/app/components/modal/footer_component.html.erb
@@ -1,4 +1,4 @@
 <div class="modal-footer <%= @class %>">
-  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+  <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Close</button>
   <%= content %>
 </div>

--- a/app/components/modal/open_button_component.html.erb
+++ b/app/components/modal/open_button_component.html.erb
@@ -1,4 +1,4 @@
-<button type="button" class="btn <%= @class %>" data-bs-toggle="modal" data-bs-target="<%= "##{@target}" %>">
+<button type="button" class="<%= @class %>" data-bs-toggle="modal" data-bs-target="<%= "##{@target}" %>">
   <% if @icon %>
     <i class="lni mr-10 lni-<%= @icon %>"></i>
   <% end %>

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -56,20 +56,24 @@ function copyOrdersFromCaseAction (id, caseNumber) {
 }
 
 function showBtn (el) {
+  if (!el) return
   el.classList.remove('d-none')
 }
 
 function hideBtn (el) {
+  if (!el) return
   el.classList.add('d-none')
 }
 
 function disableBtn (el) {
+  if (!el) return
   el.disabled = true
   el.classList.add('disabled')
   el.setAttribute('aria-disabled', true)
 }
 
 function enableBtn (el) {
+  if (!el) return
   el.disabled = false
   el.classList.remove('disabled')
   el.removeAttribute('aria-disabled')
@@ -101,6 +105,7 @@ function handleGenerateReport (e) {
     body: JSON.stringify(formData)
   }
   showBtn(spinner)
+  hideBtn($('#btnGenerateReport .lni-download')[0])
   window.fetch(url, options)
     .then(response => {
       return response.json()
@@ -113,6 +118,7 @@ function handleGenerateReport (e) {
         return
       }
       hideBtn(spinner)
+      showBtn($('#btnGenerateReport .lni-download')[0])
       enableBtn(generateBtn)
       window.open(data.link, '_blank')
     })

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -158,6 +158,12 @@ class CasaCase < ApplicationRecord
     court_dates.where("date < ?", Date.today).order(:date).last
   end
 
+  def formatted_latest_court_date
+    most_recent = most_recent_past_court_date&.date&.in_time_zone || Time.zone.now
+
+    most_recent.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT)
+  end
+
   def has_judge_name?
     judge_name
   end

--- a/app/models/case_court_report_context.rb
+++ b/app/models/case_court_report_context.rb
@@ -57,8 +57,8 @@ class CaseCourtReportContext
   end
 
   def filtered_interviewees
-    # this query is slow
-    CaseContactContactType.includes(:case_contact, :contact_type)
+    CaseContactContactType
+      .joins(:contact_type, case_contact: :casa_case)
       .where("case_contacts.casa_case_id": @casa_case.id)
       .where("case_contacts.occurred_at": @date_range)
   end

--- a/app/views/casa_cases/_generate_report_modal.html.erb
+++ b/app/views/casa_cases/_generate_report_modal.html.erb
@@ -1,0 +1,56 @@
+<%= form_with url: generate_case_court_reports_path, local: false do |form| %>
+  <% id = "generate-docx-report-modal" %>
+  <%= render(Modal::OpenButtonComponent.new(
+    target: id,
+    klass: "d-inline main-btn btn-hover btn-sm success-btn pull-right mb-2")) do %>
+    Generate Report
+  <% end %>
+  <%= render(Modal::GroupComponent.new(id: id)) do |component| %>
+    <% component.with_header(text: "Download Court Report as a .docx", id: id, klass: "content-1") %>
+    <% component.with_body do %>
+      <div class="docx-report__modal-body">
+      <p class="content-3 md-10">
+      To download a court report specify the date range.
+      </p>
+      <div class="input-style-1" id="case_select_body">
+        <%= form.hidden_field :case_number, value: @casa_case.case_number %>
+        <%= form.hidden_field :time_zone, id: "user-time-zone" %>
+        <h4 class="mb-10">Casa Case:</h4>
+        <p><%= @casa_case.decorate.court_report_select_option.first %></p>
+      </div>
+      <div class="dates-container">
+        <div class="field form-group mb-20">
+          <h6><label class="form-label" for="start_date">Starting From</label></h6>
+          <%= form.text_field :start_date,
+            value: Time.zone.now.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
+            data: { provide: "datepicker",
+                    date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+                    class: "form-control" %>
+        </div>
+
+        <div class="field form-group mb-20">
+          <h6><label class="form-label" for="end_date">Ending At</label></h6>
+          <%= form.text_field :end_date,
+            value: Time.zone.now.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
+            data: { provide: "datepicker",
+                    date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+                    class: "form-control" %>
+        </div>
+      </div>
+      </div>
+    <% end %>
+    <% component.with_footer do %>
+        <%= button_tag type: :submit,
+          data: {
+            button_name: "Generate Report"
+          },
+          id: "btnGenerateReport",
+          class: "main-btn primary-btn btn-hover btn-sm",
+          onclick: "setTimeZone()" do %>
+          <i class="lni lni-download mr-10"></i>
+          <i id="spinner" class='fas fa-spin d-none mr-10'>⏳</i>
+          Generate Report
+        <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/casa_cases/_generate_report_modal.html.erb
+++ b/app/views/casa_cases/_generate_report_modal.html.erb
@@ -22,7 +22,7 @@
         <div class="field form-group mb-20">
           <h6><label class="form-label" for="start_date">Starting From</label></h6>
           <%= form.text_field :start_date,
-            value: Time.zone.now.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
+            value: @casa_case.formatted_latest_court_date,
             data: { provide: "datepicker",
                     date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
                     class: "form-control" %>

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -23,14 +23,7 @@
                                       margin: false) %>
       <% end %>
     <% end %>
-    <%= form_with url: generate_case_court_reports_path, local: false, class: "d-inline" do |form| %>
-      <%= form.hidden_field :case_number, value: @casa_case.case_number %>
-      <%= button_tag "Generate Report", type: :submit,
-                     data: {button_name: "Generate Report"},
-                     id: "btnGenerateReport",
-                     class: "main-btn success-btn btn-hover btn-sm pull-right mb-2" %>
-      <i id="spinner" class='fas fa-spin d-none pull-right'>⏳</i>
-    <% end %>
+    <%= render "casa_cases/generate_report_modal" %>
     <% if @casa_case.casa_org.show_fund_request %>
       <%= link_to("New Fund Request", new_casa_case_fund_request_path(@casa_case),
 class: "btn btn-primary pull-left casa-case-button") %>
@@ -156,4 +149,39 @@ class: "btn btn-primary pull-left casa-case-button") %>
       window.localStorage.removeItem('casa-contact-form')
     }
   });
+  const ELEMENTS = {
+    'caseSelect': '#case-selection',
+    'generateBtn': '#btnGenerateReport',
+  }
+  const showBtn = el => el.classList.remove('d-none')
+  const enableBtn = (el) => {
+    el.disabled = false
+    el.classList.remove('disabled')
+    el.removeAttribute('aria-disabled')
+  }
+
+  const handleSelect = (e) => {
+    const selectEl = e.target
+    const generateBtn = selectEl.form.querySelector(ELEMENTS.generateBtn)
+
+    // when selecting a case, reset buttons to initial state
+    enableBtn(generateBtn)
+    showBtn(generateBtn)
+  }
+
+  const bindElements = () => {
+    const caseSelectEl = document.querySelector(ELEMENTS.caseSelect)
+
+    if (caseSelectEl)
+      caseSelectEl.addEventListener('change', handleSelect)
+  }
+
+  const setTimeZone = () => {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    document.getElementById("user-time-zone").value = timeZone
+  }
+
+  window.onload = function () {
+    bindElements()
+  }
 </script>

--- a/app/views/case_court_reports/_generate_docx.html.erb
+++ b/app/views/case_court_reports/_generate_docx.html.erb
@@ -1,0 +1,75 @@
+<%= form_with url: generate_case_court_reports_path, local: false do |form| %>
+  <% id = "generate-docx-report-modal" %>
+  <%= render(Modal::OpenButtonComponent.new(target: id, klass: "btn generate-report-button")) do %>
+    <svg viewBox="0 0 40 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <title>Word Document Logo</title>
+      <path d="M25 0H5C3.67392 0 2.40215 0.526784 1.46447 1.46447C0.526784 2.40215 0 3.67392 0 5V45C0 46.3261 0.526784 47.5979 1.46447 48.5355C2.40215 49.4732 3.67392 50 5 50H35C36.3261 50 37.5979 49.4732 38.5355 48.5355C39.4732 47.5979 40 46.3261 40 45V15L25 0ZM28 45H24.5L20 28L15.5 45H12L6.5 22.5H10.25L13.75 39.5L18.25 22.5H21.5L26 39.5L29.5 22.5H33.25L28 45ZM22.5 17.5V3.75L36.25 17.5H22.5Z" fill="#4A6CF7" />
+    </svg>
+    <div>
+      <h3 class="content-1">Download Court Report as .docx</h3>
+      <p class="content-2">
+      The Court Report is pre-filled with information for your case. You can select among currently active cases assigned to you. The document is in Microsoft Word format (.docx).
+      </p>
+    </div>
+  <% end %>
+  <%= render(Modal::GroupComponent.new(id: id)) do |component| %>
+    <% component.with_header(text: "Download Court Report as a .docx", id: id, klass: "content-1") %>
+    <% component.with_body do %>
+      <div class="docx-report__modal-body">
+      <p class="content-3 md-10">
+      To download a court report, choose an active case and specify the date range.
+      </p>
+      <div class="input-style-1" id="case_select_body">
+        <%= form.label :case_selection, "Case" %>
+        <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
+
+        <% show_search = !current_user.volunteer? %>
+
+        <% select_case_prompt = show_search ? "Search by volunteer name or case number" : "Select case number" %>
+        <% select2_class = show_search ? " select2" : "" %>
+        <%= select_tag :case_number,
+          options_for_select(select_options),
+          prompt: select_case_prompt,
+          include_blank: false,
+          id: "case-selection",
+          class: "custom-select#{select2_class}",
+          data: { dropdown_parent: "##{id}" } %>
+
+      <%= form.hidden_field :time_zone, id: "user-time-zone" %>
+      </div>
+      <div class="dates-container">
+        <div class="field form-group mb-20">
+          <h6><label class="form-label" for="start_date">Starting From</label></h6>
+          <%= form.text_field :start_date,
+            value: Time.zone.now.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
+            data: { provide: "datepicker",
+                    date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+                    class: "form-control" %>
+        </div>
+
+        <div class="field form-group mb-20">
+          <h6><label class="form-label" for="end_date">Ending At</label></h6>
+          <%= form.text_field :end_date,
+            value: Time.zone.now.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
+            data: { provide: "datepicker",
+                    date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+                    class: "form-control" %>
+        </div>
+      </div>
+      </div>
+    <% end %>
+    <% component.with_footer do %>
+        <%= button_tag type: :submit,
+          data: {
+            button_name: "Generate Report"
+          },
+          id: "btnGenerateReport",
+          class: "main-btn primary-btn btn-hover btn-sm",
+          onclick: "setTimeZone()" do %>
+          <i class="lni lni-download mr-10"></i>
+          <i id="spinner" class='fas fa-spin d-none mr-10'>⏳</i>
+          Generate Report
+        <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -2,7 +2,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <div class="title mb-30">
-        <h1>Report Categories</h1>
+        <h1>Generate Reports</h1>
       </div>
     </div>
   </div>
@@ -11,42 +11,8 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card-style mb-30">
-        <h6 class="mb-10">Generate Court Report</h6>
-        <p class="text-sm mb-25">
-          The Court Report is pre-filled with information for your case. You can select among currently active cases assigned to you. The document is in Microsoft Word format (.docx).
-        </p>
-        <%= form_with url: generate_case_court_reports_path, local: false do |form| %>
-          <div class="input-style-1">
-            <%= form.label :case_selection, "Case Number:" %>
-            <% select_options = @assigned_cases.map { |casa_case| casa_case.decorate.court_report_select_option } %>
-
-            <% show_search = !current_user.volunteer? %>
-
-            <% select_case_prompt = show_search ? "Search by volunteer name or case number" : "Select case number" %>
-            <% select2_class = show_search ? "select2" : "" %>
-
-            <%= select_tag :case_number,
-                          options_for_select(select_options),
-                          prompt: select_case_prompt,
-                          include_blank: false,
-                          id: "case-selection",
-                          class: "custom-select #{select2_class}" %>
-
-            <%= form.hidden_field :time_zone, id: "user-time-zone" %>
-          </div>
-          <div class="input-style-1">
-            <%= button_tag type: :submit,
-                           data: {
-                             button_name: "Generate Report"
-                           },
-                           id: "btnGenerateReport",
-                           class: "main-btn primary-btn btn-hover btn-sm",
-                           onclick: "setTimeZone()" do %>
-              <i class="lni lni-download mr-10"></i> Generate Report
-            <% end %>
-            <i id="spinner" class='fas fa-spin d-none'>⏳</i>
-          </div>
-        <% end %>
+        <h6 class="mb-10">Court Reports</h6>
+        <%= render "case_court_reports/generate_docx" %>
       </div>
     </div>
   </div>

--- a/spec/components/modal/open_button_component_spec.rb
+++ b/spec/components/modal/open_button_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Modal::OpenButtonComponent, type: :component do
   it "renders the button with text and icon" do
     render_inline(Modal::OpenButtonComponent.new(target: "myModal", text: "Example Text", icon: "example-icon", klass: "example-class"))
 
-    expect(page).to have_css("button[type='button'][class='btn example-class'][data-bs-toggle='modal'][data-bs-target='#myModal']")
+    expect(page).to have_css("button[type='button'][class='example-class'][data-bs-toggle='modal'][data-bs-target='#myModal']")
     expect(page).to have_css("button i.lni.mr-10.lni-example-icon")
     expect(page).to have_text("Example Text")
   end
@@ -16,7 +16,7 @@ RSpec.describe Modal::OpenButtonComponent, type: :component do
   it "renders the button with only text" do
     render_inline(Modal::OpenButtonComponent.new(target: "myModal", text: "Example Text"))
 
-    expect(page).to have_css("button[type='button'][class='btn '][data-bs-toggle='modal'][data-bs-target='#myModal']")
+    expect(page).to have_css("button[type='button'][class=''][data-bs-toggle='modal'][data-bs-target='#myModal']")
     expect(page).not_to have_css("button i")
     expect(page).to have_text("Example Text")
   end
@@ -26,7 +26,7 @@ RSpec.describe Modal::OpenButtonComponent, type: :component do
       "Example Text"
     end
 
-    expect(page).to have_css("button[type='button'][class='btn '][data-bs-toggle='modal'][data-bs-target='#myModal']")
+    expect(page).to have_css("button[type='button'][class=''][data-bs-toggle='modal'][data-bs-target='#myModal']")
     expect(page).not_to have_css("button i")
     expect(page).to have_text("Example Text")
   end
@@ -36,7 +36,7 @@ RSpec.describe Modal::OpenButtonComponent, type: :component do
       "Example Text"
     end
 
-    expect(page).to have_css("button[type='button'][class='btn '][data-bs-toggle='modal'][data-bs-target='#myModal']")
+    expect(page).to have_css("button[type='button'][class=''][data-bs-toggle='modal'][data-bs-target='#myModal']")
     expect(page).not_to have_css("button i")
     expect(page).to have_text("Example Text")
     expect(page).to_not have_text("Overwritten")

--- a/spec/factories/case_court_report_context.rb
+++ b/spec/factories/case_court_report_context.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
       case_court_orders { nil }
       path_to_report { Rails.root.join("tmp", "test_report.docx").to_s }
       path_to_template { Rails.root.join("app", "documents", "templates", "default_report_template.docx").to_s }
+      start_date { nil }
+      end_date { nil }
+      time_zone { nil }
     end
 
     initialize_with {
@@ -25,7 +28,10 @@ FactoryBot.define do
         path_to_report: path_to_report,
         path_to_template: path_to_template,
         court_date: court_date,
-        case_court_orders: case_court_orders
+        case_court_orders: case_court_orders,
+        start_date: start_date,
+        end_date: end_date,
+        time_zone: time_zone
       )
     }
   end

--- a/spec/factories/case_court_report_context.rb
+++ b/spec/factories/case_court_report_context.rb
@@ -15,13 +15,13 @@ FactoryBot.define do
       volunteer_for_context = volunteer.nil? ? create(:volunteer) : volunteer
       casa_case_for_context = casa_case.nil? ? create(:casa_case) : casa_case
 
-      unless volunteer_for_context.casa_cases.where(id: casa_case_for_context.id).exists?
+      if volunteer_for_context && volunteer_for_context.casa_cases.where(id: casa_case_for_context.id).none?
         volunteer_for_context.casa_cases << casa_case_for_context
       end
 
       new(
         case_id: casa_case_for_context.id,
-        volunteer_id: volunteer_for_context.id,
+        volunteer_id: volunteer_for_context.try(:id),
         path_to_report: path_to_report,
         path_to_template: path_to_template,
         court_date: court_date,

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -297,6 +297,34 @@ RSpec.describe CasaCase, type: :model do
     end
   end
 
+  describe "#formatted_latest_court_date" do
+    let(:casa_case) { create(:casa_case) }
+
+    before do
+      travel_to Date.new(2021, 1, 1)
+    end
+
+    context "with a past court date" do
+      it "returns the latest past court date as a formatted string" do
+        most_recent_past_court_date = create(:court_date, date: 3.months.ago)
+
+        casa_case.court_dates << create(:court_date, date: 9.months.ago)
+        casa_case.court_dates << most_recent_past_court_date
+        casa_case.court_dates << create(:court_date, date: 15.months.ago)
+
+        expect(casa_case.formatted_latest_court_date).to eq("October 01, 2020") # 3 months before 1/1/21
+      end
+    end
+
+    context "without a past court date" do
+      it "returns the current day as a formatted string" do
+        allow(casa_case).to receive(:most_recent_past_court_date).and_return(nil)
+
+        expect(casa_case.formatted_latest_court_date).to eq("January 01, 2021")
+      end
+    end
+  end
+
   context "#remove_emancipation_category" do
     let(:casa_case) { create(:casa_case) }
     let(:emancipation_category) { build(:emancipation_category) }

--- a/spec/models/case_court_report_context_spec.rb
+++ b/spec/models/case_court_report_context_spec.rb
@@ -13,274 +13,152 @@ RSpec.describe CaseCourtReportContext, type: :model do
   end
 
   describe "#context" do
+    it "has the right shape" do
+      date = 1.day.ago
+      court_date = build(:court_date, :with_hearing_type, date: date)
+      context = create(:case_court_report_context, court_date: court_date)
+
+      allow(context).to receive(:case_details).and_return({})
+      allow(context).to receive(:case_contacts).and_return([])
+      allow(context).to receive(:case_orders).and_return([])
+      allow(context).to receive(:org_address).and_return(nil)
+      allow(context).to receive(:volunteer_info).and_return({})
+      allow(context).to receive(:latest_hearing_date).and_return("")
+
+      expected_shape = {
+        created_date: "January 1, 2021",
+        casa_case: {},
+        case_contacts: [],
+        case_court_orders: [],
+        case_mandates: [],
+        latest_hearing_date: "",
+        org_address: nil,
+        volunteer: {},
+        hearing_type_name: court_date.hearing_type.name
+      }
+
+      expect(context.context).to eq(expected_shape)
+    end
+  end
+
+  describe "case_orders" do
+    it "returns the correct shape" do
+      court_orders = [
+        build(:case_court_order, text: "Court order 1", implementation_status: :unimplemented),
+        build(:case_court_order, text: "Court order 2", implementation_status: :implemented)
+      ]
+      expected = [
+        {order: "Court order 1", status: "Unimplemented"},
+        {order: "Court order 2", status: "Implemented"}
+      ]
+      context = build_stubbed(:case_court_report_context)
+
+      expect(context.case_orders(court_orders)).to match_array(expected)
+    end
+  end
+
+  describe "org_address" do
+    let(:volunteer) { create(:volunteer) }
+    let(:context) { build(:case_court_report_context, volunteer: volunteer) }
+
+    context "when volunteer and default template are provided" do
+      it "returns the CASA org address" do
+        path_to_template = "default_report_template.docx"
+        expected_address = volunteer.casa_org.address
+
+        expect(context.org_address(path_to_template)).to eq(expected_address)
+      end
+    end
+
+    context "when volunteer is provided but not default template" do
+      it "returns nil" do
+        path_to_template = "some_other_template.docx"
+
+        expect(context.org_address(path_to_template)).to be_nil
+      end
+    end
+
+    context "when volunteer is not provided" do
+      let(:context) { build(:case_court_report_context, volunteer: false) }
+
+      it "returns nil" do
+        path_to_template = "default_report_template.docx"
+        expect(context.org_address(path_to_template)).to be_nil
+      end
+    end
+  end
+
+  describe "#latest_hearing_date" do
+    context "when casa_case has court_dates" do
+      let(:court_date) { build(:court_date, date: 2.day.ago) }
+      let(:casa_case) { create(:casa_case, court_dates: [court_date]) }
+      let(:instance) { build(:case_court_report_context, casa_case: casa_case) }
+
+      it "returns the formatted date" do
+        expect(instance.latest_hearing_date).to eq("December 30, 2020") # 2 days before spec default date
+      end
+    end
+
+    context "when most recent past court date is nil" do
+      let(:instance) { build(:case_court_report_context) }
+
+      it "returns the placeholder string" do
+        expect(instance.latest_hearing_date).to eq("___<LATEST HEARING DATE>____")
+      end
+    end
+  end
+
+  describe "#case_contacts" do
+    let(:casa_case) { create(:casa_case) }
+    let(:context) { build(:case_court_report_context, casa_case: casa_case) }
+
+    it "returns an empty array if there are no interviewees" do
+      expect(context.case_contacts).to eq([])
+    end
+
+    # not sure how to test this without just restating the code
+    # context 'when there are interviewees' do
+    #   it 'it calls CaseContactsContactDates with filtered values' do
+    #     create_list(:case_contact_contact_type, 3, case_contact: create(:case_contact, casa_case: casa_case))
+    #     context.case_contacts
+    #   end
+    # end
+  end
+
+  describe "#filter_out_old_case_contacts" do
+    let(:casa_case) { create(:casa_case) }
+    let(:court_date) { nil }
+    let(:court_report_context) { build(:case_court_report_context, casa_case: casa_case, court_date: court_date) }
+
+    context "when there is no most recent court date" do
+      it "returns all interviewees" do
+        interviewees = build_list(:case_contact, 3)
+        expect(court_report_context.filter_out_old_case_contacts(interviewees)).to match_array(interviewees)
+      end
+    end
+
+    context "when there is a most recent court date" do
+      let(:date) { 5.day.ago }
+      let(:court_date) { build(:court_date, date: date) }
+      let(:casa_case) { create(:casa_case, court_dates: [court_date]) }
+
+      it "filters out case contacts before the court date" do
+        create_list(:case_contact, 3, occurred_at: date - 1.day, casa_case: casa_case)
+        included_interviewee = create(:case_contact, occurred_at: date + 1.day, casa_case: casa_case)
+
+        result = court_report_context.filter_out_old_case_contacts(CaseContact.all)
+
+        expect(result).to contain_exactly(included_interviewee)
+      end
+    end
+  end
+
+  describe "#context" do
     let(:court_report_context) { build(:case_court_report_context) }
 
     describe ":created_date" do
       it "has a created date equal to the current date" do
         expect(court_report_context.context[:created_date]).to eq("January 1, 2021")
-      end
-    end
-
-    describe ":casa_case" do
-      let(:case_number) { "Sample-Case-12345" }
-      let(:casa_case) {
-        create(:casa_case,
-          birth_month_year_youth: 121.months.ago, # 10 Years 1 month ago
-          case_number: case_number)
-      }
-      let(:court_report_context) { build(:case_court_report_context, casa_case: casa_case) }
-
-      describe ":court_date" do
-        context "when there are future court dates" do
-          let(:court_date_1) { create(:court_date, date: 2.months.since) }
-          let(:court_date_2) { create(:court_date, date: 5.months.since) }
-
-          before(:each) do
-            casa_case.court_dates << court_date_1
-            casa_case.court_dates << court_date_2
-          end
-
-          it "contains the soonest future court date in a human readable format" do
-            expect(court_report_context.context[:casa_case][:court_date]).to eq("March 1, 2021")
-          end
-        end
-
-        context "when they specify a specific court date they are interested in looking at" do
-          it "contains the selected court date in a human readable format" do
-            court_date_1 = create(:court_date, date: 2.months.since)
-            court_date_2 = create(:court_date, date: 5.months.since)
-
-            casa_case.court_dates << court_date_1
-            casa_case.court_dates << court_date_2
-
-            court_report_context = build(:case_court_report_context, casa_case: casa_case, court_date: court_date_2)
-            expect(court_report_context.context[:casa_case][:court_date]).to eq("June 1, 2021")
-          end
-        end
-
-        context "when there are no future court dates" do
-          let(:past_court_date) { create(:court_date, date: 2.months.ago) }
-
-          before(:each) do
-            casa_case.court_dates << past_court_date
-          end
-
-          it "contains the soonest future court date in a human readable format" do
-            expect(court_report_context.context[:casa_case][:court_date]).to be_nil
-          end
-        end
-      end
-
-      describe ":case_number" do
-        it "contains the case number of the casa case" do
-          expect(court_report_context.context[:casa_case][:case_number]).to eq(case_number)
-        end
-      end
-
-      describe ":dob" do
-        it "contains the month and year of birth" do
-          expect(court_report_context.context[:casa_case][:dob]).to eq("December 2010")
-        end
-      end
-
-      describe ":is_transitioning" do
-        context "when the case birth month and year is less than 14 years ago" do
-          before(:each) do
-            casa_case.update_attribute(:birth_month_year_youth, 167.months.ago)
-          end
-
-          it "contains false" do
-            expect(court_report_context.context[:casa_case][:is_transitioning]).to eq(false)
-          end
-        end
-
-        context "when the case birth month and year is greater or equal to 14 years ago" do
-          before(:each) do
-            casa_case.update_attribute(:birth_month_year_youth, 14.years.ago)
-          end
-
-          it "contains true" do
-            expect(court_report_context.context[:casa_case][:is_transitioning]).to eq(true)
-          end
-        end
-      end
-
-      describe ":judge_name" do
-        context "when there are future court dates" do
-          let(:next_court_date_judge_name) { "Judge A" }
-          let(:court_date_1) { create(:court_date, :with_judge, date: 2.months.since) }
-          let(:court_date_2) { create(:court_date, :with_judge, date: 5.months.since) }
-
-          before(:each) do
-            court_date_1.judge.update_attribute(:name, next_court_date_judge_name)
-            court_date_2.judge.update_attribute(:name, "Judge B")
-
-            casa_case.court_dates << court_date_1
-            casa_case.court_dates << court_date_2
-          end
-
-          it "contains the soonest future court date in a human readable format" do
-            expect(court_report_context.context[:casa_case][:judge_name]).to eq(next_court_date_judge_name)
-          end
-        end
-      end
-    end
-
-    describe ":case_contacts" do
-      let(:casa_case) { create(:casa_case) }
-      let(:case_contact_1_date) { 30.days.ago }
-      let(:case_contact_2_date) { 45.days.ago }
-      let(:case_contact_3_date) { 60.days.ago }
-      let(:case_contact_4_date) { 75.days.ago }
-      let(:case_contact_1) { build(:case_contact, occurred_at: case_contact_1_date) }
-      let(:case_contact_2) { build(:case_contact, occurred_at: case_contact_2_date) }
-      let(:case_contact_3) { build(:case_contact, occurred_at: case_contact_3_date) }
-      let(:case_contact_4) { build(:case_contact, occurred_at: case_contact_4_date) }
-      let(:contact_type_1) { build(:contact_type, name: "XM_L!_g=Ko\\-'A!") }
-      let(:contact_type_2) { build(:contact_type, name: "uHp$O2;oq!C3{]l") }
-      let(:contact_type_3) { build(:contact_type, name: "\"PlqEsCP[JktjTS") }
-      let(:contact_type_4) { build(:contact_type, name: "K3BbzNCni4mVC5@") }
-      let(:contact_type_5) { build(:contact_type, name: "lf7CA&n8BQ*qJ?E") }
-      let(:court_report_context) { build(:case_court_report_context, casa_case: casa_case).context }
-
-      before(:each) do
-        case_contact_1.contact_types << contact_type_1
-        case_contact_2.contact_types << contact_type_2
-        case_contact_3.contact_types << contact_type_3
-        case_contact_4.contact_types << contact_type_4
-        case_contact_1.contact_types << contact_type_5
-
-        casa_case.case_contacts << case_contact_1
-        casa_case.case_contacts << case_contact_2
-        casa_case.case_contacts << case_contact_3
-        casa_case.case_contacts << case_contact_4
-      end
-
-      it "for each contact type in a case contact, contains the name of the type and the occurred at date" do
-        expect(court_report_context[:case_contacts]).to include(include(dates: case_contact_1_date.strftime("%m/%d*"), type: contact_type_1.name))
-        expect(court_report_context[:case_contacts]).to include(include(dates: case_contact_2_date.strftime("%m/%d*"), type: contact_type_2.name))
-        expect(court_report_context[:case_contacts]).to include(include(dates: case_contact_3_date.strftime("%m/%d*"), type: contact_type_3.name))
-        expect(court_report_context[:case_contacts]).to include(include(dates: case_contact_4_date.strftime("%m/%d*"), type: contact_type_4.name))
-        expect(court_report_context[:case_contacts]).to include(include(dates: case_contact_1_date.strftime("%m/%d*"), type: contact_type_5.name))
-      end
-
-      it "for each contact type in a case contact, contains a placeholder value for the name(s) of the people involved" do
-        case_contact_report_data = court_report_context[:case_contacts]
-        expect(case_contact_report_data.length).to be > 0
-
-        case_contact_report_data.each { |contact_type_and_dates|
-          expect(contact_type_and_dates[:name]).to eq("Names of persons involved, starting with the child's name")
-        }
-      end
-
-      context "when a contact type is included in multiple case contacts" do
-        before(:each) do
-          case_contact_2.contact_types << contact_type_1
-          case_contact_4.contact_types << contact_type_1
-        end
-
-        it "includes an object with the contact type name and the dates of all case contacts" do
-          contact_type_and_dates = court_report_context[:case_contacts].find { |case_contact_type_and_dates|
-            case_contact_type_and_dates[:type] == contact_type_1.name
-          }
-
-          expect(contact_type_and_dates).to_not be_nil
-          expect(contact_type_and_dates[:dates]).to include(case_contact_1_date.strftime("%m/%d"))
-          expect(contact_type_and_dates[:dates]).to include(case_contact_2_date.strftime("%m/%d"))
-          expect(contact_type_and_dates[:dates]).to include(case_contact_4_date.strftime("%m/%d"))
-          expect(contact_type_and_dates[:dates]).to_not include(case_contact_3_date.strftime("%m/%d"))
-        end
-
-        it "contains a string with the dates of the case contacts with the contact type sorted by oldest date first" do
-          contact_type_and_dates = court_report_context[:case_contacts].find { |case_contact_type_and_dates|
-            case_contact_type_and_dates[:type] == contact_type_1.name
-          }
-
-          expect(contact_type_and_dates).to_not be_nil
-
-          dates = contact_type_and_dates[:dates]
-          case_contact_1_date_index = dates.index(case_contact_1_date.strftime("%m/%d"))
-          case_contact_2_date_index = dates.index(case_contact_2_date.strftime("%m/%d"))
-          case_contact_4_date_index = dates.index(case_contact_4_date.strftime("%m/%d"))
-
-          expect(case_contact_1_date_index).to be > case_contact_2_date_index
-          expect(case_contact_2_date_index).to be > case_contact_4_date_index
-        end
-
-        context "when there are multiple medium types" do
-          before(:each) do
-            case_contact_4.update_attribute(:medium_type, "voice-only")
-          end
-
-          describe ":dates_by_medium_type" do
-            it "contains a key for each medium type and the dates of the case contacts with the medium type the values" do
-              case_contact_object_containing_complex_dates_by_medium_type = court_report_context[:case_contacts].find { |case_contact_type_and_dates|
-                case_contact_type_and_dates[:type] == contact_type_1.name
-              }
-
-              dates_by_medium_type = case_contact_object_containing_complex_dates_by_medium_type[:dates_by_medium_type]
-
-              expect(dates_by_medium_type).to have_key(case_contact_1.medium_type)
-              expect(dates_by_medium_type).to have_key(case_contact_4.medium_type)
-
-              expect(dates_by_medium_type[case_contact_1.medium_type]).to include(case_contact_1_date.strftime("%m/%d"))
-              expect(dates_by_medium_type[case_contact_2.medium_type]).to include(case_contact_2_date.strftime("%m/%d"))
-              expect(dates_by_medium_type[case_contact_4.medium_type]).to include(case_contact_4_date.strftime("%m/%d"))
-            end
-          end
-        end
-      end
-
-      context "when there are past court dates" do
-        let!(:past_court_date) { create(:court_date, date: 50.days.ago, casa_case: casa_case) }
-
-        it "contains only case contacts information after the latest past court date" do
-          expect(court_report_context[:case_contacts]).to include(include(type: contact_type_1.name))
-          expect(court_report_context[:case_contacts]).to include(include(type: contact_type_5.name))
-          expect(court_report_context[:case_contacts]).to include(include(type: contact_type_2.name))
-          expect(court_report_context[:case_contacts]).to_not include(include(type: contact_type_3.name))
-          expect(court_report_context[:case_contacts]).to_not include(include(type: contact_type_4.name))
-        end
-      end
-    end
-
-    describe ":case_court_orders and :case_mandates" do
-      let(:casa_case) { create(:casa_case, case_number: "Sample-Case-12345") }
-      let!(:court_order_implemented) { build(:case_court_order, text: "K6N-ce8|NuXnht(", implementation_status: :implemented) }
-      let!(:court_order_unimplemented) { build(:case_court_order, text: "'q\"tE1LP-9W>,2)", implementation_status: :unimplemented) }
-      let!(:court_order_partially_implemented) { build(:case_court_order, text: "ZmCw@w@\d`&roct", implementation_status: :partially_implemented) }
-      let!(:court_order_not_specified) { build(:case_court_order, text: "(4WqOL7e'FRYd@%", implementation_status: nil) }
-      let(:court_report_context) { build(:case_court_report_context, casa_case: casa_case).context }
-
-      before(:each) do
-        casa_case.case_court_orders << court_order_implemented
-        casa_case.case_court_orders << court_order_not_specified
-        casa_case.case_court_orders << court_order_partially_implemented
-
-        casa_case.case_court_orders << court_order_unimplemented
-      end
-
-      context "when using specified orders to a specific casa date" do
-        it "does not lean on orders of the casa case if specified directly" do
-          court_order = build(:case_court_order, text: "Some Court Text", implementation_status: :implemented)
-          court_report_context = build(:case_court_report_context, casa_case: casa_case, case_court_orders: [court_order]).context
-          expect(court_report_context[:case_court_orders]).to eq([{order: "Some Court Text", status: "Implemented"}])
-        end
-      end
-
-      it "has a list of court orders the same length as all the court orders in the case" do
-        expect(court_report_context[:case_court_orders].length).to eq(casa_case.case_court_orders.length)
-      end
-
-      it "includes the implementation status and text of each court order" do
-        expect(court_report_context[:case_court_orders]).to include({order: court_order_implemented.text, status: court_order_implemented.implementation_status&.humanize})
-        expect(court_report_context[:case_court_orders]).to include({order: court_order_not_specified.text, status: court_order_not_specified.implementation_status&.humanize})
-        expect(court_report_context[:case_court_orders]).to include({order: court_order_partially_implemented.text, status: court_order_partially_implemented.implementation_status&.humanize})
-        expect(court_report_context[:case_court_orders]).to include({order: court_order_unimplemented.text, status: court_order_unimplemented.implementation_status&.humanize})
-      end
-
-      it "has identical values for :case_court_orders and :case_mandates" do
-        expect(court_report_context[:case_mandates]).to eq(court_report_context[:case_court_orders]) # backwards compatibility for old names in old montgomery template - TODO track it down and update prod templates
       end
     end
 
@@ -309,47 +187,20 @@ RSpec.describe CaseCourtReportContext, type: :model do
         end
       end
     end
+  end
 
-    describe ":org_address" do
-      let(:casa_org_address) { "-m}~2c<Lk/te{<\"" }
-      let(:case_court_report_context_with_org_address) {
-        volunteer = create(:volunteer)
+  describe "#volunteer_info" do
+    let(:volunteer) { create(:volunteer, display_name: "Y>cy%F7v;\\].-g$", supervisor: build(:supervisor, display_name: "Mm^ED;`zg(g<Z]q")) }
+    let(:context) { build(:case_court_report_context, volunteer: volunteer) }
 
-        volunteer.casa_org.update_attribute(:address, casa_org_address)
-
-        build(:case_court_report_context, volunteer: volunteer)
+    it "correctly transforms the info" do
+      expected = {
+        name: "Y>cy%F7v;\\].-g$",
+        supervisor_name: "Mm^ED;`zg(g<Z]q",
+        assignment_date: "January 1, 2021" # This is the default set in the spec
       }
 
-      context "when the casa org has an address" do
-        it "appears in the context under the org_address key" do
-          expect(case_court_report_context_with_org_address.context[:org_address]).to eq(casa_org_address)
-        end
-      end
-    end
-
-    describe ":volunteer" do
-      let(:volunteer) { create(:volunteer, display_name: "Y>cy%F7v;\\].-g$", supervisor: build(:supervisor, display_name: "Mm^ED;`zg(g<Z]q")) }
-      let(:case_court_report_context) { build(:case_court_report_context, volunteer: volunteer) }
-
-      describe ":assignment_date" do
-        it "contains the assignment date in a human readable format" do
-          case_court_report_context.instance_variable_get(:@casa_case).case_assignments.first.update_attribute(:created_at, 24.months.ago)
-
-          expect(case_court_report_context.context[:volunteer][:assignment_date]).to eq("January 1, 2019")
-        end
-      end
-
-      describe ":name" do
-        it "contains the volunteer's name" do
-          expect(case_court_report_context.context[:volunteer][:name]).to eq(volunteer.display_name)
-        end
-      end
-
-      describe ":supervisor_name" do
-        it "contains the name of the volunteer's supervisor" do
-          expect(case_court_report_context.context[:volunteer][:supervisor_name]).to eq(volunteer.supervisor.display_name)
-        end
-      end
+      expect(context.volunteer_info).to eq(expected)
     end
   end
 end

--- a/spec/models/case_court_report_spec.rb
+++ b/spec/models/case_court_report_spec.rb
@@ -32,30 +32,6 @@ RSpec.describe CaseCourtReport, type: :model do
         end
       end
 
-      describe "with court date in the future" do
-        let!(:far_past_case_contact) { create :case_contact, occurred_at: 5.days.ago, casa_case_id: casa_case_with_contacts.id }
-
-        before do
-          create(:court_date, casa_case: casa_case_with_contacts, date: 1.day.from_now)
-        end
-
-        describe "without past court date" do
-          it "has all case contacts ever created for the youth" do
-            expect(report.context[:case_contacts].length).to eq(5)
-          end
-        end
-
-        describe "with past court date" do
-          let!(:court_date) { create(:court_date, date: 2.days.ago, casa_case_id: casa_case_with_contacts.id) }
-
-          it "has all case contacts created since the previous court date including case contact created on the court date" do
-            create(:case_contact, casa_case: casa_case_with_contacts, created_at: court_date.date, notes: "created ON most recent court date")
-            expect(casa_case_with_contacts.court_dates.length).to eq(2)
-            expect(report.context[:case_contacts].length).to eq(5)
-          end
-        end
-      end
-
       describe "has valid @context" do
         subject { report.context }
 

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -99,7 +99,15 @@ RSpec.describe "/case_court_reports", type: :request do
   # case_court_reports#generate
   describe "POST /case_court_reports" do
     let(:casa_case) { volunteer.casa_cases.first }
-    let(:params) { {case_court_report: {case_number: casa_case.case_number.to_s}} }
+    let(:params) {
+      {
+        case_court_report: {
+          case_number: casa_case.case_number.to_s,
+          start_date: "January 1, 2020",
+          end_date: "January 1, 2021"
+        }
+      }
+    }
 
     subject(:request) do
       post generate_case_court_reports_path, params: params, headers: {ACCEPT: "application/json"}
@@ -175,7 +183,9 @@ RSpec.describe "/case_court_reports", type: :request do
 
         docx_response = Docx::Document.open(StringIO.new(followed_link_response.body))
 
-        expect(docx_response.paragraphs.map(&:to_s)).to include("Date Written: #{I18n.l(user_different_timezone.at(server_time).to_date, format: :full, default: nil)}")
+        expect(docx_response.paragraphs.map(&:to_s))
+          .to include("Date Written: #{I18n.l(user_different_timezone.at(server_time)
+            .to_date, format: :full, default: nil)}")
       end
     end
 

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -41,6 +41,58 @@ RSpec.describe "casa_cases/show", type: :system do
     end
   end
 
+  describe "Report Generation", js: true do
+    let(:modal_selector) { '[data-bs-target="#generate-docx-report-modal"]' }
+    let(:user) { volunteer }
+
+    before do
+      travel_to Date.new(2021, 1, 1)
+      sign_in user
+      visit casa_case_path(casa_case.id)
+    end
+
+    context "when first arriving to 'Generate Court Report' page" do
+      it "generation modal hidden" do
+        expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: false
+        expect(page).not_to have_selector ".select2"
+      end
+    end
+
+    context "after opening 'Download Court Report' modal" do
+      before do
+        page.find(modal_selector).click
+      end
+
+      # putting all this in the same system test shaves 3 seconds off the test suite
+      it "modal has correct contents" do
+        start_date = page.find("#start_date").value
+        expect(start_date).to eq("January 01, 2021") # default date
+
+        end_date = page.find("#end_date").value
+        expect(end_date).to eq("January 01, 2021") # default date
+
+        expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: true
+        expect(page).to_not have_selector ".select2"
+
+        expect(page).to have_selector("#btnGenerateReport .lni-download", visible: true)
+        expect(page).to_not have_selector("#btnGenerateReport[disabled]")
+        expect(page).to have_selector("#spinner", visible: :hidden)
+
+        within("#generate-docx-report-modal") do
+          expect(page).to have_content(casa_case.case_number)
+
+          # when choosing the prompt option (value is empty) and click on 'Generate Report' button, nothing should happen"
+          # should have disabled generate button, download icon and no spinner
+          click_button "Generate Report"
+        end
+
+        expect(page).to have_selector("#btnGenerateReport .lni-download", visible: :hidden)
+        expect(page).to have_selector("#btnGenerateReport[disabled]")
+        expect(page).to have_selector("#spinner", visible: true)
+      end
+    end
+  end
+
   context "admin user" do
     let(:user) { admin }
 
@@ -135,28 +187,6 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content("Court Orders")
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
-    end
-
-    context "when generating a report, supervisor sees waiting page", js: true do
-      before do
-        click_button "Generate Report"
-      end
-
-      describe "'Generate Report' button" do
-        it "has been disabled" do
-          options = {visible: :visible}
-
-          expect(page).to have_selector "#btnGenerateReport[disabled]", **options
-        end
-      end
-
-      describe "Spinner" do
-        it "becomes visible" do
-          options = {visible: :visible}
-
-          expect(page).to have_selector "#spinner", **options
-        end
-      end
     end
 
     context "when old case contacts are hidden" do

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -6,79 +6,71 @@ RSpec.describe "case_court_reports/index", type: :system do
   let(:casa_cases) { CasaCase.actively_assigned_to(volunteer) }
   let(:younger_than_transition_age) { volunteer.casa_cases.reject(&:in_transition_age?).first }
   let(:at_least_transition_age) { volunteer.casa_cases.find(&:in_transition_age?) }
+  let(:modal_selector) { '[data-bs-target="#generate-docx-report-modal"]' }
 
   before do
+    travel_to Date.new(2021, 1, 1)
     sign_in volunteer
     visit case_court_reports_path
   end
 
-  context "when first arriving to 'Generate Court Report' page" do
-    it "sees 'Generate Report' button" do
-      options = {text: "Generate Report", visible: true}
+  context "when first arriving to 'Generate Court Report' page", js: true do
+    it "generation modal hidden" do
+      expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: false
+      expect(page).to have_selector "#case-selection", visible: false
+      expect(page).not_to have_selector ".select2"
+    end
+  end
 
-      expect(page).to have_selector "#btnGenerateReport", **options
+  context "after opening 'Download Court Report' modal", js: true do
+    before do
+      page.find(modal_selector).click
     end
 
-    it { expect(page).not_to have_selector ".select2" }
+    # putting all this in the same system test shaves 3 seconds off the test suite
+    it "modal has correct contents" do
+      start_date = page.find("#start_date").value
+      expect(start_date).to eq("January 01, 2021") # default date
 
-    it "shows a select element with default selection 'Select case number'" do
+      end_date = page.find("#end_date").value
+      expect(end_date).to eq("January 01, 2021") # default date
+
+      expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: true
+      expect(page).to_not have_selector ".select2"
+
+      # shows n+1 options in total, e.g 3 options <- 2 assigned cases + 1 prompt text
+      expected_number_of_options = casa_cases.size + 1
+      expect(page).to have_selector "#case-selection option", count: expected_number_of_options
+
+      # shows transition stamp for transitioned case
+      expected_text = "#{at_least_transition_age.case_number} - transition"
+      expect(page).to have_selector "#case-selection option", text: expected_text
+
+      # adds data-lookup attribute for searching by volunteer name
+      casa_cases.each do |casa_case|
+        lookup = casa_case.assigned_volunteers.map(&:display_name).join(",")
+        expect(page).to have_selector "#case-selection option[data-lookup='#{lookup}']"
+      end
+
+      # shows non-transition stamp for non-transitioned case
+      expected_text = "#{younger_than_transition_age.case_number} - non-transition"
+      expect(page).to have_selector "#case-selection option", text: expected_text
+
+      # shows a select element with default selection 'Select case number'
       expected_text = "Select case number"
       find("#case-selection").click.first("option", text: expected_text).select_option
 
       expect(page).to have_selector "#case-selection option:first-of-type", text: expected_text
       expect(page).to have_select "case-selection", selected: expected_text
-    end
 
-    it "shows n+1 options in total, e.g 3 options <- 2 assigned cases + 1 prompt text" do
-      expected_number_of_options = casa_cases.size + 1
-
-      expect(page).to have_selector "#case-selection option", count: expected_number_of_options
-    end
-
-    it "shows transition stamp for transitioned case" do
-      expected_text = "#{at_least_transition_age.case_number} - transition"
-
-      expect(page).to have_selector "#case-selection option", text: expected_text
-    end
-
-    it "shows non-transition stamp for non-transitioned case" do
-      expected_text = "#{younger_than_transition_age.case_number} - non-transition"
-
-      expect(page).to have_selector "#case-selection option", text: expected_text
-    end
-
-    it "adds data-lookup attribute for searching by volunteer name" do
-      casa_cases.each do |casa_case|
-        lookup = casa_case.assigned_volunteers.map(&:display_name).join(",")
-        expect(page).to have_selector "#case-selection option[data-lookup='#{lookup}']"
-      end
-    end
-  end
-
-  context "when choosing the prompt option (value is empty) and click on 'Generate Report' button, nothing should happen", js: true do
-    let(:option_text) { "Select case number" }
-
-    before do
-      # to find the select element, use either 'name' or 'id' attribute
-      # in this case, id = "case-selection", name = "case_number"
+      # when choosing the prompt option (value is empty) and click on 'Generate Report' button, nothing should happen"
+      # should have disabled generate button, download icon and no spinner
       page.select "Select case number", from: "case-selection"
-      # the above will have the same effect as the below
-      # find("#case-selection").select "Select case number"
       click_button "Generate Report"
-    end
 
-    describe "'Generate Report' button" do
-      it "does not become disabled" do
-        expect(page).not_to have_selector "#btnGenerateReport[disabled]"
-      end
-    end
-
-    describe "Spinner" do
-      it "does not become visible" do
-        options = {visible: :hidden}
-
-        expect(page).to have_selector "#spinner", **options
-      end
+      expect(page).to have_selector("#btnGenerateReport .lni-download", visible: true)
+      expect(page).to_not have_selector("#btnGenerateReport[disabled]")
+      expect(page).to have_selector("#spinner", visible: :hidden)
     end
   end
 
@@ -89,6 +81,7 @@ RSpec.describe "case_court_reports/index", type: :system do
     let(:non_transitioned_option_text) { "#{non_transitioned_case_number} - non-transition(assigned to Name Last)" }
 
     it "has transition case option selected" do
+      page.find(modal_selector).click
       page.select transitioned_option_text, from: "case-selection"
 
       click_button "Generate Report"
@@ -97,6 +90,7 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     it "has non-transitioned case option selected" do
+      page.find(modal_selector).click
       page.select non_transitioned_option_text, from: "case-selection"
 
       click_button "Generate Report"
@@ -105,39 +99,12 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
   end
 
-  context "when generating a report, volunteer sees waiting page", js: true do
-    let(:casa_case) { casa_cases.find(&:in_transition_age?) }
-    let(:option_text) { "#{casa_case.case_number} - transition" }
-
-    before do
-      # to find the select element, use either 'name' or 'id' attribute
-      # in this case, id = "case-selection", name = "case_number"
-      page.select option_text, from: "case-selection"
-      click_button "Generate Report"
-    end
-
-    describe "'Generate Report' button" do
-      it "has been disabled" do
-        options = {visible: :visible}
-
-        expect(page).to have_selector "#btnGenerateReport[disabled]", **options
-      end
-    end
-
-    describe "Spinner" do
-      it "becomes visible" do
-        options = {visible: :visible}
-
-        expect(page).to have_selector "#spinner", **options
-      end
-    end
-  end
-
   context "when selecting a case, volunteer can generate and download a report", js: true do
     let(:casa_case) { casa_cases.find(&:in_transition_age?) }
     let(:option_text) { "#{casa_case.case_number} - transition" }
 
     before do
+      page.find(modal_selector).click
       # to find the select element, use either 'name' or 'id' attribute
       # in this case, id = "case-selection", name = "case_number"
       page.select option_text, from: "case-selection"
@@ -204,6 +171,7 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
   end
 
+  # TODO: make this a request spec
   describe "as a supervisor" do
     before do
       sign_in supervisor

--- a/spec/views/case_court_reports/index.html.erb_spec.rb
+++ b/spec/views/case_court_reports/index.html.erb_spec.rb
@@ -16,28 +16,16 @@ RSpec.describe "case_court_reports/index", type: :view do
     end
 
     it "has a card with card title 'Generate Court Report'", :aggregate_failures do
+      expect(rendered).to have_selector("h6", text: "Court Reports", count: 1)
       expect(rendered).to have_selector("div", class: "card-style", count: 1)
-      expect(rendered).to have_selector("h6", text: "Generate Court Report", count: 1)
     end
 
-    it "displays a form" do
-      expect(rendered).to have_selector("form", count: 1)
+    it "page has title 'Gererate Reports'" do
+      expect(rendered).to have_selector("h1", text: "Generate Reports", count: 1)
     end
 
-    it "has a dropdown select with shows 2 options" do
-      expect(rendered).to have_selector("select#case-selection option", count: 3)
-    end
-
-    it "has a drowndown select element for CASA case" do
-      expect(rendered).to have_selector("select#case-selection")
-    end
-
-    it "has a 'Generate Report' button" do
-      expect(rendered).to have_selector("button[@type='submit']", text: "Generate Report", id: "btnGenerateReport")
-    end
-
-    it "has a 'Spinner' button" do
-      expect(rendered).to have_selector("i#spinner")
+    it "has button with 'Download Court Report as .docx' text" do
+      expect(rendered).to have_selector("button", text: /Download Court Report as \.docx/i, count: 1)
     end
   end
 end


### PR DESCRIPTION
Issue https://github.com/rubyforgood/casa/issues/5579
Blocked by https://github.com/rubyforgood/casa/pull/5590
Fixes https://github.com/rubyforgood/casa/issues/3243 (i think? i just randomly found this issue)

To close issue still need to implement adding court topics, etc to reports themselves. 

Reworks report generation page to use a modal and allow selection of contacts into report by date range.

New generate page with new button:
![image](https://github.com/rubyforgood/casa/assets/14540596/e6a98566-1257-42ea-b446-e12f39db8c29)

New modal with generation options:
![image](https://github.com/rubyforgood/casa/assets/14540596/ae374267-0ff9-4369-aa36-d1f54ff07408)
![image](https://github.com/rubyforgood/casa/assets/14540596/cb613c95-ab48-41a5-bef5-c79d30e8a219)

Modal on both generation pages:
![image](https://github.com/rubyforgood/casa/assets/14540596/a75cf07b-760f-4436-be22-ad97b4cbeff0)

