### PR TITLE
fix: restore old rspec in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,25 @@ on:
       - main
 
 jobs:
+  preparation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/gallium
+          cache: "yarn"
+
   rspec_parallel:
+    needs: [preparation]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Continuous Integration (experimental)
 
 on:
   push:
@@ -12,12 +12,12 @@ on:
       - main
 
 jobs:
-  rspec:
+  rspec_parallel:
     strategy:
       fail-fast: false
       matrix:
         groups: ["[0, 1, 2]", "[3, 4, 5]", "[6, 7, 8]", "[9, 10, 11]"]
-    uses: ./.github/workflows/rspec.yml
+    uses: ./.github/workflows/rspec_parallel.yml
     secrets: inherit
     with:
       groups: ${{ matrix.groups }}
@@ -26,5 +26,5 @@ jobs:
       # inner arrays in the matrix.groups
   combine_and_report:
     uses: ./.github/workflows/combine_and_report.yml
-    needs: [rspec]
+    needs: [rspec_parallel]
     secrets: inherit

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,31 +1,22 @@
 name: rspec
 
 on:
-  workflow_call:
-    inputs:
-      groups:
-        required: true
-        type: string
-      group_count:
-        required: true
-        type: number
-      parallel_processes_count:
-        required: true
-        type: number
-env:
-  GROUPS_COMMA: ${{ join(fromJSON(inputs.groups), ',') }}
-  GROUPS_UNDERSCORE: ${{ join(fromJSON(inputs.groups), '_') }}
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "doc/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   rspec:
-    name: RSpec Groups ${{ inputs.groups }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     env:
       RAILS_ENV: test
-      BUNDLE_WITHOUT: "development"
-      CI_TOTAL_JOBS: ${{ inputs.group_count }}
-      CI_JOB_INDEX: ${{ inputs.groups }}
+
     services:
       db:
         image: postgres:14.8
@@ -38,40 +29,21 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download parallel runtime log from Azure Blob Storage
-        env:
-          AZURE_STORAGE_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
-          AZURE_STORAGE_ACCOUNT: ${{ secrets.ACCOUNT_NAME }}
-          STORAGE_CONTAINER: ${{ secrets.STORAGE_CONTAINER }}
-        if: env.AZURE_STORAGE_KEY != ''
-        run: |
-          az storage blob download \
-          -c $STORAGE_CONTAINER \
-          --file old_parallel_runtime.log \
-          -n parallel_runtime.log
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - name: Set up JS
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/gallium
-          cache: 'yarn'
-      - run: yarn
-
       - name: Install PostgreSQL client
         run: |
           sudo apt-get -yqq install libpq-dev
 
-      - name: Setup Parallel Database
+      - name: Build App
         env:
-          RAILS_ENV: test
           POSTGRES_HOST: localhost
           DATABASE_HOST: localhost
           POSTGRES_USER: postgres
@@ -80,69 +52,32 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          echo "setting up database"
-          bundle exec rake parallel:create
-          bundle exec rake parallel:rake[db:schema:load]
-          echo "done"
-
-      - name: Build App
-        run: |
+          yarn
+          bundle exec rake db:create
+          bundle exec rake db:schema:load
           bundle exec rails css:build
           bundle exec rails javascript:build
 
-      - name: Run rspec group ${{ inputs.group }}
+      - name: Run rspec and upload code coverage
         env:
-          RAILS_ENV: test
-          POSTGRES_HOST: localhost
           DATABASE_HOST: localhost
           POSTGRES_USER: postgres
           CASA_DATABASE_PASSWORD: password
-          POSTGRES_PASSWORD: password
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_PORT: 5432
           RUN_SIMPLECOV: true
           CC_TEST_REPORTER_ID: 31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
-        continue-on-error: true
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
-
-          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec parallel_rspec \
-          -n "${CI_TOTAL_JOBS}" \
-          --only-group "${CI_JOB_INDEX}" \
-          --runtime-log old_parallel_runtime.log \
-          --verbose-command ./spec
-
-          echo 'Tests completed. Uploading to Code Climate'
+          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
           ./cc-test-reporter after-build --exit-code $?
-          cat tmp/spec_summary.log
 
-      - name: Compress reports
-        run: |
-          zip -r test_reports_${{ env.GROUPS_UNDERSCORE }}.zip tmp/reports
-
-      - name: Compress log
-        if: env.AZURE_STORAGE_KEY != ''
-        run: |
-          mv tmp/parallel_runtime.log parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
-
-      - name: Upload test reports
+      - name: Archive selenium screenshots
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test_reports_${{ env.GROUPS_UNDERSCORE }}.zip
-          path: test_reports_${{ env.GROUPS_UNDERSCORE }}.zip
-
-      - name: Upload file parallel tests runtime log
-        if: env.AZURE_STORAGE_KEY != ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
-          path: parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
-
-      - name: Upload Selenium Screenshots
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots_${{ env.GROUPS_UNDERSCORE }}
-          path: ${{ github.workspace }}/tmp/screenshots${{ env.GROUPS_UNDERSCORE }}/
-          if-no-files-found: ignore
+          name: selenium-screenshots
+          path: |
+            ${{ github.workspace }}/tmp/capybara/*.png
+            ${{ github.workspace }}/tmp/capybara/*.html

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Set up JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/gallium
+          cache: "yarn"
+      - run: yarn
+
       - name: Install PostgreSQL client
         run: |
           sudo apt-get -yqq install libpq-dev
@@ -52,7 +59,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
         run: |
-          yarn
           bundle exec rake db:create
           bundle exec rake db:schema:load
           bundle exec rails css:build

--- a/.github/workflows/rspec_parallel.yml
+++ b/.github/workflows/rspec_parallel.yml
@@ -1,0 +1,148 @@
+name: rspec_parallel
+
+on:
+  workflow_call:
+    inputs:
+      groups:
+        required: true
+        type: string
+      group_count:
+        required: true
+        type: number
+      parallel_processes_count:
+        required: true
+        type: number
+env:
+  GROUPS_COMMA: ${{ join(fromJSON(inputs.groups), ',') }}
+  GROUPS_UNDERSCORE: ${{ join(fromJSON(inputs.groups), '_') }}
+
+jobs:
+  rspec_parallel:
+    name: RSpec Groups ${{ inputs.groups }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    env:
+      RAILS_ENV: test
+      BUNDLE_WITHOUT: "development"
+      CI_TOTAL_JOBS: ${{ inputs.group_count }}
+      CI_JOB_INDEX: ${{ inputs.groups }}
+    services:
+      db:
+        image: postgres:14.8
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download parallel runtime log from Azure Blob Storage
+        env:
+          AZURE_STORAGE_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          AZURE_STORAGE_ACCOUNT: ${{ secrets.ACCOUNT_NAME }}
+          STORAGE_CONTAINER: ${{ secrets.STORAGE_CONTAINER }}
+        if: env.AZURE_STORAGE_KEY != ''
+        run: |
+          az storage blob download \
+          -c $STORAGE_CONTAINER \
+          --file old_parallel_runtime.log \
+          -n parallel_runtime.log
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/gallium
+          cache: "yarn"
+      - run: yarn
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get -yqq install libpq-dev
+
+      - name: Setup Parallel Database
+        env:
+          RAILS_ENV: test
+          POSTGRES_HOST: localhost
+          DATABASE_HOST: localhost
+          POSTGRES_USER: postgres
+          CASA_DATABASE_PASSWORD: password
+          POSTGRES_PASSWORD: password
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PORT: 5432
+        run: |
+          echo "setting up database"
+          bundle exec rake parallel:create
+          bundle exec rake parallel:rake[db:schema:load]
+          echo "done"
+
+      - name: Build App
+        run: |
+          bundle exec rails css:build
+          bundle exec rails javascript:build
+
+      - name: Run rspec group ${{ inputs.group }}
+        env:
+          RAILS_ENV: test
+          POSTGRES_HOST: localhost
+          DATABASE_HOST: localhost
+          POSTGRES_USER: postgres
+          CASA_DATABASE_PASSWORD: password
+          POSTGRES_PASSWORD: password
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_PORT: 5432
+          RUN_SIMPLECOV: true
+          CC_TEST_REPORTER_ID: 31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
+        continue-on-error: true
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
+          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec parallel_rspec \
+          -n "${CI_TOTAL_JOBS}" \
+          --only-group "${CI_JOB_INDEX}" \
+          --runtime-log old_parallel_runtime.log \
+          --verbose ./spec
+
+          echo 'Tests completed. Uploading to Code Climate'
+          ./cc-test-reporter after-build --exit-code $?
+          cat tmp/spec_summary.log
+
+      - name: Compress reports
+        run: |
+          zip -r test_reports_${{ env.GROUPS_UNDERSCORE }}.zip tmp/reports
+
+      - name: Compress log
+        if: env.AZURE_STORAGE_KEY != ''
+        run: |
+          mv tmp/parallel_runtime.log parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: test_reports_${{ env.GROUPS_UNDERSCORE }}.zip
+          path: test_reports_${{ env.GROUPS_UNDERSCORE }}.zip
+
+      - name: Upload file parallel tests runtime log
+        if: env.AZURE_STORAGE_KEY != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
+          path: parallel_runtime_rspec_${{ env.GROUPS_UNDERSCORE }}.log
+
+      - name: Upload Selenium Screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots_${{ env.GROUPS_UNDERSCORE }}
+          path: ${{ github.workspace }}/tmp/screenshots${{ env.GROUPS_UNDERSCORE }}/
+          if-no-files-found: ignore


### PR DESCRIPTION
RSpec parallel is still too flaky. Bring back old pipeline until the new one is ready.

This is one option. If there is not enough CI budget for all the runners I will open a PR to disable the parallel ones completely until they are more ready.