### PR TITLE
prod fix

### DIFF
--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -2,6 +2,7 @@
 
 <div>
   <%= form_with(model: @case_contact, url: wizard_path(nil, case_contact_id: @case_contact.id), local: true, id: "casa-contact-form", class: "component-validated-form") do |form| %>
+    <%= form.hidden_field :placeholder, value: true %>
     <%= render "/shared/error_messages", resource: @case_contact %>
 
     <div class="card-style-1 pl-25 mb-10 pr-50">


### PR DESCRIPTION
> Error happens when trying to fill in the details page on a case contact for an org that has neither reimbursement or travel expenses enabled. 


https://github.com/rubyforgood/casa/wiki/Postmortem-%E2%80%90-prod-outage-April-May-2024
Related PRs
https://github.com/rubyforgood/casa/pull/5658
https://github.com/rubyforgood/casa/pull/5656
https://github.com/rubyforgood/casa/pull/5655
https://github.com/rubyforgood/casa/pull/5654
https://github.com/rubyforgood/casa/pull/5643
https://github.com/rubyforgood/casa/pull/5642
https://github.com/rubyforgood/casa/pull/5641