### PR TITLE
Fix Line Chart: MAU (Monthly Active Users) by User Type

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -42,9 +42,9 @@ class HealthController < ApplicationController
   def monthly_unique_users_graph_data
     first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month.strftime("%b %Y") }
 
-    monthly_counts_of_volunteers = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "Volunteer" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
-    monthly_counts_of_supervisors = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "Supervisor" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
-    monthly_counts_of_casa_admins = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "CasaAdmin" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
+    monthly_counts_of_volunteers = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: {type: "Volunteer"}, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
+    monthly_counts_of_supervisors = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: {type: "Supervisor"}, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
+    monthly_counts_of_casa_admins = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: {type: "CasaAdmin"}, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
 
     monthly_line_graph_combined_data = first_day_of_last_12_months.map do |month|
       [

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -40,18 +40,18 @@ class HealthController < ApplicationController
   end
 
   def monthly_unique_users_graph_data
-    first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month }
+    first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month.strftime("%b %Y") }
 
-    monthly_counts_of_volunteers = User.where(type: "Volunteer").group_by_month(:current_sign_in_at, format: "%b %Y").count
-    monthly_counts_of_supervisors = User.where(type: "Supervisor").group_by_month(:current_sign_in_at, format: "%b %Y").count
-    monthly_counts_of_casa_admins = User.where(type: "CasaAdmin").group_by_month(:current_sign_in_at, format: "%b %Y").count
+    monthly_counts_of_volunteers = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "Volunteer" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
+    monthly_counts_of_supervisors = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "Supervisor" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
+    monthly_counts_of_casa_admins = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: { type: "CasaAdmin" }, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
 
     monthly_line_graph_combined_data = first_day_of_last_12_months.map do |month|
       [
-        month.strftime("%b %Y"),
-        monthly_counts_of_volunteers[month.strftime("%b %Y")] || 0,
-        monthly_counts_of_supervisors[month.strftime("%b %Y")] || 0,
-        monthly_counts_of_casa_admins[month.strftime("%b %Y")] || 0
+        month,
+        monthly_counts_of_volunteers[month] || 0,
+        monthly_counts_of_supervisors[month] || 0,
+        monthly_counts_of_casa_admins[month] || 0
       ]
     end
 

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -75,14 +75,19 @@ RSpec.describe "Health", type: :request do
 
   describe "GET #monthly_unique_users_graph_data" do
     it "returns monthly unique users data for volunteers, supervisors, and admins in the last year" do
-      create(:user, type: "Volunteer", current_sign_in_at: 11.months.ago)
-      create(:user, type: "Volunteer", current_sign_in_at: 11.months.ago)
-      create(:user, type: "Supervisor", current_sign_in_at: 11.months.ago)
-      create(:user, type: "CasaAdmin", current_sign_in_at: 11.months.ago)
-      create(:user, type: "Volunteer", current_sign_in_at: 10.months.ago)
-      create(:user, type: "Volunteer", current_sign_in_at: 9.months.ago)
-      create(:user, type: "Supervisor", current_sign_in_at: 9.months.ago)
-      create(:user, type: "CasaAdmin", current_sign_in_at: 9.months.ago)
+      volunteer1 = create(:user, type: "Volunteer")
+      volunteer2 = create(:user, type: "Volunteer")
+      supervisor = create(:user, type: "Supervisor")
+      casa_admin = create(:user, type: "CasaAdmin")
+
+      create(:login_activity, user: volunteer1, created_at: 11.months.ago, success: true)
+      create(:login_activity, user: volunteer2, created_at: 11.months.ago, success: true)
+      create(:login_activity, user: supervisor, created_at: 11.months.ago, success: true)
+      create(:login_activity, user: casa_admin, created_at: 11.months.ago, success: true)
+      create(:login_activity, user: volunteer1, created_at: 10.months.ago, success: true)
+      create(:login_activity, user: volunteer2, created_at: 9.months.ago, success: true)
+      create(:login_activity, user: supervisor, created_at: 9.months.ago, success: true)
+      create(:login_activity, user: casa_admin, created_at: 9.months.ago, success: true)
 
       get monthly_unique_users_graph_data_health_index_path
       expect(response).to have_http_status(:ok)
@@ -95,7 +100,6 @@ RSpec.describe "Health", type: :request do
       expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 1])
       expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 0])
       expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
-      expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5723

### What changed, and _why_?
Need to fix Monthly Active Users chart data by fetching details from new table login_activity which tracks history of User's login to calculate correct details.

### How is this **tested**? (please write tests!) 💖💪
Added tests to check calculation based on data.

### Screenshots please :)
![CASA-MAU](https://github.com/rubyforgood/casa/assets/514363/31377098-c35e-451b-a62c-654a7055b43a)



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
