### PR TITLE
fix: format date to US format MM/DD/YYYY

### DIFF
--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -64,9 +64,7 @@
             <%= cdf.label :date, "Next Court Date" %>
             <br>
             <div class="input-style-1">
-              <%= cdf.text_field :date,
-                                 data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
-                                 class: "form-control" %>
+              <%= cdf.date_field :date, class: "form-control" %>
             </div>
           </div>
         <% end %>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -50,13 +50,11 @@
           </div>
           <div class="col-sm-6 input-style-1">
             <%= f.label "Starting from", for: "filterrific_occurred_starting_at" %>
-            <%= f.text_field(:occurred_starting_at, data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
-                                                  class: "") %>
+            <%= f.date_field(:occurred_starting_at, class: "") %>
           </div>
           <div class="col-sm-6 input-style-1">
             <%= f.label "Ending at", for: "filterrific_occurred_ending_at" %>
-            <%= f.text_field(:occurred_ending_at, data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
-                                                  class: "") %>
+            <%= f.date_field(:occurred_ending_at, class: "") %>
           </div>
         </div>
         <div class="row mb-4">

--- a/app/views/court_dates/_fields.html.erb
+++ b/app/views/court_dates/_fields.html.erb
@@ -1,15 +1,13 @@
 <div class="input-style-1">
   <%= form.label :date, "Add Court Date" %>
-  <%= form.text_field :date,
+  <%= form.date_field :date,
                       value: court_date.date&.to_date || Time.zone.now,
-                      data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                       class: "form-control" %>
 </div>
 <div class="input-style-1">
   <%= form.label :court_report_due_date, "Add Court Report Due Date" %>
-  <%= form.text_field :court_report_due_date,
+  <%= form.date_field :court_report_due_date,
                       value: court_date.court_report_due_date&.to_date,
-                      data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                       class: "form-control" %>
 </div>
 <div class="select-style-1">

--- a/app/views/court_dates/show.html.erb
+++ b/app/views/court_dates/show.html.erb
@@ -26,7 +26,7 @@
       <dt>
         <h6>Court Report Due Date:</h6>
       </dt>
-      <dd class="mb-3"><%= @court_date.court_report_due_date&.to_date || "None" %></dd>
+      <dd class="mb-3"><%= I18n.l(@court_date.court_report_due_date, format: :full, default: "None") %></dd>
       <dt>
         <h6>Judge:</h6>
       </dt>

--- a/app/views/layouts/components/_ranged_date_picker.html.erb
+++ b/app/views/layouts/components/_ranged_date_picker.html.erb
@@ -1,5 +1,5 @@
-<%= form.text_field model_field,
+<%= form.date_field model_field,
     value: initial_value,
-    data: {date_format: "yyyy/mm/dd", provide: "datepicker", max_date: local_assigns.has_key?(:max_date) ? max_date : nil, min_date: local_assigns.has_key?(:min_date) ? min_date : nil},
+    data: { max_date: local_assigns.has_key?(:max_date) ? max_date : nil, min_date: local_assigns.has_key?(:min_date) ? min_date : nil },
     class: "card-style-1 component-date-picker-range",
     "component-name": component_name %>

--- a/app/views/learning_hours/_form.html.erb
+++ b/app/views/learning_hours/_form.html.erb
@@ -51,9 +51,8 @@
     <h5 class="mb-3"><%= form.label :occurred_at, "Occurred On" %>:</h5>
     <% occurred_at = learning_hour.occurred_at || Date.today %>
     <div class="input-style-1">
-      <%= form.text_field :occurred_at,
+      <%= form.date_field :occurred_at,
                           value: occurred_at.to_date,
-                          data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
                           class: "form-control label-font-weight" %>
     </div>
   </div>

--- a/app/views/learning_hours/show.html.erb
+++ b/app/views/learning_hours/show.html.erb
@@ -21,7 +21,7 @@
           <tr>
             <td><%= @learning_hour.name %></td>
             <td><%= @learning_hour.learning_hour_type.name %></td>
-            <td><%= @learning_hour.occurred_at.strftime("%B %d, %Y") %></td>
+            <td><%= I18n.l(@learning_hour.occurred_at, format: :full) %></td>
             <td>
               <% if (@learning_hour.duration_hours > 0) %>
                 <%= @learning_hour.duration_hours %> hr

