### PR TITLE
Fix spec warning Fix spec warning The :make_visible option is not supported by the current driver - ignoring

### DIFF
--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "casa_org/edit", type: :system do
     sign_in admin
     visit edit_casa_org_path(organization)
 
-    page.attach_file("Logo", "spec/fixtures/company_logo.png", make_visible: true)
+    page.attach_file("Logo", "spec/fixtures/company_logo.png", visible: :visible)
 
     expect(organization.logo).to_not be_attached
 


### PR DESCRIPTION
Fix spec warning `Fix spec warning The :make_visible option is not supported by the current driver - ignoring`

### What github issue is this PR for, if any?
Resolves #5691 

### What changed, and _why_?
change `make_visible: true` to `visible: visible` to fix spec warning

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
![Screen Shot 2024-05-08 at 02 26 00](https://github.com/rubyforgood/casa/assets/17536001/12c56c23-90d9-4fc3-b7b6-84bfa5c9c678)
URL: http://localhost:3000/casa_org/1/edit
![Screen Shot 2024-05-08 at 02 29 51](https://github.com/rubyforgood/casa/assets/17536001/e5c4c975-4659-4ad3-928b-40fa0c1b54f4)



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
![alt text](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3NyM25iOGcyMWpucHJrZTh0aTY5MmcyaHVqYzdqazM3OWJ3YWplayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7yORCExjS87Jk10xSU/giphy.gif)
