### PR TITLE
Fix: The first part of the new Casa Case form does not save certain input on error

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -55,6 +55,7 @@ class CasaCasesController < ApplicationController
       end
     else
       set_contact_types
+      @empty_court_date = params[:casa_case][:empty_court_date] == "1"
       respond_to do |format|
         format.html { render :new }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -54,6 +54,7 @@ class CasaCasesController < ApplicationController
         format.json { render json: @casa_case, status: :created }
       end
     else
+      set_contact_types
       respond_to do |format|
         format.html { render :new }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -55,7 +55,7 @@ class CasaCasesController < ApplicationController
       end
     else
       set_contact_types
-      @empty_court_date = params[:casa_case][:empty_court_date] == "1"
+      @empty_court_date = court_date_unknown?
       respond_to do |format|
         format.html { render :new }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -64,7 +64,7 @@
             <%= cdf.label :date, "Next Court Date" %>
             <br>
             <div class="input-style-1">
-              <%= cdf.date_field :date, class: "form-control" %>
+              <%= cdf.date_field :date, class: "form-control", hidden: @empty_court_date %>
             </div>
           </div>
         <% end %>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -68,7 +68,7 @@
             </div>
           </div>
         <% end %>
-        <%= form.check_box :empty_court_date, class: "toggle-court-date-input" %>
+        <%= form.check_box :empty_court_date, checked: @empty_court_date, class: "toggle-court-date-input" %>
         <%= form.label :empty_court_date, "I don't know the court date yet" %>
       <% end %>
       <div class="select-style-1">

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -127,9 +127,11 @@ RSpec.describe "casa_cases/new", type: :system do
       end
 
       context "when empty court date checkbox is not checked" do
-        it "does not create a new case" do
+        it "does not create a new case", js: true do
           casa_org = build(:casa_org)
           admin = create(:casa_admin, casa_org: casa_org)
+          contact_type_group = create(:contact_type_group, casa_org: casa_org)
+          contact_type = create(:contact_type, contact_type_group: contact_type_group)
           case_number = "12345"
 
           sign_in admin
@@ -140,10 +142,16 @@ RSpec.describe "casa_cases/new", type: :system do
           select "March", from: "casa_case_birth_month_year_youth_2i"
           select five_years, from: "casa_case_birth_month_year_youth_1i"
 
+          find(".ts-control").click
+          find("span", text: contact_type.name).click
+
           within ".actions-cc" do
             click_on "Create CASA Case"
           end
 
+          selected_contact_type = find(".ts-control .item").text
+
+          expect(selected_contact_type).to eq(contact_type.name)
           expect(page).to have_current_path(casa_cases_path, ignore_query: true)
           expect(page).to have_content("Court dates date can't be blank")
         end

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -83,11 +83,13 @@ RSpec.describe "casa_cases/new", type: :system do
 
         sign_in admin
         visit new_casa_case_path
+        check "casa_case_empty_court_date"
 
         within ".actions-cc" do
           click_on "Create CASA Case"
         end
 
+        expect(find('#casa_case_empty_court_date')).to be_checked
         expect(page).to have_current_path(casa_cases_path, ignore_query: true)
         expect(page).to have_content("Case number can't be blank")
       end

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "casa_cases/new", type: :system do
           click_on "Create CASA Case"
         end
 
-        expect(find('#casa_case_empty_court_date')).to be_checked
+        expect(find("#casa_case_empty_court_date")).to be_checked
         expect(page).to have_current_path(casa_cases_path, ignore_query: true)
         expect(page).to have_content("Case number can't be blank")
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5760

### What changed, and _why_?
 Fixed values for "I don't know court date" and contact types all get cleared when there is error in form

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/75837235/1f25a086-9214-44e2-8b32-50c9af845096)



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
