### PR TITLE
fix: add logging for URI error in afterparty

### DIFF
--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -137,6 +137,13 @@ class CasaOrg < ApplicationRecord
       client.messages.list(limit: 1)
     rescue Twilio::REST::RestError
       errors.add(:base, "Your Twilio credentials are incorrect, kindly check and try again.")
+    rescue URI::InvalidURIError => e
+      Bugsnag.notify("Invalid Twilio URI: #{e.message}.
+        org: #{id} #{name} =>
+        twilio_enabled: #{twilio_enabled}
+        key_sid: #{twilio_api_key_sid.present?}
+        account_sid: #{twilio_account_sid.present?}
+        key_secret: #{twilio_api_key_secret.present?}")
     end
   end
 

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -5,7 +5,7 @@ if ENV["BUGSNAG_API_KEY"].present?
     config.release_stage = ENV["HEROKU_APP_NAME"] || ENV["APP_ENVIRONMENT"]
 
     callback = proc do |event|
-      event.set_user(current_user&.id, current_user&.email)
+      event.set_user(current_user&.id, current_user&.email) if defined?(current_user)
     end
 
     config.add_on_error(callback)


### PR DESCRIPTION
Last deploy failed due to
```console
URI::InvalidURIError: bad URI(is not URI?): "https://api.twilio.com/2010-04-01/Accounts/{\"p\":\"\",\"h\":{\"iv\":\"WCWQJURMuJ7Cy1y4\",\"at\":\"GSwNz4L/qh0FMCOAHc2rxQ==\"}}/Messages.json" (URI::InvalidURIError)
```

![image](https://github.com/rubyforgood/casa/assets/14540596/e26ed6c2-9d46-4fd0-8247-4cff808f8057)


https://app.bugsnag.com/ruby-for-good/casa/errors/664d4d0b29d5440008cf42d8?filters%5Bevent.unhandled%5D=true&filters%5Bevent.since%5D=30d&filters%5Bapp.release_stage%5D=production

This PR add some logging for that error so we can figure out what the issue is.