--- a/app/views/mileage_rates/_form.html.erb
+++ b/app/views/mileage_rates/_form.html.erb
@@ -18,10 +18,9 @@
     </div>
     <div class="input-style-1">
       <%= form.label :effective_date, 'Effective date' %>
-      <%= form.text_field :effective_date, value: effective_date_parser(mileage_rate.effective_date),
-                                        data: { provide: "datepicker",
-                                        date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
-                                        class: "form-control" %>
+      <%= form.date_field :effective_date,
+                          value: mileage_rate.effective_date,
+                          class: "form-control" %>
     </div>
     <div class="input-style-1">
       <%= form.label :amount, 'Amount' %>

--- a/app/views/other_duties/_form.html.erb
+++ b/app/views/other_duties/_form.html.erb
@@ -15,9 +15,7 @@
   <div class="input-style-1">
     <%= form.label :occurred_at, "Occurred On" %>
     <% occurred_at = @other_duty.occurred_at || Time.zone.now %>
-    <%= form.text_field :occurred_at,
-                        value: occurred_at.to_date,
-                        data: {provide: "datepicker", date_format: "yyyy/mm/dd"} %>
+    <%= form.date_field :occurred_at, value: occurred_at.to_date %>
   </div>
 
     <div class="row input-style-1">

--- a/app/views/reimbursements/_occurred_at_filter_input.html.erb
+++ b/app/views/reimbursements/_occurred_at_filter_input.html.erb
@@ -1,11 +1,9 @@
 <div>
   <%= label %>
-  <%= text_field(
+  <%= date_field(
     nil,
     name,
     data: {
-      provide: "datepicker",
-      date_format: "yyyy/mm/dd",
       date_end_date: Time.now,
       date_start_date: @occurred_at_filter_start_date
     },

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -90,17 +90,15 @@
 
             <div class="field form-group mb-20">
               <label class="form-label"><h6>Starting From</h6></label>
-              <%= f.text_field :start_date, value: 6.months.ago.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
-                               data: { provide: "datepicker",
-                                       date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+              <%= f.date_field :start_date,
+                               value: 6.months.ago,
                                class: "form-control" %>
             </div>
 
             <div class="field form-group mb-20">
               <label class="form-label"><h6>Ending At</h6></label>
-              <%= f.text_field :end_date, value: Date.today.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT),
-                               data: { provide: "datepicker",
-                                       date_format: ::DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT },
+              <%= f.date_field :end_date,
+                               value: Date.today,
                                class: "form-control" %>
             </div>
 

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -31,9 +31,8 @@
 <div class="input-style-1">
   <%= f.label :date_of_birth, "Date of birth" %>
   <% if policy(resource).update_user_setting? %>
-    <%= f.text_field :date_of_birth,
-                     value: resource.decorate.formatted_date_of_birth,
-                     data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+    <%= f.date_field :date_of_birth,
+                     value: resource.date_of_birth,
                      class: "form-control label-font-weight" %>
   <% else %>
     <input type="text" placeholder="<%= resource.decorate.formatted_date_of_birth %>" autocomplete="off" readonly>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -25,9 +25,8 @@
 
             <div class="input-style-1">
               <%= form.label :date_of_birth, "Date of birth" %>
-              <%= form.text_field :date_of_birth,
-                                  value: @user.decorate.formatted_date_of_birth,
-                                  data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+              <%= form.date_field :date_of_birth,
+                                  value: @user.date_of_birth,
                                   class: "form-control label-font-weight" %>
             </div>
 

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -18,9 +18,8 @@
 
   <div class="input-style-1">
     <%= form.label :date_of_birth, "Date of birth" %>
-    <%= form.text_field :date_of_birth,
-                        value: @volunteer.date_of_birth&.strftime("%Y/%m/%d"),
-                        data: {provide: "datepicker", date_format: "yyyy/mm/dd"},
+    <%= form.date_field :date_of_birth,
+                        value: @volunteer.date_of_birth,
                         class: "form-control label-font-weight" %>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@
 en:
   time:
     formats:
-      day_and_date: "%A, %d-%b-%Y"
+      day_and_date: "%A, %b %d, %Y"
       standard: "%m-%d-%Y"
       contact_occurred_at: "%Y%m%d%H%M%s"
       full: "%B %-d, %Y"

--- a/spec/support/fill_in_case_contact_fields.rb
+++ b/spec/support/fill_in_case_contact_fields.rb
@@ -20,7 +20,6 @@ module FillInCaseContactFields
     end
     choose medium if medium
     fill_in "case_contact_occurred_at", with: occurred_on if occurred_on
-
     fill_in "case_contact_duration_hours", with: hours if hours
     fill_in "case_contact_duration_minutes", with: minutes if minutes
 

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "casa_cases/new", type: :system do
           fourteen_years = (Date.today.year - 14).to_s
           fill_in "Case number", with: case_number
 
-          fill_in "Court Date", with: court_date.strftime("%Y/%m/%d")
+          fill_in "Court Date", with: court_date
 
           select "March", from: "casa_case_birth_month_year_youth_2i"
           select fourteen_years, from: "casa_case_birth_month_year_youth_1i"
@@ -56,7 +56,7 @@ RSpec.describe "casa_cases/new", type: :system do
         visit new_casa_case_path
 
         fill_in "Case number", with: case_number
-        fill_in "Next Court Date", with: DateTime.now.next_month.strftime("%Y/%m/%d")
+        fill_in "Next Court Date", with: DateTime.now.next_month
         five_years = (Date.today.year - 5).to_s
         select "March", from: "casa_case_birth_month_year_youth_2i"
         select five_years, from: "casa_case_birth_month_year_youth_1i"
@@ -67,7 +67,7 @@ RSpec.describe "casa_cases/new", type: :system do
 
         expect(page).to have_content(case_number)
         expect(page).to have_content("CASA case was successfully created.")
-        expect(page).to have_content("Next Court Date:")
+        expect(page).to have_content("Next Court Date: ")
         expect(page).not_to have_content("Court Report Due Date:")
         expect(page).to have_content("Transition Aged Youth: No")
       end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
             visit case_contacts_path
             click_button "Show / Hide"
 
-            fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday.to_s
-            fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow.to_s
+            fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday
+            fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
 
             click_button "Filter"
 
@@ -150,8 +150,8 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
 
         # filtering to only show case 2
         click_button "Show / Hide"
-        fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday.to_s
-        fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow.to_s
+        fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday
+        fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
         click_button "Filter"
         expect(page).to have_text("Case 2 Notes")
         expect(page).to_not have_text("Case 1 Notes")

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -30,14 +30,13 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
       expect(page).to_not have_text("Hidden")
 
       click_on "New Case Contact"
-      complete_details_page(case_numbers: [], contact_types: %w[School Therapist], contact_made: true, medium: "Video", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(case_numbers: [], contact_types: %w[School Therapist], contact_made: true, medium: "Video", occurred_on: Date.new(2020, 4, 5), hours: 1, minutes: 45)
       complete_notes_page
       fill_in_expenses_page
 
       expect {
         click_on "Submit"
       }.to change(CaseContact.where(status: "active"), :count).by(1)
-
       expect(CaseContact.first.casa_case_id).to eq casa_case.id
       expect(CaseContact.first.contact_types).to match_array([school, therapist])
       expect(CaseContact.first.duration_minutes).to eq 105
@@ -55,7 +54,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
       visit casa_case_path(casa_case.id)
       click_on "New Case Contact"
 
-      complete_details_page(case_numbers: [], contact_types: %w[School Therapist], contact_made: true, medium: "Video", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(case_numbers: [], contact_types: %w[School Therapist], contact_made: true, medium: "Video", occurred_on: "04/05/2020", hours: 1, minutes: 45)
       short_notes = "Hello world!"
       complete_notes_page(notes: short_notes)
       fill_in_expenses_page
@@ -176,7 +175,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
 
       visit new_case_contact_path(volunteer_casa_case_one.id)
 
-      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: Date.new(2020, 0o4, 0o6), hours: 1, minutes: 45)
       complete_notes_page(notes: "Hello world")
       fill_in_expenses_page
 

--- a/spec/system/court_dates/new_spec.rb
+++ b/spec/system/court_dates/new_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "court_dates/new", type: :system do
-  let(:now) { Date.new(2021, 1, 1) }
+  let(:now) { Date.new(2021, 1, 2) }
   let(:casa_org) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: casa_org) }
   let!(:casa_case) { create(:casa_case, casa_org: casa_org) }
@@ -23,8 +23,8 @@ RSpec.describe "court_dates/new", type: :system do
     it "is successful", js: true do
       expect(page).to have_content(casa_case.case_number)
 
-      fill_in "court_date_date", with: :now
-      fill_in "court_date_court_report_due_date", with: :now
+      fill_in "court_date_date", with: now
+      fill_in "court_date_court_report_due_date", with: now
       select judge.name, from: "Judge"
       select hearing_type.name, from: "Hearing type"
 
@@ -39,7 +39,7 @@ RSpec.describe "court_dates/new", type: :system do
 
       expect(page).to have_content("Court date was successfully created.")
       expect(page).to have_content(casa_case.case_number)
-      expect(page).to have_content("Court Report Due Date:")
+      expect(page).to have_content("Court Report Due Date:\nJanuary 2, 2021")
       expect(page).to have_content(judge.name)
       expect(page).to have_content(hearing_type.name)
       expect(page).to have_content(text)

--- a/spec/system/learning_hours/new_spec.rb
+++ b/spec/system/learning_hours/new_spec.rb
@@ -56,4 +56,15 @@ RSpec.describe "learning_hours/new", type: :system, js: true do
 
     expect(page).to have_text("Duration minutes and hours (total duration) must be greater than 0")
   end
+
+  it "errors if occured on date set in the future" do
+    fill_in "Learning Hours Title", with: "Test title"
+    select "Book", from: "Type of Learning"
+    fill_in "Hour(s)", with: "2"
+    fill_in "Minute(s)", with: "30"
+    fill_in "Occurred On", with: Date.tomorrow
+    click_on "Create New Learning Hours Entry"
+
+    expect(page).to have_text("Date cannot be in the future")
+  end
 end

--- a/spec/system/learning_hours/volunteers/show_spec.rb
+++ b/spec/system/learning_hours/volunteers/show_spec.rb
@@ -31,12 +31,12 @@ RSpec.describe "LearningHours::Volunteers #show", type: :system do
 
     it "displays the volunteer's first learning hours", js: true do
       expect(page).to have_content(learning_hours.first.name)
-      expect(page).to have_content(learning_hours.first.occurred_at.strftime("%B %d, %Y"))
+      expect(page).to have_content(learning_hours.first.occurred_at.strftime("%B %-d, %Y"))
     end
 
     it "displays the volunteer's last learning hours", js: true do
       expect(page).to have_content(learning_hours.last.name)
-      expect(page).to have_content(learning_hours.last.occurred_at.strftime("%B %d, %Y"))
+      expect(page).to have_content(learning_hours.last.occurred_at.strftime("%B %-d, %Y"))
     end
   end
 end

--- a/spec/system/mileage_rates/mileage_rates_spec.rb
+++ b/spec/system/mileage_rates/mileage_rates_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "mileage_rates/new", type: :system, js: true do
   it "add new mileage rate" do
     click_on "New Mileage Rate"
     expect(page).to have_text("New Mileage Rate")
-    fill_in "Effective date", with: "01-01-2020"
+    fill_in "Effective date", with: "02/01/2020"
     fill_in "Amount", with: 1.35
     uncheck "Currently active?"
     click_on "Save Mileage Rate"
 
     expect(page).to have_text("Mileage Rates")
     expect(page).to have_text("Effective date")
-    expect(page).to have_text("January 1, 2020")
+    expect(page).to have_text("February 1, 2020")
     expect(page).to have_text("Amount")
     expect(page).to have_text("$1.35")
     expect(page).to have_text("Active?")

--- a/spec/system/reports/export_data_spec.rb
+++ b/spec/system/reports/export_data_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe "case_contact_reports/index", type: :system do
     excluded_by_contact_type = create(:case_contact, occurred_at: 20.days.ago, contact_types: [school], notes: "Excluded by Contact Type")
 
     visit reports_path
-    start_date = 30.days.ago.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT)
-    end_date = 10.days.ago.strftime(::DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT)
-    page.execute_script("document.getElementById('report_start_date').setAttribute('value', '#{start_date}')")
-    page.execute_script("document.getElementById('report_end_date').setAttribute('value', '#{end_date}')")
+    start_date = 30.days.ago
+    end_date = 10.days.ago
+    fill_in "report_start_date", with: start_date
+    fill_in "report_end_date", with: end_date
     select court.name, from: "multiple-select-field3"
     click_button "Download Report"
     wait_for_download

--- a/spec/system/reports/index_spec.rb
+++ b/spec/system/reports/index_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "reports", type: :system, js: true do
       visit reports_path
 
       expect(page).to have_text "Case Contacts Report"
-      expect(page).to have_text I18n.l(6.months.ago.to_date, format: :day_and_date, default: "")
-      expect(page).to have_text I18n.l(Date.today.to_date, format: :day_and_date, default: "")
+      expect(page).to have_field("report_start_date", with: 6.months.ago.strftime("%Y-%m-%d"))
+      expect(page).to have_field("report_end_date", with: Date.today)
       expect(page).to have_text "Assigned To"
       expect(page).to have_text "Volunteers"
       expect(page).to have_text "Contact Type"
@@ -54,8 +54,8 @@ RSpec.describe "reports", type: :system, js: true do
       visit reports_path
 
       expect(page).to have_text "Case Contacts Report"
-      expect(page).to have_text I18n.l(6.months.ago.to_date, format: :day_and_date, default: "")
-      expect(page).to have_text I18n.l(Date.today.to_date, format: :day_and_date, default: "")
+      expect(page).to have_field("report_start_date", with: 6.months.ago.strftime("%Y-%m-%d"))
+      expect(page).to have_field("report_end_date", with: Date.today)
       expect(page).to have_text "Assigned To"
       expect(page).to have_text "Volunteers"
       expect(page).to have_text "Contact Type"

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
         fill_in "volunteer_display_name", with: "Kamisato Ayato"
         fill_in "volunteer_phone_number", with: "+14163248967"
-        fill_in "volunteer_date_of_birth", with: "1988/07/01"
+        fill_in "volunteer_date_of_birth", with: Date.new(1998, 7, 1)
         click_on "Submit"
 
         expect(page).to have_text "Volunteer was successfully updated."
@@ -85,7 +85,7 @@ RSpec.describe "volunteers/edit", type: :system do
           sign_in admin
           visit edit_volunteer_path(volunteer)
 
-          fill_in "volunteer_date_of_birth", with: 5.days.from_now.strftime("%Y/%m/%d")
+          fill_in "volunteer_date_of_birth", with: 5.days.from_now
           click_on "Submit"
 
           expect(page).to have_text "Date of birth must be in the past."

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "volunteers/new", type: :system do
 
       fill_in "Email", with: "new_volunteer@example.com"
       fill_in "Display name", with: "New Volunteer Display Name"
-      fill_in "Date of birth", with: "08/08/2001"
+      fill_in "Date of birth", with: Date.new(2001, 8, 8)
 
       click_on "Create Volunteer"
 
@@ -31,7 +31,7 @@ RSpec.describe "volunteers/new", type: :system do
 
       fill_in "Email", with: "new_volunteer2@example.com"
       fill_in "Display name", with: "New Volunteer Display Name 2"
-      fill_in "Date of birth", with: "01/01/2000"
+      fill_in "Date of birth", with: Date.new(2000, 1, 2)
 
       expect do
         click_on "Create Volunteer"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5580

### What changed, and why?
Bootstrap datepicker was replaced to use the native browser datepicker. The native browser will default to MM/DD/YYYY format based on the user locale.

### How will this affect user permissions?
- Volunteer permissions: N/A
- Supervisor permissions: N/A
- Admin permissions: N/A

### How is this tested? (please write tests!) 💖💪
Included DateTime objects to impacted test

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/143149354/d99db184-57d4-4c67-8690-5762b2d5a90a)
![image](https://github.com/rubyforgood/casa/assets/143149354/8176b65d-acbc-43a8-9bde-42fe097807d9)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
