### PR TITLE
feat: disable simplecov in parallel ci

### DIFF
--- a/.github/workflows/rspec_parallel.yml
+++ b/.github/workflows/rspec_parallel.yml
@@ -99,8 +99,8 @@ jobs:
           POSTGRES_PASSWORD: password
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_PORT: 5432
-          RUN_SIMPLECOV: true
-          CC_TEST_REPORTER_ID: 31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
+          # RUN_SIMPLECOV: true
+          # CC_TEST_REPORTER_ID: 31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
         # continue-on-error: true
         run: |
           # curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
It seems like a lot of the timeouts are happening after the tests finish but when simplecov is outputting the coverage reports.

Lets try disabling simplecov and seeing what happens.