### PR TITLE
Moved impersonate message to top of the page, put it in a red box

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,13 @@
 <header class="header pt-0">
   <%= render 'layouts/banner' %>
 
+  <% if current_user != true_user %>
+    <%= link_to stop_impersonating_volunteers_path, method: :post, class: "pt-4 pb-4 bg-danger", style: "padding-left: 15px; display: block;" do %>
+      You (<%= true_user.display_name %>) are signed in as <%= current_user.display_name %>.
+      Click here to stop impersonating.
+    <% end %>
+  <% end %>
+
   <div class="container-fluid pt-30">
     <div class="row">
       <div class="col-lg-5 col-md-5 col-6">

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -53,14 +53,6 @@
               { title: "Edit Organization", icon: "cogs", path: edit_casa_org_path(current_organization), render_check: policy(:application).modify_organization? }
             ]) %>
           <% end %>
-          <li>
-            <% if current_user != true_user %>
-              <%= link_to stop_impersonating_volunteers_path, method: :post, class: "mr-10 ml-10" do %>
-                You (<%= true_user.display_name %>) are signed in as <%= current_user.display_name %>.
-                Click here to stop impersonating.
-              <% end %>
-            <% end %>
-          </li>
         </ul>
       </nav>
     </nav>

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -560,7 +560,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
         click_on "Impersonate"
 
-        within(".sidebar-nav-wrapper") do
+        within(".header") do
           expect(page).to have_text(
             "You (#{admin.display_name}) are signed in as John Doe. " \
               "Click here to stop impersonating."
@@ -579,7 +579,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
         click_on "Impersonate"
 
-        within(".sidebar-nav-wrapper") do
+        within(".header") do
           expect(page).to have_text(
             "You (#{supervisor.display_name}) are signed in as John Doe. " \
               "Click here to stop impersonating."

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -117,5 +117,13 @@ RSpec.describe "layout/header", type: :view do
 
       expect(rendered).to match "<strong>Role: Volunteer</strong>"
     end
+
+    it "renders a stop impersonating link when impersonating" do
+      allow(view).to receive(:true_user).and_return(true_user)
+
+      render partial: "layouts/header"
+
+      expect(rendered).to have_link(href: "/volunteers/stop_impersonating")
+    end
   end
 end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -145,17 +145,4 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
     end
   end
-
-  context "impersonation" do
-    let(:user) { build_stubbed :volunteer }
-    let(:true_user) { build_stubbed :casa_admin }
-
-    it "renders a stop impersonating link when impersonating" do
-      allow(view).to receive(:true_user).and_return(true_user)
-
-      render partial: "layouts/sidebar"
-
-      expect(rendered).to have_link(href: "/volunteers/stop_impersonating")
-    end
-  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5758 

### What changed, and _why_?
Moved the impersonate banner from the sidebar to the top of the page
Put it inside a red box, make it more prominent.

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
<img width="1728" alt="Screenshot 2024-06-01 at 11 06 19" src="https://github.com/rubyforgood/casa/assets/16199259/12379d83-b8a6-4cef-8a7a-bd538a3d4e7e">


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
