### PR TITLE
fix: flaky volunteers edit request spec

### DIFF
--- a/app/views/volunteers/_manage_supervisor.erb
+++ b/app/views/volunteers/_manage_supervisor.erb
@@ -21,7 +21,7 @@
         <%= form_for SupervisorVolunteer.new, url: supervisor_volunteers_path(volunteer_id: @volunteer.id) do |form| %>
           <div class="select-style-1">
             <label for='supervisor_volunteer_supervisor_id'>Select a Supervisor</label>
-            <select name='supervisor_volunteer[supervisor_id]' class='form-control select2'>
+            <select name='supervisor_volunteer[supervisor_id]' id="supervisor_volunteer_supervisor_id" class='form-control select2'>
               <% @supervisors.each do |supervisor| %>
                 <option value="<%= supervisor.id %>"><%= supervisor.display_name %></option>
               <% end %>

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -105,9 +105,11 @@ RSpec.describe "/volunteers", type: :request do
 
     it "shows correct supervisor options", :aggregate_failures do
       supervisors = create_list(:supervisor, 3, casa_org: organization)
+      supervisors.append(create(:supervisor, casa_org: organization, display_name: "O'Hara")) # test for HTML escaping
 
-      page = request.parsed_body.to_html
-      supervisors.each { |supervisor| expect(page).to include(CGI.escape_html(supervisor.display_name)) }
+      page = Nokogiri::HTML(subject.body)
+      names = page.css("#supervisor_volunteer_supervisor_id option").map(&:text)
+      expect(supervisors.map(&:display_name)).to match_array(names)
     end
   end
 


### PR DESCRIPTION
Fixes:
https://github.com/rubyforgood/casa/actions/runs/8688501813/job/23824266895?pr=5621


```console
Failure/Error: supervisors.each { |supervisor| expect(page).to include(CGI.escape_html(supervisor.display_name)) }

       expected "<!DOCTYPE html><html><head>\n  <title>CASA Volunteer Tracking</title>\n\n  <meta name=\"description\...er end =========== -->\n</main>\n<!-- ======== main-wrapper end =========== -->\n\n\n</body></html>" to include "Marcus O&#39;Conner DC"
```

The test is looking for `CGI.escape_html` values which but the view does not use HTML escaped values so if the input is a name like `O'Hara` it looks for `O&#39;hara`. **Note:** the view is correct, if you use `CGI.escape_html` in the view the options within the select get funky.

Oh, and I fixed a text label :muscle: 