### PR TITLE
Add expiration to banners

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,9 @@ class ApplicationController < ActionController::Base
     return nil unless current_organization
 
     @active_banner = current_organization.banners.active.first
+
     @active_banner = nil if session[:dismissed_banner] == @active_banner&.id
+    @active_banner = nil if @active_banner&.expires_at && Time.now.in_time_zone(cookies[:browser_time_zone]) > @active_banner&.expires_at
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
     @active_banner = current_organization.banners.active.first
 
     @active_banner = nil if session[:dismissed_banner] == @active_banner&.id
-    @active_banner = nil if @active_banner&.expires_at && Time.now.in_time_zone(cookies[:browser_time_zone]) > @active_banner&.expires_at
+    @active_banner = nil if @active_banner&.expired?
   end
 
   protected

--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -65,12 +65,7 @@ class BannersController < ApplicationController
   end
 
   def banner_params
-    params.require(:banner).permit(:active, :content, :name, :expires_at).merge(user: current_user)
-      .tap { |banner_params| set_expires_at_in_user_time_zone(banner_params) }
-  end
-
-  def set_expires_at_in_user_time_zone(banner_params)
-    banner_params[:expires_at] = banner_params[:expires_at].in_time_zone(cookies[:browser_time_zone])
+    BannerParameters.new(params, current_user, cookies[:browser_time_zone])
   end
 
   def deactivate_alternate_active_banner

--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -65,7 +65,12 @@ class BannersController < ApplicationController
   end
 
   def banner_params
-    params.require(:banner).permit(:active, :content, :name).merge(user: current_user)
+    params.require(:banner).permit(:active, :content, :name, :expires_at).merge(user: current_user)
+      .tap { |banner_params| set_expires_at_in_user_time_zone(banner_params) }
+  end
+
+  def set_expires_at_in_user_time_zone(banner_params)
+    banner_params[:expires_at] = banner_params[:expires_at].in_time_zone(cookies[:browser_time_zone])
   end
 
   def deactivate_alternate_active_banner

--- a/app/helpers/banner_helper.rb
+++ b/app/helpers/banner_helper.rb
@@ -4,4 +4,14 @@ module BannerHelper
       "d-none"
     end
   end
+
+  def banner_expiration_time_in_words(banner)
+    if banner.expired?
+      "Yes"
+    elsif banner.expires_at
+      "in #{distance_of_time_in_words(Time.now, banner.expires_at)}"
+    else
+      "No"
+    end
+  end
 end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -25,6 +25,7 @@ end
 #
 #  id          :bigint           not null, primary key
 #  active      :boolean          default(FALSE)
+#  expires_at  :datetime
 #  name        :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -8,6 +8,10 @@ class Banner < ApplicationRecord
   validates_presence_of :name
   validate :only_one_banner_is_active_per_organization
 
+  def expired?
+    expires_at && Time.current > expires_at
+  end
+
   private
 
   def only_one_banner_is_active_per_organization

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -12,6 +12,8 @@ class Banner < ApplicationRecord
     expires_at && Time.current > expires_at
   end
 
+  # `expires_at` is stored in the database as UTC, but timezone information will be stripped before displaying on frontend
+  # so this method converts the time to the user's timezone before displaying it
   def expires_at_in_time_zone(timezone)
     expires_at&.in_time_zone(timezone)
   end

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -12,6 +12,10 @@ class Banner < ApplicationRecord
     expires_at && Time.current > expires_at
   end
 
+  def expires_at_in_time_zone(timezone)
+    expires_at&.in_time_zone(timezone)
+  end
+
   private
 
   def only_one_banner_is_active_per_organization

--- a/app/values/banner_parameters.rb
+++ b/app/values/banner_parameters.rb
@@ -4,7 +4,7 @@ class BannerParameters < SimpleDelegator
     new_params = params.require(:banner).permit(:active, :content, :name, :expires_at).merge(user: user)
 
     if params.dig(:banner, :expires_at)
