### PR TITLE
Fix test failures related to time

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -23,6 +23,10 @@ class HealthController < ApplicationController
   def monthly_line_graph_data
     first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month }
 
+    if first_day_of_last_12_months.size > 12
+      first_day_of_last_12_months = first_day_of_last_12_months[1..12]
+    end
+
     monthly_counts_of_case_contacts_created = CaseContact.group_by_month(:created_at, last: 12).count
     monthly_counts_of_case_contacts_with_notes_created = CaseContact.left_outer_joins(:contact_topic_answers).where("case_contacts.notes != '' OR contact_topic_answers.value != ''").select(:id).distinct.group_by_month(:created_at, last: 12).count
     monthly_counts_of_users_who_have_created_case_contacts = CaseContact.select(:creator_id).distinct.group_by_month(:created_at, last: 12).count
@@ -41,6 +45,10 @@ class HealthController < ApplicationController
 
   def monthly_unique_users_graph_data
     first_day_of_last_12_months = (12.months.ago.to_date..Date.current).select { |date| date.day == 1 }.map { |date| date.beginning_of_month.strftime("%b %Y") }
+
+    if first_day_of_last_12_months.size > 12
+      first_day_of_last_12_months = first_day_of_last_12_months[1..12]
+    end
 
     monthly_counts_of_volunteers = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: {type: "Volunteer"}, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)
     monthly_counts_of_supervisors = LoginActivity.joins("INNER JOIN users ON users.id = login_activities.user_id AND login_activities.user_type = 'User'").where(users: {type: "Supervisor"}, success: true).group_by_month(:created_at, format: "%b %Y").distinct.count(:user_id)

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Health", type: :request do
   end
 
   describe "GET #monthly_line_graph_data" do
-    it "returns case contacts creation times in the last year" do
+    def setup
       # Create case contacts for testing
       create(:case_contact, notes: "Test Notes", created_at: 11.months.ago)
       create(:case_contact, notes: "", created_at: 11.months.ago)
@@ -57,8 +57,37 @@ RSpec.describe "Health", type: :request do
       # Create associated contact_topic_answers
       create(:contact_topic_answer, case_contact: CaseContact.first)
       create(:contact_topic_answer, case_contact: CaseContact.last)
+    end
+
+    after do
+      travel_back
+    end
+
+    it "returns case contacts creation times in the last year" do
+      travel_to Time.zone.local(2024, 5, 2)
+      setup
 
       get monthly_line_graph_data_health_index_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("application/json")
+
+      chart_data = JSON.parse(response.body)
+      expect(chart_data).to be_an(Array)
+      expect(chart_data.length).to eq(12)
+
+      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 2])
+      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 1])
+      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
+      expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
+    end
+
+    it "returns case contacts creation times in the last year (on the first of the month)" do
+      travel_to Time.zone.local(2024, 5, 1)
+      setup
+
+      get monthly_line_graph_data_health_index_path
+
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to include("application/json")
 
@@ -74,7 +103,7 @@ RSpec.describe "Health", type: :request do
   end
 
   describe "GET #monthly_unique_users_graph_data" do
-    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year" do
+    def setup
       volunteer1 = create(:user, type: "Volunteer")
       volunteer2 = create(:user, type: "Volunteer")
       supervisor = create(:user, type: "Supervisor")
@@ -88,8 +117,36 @@ RSpec.describe "Health", type: :request do
       create(:login_activity, user: volunteer2, created_at: 9.months.ago, success: true)
       create(:login_activity, user: supervisor, created_at: 9.months.ago, success: true)
       create(:login_activity, user: casa_admin, created_at: 9.months.ago, success: true)
+    end
+
+    after do
+      travel_back
+    end
+
+    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year" do
+      travel_to Time.zone.local(2024, 5, 2)
+      setup
 
       get monthly_unique_users_graph_data_health_index_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("application/json")
+
+      chart_data = JSON.parse(response.body)
+      expect(chart_data).to be_an(Array)
+      expect(chart_data.length).to eq(12)
+
+      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 1])
+      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 0])
+      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
+    end
+
+    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year (on the first of the month)" do
+      travel_to Time.zone.local(2024, 5, 1)
+      setup
+
+      get monthly_unique_users_graph_data_health_index_path
+
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to include("application/json")
 


### PR DESCRIPTION
### What github issue is this PR for, if any?


### What changed, and _why_?
On June 1, I ran into some test failures unrelated to the PRs I was working on.  ~Considering it's June 1, I decided to set the time to the previous month to emulate the same working conditions we had yesterday.~

As a stopgap, we introduce measures to ensure we only show 12 months worth of data for the two graphs on matter what time of the month we're at, and introduce tests to assert this behavior.

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
