### PR TITLE
feat: precompile assets in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,10 +34,8 @@ jobs:
         run: docker-compose up -d
       - name: db:reset
         run: docker-compose exec -T web rails db:reset
-      - name: compile css
-        run: docker-compose exec -T web bundle exec rails css:build
-      - name: compile js
-        run: docker-compose exec -T web bundle exec rails javascript:build
+      - name: compile assets
+        run: docker-compose exec -T web bundle exec rails assets:precompile
       - name: Test
         run: docker-compose exec -T web bundle exec rspec spec --format documentation
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -61,8 +61,7 @@ jobs:
         run: |
           bundle exec rake db:create
           bundle exec rake db:schema:load
-          bundle exec rails css:build
-          bundle exec rails javascript:build
+          bundle exec rails assets:precompile
 
       - name: Run rspec and upload code coverage
         env:

--- a/.github/workflows/rspec_parallel.yml
+++ b/.github/workflows/rspec_parallel.yml
@@ -87,8 +87,7 @@ jobs:
 
       - name: Build App
         run: |
-          bundle exec rails css:build
-          bundle exec rails javascript:build
+          bundle exec rails assets:precompile
 
       - name: Run rspec group ${{ inputs.group }}
         env:


### PR DESCRIPTION
Maybe this will reduce memory consumption? (Is memory consumption even the issue?)

`rails assets:precompile` does the equivalent of `yarn:build` + `yarn:build:css` + compiles other assets to serve statically