-      new_params[:expires_at] = convert_expires_at_in_user_time_zone(params, timezone)
+      new_params[:expires_at] = convert_expires_at_with_user_time_zone(params, timezone)
     end
 
     super(new_params)
@@ -12,7 +12,10 @@ class BannerParameters < SimpleDelegator
 
   private
 
-  def convert_expires_at_in_user_time_zone(params, timezone)
+  # `expires_at` comes from the frontend without any timezone information, so we use `in_time_zone` to attach
+  # timezone information to it before saving to the database. If we don't do this, the time will be stored at UTC
+  # by default.
+  def convert_expires_at_with_user_time_zone(params, timezone)
     params[:banner][:expires_at].in_time_zone(timezone)
   end
 

--- a/app/values/banner_parameters.rb
+++ b/app/values/banner_parameters.rb
@@ -1,0 +1,22 @@
+# Calculate values when using banner parameters
+class BannerParameters < SimpleDelegator
+  def initialize(params, user, timezone)
+    new_params = params.require(:banner).permit(:active, :content, :name, :expires_at).merge(user: user)
+
+    if params.dig(:banner, :expires_at)
+      new_params[:expires_at] = convert_expires_at_in_user_time_zone(params, timezone)
+    end
+
+    super(new_params)
+  end
+
+  private
+
+  def convert_expires_at_in_user_time_zone(params, timezone)
+    params[:banner][:expires_at].in_time_zone(timezone)
+  end
+
+  def params
+    __getobj__
+  end
+end

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -28,7 +28,7 @@
     </div>
     <span class="input-style-1">
       <%= form.label :expires_at, "Expires at (optional)" %>
-      <%= form.datetime_field :expires_at, required: false %>
+      <%= form.datetime_field :expires_at, value: banner.expires_at&.in_time_zone(cookies[:browser_time_zone]), required: false %>
     </span>
     <div class="input-style-1">
       <%= form.label :content %>

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -26,6 +26,10 @@
       <%= form.label :active, "Active?", class: 'form-check-label' %>
       <span data-reveal-target="item" class="text-danger <%= conditionally_add_hidden_class(form.object.active) %>">Warning: This will replace your current active banner</span>
     </div>
+    <span class="input-style-1">
+      <%= form.label :expires_at, "Expires at (optional)" %>
+      <%= form.datetime_field :expires_at, required: false %>
+    </span>
     <div class="input-style-1">
       <%= form.label :content %>
       <%= form.rich_text_area :content %>

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -28,7 +28,7 @@
     </div>
     <span class="input-style-1">
       <%= form.label :expires_at, "Expires at (optional)" %>
-      <%= form.datetime_field :expires_at, value: banner.expires_at&.in_time_zone(cookies[:browser_time_zone]), required: false %>
+      <%= form.datetime_field :expires_at, value: banner.expires_at_in_time_zone(cookies[:browser_time]), required: false %>
     </span>
     <div class="input-style-1">
       <%= form.label :content %>

--- a/app/views/banners/index.html.erb
+++ b/app/views/banners/index.html.erb
@@ -25,6 +25,7 @@
             <tr>
               <th>Name</th>
               <th>Active?</th>
+              <th>Expires At</th>
               <th>Last Updated By</th>
               <th>Updated At</th>
               <th>Actions</th>
@@ -39,6 +40,13 @@
                 <td class="min-width">
                   <% if banner.active? %>
                     Yes
+                  <% else %>
+                    No
+                  <% end %>
+                </td>
+                <td class="min-width">
+                  <% if banner.expires_at %>
+                    <%= distance_of_time_in_words(Time.now, banner.expires_at) %>
                   <% else %>
                     No
                   <% end %>

--- a/app/views/banners/index.html.erb
+++ b/app/views/banners/index.html.erb
@@ -45,11 +45,7 @@
                   <% end %>
                 </td>
                 <td class="min-width">
