### PR TITLE
feat: add devcontainers

### DIFF
--- a/.devcontainer/.env.codespaces
+++ b/.devcontainer/.env.codespaces
@@ -1,0 +1,6 @@
+# This is the .env that is used by the codespaces environment.
+# See the .devcontainer/devcontainer.json file for how this is configured.
+PG_USERNAME=postgres
+PG_PASSWORD=postgres
+DELAYED_JOB_USERNAME='admin'
+DELAYED_JOB_PASSWORD='password'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/devcontainers/ruby:dev-3.2-buster
+RUN apt -y update && apt install -y vim curl gpg postgresql postgresql-contrib tzdata imagemagick

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/postgres
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "forwardPorts": [3000, 5432],
+  "workspaceFolder": "/workspaces/casa",
+  "service": "app",
+  "customizations": {
+    "vscode": {
+      "extensions": ["Shopify.ruby-extensions-pack"],
+      "settings": {
+        "rubyLsp.rubyVersionManager": {
+          "identifier": "rvm"
+        }
+      }
+    }
+  },
+  "containerEnv": {
+    "DATABASE_HOST": "postgres",
+    "POSTGRES_USER": "postgres",
+    "POSTGRES_PASSWORD": "postgres"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  },
+
+  "postCreateCommand": ".devcontainer/post-create.sh"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+    networks:
+      - default
+
+  postgres:
+    image: postgres:latest
+    restart: always
+    networks:
+      - default
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+    # Note that these ports are ignored by the devcontainer.
+    # Instead, the ports are specified in .devcontainer/devcontainer.json.
+    # ports:
+    #  - "5432:5432"
+volumes:
+  postgres-data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+RUBY_VERSION="$(cat .ruby-version | tr -d '\n')"
+
+# copy the file only if it doesn't already exist
+cp -n .devcontainer/.env.codespaces .env
+
+# If the project's required ruby version changes from 3.2.2, this command
+# will download and compile the correct version, but it will take a long time.
+if [ "$RUBY_VERSION" != "3.2.2" ]; then
+	rvm install $RUBY_VERSION
+	rvm use $RUBY_VERSION
+	echo "Ruby $RUBY_VERSION installed"
+fi
+
+bin/setup

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,7 +80,12 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Uncomment if you wish to use codespaces
+  # config.action_controller.forgery_protection_origin_check = false
+
   config.hosts << ENV["DEV_HOSTS"]
+  config.hosts << ".app.github.dev"
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = false


### PR DESCRIPTION
Most of dev container code sourced from HE
https://github.com/rubyforgood/human-essentials/tree/main/.devcontainer

and Rails 7.2.beta
https://github.com/rails/rails/tree/main/.devcontainer

Needed to add values from rails/rails with otherwise the node version was very out of date

Had to disable CSRF in dev (pretty yikes). Otherwise logins from whatever-github.app.dev would not work.