### PR TITLE
WIP: [Fix] Weekly supervisor email bottom section includes unknown names - probably volunteers from other orgs

### DIFF
--- a/app/mailers/supervisor_mailer.rb
+++ b/app/mailers/supervisor_mailer.rb
@@ -10,7 +10,7 @@ class SupervisorMailer < UserMailer
     @supervisor = supervisor
     @casa_organization = supervisor.casa_org
     @inactive_messages = InactiveMessagesService.new(supervisor).inactive_messages
-    @inactive_volunteers = supervisor.inactive_volunteers
+    @inactive_volunteers = supervisor.inactive_volunteers.where(casa_org_id: @casa_organization.id)
     if supervisor.receive_reimbursement_email
       mileage_report_attachment = MileageReport.new(@casa_organization.id).to_csv
       attachments["mileage-report-#{Time.current.strftime("%Y-%m-%d")}.csv"] = mileage_report_attachment


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5597 

### What changed, and why?
- New where the condition is added in in the `SupervisorMailer#weekly_digest` in order to get the volunteer of same organization only


### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪


### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