-                  <% if banner.expires_at %>
-                    <%= distance_of_time_in_words(Time.now, banner.expires_at) %>
-                  <% else %>
-                    No
-                  <% end %>
+                  <%= banner_expiration_time_in_words(banner) %>
                 </td>
                 <td class="min-width">
                   <%= banner.user.display_name %>

--- a/db/migrate/20240531172823_add_expires_at_to_banner.rb
+++ b/db/migrate/20240531172823_add_expires_at_to_banner.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToBanner < ActiveRecord::Migration[7.1]
+  def change
+    add_column :banners, :expires_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_101303) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_172823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,6 +95,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_101303) do
     t.boolean "active", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "expires_at"
     t.index ["casa_org_id"], name: "index_banners_on_casa_org_id"
     t.index ["user_id"], name: "index_banners_on_user_id"
   end

--- a/spec/helpers/banner_helper_spec.rb
+++ b/spec/helpers/banner_helper_spec.rb
@@ -35,4 +35,32 @@ RSpec.describe BannerHelper do
       expect(helper.conditionally_add_hidden_class(true)).to eq(nil)
     end
   end
+
+  describe "#banner_expiration_time_in_words" do
+    let(:banner) { create(:banner, expires_at: expires_at) }
+
+    context "when expires_at isn't set" do
+      let(:expires_at) { nil }
+
+      it "returns No" do
+        expect(helper.banner_expiration_time_in_words(banner)).to eq("No")
+      end
+    end
+
+    context "when expires_at is in the future" do
+      let(:expires_at) { 7.days.from_now }
+
+      it "returns a word description of how far in the future" do
+        expect(helper.banner_expiration_time_in_words(banner)).to eq("in 7 days")
+      end
+    end
+
+    context "when expires_at is in the past" do
+      let(:expires_at) { 7.days.ago }
+
+      it "returns yes" do
+        expect(helper.banner_expiration_time_in_words(banner)).to eq("Yes")
+      end
+    end
+  end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -22,4 +22,24 @@ RSpec.describe Banner, type: :model do
       expect(banner).to be_valid
     end
   end
+
+  describe "#expired?" do
+    it "is false when expires_at is nil" do
+      banner = create(:banner, expires_at: nil)
+
+      expect(banner).not_to be_expired
+    end
+
+    it "is false when expires_at is set but is after today" do
+      banner = create(:banner, expires_at: 7.days.from_now)
+
+      expect(banner).not_to be_expired
+    end
+
+    it "is true when expires_at is set but is before today" do
+      banner = create(:banner, expires_at: 7.days.ago)
+
+      expect(banner).to be_expired
+    end
+  end
 end

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -42,4 +42,18 @@ RSpec.describe Banner, type: :model do
       expect(banner).to be_expired
     end
   end
+
+  describe "#expires_at_in_time_zone" do
+    it "can shift time by timezone for equivalent times" do
+      banner = create(:banner, expires_at: "2024-06-13 12:00:00 UTC")
+
+      expires_at_in_pacific_time = banner.expires_at_in_time_zone("America/Los_Angeles")
+      expect(expires_at_in_pacific_time.to_s).to eq("2024-06-13 05:00:00 -0700")
+
+      expires_at_in_eastern_time = banner.expires_at_in_time_zone("America/New_York")
+      expect(expires_at_in_eastern_time.to_s).to eq("2024-06-13 08:00:00 -0400")
+
+      expect(expires_at_in_pacific_time).to eq(expires_at_in_eastern_time)
+    end
+  end
 end

--- a/spec/requests/banners_spec.rb
+++ b/spec/requests/banners_spec.rb
@@ -47,4 +47,28 @@ RSpec.describe "Banners", type: :request do
       end
     end
   end
+
+  context "when a banner has expires_at" do
+    let!(:active_banner) { create(:banner, casa_org: casa_org, expires_at: expires_at) }
+
+    context "when expires_at is after today" do
+      let(:expires_at) { 7.days.from_now }
+
+      it "displays the banner" do
+        sign_in volunteer
+        get casa_cases_path
+        expect(response.body).to include "Please fill out this survey"
+      end
+    end
+
+    context "when expires_at is before today" do
+      let(:expires_at) { 7.days.ago }
+
+      it "does not display the banner" do
+        sign_in volunteer
+        get casa_cases_path
+        expect(response.body).not_to include "Please fill out this survey"
+      end
+    end
+  end
 end

