### PR TITLE
fix: temporarliy "replace site issue" typeform link with google form

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
               <a href="https://rubyforgood.org/">Ruby For Good</a>
             </p>
             <p class="text-sm ml-15">
-              <%= link_to "Report a site issue", "https://form.typeform.com/to/iXY4BubB" %>
+              <%= link_to "Report a site issue", "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform" %>
             </p>
             <p class="text-sm ml-15">
               <%= link_to "SMS Terms & Conditions", "/sms-terms-conditions.html" %>

--- a/app/views/layouts/footers/_logged_in.html.erb
+++ b/app/views/layouts/footers/_logged_in.html.erb
@@ -5,7 +5,7 @@
       Built by <a href="https://rubyforgood.org/">Ruby For Good</a>
     </span>
     <span class="col-12 col-sm-2">
-      <%= link_to "Report a site issue", "https://form.typeform.com/to/iXY4BubB" %>
+      <%= link_to "Report a site issue", "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform" %>
     </span>
     <span class="col-12 col-sm-2">
       <%= link_to "SMS Terms & Conditions", "/sms-terms-conditions.html" %>

--- a/app/views/layouts/footers/_not_logged_in.html.erb
+++ b/app/views/layouts/footers/_not_logged_in.html.erb
@@ -5,7 +5,7 @@
     <a href="https://rubyforgood.org/" class="rfglink" target="_blank">
       <%= image_tag("rfglogo.png", class: "rfglogo") %>
     </a>
-    <%= link_to "Report a site issue", "https://form.typeform.com/to/iXY4BubB", class: "rfglink" %><br>
+    <%= link_to "Report a site issue", "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform", class: "rfglink" %><br>
     <%= link_to "SMS Terms & Conditions", "/sms-terms-conditions.html", class: "terms-conditions-link" %>
   </span>
 

--- a/spec/system/all_casa_admins/all_casa_admin_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admin_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "all_casa_admins/casa_orgs/casa_admins/new", type: :system do
 
     # footer
     expect(page).to have_link("Ruby For Good", href: "https://rubyforgood.org/")
-    expect(page).to have_link("Report a site issue", href: "https://form.typeform.com/to/iXY4BubB")
+    expect(page).to have_link("Report a site issue", href: "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform")
     expect(page).to have_link("SMS Terms & Conditions", href: "/sms-terms-conditions.html")
 
     # create new org

--- a/spec/views/layouts/footer.html.erb_spec.rb
+++ b/spec/views/layouts/footer.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "layout/footer", type: :view do
   context "when not logged in" do
     it "renders report issue link on the footer" do
       render partial: "layouts/footers/not_logged_in"
-      expect(rendered).to have_link("Report a site issue", href: "https://form.typeform.com/to/iXY4BubB")
+      expect(rendered).to have_link("Report a site issue", href: "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform")
     end
 
     it "renders SMS terms and conditions link on the footer" do
@@ -21,7 +21,7 @@ RSpec.describe "layout/footer", type: :view do
   context "when logged in" do
     it "renders report issue link on the footer" do
       render partial: "layouts/footers/logged_in"
-      expect(rendered).to have_link("Report a site issue", href: "https://form.typeform.com/to/iXY4BubB")
+      expect(rendered).to have_link("Report a site issue", href: "https://docs.google.com/forms/d/e/1FAIpQLSfM6dA5KkCuzIcdikete7C3wusoQ8p-EAyGyb38DFBlxzZjrg/viewform")
     end
 
     it "renders SMS terms and conditions link on the footer" do


### PR DESCRIPTION
Temporarily replace the typeform "report a site issue" with a google form until we get it figured out.
