### PR TITLE
fix: select correct report in controller

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -28,7 +28,7 @@ class CaseCourtReportsController < ApplicationController
 
   def generate
     authorize CaseCourtReport
-    casa_case = CasaCase.find_by(case_number: case_params[:case_number])
+    casa_case = CasaCase.find_by(case_number: case_params[:case_number], casa_org: current_user.casa_org)
 
     respond_to do |format|
       format.json do
@@ -63,7 +63,7 @@ class CaseCourtReportsController < ApplicationController
   end
 
   def set_casa_case
-    @casa_case = CasaCase.find_by(case_number: params[:id])
+    @casa_case = CasaCase.find_by(case_number: params[:id], casa_org: current_user.casa_org)
   end
 
   def assigned_cases

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -86,9 +86,8 @@ RSpec.describe "casa_cases/show", type: :system do
           click_button "Generate Report"
         end
 
-        expect(page).to have_selector("#btnGenerateReport .lni-download", visible: :hidden)
-        expect(page).to have_selector("#btnGenerateReport[disabled]")
-        expect(page).to have_selector("#spinner", visible: true)
+        wait_for_download
+        expect(download_file_name).to match(/#{casa_case.case_number}.docx/)
       end
     end
   end


### PR DESCRIPTION
![image](https://github.com/rubyforgood/casa/assets/14540596/41ca7103-16f6-4691-b15c-bf02afbf10ba)

Failures on main for me. Not sure how CI is passing.  

Apparently in controllers relating to court reports, when were never scoping correctly. If there were multiple reports with the same case number it would show the incorrect report.

This is possible if two orgs have cases with the same number.



