### PR TITLE
FIx: un nest generate court report for volunteers only

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -42,7 +42,8 @@
           <%= render(Sidebar::LinkComponent.new(title: "Emancipation Checklist(s)", icon: "list", path: emancipation_checklists_path, render_check: current_user.serving_transition_aged_youth?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.volunteer?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Banners", icon: "flag", path: banners_path, render_check: policy(:application).see_banner_page?)) %>
-          <%= render(Sidebar::GroupComponent.new(title: "Group Actions", icon: "list")) do |group| %>
+          <%= render(Sidebar::LinkComponent.new(title: "Generate Court Reports", icon: "paperclip", path: case_court_reports_path, render_check: policy(:application).see_court_reports_page? && current_user.volunteer?)) %>
+          <%= render(Sidebar::GroupComponent.new(title: "Group Actions", icon: "list", render_check: !current_user.volunteer?)) do |group| %>
             <% group.with_links([
               { title: "Generate Court Reports", icon: "paperclip", path: case_court_reports_path, render_check: policy(:application).see_court_reports_page? },
               { title: "Reimbursement Queue", icon: "money-location", path: reimbursements_path, render_check: policy(:reimbursement).index? },


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5599

### What changed, and _why_?
Un nested "generate court reports" from group action and got rid of group actions for Volunteers only.

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)

For Volunteer
![volunteers_screenshot](https://github.com/rubyforgood/casa/assets/75837235/a8fa1c3f-0583-4030-a1be-23666099f9bd)


For Supervisor
![supervisor_screenshot](https://github.com/rubyforgood/casa/assets/75837235/6c491d11-0d43-4b78-98dd-cbb23a221bb5)


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
