### PR TITLE
Fixes local database discrepencies

### DIFF
--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -52,7 +52,6 @@ end
 #  id                     :bigint           not null, primary key
 #  duration_hours         :integer          not null
 #  duration_minutes       :integer          not null
-#  learning_type          :integer          default(5)
 #  name                   :string           not null
 #  occurred_at            :datetime         not null
 #  created_at             :datetime         not null

--- a/db/migrate/20240523101303_fix_local_discrepencies.rb
+++ b/db/migrate/20240523101303_fix_local_discrepencies.rb
@@ -1,0 +1,4 @@
+class FixLocalDiscrepencies < ActiveRecord::Migration[7.1]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_07_022441) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_23_101303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -420,7 +420,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_022441) do
 
   create_table "learning_hours", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "learning_type", default: 5
     t.string "name", null: false
     t.integer "duration_minutes", null: false
     t.integer "duration_hours", null: false
@@ -692,14 +691,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_07_022441) do
   add_foreign_key "learning_hour_types", "casa_orgs"
   add_foreign_key "learning_hours", "learning_hour_types"
   add_foreign_key "learning_hours", "users"
-  add_foreign_key "mileage_rates", "casa_orgs"
+  add_foreign_key "mileage_rates", "casa_orgs", validate: false
   add_foreign_key "mileage_rates", "users"
-  add_foreign_key "notes", "users", column: "creator_id"
+  add_foreign_key "notes", "users", column: "creator_id", validate: false
   add_foreign_key "other_duties", "users", column: "creator_id"
   add_foreign_key "patch_notes", "patch_note_groups"
   add_foreign_key "patch_notes", "patch_note_types"
   add_foreign_key "placement_types", "casa_orgs"
-  add_foreign_key "placements", "casa_cases"
+  add_foreign_key "placements", "casa_cases", validate: false
   add_foreign_key "placements", "placement_types"
   add_foreign_key "placements", "users", column: "creator_id"
   add_foreign_key "preference_sets", "users"


### PR DESCRIPTION
### What github issue is this PR for, if any?
N/A

This should fix the issue with local setups having bad schema listings. I verified these changes are already in prod and just need to be added to `schema.rb`.
<img width="665" alt="Screenshot 2024-05-23 at 6 11 06 AM" src="https://github.com/rubyforgood/casa/assets/50247514/6e8dd3f8-8a9e-4acc-b8a2-92e5a74440ba">
<img width="635" alt="Screenshot 2024-05-23 at 6 10 42 AM" src="https://github.com/rubyforgood/casa/assets/50247514/03f11286-4799-4ace-9724-3e58538a4808">
<img width="677" alt="Screenshot 2024-05-23 at 6 10 14 AM" src="https://github.com/rubyforgood/casa/assets/50247514/a727e620-e1f6-4a3e-860e-ab5808ab1f36">


### What changed, and _why_?
I initially made this with a migration that looked like this, and then emptied the migration file.
<img width="1120" alt="Screenshot 2024-05-23 at 6 17 52 AM" src="https://github.com/rubyforgood/casa/assets/50247514/44283587-a1e2-4e7c-8d49-c0e4dfe94640">

### How is this **tested**? (please write tests!) 💖💪
I ran the following commands after the commit and got no additional changes:
```
bin/rails db:migrate
bin/rails db:reset
bin/update
bin/setup
```


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
