### PR TITLE
fix: dependabot failures due to no secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        groups: ["[0, 1, 2, 3]", "[4, 5, 6, 7]", "[8, 9, 10, 11]"]
+        groups: ["[0, 1, 2]", "[3, 4, 5]", "[6, 7, 8]", "[9, 10, 11]"]
     uses: ./.github/workflows/rspec.yml
     secrets: inherit
     with:
       groups: ${{ matrix.groups }}
       group_count: 12 # the total number of test groups, must match the groups listed in the matrix.groups
-      parallel_processes_count: 4 # the number of parallel processes to run tests in worker, must match the size of the
+      parallel_processes_count: 3 # the number of parallel processes to run tests in worker, must match the size of the
       # inner arrays in the matrix.groups
   combine_and_report:
     uses: ./.github/workflows/combine_and_report.yml

--- a/.github/workflows/combine_and_report.yml
+++ b/.github/workflows/combine_and_report.yml
@@ -15,15 +15,15 @@ jobs:
           find artifacts -name "test_reports*.zip" -exec unzip -d test_reports {} \;
           find test_reports -name "**/test_reports*.zip" -exec unzip -d test_reports {} \;
       - name: Merge parallel runtime log parts
-        if: github.repository == github.event.pull_request.head.repo.full_name
+        if: env.AZURE_STORAGE_KEY != ''
         run: |
           cat artifacts/**/parallel_runtime_rspec*.log > parallel_runtime.log
       - name: Upload log file to Azure Blob Storage
-        if: github.repository == github.event.pull_request.head.repo.full_name
         env:
           AZURE_STORAGE_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           AZURE_STORAGE_ACCOUNT: ${{ secrets.ACCOUNT_NAME }}
           STORAGE_CONTAINER: ${{ secrets.STORAGE_CONTAINER }}
+        if: env.AZURE_STORAGE_KEY != ''
         run: |
           az storage blob upload \
           -c $STORAGE_CONTAINER \

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -42,14 +42,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download parallel runtime log from Azure Blob Storage
-        if: github.repository == github.event.pull_request.head.repo.full_name
         env:
           AZURE_STORAGE_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           AZURE_STORAGE_ACCOUNT: ${{ secrets.ACCOUNT_NAME }}
           STORAGE_CONTAINER: ${{ secrets.STORAGE_CONTAINER }}
+        if: env.AZURE_STORAGE_KEY != ''
         run: |
-          echo $STORAGE_CONTAINER
-          echo ${{ secrets.STORAGE_CONTAINER }}
           az storage blob download \
           -c $STORAGE_CONTAINER \
           --file old_parallel_runtime.log \
@@ -116,6 +114,7 @@ jobs:
           --runtime-log old_parallel_runtime.log \
           --verbose-command ./spec
 
+          echo 'Tests completed. Uploading to Code Climate'
           ./cc-test-reporter after-build --exit-code $?
           cat tmp/spec_summary.log
 
@@ -124,7 +123,7 @@ jobs:
           zip -r test_reports_${{ env.GROUPS_UNDERSCORE }}.zip tmp/reports
 
       - name: Compress log
-        if: github.repository == github.event.pull_request.head.repo.full_name
+        if: env.AZURE_STORAGE_KEY != ''
         run: |
           mv tmp/parallel_runtime.log parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
 
@@ -135,7 +134,7 @@ jobs:
           path: test_reports_${{ env.GROUPS_UNDERSCORE }}.zip
 
       - name: Upload file parallel tests runtime log
-        if: github.repository == github.event.pull_request.head.repo.full_name
+        if: env.AZURE_STORAGE_KEY != ''
         uses: actions/upload-artifact@v4
         with:
           name: parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log


### PR DESCRIPTION
Dependabot does not get passed secrets. Just don't run the actions that require secrets if they aren't passed in.