### PR TITLE
feat: add initial tag for future releases

### DIFF
--- a/DEPLOY_CHECKLIST.md
+++ b/DEPLOY_CHECKLIST.md
@@ -1,1 +1,1 @@
-See https://github.com/rubyforgood/casa/wiki/deploy-checklist
+See [the deploy checklist](https://github.com/rubyforgood/casa/wiki/deploy-checklist)


### PR DESCRIPTION
I want to experiment with using tags for releases to auto-generate release notes. Something like https://github.com/Shopify/cli/releases

Github can auto-generate release notes but it requires git tags so that it knows which range of commits to include in the notes.

This adds a commit that is basically a no-op but it has a tag that we can reference off of for future releases.