### PR TITLE
fix: remove sleeps

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -28,7 +28,7 @@ class CaseCourtReportsController < ApplicationController
 
   def generate
     authorize CaseCourtReport
-    casa_case = CasaCase.find_by(case_number: case_params[:case_number])
+    casa_case = CasaCase.find_by(case_number: case_params[:case_number], casa_org: current_user.casa_org)
 
     respond_to do |format|
       format.json do
@@ -63,7 +63,7 @@ class CaseCourtReportsController < ApplicationController
   end
 
   def set_casa_case
-    @casa_case = CasaCase.find_by(case_number: params[:id])
+    @casa_case = CasaCase.find_by(case_number: params[:id], casa_org: current_user.casa_org)
   end
 
   def assigned_cases

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -11,6 +11,9 @@ Capybara.register_driver :selenium_chrome_in_container do |app|
     capabilities: [:chrome]
 end
 
+# disable CSS transitions and js animations
+Capybara.disable_animation = true
+
 options = Selenium::WebDriver::Chrome::Options.new
 options.add_argument("--disable-gpu")
 options.add_argument("--ignore-certificate-errors")

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -86,9 +86,8 @@ RSpec.describe "casa_cases/show", type: :system do
           click_button "Generate Report"
         end
 
-        expect(page).to have_selector("#btnGenerateReport .lni-download", visible: :hidden)
-        expect(page).to have_selector("#btnGenerateReport[disabled]")
-        expect(page).to have_selector("#spinner", visible: true)
+        wait_for_download
+        expect(download_file_name).to match(/#{casa_case.case_number}.docx/)
       end
     end
   end

--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe "case_contacts/create", type: :system, js: true do
       expect(page).to_not have_text(contact_topics.first.details)
       expect(page).to_not have_selector("##{topic_id} textarea")
 
-      sleep 0.4 # BUG: have to wait for the animation to finish
       find("##{topic_id}_button").click
 
       expect(page).to have_text(contact_topics.first.question)
@@ -117,7 +116,6 @@ RSpec.describe "case_contacts/create", type: :system, js: true do
         expect(page).to have_text(contact_topics.first.details)
         expect(page).to have_selector("##{topic_id} textarea")
 
-        sleep 0.4 # BUG: have to wait for the animation to finish
         click_on "read less"
 
         expect(page).to_not have_text(contact_topics.first.details)

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -127,9 +127,12 @@ you are trying to set the address for both of them. This is not currently possib
       expect(CaseContact.last.notes).not_to eq "Hello world"
 
       complete_notes_page(notes: "Hello world", click_continue: false)
-      # Wait for autosave to work
-      sleep(2)
-      expect(CaseContact.where(notes: "Hello world").count).to eq(1)
+
+      within 'div[data-controller="autosave"]' do
+        find('small[data-autosave-target="alert"]', text: "Saved!")
+      end
+
+      expect(CaseContact.last.notes).to eq "Hello world"
     end
   end
 end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -199,8 +199,11 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
       expect(CaseContact.last.notes).not_to eq "Hello world"
 
       complete_notes_page(notes: "Hello world", click_continue: false)
-      # Wait for autosave to work
-      sleep(2)
+
+      within 'div[data-controller="autosave"]' do
+        find('small[data-autosave-target="alert"]', text: "Saved!")
+      end
+
       expect(CaseContact.last.notes).to eq "Hello world"
     end
 


### PR DESCRIPTION
Blocked by https://github.com/rubyforgood/casa/pull/5625

Some system specs were relying on sleep to wait for client side JS to finish.

This changes the behavior to be more reliable by using built in Capybara methods.

Also removes animations in systems tests.