--- a/spec/system/banners/new_spec.rb
+++ b/spec/system/banners/new_spec.rb
@@ -31,6 +31,34 @@ RSpec.describe "Banners", type: :system, js: true do
     expect(page).to have_text("Please fill out this survey.")
   end
 
+  it "lets you create banner with expiration time and edit it" do
+    sign_in admin
+
+    visit banners_path
+    click_on "New Banner"
+    fill_in "Name", with: "Expiring Announcement"
+    check "Active?"
+    fill_in "banner_expires_at", with: 7.days.from_now.strftime("%m%d%Y\t%I%M%P")
+    fill_in_rich_text_area "banner_content", with: "Please fill out this survey."
+    click_on "Submit"
+
+    visit banners_path
+    expect(page).to have_text("Expiring Announcement")
+
+    visit banners_path
+    within "#banners" do
+      click_on "Edit", match: :first
+    end
+    fill_in "banner_expires_at", with: 7.days.ago.strftime("%m%d%Y\t%I%M%P")
+    click_on "Submit"
+
+    visit banners_path
+    expect(page).to have_text("Expiring Announcement")
+
+    visit root_path
+    expect(page).not_to have_text("Please fill out this survey.")
+  end
+
   describe "when an organization has an active banner" do
     let(:admin) { create(:casa_admin) }
     let(:organization) { create(:casa_org) }

--- a/spec/values/banner_parameters_spec.rb
+++ b/spec/values/banner_parameters_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe BannerParameters do
+  subject { described_class.new(params, user, timezone) }
+
+  let(:params) {
+    ActionController::Parameters.new(
+      banner: ActionController::Parameters.new(
+        active: "1",
+        content: "content",
+        name: "name"
+      )
+    )
+  }
+
+  let(:user) { create(:user) }
+
+  let(:timezone) { nil }
+
+  it "returns data" do
+    expect(subject["active"]).to eq("1")
+    expect(subject["content"]).to eq("content")
+    expect(subject["name"]).to eq("name")
+    expect(subject["expires_at"]).to be_blank
+    expect(subject["user"]).to eq(user)
+  end
+
+  context "when expires_at is set" do
+    let(:params) {
+      ActionController::Parameters.new(
+        banner: ActionController::Parameters.new(
+          expires_at: "2024-06-10T12:12"
+        )
+      )
+    }
+
+    let(:timezone) { "America/Los_Angeles" }
+
+    it "attaches timezone information to expires_at" do
+      expect(subject["expires_at"]).to eq("2024-06-10 12:12:00 -0700")
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5604

### What changed, and _why_?

Add an optional expiration time to banners.
The timezone will be set to the creator's current timezone.
If a banner is active, but the time is past the expires_at, we will hide the banner.
If the banner is not active, we hide the banner regardless (existing behavior).
Also added displaying the banner on the banners index page

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 

Added tests for showing/hiding banner based on `expires_at`. Also added tests for setting `expires_at` in the banner new/edit form.

### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
<img width="1728" alt="Screenshot 2024-05-31 at 1 50 04 PM" src="https://github.com/rubyforgood/casa/assets/217050/759c4f5d-4af5-4ef2-9a00-4121f4204a16">
<img width="1721" alt="Screenshot 2024-05-31 at 1 50 22 PM" src="https://github.com/rubyforgood/casa/assets/217050/96d4215e-c663-42eb-a38c-5c753ecdf12d">
<img width="1718" alt="Screenshot 2024-05-31 at 1 50 42 PM" src="https://github.com/rubyforgood/casa/assets/217050/4c4af923-0e0b-4b7f-96a0-a447d2700dec">


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
![clocks](https://media.giphy.com/media/Kvjugjvc1L9iE/giphy.gif)
