### PR TITLE
refactor: twilio validation 

### DIFF
--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -137,6 +137,13 @@ class CasaOrg < ApplicationRecord
       client.messages.list(limit: 1)
     rescue Twilio::REST::RestError
       errors.add(:base, "Your Twilio credentials are incorrect, kindly check and try again.")
+    rescue URI::InvalidURIError => e
+      Bugsnag.notify("Invalid Twilio URI: #{e.message}.
+        org: #{id} #{name} =>
+        twilio_enabled: #{twilio_enabled}
+        key_sid: #{twilio_api_key_sid.present?}
+        account_sid: #{twilio_account_sid.present?}
+        key_secret: #{twilio_api_key_secret.present?}")
     end
   end
 

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -11,7 +11,7 @@ class CasaOrg < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates_with CasaOrgValidator
-  validate :validate_twilio_credentials, if: -> { twilio_enabled || twilio_account_sid.present? || twilio_api_key_sid.present? || twilio_api_key_secret.present? }, on: :update
+  validate :validate_twilio_credentials, if: :twilio_enabled, on: :update
 
   has_many :users, dependent: :destroy
   has_many :casa_cases, dependent: :destroy
@@ -135,15 +135,8 @@ class CasaOrg < ApplicationRecord
     client = Twilio::REST::Client.new(twilio_api_key_sid, twilio_api_key_secret, twilio_account_sid)
     begin
       client.messages.list(limit: 1)
-    rescue Twilio::REST::RestError
+    rescue Twilio::REST::RestError, URI::InvalidURIError
       errors.add(:base, "Your Twilio credentials are incorrect, kindly check and try again.")
-    rescue URI::InvalidURIError => e
-      Bugsnag.notify("Invalid Twilio URI: #{e.message}.
-        org: #{id} #{name} =>
-        twilio_enabled: #{twilio_enabled}
-        key_sid: #{twilio_api_key_sid.present?}
-        account_sid: #{twilio_account_sid.present?}
-        key_secret: #{twilio_api_key_secret.present?}")
     end
   end
 

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -5,7 +5,7 @@ if ENV["BUGSNAG_API_KEY"].present?
     config.release_stage = ENV["HEROKU_APP_NAME"] || ENV["APP_ENVIRONMENT"]
 
     callback = proc do |event|
-      event.set_user(current_user&.id, current_user&.email)
+      event.set_user(current_user&.id, current_user&.email) if defined?(current_user)
     end
 
     config.add_on_error(callback)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,3 +86,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :ci_only
   end
 end
+
+def stub_twillio
+  twillio_client = instance_double(Twilio::REST::Client)
+  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
+  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
+  allow(twillio_client).to receive(:messages).and_return(messages)
+  allow(messages).to receive(:list).and_return([])
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,8 @@ RSpec.configure do |config|
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
   config.include ActionText::SystemTestHelper, type: :system
+  config.include TwilioHelper, type: :request
+  config.include TwilioHelper, type: :system
 
   config.after do
     Warden.test_reset!
@@ -82,15 +84,5 @@ RSpec.configure do |config|
     example.run
   end
 
-  unless ENV["GITHUB_ACTIONS"]
-    config.filter_run_excluding :ci_only
-  end
-end
-
-def stub_twillio
-  twillio_client = instance_double(Twilio::REST::Client)
-  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
-  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
-  allow(twillio_client).to receive(:messages).and_return(messages)
-  allow(messages).to receive(:list).and_return([])
+  config.filter_run_excluding :ci_only unless ENV["GITHUB_ACTIONS"]
 end

--- a/spec/requests/casa_org_spec.rb
+++ b/spec/requests/casa_org_spec.rb
@@ -137,11 +137,3 @@ RSpec.describe "CasaOrg", type: :request do
     end
   end
 end
-
-def stub_twillio
-  twillio_client = instance_double(Twilio::REST::Client)
-  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
-  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
-  allow(twillio_client).to receive(:messages).and_return(messages)
-  allow(messages).to receive(:list).and_return([])
-end

--- a/spec/requests/casa_org_spec.rb
+++ b/spec/requests/casa_org_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "CasaOrg", type: :request do
   let(:casa_case) { build_stubbed(:casa_case, casa_org: casa_org) }
 
   before {
-    stub_twillio
+    stub_twilio
     sign_in create(:casa_admin, casa_org: casa_org)
   }
 

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -244,11 +244,3 @@ RSpec.describe "/case_court_reports", type: :request do
     end
   end
 end
-
-def stub_twillio
-  twillio_client = instance_double(Twilio::REST::Client)
-  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
-  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
-  allow(twillio_client).to receive(:messages).and_return(messages)
-  allow(messages).to receive(:list).and_return([])
-end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "/case_court_reports", type: :request do
 
     context "when a custom template is set" do
       before do
-        stub_twillio
+        stub_twilio
         volunteer.casa_org.court_report_template.attach(io: File.new(Rails.root.join("app", "documents", "templates", "montgomery_report_template.docx")), filename: "montgomery_report_template.docx")
       end
 

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -1,0 +1,9 @@
+module TwilioHelper
+  def stub_twilio
+    twilio_client = instance_double(Twilio::REST::Client)
+    messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
+    allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twilio_client)
+    allow(twilio_client).to receive(:messages).and_return(messages)
+    allow(messages).to receive(:list).and_return([])
+  end
+end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -614,11 +614,3 @@ of it unless it was included in a previous court report.")
     end
   end
 end
-
-def stub_twillio
-  twillio_client = instance_double(Twilio::REST::Client)
-  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
-  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
-  allow(twillio_client).to receive(:messages).and_return(messages)
-  allow(messages).to receive(:list).and_return([])
-end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "Edit CASA Case", type: :system do
     it_behaves_like "shows court dates links"
 
     it "edits case", js: true do
-      stub_twillio
+      stub_twilio
       visit casa_case_path(casa_case)
       expect(page).to have_text("Court Report Status: Not submitted")
       visit edit_casa_case_path(casa_case)

--- a/spec/system/casa_org/edit_spec.rb
+++ b/spec/system/casa_org/edit_spec.rb
@@ -76,11 +76,3 @@ RSpec.describe "casa_org/edit", type: :system do
     expect(message).to eq "Please fill out this field."
   end
 end
-
-def stub_twilio
-  twillio_client = instance_double(Twilio::REST::Client)
-  messages = instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList)
-  allow(Twilio::REST::Client).to receive(:new).with("Aladdin", "open sesame", "articuno34").and_return(twillio_client)
-  allow(twillio_client).to receive(:messages).and_return(messages)
-  allow(messages).to receive(:list).and_return([])
-end


### PR DESCRIPTION
#5742 added logging. This removes that logging and changes some validation behavior. The actual fixes to the data will probably need to be done manually in the prod console.

My current theory is that there is just bad data in some organization but the updates have never happened in `after_party` so a deploy has never failed to the issues.

