### PR TITLE
Fix 'Manage Volunteers' Styling on /volunteers page rubyforgood#5761

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,4 +659,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.22
+   2.5.11

--- a/app/assets/stylesheets/pages/volunteers.scss
+++ b/app/assets/stylesheets/pages/volunteers.scss
@@ -30,6 +30,6 @@ table#volunteers.dataTable.hover > tbody > tr.selected:hover > * {
 }
 
 .form-check-input {
-  background-color: #757575;
+  border: 1px solid #757575;
 }
 

--- a/app/assets/stylesheets/pages/volunteers.scss
+++ b/app/assets/stylesheets/pages/volunteers.scss
@@ -18,16 +18,18 @@ body.volunteers {
     }
   }
 }
-
-
 table#volunteers.dataTable.hover tbody tr.selected > * {
   background-color: rgba(54, 92, 245, 0.1);
   box-shadow: none; 
   color: inherit;
 }
-
 table#volunteers.dataTable.hover > tbody > tr.selected:hover > * {
   background-color: rgba(54, 92, 245, 0.15);
   box-shadow: none !important; 
   color: inherit;
 }
+
+.form-check-input {
+  background-color: #757575;
+}
+

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -157,12 +157,12 @@
   </div>
 </div>
 
-<div class="tables-wrapper" data-controller="select-all" data-select-all-hidden-class="d-none" data-select-all-button-label-value="Manage Volunteer">
+<div class="tables-wrapper" data-controller="select-all" data-select-all-hidden-class="invisible" data-select-all-button-label-value="Manage Volunteer">
   <div class="row">
     <div class="col-lg-12">
       <div class="card-style mb-30">
         <div class="mb-3">
-          <button type="button" class="main-btn dark-btn btn-sm mb-2 mb-md-0 d-none" data-bs-toggle="modal" data-bs-target="#bulk-assigment-modal" data-select-all-target="button">
+          <button type="button" class="main-btn dark-btn btn-sm mb-2 mb-md-0 invisible" data-bs-toggle="modal" data-bs-target="#bulk-assigment-modal" data-select-all-target="button">
             <i class="lni lni-users mr-10"></i>
             <span class="d-inline" data-select-all-target="buttonLabel"></span>
           </button>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves rubyforgood#5761

### What changed, and _why_?
The button no longer moves the page down by becoming invisible instead of being removed. Additionally, the checkboxes now have a darker background color for better contrast.


### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 

No changes in tests since it's UI only.

### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
![image](https://github.com/rubyforgood/casa/assets/22929670/896aa305-cba5-471d-9dee-c2543b07dbaf)
![image](https://github.com/rubyforgood/casa/assets/22929670/670f7eff-8f56-4698-9fcb-1999944868e6)



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
