### PR TITLE
Restyle Enter Contact Details form on case contact form

### DIFF
--- a/app/components/form/hour_minute_duration_component.html.erb
+++ b/app/components/form/hour_minute_duration_component.html.erb
@@ -1,19 +1,21 @@
-<div class="row align-items-center">
-  <div class="input-style-1 col pl-0">
+<div class="d-flex flex-column flex-lg-row gap-2">
+  <div class="col input-style-1">
     <%= @form.label :duration_hours, "Hour(s)" %>
     <%= @form.number_field :duration_hours,
       min: 0,
-      class: "cc-field",
+      class: "form-control",
       size: "10",
+
       value: @hour_value,
       required: true %>
   </div>
-  <div class="input-style-1 col">
+  <div class="col input-style-1">
     <%= @form.label :duration_minutes, "Minute(s)" %>
     <%= @form.number_field :duration_minutes,
       min: 0,
-      class: "cc-field",
+      class: "form-control",
       size: "10",
+      style: "background:white",
       value: @minute_value,
       required: true %>
   </div>

--- a/app/views/case_contacts/form/details.html.erb
+++ b/app/views/case_contacts/form/details.html.erb
@@ -32,9 +32,9 @@
     </div>
 
     <div id="enter-contact-details" class="card-style-1 pl-25 mb-10">
-      <h4 class="mb-3"><label>3. Enter Contact Details</label><span class="red-letter"> *</span></h4>
+      <h4 class="mb-3"><label>3. Record contact details</label><span class="red-letter"> *</span></h4>
       <div class="">
-        <h5 classs="mb-3"><label>a. Contact Made</label></h5>
+        <h5 classs="mb-3"><label>a. Was contact made?</label></h5>
         <div class="form-check radio-style mb-20">
           <%= form.radio_button :contact_made, true,
             checked: @case_contact.contact_made,
@@ -54,7 +54,7 @@
       </div>
 
       <div class="field contact-medium form-group">
-        <h5 classs="mb-3"><label>b. Contact Medium</label></h5>
+        <h5 classs="mb-3"><label>b. How was contact made?</label></h5>
         <%= form.collection_radio_buttons(:medium_type, contact_mediums, 'value', 'label') do |b| %>
           <div class="form-check radio-style mb-20">
             <%= b.radio_button(class: "form-check-input") %>
@@ -64,7 +64,7 @@
       </div>
 
       <div class="pr-50">
-        <h5 class="mb-3"><%= form.label :occurred_at, "c. Occurred On" %></h5>
+        <h5 class="mb-3"><%= form.label :occurred_at, "c. Date of contact" %></h5>
         <div class="input-style-1">
           <% occurred_at = @case_contact.occurred_at || Time.zone.now %>
           <%= render "layouts/components/ranged_date_picker",
@@ -74,7 +74,7 @@
       </div>
 
       <div class="pr-50 ">
-        <h5 class="mb-3"><label>d. Duration of Meeting</label></h5>
+        <h5 class="mb-3"><label>d. Duration of contact</label></h5>
         <%= render(Form::HourMinuteDurationComponent.new(form: form, hour_value: duration_hours(@case_contact), minute_value: duration_minutes(@case_contact))) %>
       </div>
     </div>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5348 

### What changed, and _why_?
Updated text content to match updated design spec in figma file. Also updated contact duration input fields.

### How is this **tested**? (please write tests!) 💖💪
Tested by existing specs.

### Screenshots please :)
**Desktop**
![Selection_415](https://github.com/rubyforgood/casa/assets/88392688/eb872c12-c658-4949-80b9-85029c7f99c2)

**Mobile**
![Selection_416](https://github.com/rubyforgood/casa/assets/88392688/e60a92b7-dda1-4e2e-af7d-af5aed74d6b5)

### Questions

Our work currently differs from the figma in a couple of ways. Here's ours:
![differences_figma](https://github.com/rubyforgood/casa/assets/88392688/4d61ee78-cd95-490a-8319-c69f2af8207d)

And here's what's in the figma
![Selection_417](https://github.com/rubyforgood/casa/assets/88392688/e0c6d1a5-7d17-4a4c-85f3-41017fef3108)

For the first difference, changing `Text/Email` isn't so straightforward because it relies on these [string values](https://github.com/rubyforgood/casa/blob/main/app/models/case_contact.rb#L157-L162) that are saved to the database. Changing this input value introduces a conflict between the form and the underlying data. Any preference for how to proceed on this?

For the second difference, introducing text content that directly trails the numeric input value is tricky to do and is less accessible than just having normal labels. If this is really required though, we can probably put in the work to figure out something for it.

### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
