### PR TITLE
Add error message assertions for detail status context

### DIFF
--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -97,15 +97,21 @@ RSpec.describe CaseContact, type: :model do
     end
 
     it "requires medium type" do
-      expect(build_stubbed(:case_contact, :details_status, medium_type: nil)).not_to be_valid
+      case_contact = build_stubbed(:case_contact, :details_status, medium_type: nil)
+      expect(case_contact).not_to be_valid
+      expect(case_contact.errors.full_messages).to include("Medium type can't be blank")
     end
 
     it "requires a case to be selected" do
-      expect(build_stubbed(:case_contact, :details_status, draft_case_ids: [])).not_to be_valid
+      case_contact = build_stubbed(:case_contact, :details_status, draft_case_ids: [])
+      expect(case_contact).not_to be_valid
+      expect(case_contact.errors.full_messages).to include("You must select at least one casa case.")
     end
 
     it "requires occurred at" do
-      expect(build_stubbed(:case_contact, :details_status, occurred_at: nil)).not_to be_valid
+      case_contact = build_stubbed(:case_contact, :details_status, occurred_at: nil)
+      expect(case_contact).not_to be_valid
+      expect(case_contact.errors.full_messages).to include("Occurred at can't be blank")
     end
 
     it "requires duration minutes" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5607 

### What changed, and _why_?
For tests in `spec/models/case_contacts_spec.rb` that are asserting that the case contact is invalid, make sure that the tests are also asserting the presence of the correct error messages.

This more thoroughly tests the behavior of the validations.

### How is this **tested**? (please write tests!) 💖💪
N/A

### Screenshots please :)
N/A

### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
