### PR TITLE
Date validations to prevent invalid dates like 6/1/20000

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -25,6 +25,7 @@ helpers/template_helper.rb
 jobs/application_job.rb
 mailers/application_mailer.rb
 models/application_record.rb
+models/concerns/CasaCase/validations.rb
 models/concerns/by_organization_scope.rb
 models/concerns/roles.rb
 models/fund_request.rb

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -1,6 +1,7 @@
 class CasaCase < ApplicationRecord
   include ByOrganizationScope
   include DateHelper
+  include CasaCase::Validations
   extend FriendlyId
 
   self.ignored_columns = %w[transition_aged_youth court_report_due_date]
@@ -38,16 +39,13 @@ class CasaCase < ApplicationRecord
   has_many :case_groups, through: :case_group_memberships
   has_many_attached :court_reports
 
-  validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true
   belongs_to :hearing_type, optional: true
   belongs_to :judge, optional: true
   belongs_to :casa_org
-  validates :birth_month_year_youth, presence: true
+
   has_many :casa_case_contact_types
   has_many :contact_types, through: :casa_case_contact_types
   accepts_nested_attributes_for :casa_case_contact_types
-  validates_presence_of :casa_case_contact_types, message: ": At least one contact type must be selected",
-    if: :validate_contact_type
   accepts_nested_attributes_for :court_dates
   accepts_nested_attributes_for :volunteers
 
@@ -106,9 +104,6 @@ class CasaCase < ApplicationRecord
 
   delegate :name, to: :hearing_type, prefix: true, allow_nil: true
   delegate :name, to: :judge, prefix: true, allow_nil: true
-
-  # Validation to check timestamp and submission status of a case
-  validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
 
   def add_emancipation_category(category_id)
     emancipation_categories << EmancipationCategory.find(category_id)

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -12,7 +12,8 @@ class CaseContact < ApplicationRecord
   validate :occurred_at_not_in_future
   validates :occurred_at, comparison: {
     greater_than_or_equal_to: "1989-01-01".to_date,
-    message: "is not valid: Date of Contact cannot be prior to 1/1/1989.", allow_nil: true
+    message: "is not valid: Date of Contact cannot be prior to 1/1/1989.",
+    allow_nil: true
   }
   validate :reimbursement_only_when_miles_driven, if: :active_or_expenses?
   validate :volunteer_address_when_reimbursement_wanted, if: :active_or_expenses?

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -10,6 +10,10 @@ class CaseContact < ApplicationRecord
   validates :occurred_at, presence: true, if: :active_or_details?
   validates :duration_minutes, presence: true, if: :active_or_details?
   validate :occurred_at_not_in_future
+  validates :occurred_at, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "is not valid: Date of Contact cannot be prior to 1/1/1989.", allow_nil: true
+  }
   validate :reimbursement_only_when_miles_driven, if: :active_or_expenses?
   validate :volunteer_address_when_reimbursement_wanted, if: :active_or_expenses?
   validate :volunteer_address_is_valid, if: :active_or_expenses?

--- a/app/models/concerns/CasaCase/validations.rb
+++ b/app/models/concerns/CasaCase/validations.rb
@@ -33,6 +33,5 @@ module CasaCase::Validations
 
     # Validation to check timestamp and submission status of a case
     validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
-
   end
 end

--- a/app/models/concerns/CasaCase/validations.rb
+++ b/app/models/concerns/CasaCase/validations.rb
@@ -1,0 +1,36 @@
+require "active_support/concern"
+
+module CasaCase::Validations
+  extend ActiveSupport::Concern
+
+  included do
+    validates :birth_month_year_youth, presence: true
+    validates :birth_month_year_youth, comparison: {
+      less_than_or_equal_to: -> { Time.now.end_of_day },
+      message: "is not valid: Youth's Birth Month & Year cannot be a future date."
+    }
+    validates :birth_month_year_youth, comparison: {
+      greater_than_or_equal_to: "1989-01-01".to_date,
+      message: "is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989."
+    }
+
+    validates :date_in_care, comparison: {
+      less_than_or_equal_to: -> { Time.now.end_of_day },
+      message: "is not valid: Youth's Date in Care cannot be a future date.", allow_nil: true
+    }
+    validates :date_in_care, comparison: {
+      greater_than_or_equal_to: "1989-01-01".to_date,
+      message: "is not valid: Youth's Date in Care cannot be prior to 1/1/1989.", allow_nil: true
+    }
+
+    validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true
+
+    validates_presence_of :casa_case_contact_types,
+      message: ": At least one contact type must be selected",
+      if: :validate_contact_type
+
+    # Validation to check timestamp and submission status of a case
+    validates_with CourtReportValidator, fields: [:court_report_status, :court_report_submitted_at]
+
+  end
+end

--- a/app/models/concerns/CasaCase/validations.rb
+++ b/app/models/concerns/CasaCase/validations.rb
@@ -16,11 +16,13 @@ module CasaCase::Validations
 
     validates :date_in_care, comparison: {
       less_than_or_equal_to: -> { Time.now.end_of_day },
-      message: "is not valid: Youth's Date in Care cannot be a future date.", allow_nil: true
+      message: "is not valid: Youth's Date in Care cannot be a future date.",
+      allow_nil: true
     }
     validates :date_in_care, comparison: {
       greater_than_or_equal_to: "1989-01-01".to_date,
-      message: "is not valid: Youth's Date in Care cannot be prior to 1/1/1989.", allow_nil: true
+      message: "is not valid: Youth's Date in Care cannot be prior to 1/1/1989.",
+      allow_nil: true
     }
 
     validates :case_number, uniqueness: {scope: :casa_org_id, case_sensitive: false}, presence: true

--- a/app/models/court_date.rb
+++ b/app/models/court_date.rb
@@ -5,6 +5,14 @@ require "sablon"
 class CourtDate < ApplicationRecord
   belongs_to :casa_case
   validates :date, presence: true
+  validates :date, comparison: {
+    less_than_or_equal_to: -> { 1.year.from_now },
+    message: "is not valid. Court date must be within one year from today."
+  }
+  validates :date, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "is not valid. Court date cannot be prior to 1/1/1989."
+  }
 
   has_many :case_court_orders
   belongs_to :hearing_type, optional: true

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -8,6 +8,10 @@ class LearningHour < ApplicationRecord
   validates :name, presence: {message: "/ Title cannot be blank"}
   validates :occurred_at, presence: true
   validate :occurred_at_not_in_future
+  validates :occurred_at, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "is not valid: Occurred on Date cannot be prior to 1/1/1989.", allow_nil: true
+  }
   validates :learning_hour_topic, presence: true, if: :user_org_learning_topic_enable?
 
   scope :supervisor_volunteers_learning_hours, ->(supervisor_id) {

--- a/app/models/learning_hour.rb
+++ b/app/models/learning_hour.rb
@@ -10,7 +10,8 @@ class LearningHour < ApplicationRecord
   validate :occurred_at_not_in_future
   validates :occurred_at, comparison: {
     greater_than_or_equal_to: "1989-01-01".to_date,
-    message: "is not valid: Occurred on Date cannot be prior to 1/1/1989.", allow_nil: true
+    message: "is not valid: Occurred on Date cannot be prior to 1/1/1989.",
+    allow_nil: true
   }
   validates :learning_hour_topic, presence: true, if: :user_org_learning_topic_enable?
 

--- a/app/models/mileage_rate.rb
+++ b/app/models/mileage_rate.rb
@@ -5,6 +5,14 @@ class MileageRate < ApplicationRecord
 
   validates :effective_date, presence: true, allow_blank: false
   validates :effective_date, uniqueness: {scope: [:is_active, :casa_org], message: "must not have duplicate active dates"}, if: :is_active?
+  validates :effective_date, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "cannot be prior to 1/1/1989."
+  }
+  validates :effective_date, comparison: {
+    less_than_or_equal_to: -> { 1.year.from_now },
+    message: "must not be more than one year in the future."
+  }
   validates :amount, presence: true, allow_blank: false
   validates :casa_org, presence: true, allow_blank: false
   scope :for_organization, ->(org) { where(casa_org: org) }

--- a/app/models/other_duty.rb
+++ b/app/models/other_duty.rb
@@ -11,7 +11,6 @@ class OtherDuty < ApplicationRecord
     greater_than_or_equal_to: "1989-01-01".to_date,
     message: "is not valid. Occured on date cannot be prior to 1/1/1989."
   }
-
 end
 
 # == Schema Information

--- a/app/models/other_duty.rb
+++ b/app/models/other_duty.rb
@@ -3,6 +3,15 @@ class OtherDuty < ApplicationRecord
   delegate :type, to: :creator, prefix: true
 
   validates :notes, presence: true
+  validates :occurred_at, comparison: {
+    less_than_or_equal_to: -> { 1.year.from_now },
+    message: "is not valid. Occured on date must be within one year from today."
+  }
+  validates :occurred_at, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "is not valid. Occured on date cannot be prior to 1/1/1989."
+  }
+
 end
 
 # == Schema Information

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -2,6 +2,17 @@ class Placement < ApplicationRecord
   belongs_to :casa_case
   belongs_to :placement_type
   belongs_to :creator, class_name: "User"
+
+  validates :placement_started_at, comparison: {
+    greater_than_or_equal_to: "1989-01-01".to_date,
+    message: "cannot be prior to 1/1/1989.",
+    allow_nil: true
+  }
+  validates :placement_started_at, comparison: {
+    less_than_or_equal_to: -> { 1.year.from_now },
+    message: "must not be more than one year in the future.",
+    allow_nil: true
+  }
 end
 
 # == Schema Information

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -42,5 +42,7 @@ class UserValidator < ActiveModel::Validator
     return unless date_of_birth.present?
 
     record.errors.add(:base, " Date of birth must be in the past.") unless date_of_birth.past?
+    record.errors.add(:base, " Date of birth must be on or after 1/1/1920.") unless date_of_birth >= "1920-01-01".to_date
+
   end
 end

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -43,6 +43,5 @@ class UserValidator < ActiveModel::Validator
 
     record.errors.add(:base, " Date of birth must be in the past.") unless date_of_birth.past?
     record.errors.add(:base, " Date of birth must be on or after 1/1/1920.") unless date_of_birth >= "1920-01-01".to_date
-
   end
 end

--- a/app/validators/user_validator.rb
+++ b/app/validators/user_validator.rb
@@ -6,7 +6,8 @@ class UserValidator < ActiveModel::Validator
     validate_presence(:display_name, record)
     at_least_one_communication_preference_selected(record)
     valid_phone_number_if_receive_sms_notifications(record)
-    valid_date_of_birth(record.date_of_birth, record)
+    validate_date_of_birth_in_past(record.date_of_birth, record)
+    validate_date_of_birth_not_before_1920(record.date_of_birth, record)
   end
 
   private
@@ -38,10 +39,15 @@ class UserValidator < ActiveModel::Validator
     end
   end
 
-  def valid_date_of_birth(date_of_birth, record)
+  def validate_date_of_birth_in_past(date_of_birth, record)
     return unless date_of_birth.present?
 
     record.errors.add(:base, " Date of birth must be in the past.") unless date_of_birth.past?
+  end
+
+  def validate_date_of_birth_not_before_1920(date_of_birth, record)
+    return unless date_of_birth.present?
+
     record.errors.add(:base, " Date of birth must be on or after 1/1/1920.") unless date_of_birth >= "1920-01-01".to_date
   end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -9,11 +9,75 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to have_many(:emancipation_categories).through(:casa_case_emancipation_categories) }
   it { is_expected.to have_many(:casa_cases_emancipation_options).dependent(:destroy) }
   it { is_expected.to have_many(:emancipation_options).through(:casa_cases_emancipation_options) }
-  it { is_expected.to validate_presence_of(:case_number) }
-  it { is_expected.to validate_presence_of(:birth_month_year_youth) }
-  it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id).case_insensitive }
   it { is_expected.to have_many(:case_court_orders).dependent(:destroy) }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }
+
+  describe "validations" do
+    describe "case_number" do
+      it { is_expected.to validate_presence_of(:case_number) }
+      it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id).case_insensitive }
+    end
+
+    describe "date_in_care" do
+      it "is valid when blank" do
+        casa_case = CasaCase.new(date_in_care: nil)
+        casa_case.valid?
+        expect(casa_case.errors[:date_in_care]).to eq([])
+      end
+
+      it "is not valid before 1989" do
+        casa_case = CasaCase.new(date_in_care: "1984-01-01".to_date)
+        expect(casa_case.valid?).to be false
+        expect(casa_case.errors[:date_in_care]).to eq(["is not valid: Youth's Date in Care cannot be prior to 1/1/1989."])
+      end
+
+      it "is not valid with a future date" do
+        casa_case = CasaCase.new(date_in_care: 1.day.from_now)
+        expect(casa_case.valid?).to be false
+        expect(casa_case.errors[:date_in_care]).to eq(["is not valid: Youth's Date in Care cannot be a future date."])
+      end
+
+      it "is valid today" do
+        casa_case = CasaCase.new(date_in_care: Time.now)
+        casa_case.valid?
+        expect(casa_case.errors[:date_in_care]).to eq([])
+      end
+
+      it "is valid in the past after 1989" do
+        casa_case = CasaCase.new(date_in_care: "1997-08-29".to_date)
+        casa_case.valid?
+        expect(casa_case.errors[:date_in_care]).to eq([])
+      end
+    end
+
+    describe "birth_month_year_youth" do
+      it { is_expected.to validate_presence_of(:birth_month_year_youth) }
+
+      it "is not valid before 1989" do
+        casa_case = CasaCase.new(birth_month_year_youth: "1984-01-01".to_date)
+        expect(casa_case.valid?).to be false
+        expect(casa_case.errors[:birth_month_year_youth]).to eq(["is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989."])
+      end
+
+      it "is not valid with a future date" do
+        casa_case = CasaCase.new(birth_month_year_youth: 1.day.from_now)
+        expect(casa_case.valid?).to be false
+        expect(casa_case.errors[:birth_month_year_youth]).to eq(["is not valid: Youth's Birth Month & Year cannot be a future date."])
+      end
+
+      it "is valid today" do
+        casa_case = CasaCase.new(birth_month_year_youth: Time.now)
+        casa_case.valid?
+        expect(casa_case.errors[:birth_month_year_youth]).to eq([])
+      end
+
+      it "is valid in the past after 1989" do
+        casa_case = CasaCase.new(birth_month_year_youth: "1997-08-29".to_date)
+        casa_case.valid?
+        expect(casa_case.errors[:birth_month_year_youth]).to eq([])
+      end
+    end
+  end
 
   describe "scopes" do
     describe ".due_date_passed" do
@@ -38,7 +102,7 @@ RSpec.describe CasaCase, type: :model do
       subject { described_class.birthday_next_month }
 
       context "when a youth has a birthday next month" do
-        let(:casa_case) { create(:casa_case, birth_month_year_youth: DateTime.now.next_month) }
+        let(:casa_case) { create(:casa_case, birth_month_year_youth: 10.years.ago + 1.month) }
 
         it { is_expected.to include(casa_case) }
       end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe CaseContact, type: :model do
       expect(case_contact.errors[:occurred_at]).to eq(["cannot be in the future"])
     end
 
+    it "verifies occurred at is not before 1/1/1989" do
+      case_contact = build_stubbed(:case_contact, occurred_at: "1984-01-01".to_date)
+      expect(case_contact).to_not be_valid
+      expect(case_contact.errors[:occurred_at]).to eq(["is not valid: Date of Contact cannot be prior to 1/1/1989."])
+    end
+
     it "validates want_driving_reimbursement can be true when miles_driven is  positive" do
       case_contact = build_stubbed(:case_contact, want_driving_reimbursement: true, miles_driven: 1)
       expect(case_contact).to be_valid

--- a/spec/models/court_date_spec.rb
+++ b/spec/models/court_date_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CourtDate, type: :model do
       expect(court_date.errors[:date]).to eq(["is not valid. Court date cannot be prior to 1/1/1989."])
     end
 
-    fit "is not valid more than 1 year in the future" do
+    it "is not valid more than 1 year in the future" do
       court_date = CourtDate.new(date: 367.days.from_now)
       expect(court_date.valid?).to be false
       expect(court_date.errors[:date]).to eq(["is not valid. Court date must be within one year from today."])

--- a/spec/models/court_date_spec.rb
+++ b/spec/models/court_date_spec.rb
@@ -17,15 +17,41 @@ RSpec.describe CourtDate, type: :model do
   it { is_expected.to belong_to(:hearing_type).optional }
   it { is_expected.to belong_to(:judge).optional }
 
+  before do
+    travel_to Date.new(2021, 1, 1)
+  end
+
+  describe "date validation" do
+    it "is not valid before 1989" do
+      court_date = CourtDate.new(date: "1984-01-01".to_date)
+      expect(court_date.valid?).to be false
+      expect(court_date.errors[:date]).to eq(["is not valid. Court date cannot be prior to 1/1/1989."])
+    end
+
+    fit "is not valid more than 1 year in the future" do
+      court_date = CourtDate.new(date: 367.days.from_now)
+      expect(court_date.valid?).to be false
+      expect(court_date.errors[:date]).to eq(["is not valid. Court date must be within one year from today."])
+    end
+
+    it "is valid within one year in the future" do
+      court_date = CourtDate.new(date: 6.months.from_now)
+      court_date.valid?
+      expect(court_date.errors[:date]).to eq([])
+    end
+
+    it "is valid in the past after 1989" do
+      court_date = CourtDate.new(date: "1997-08-29".to_date)
+      court_date.valid?
+      expect(court_date.errors[:date]).to eq([])
+    end
+  end
+
   it "is invalid without a casa_case" do
     court_date = build(:court_date, casa_case: nil)
     expect do
       court_date.casa_case = casa_case
     end.to change { court_date.valid? }.from(false).to(true)
-  end
-
-  before do
-    travel_to Date.new(2021, 1, 1)
   end
 
   describe ".ordered_ascending" do

--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe LearningHour, type: :model do
     expect(learning_hour).to_not be_valid
   end
 
+  it "Date cannot be before 01-01-1989" do
+    learning_hour = build_stubbed(:learning_hour, occurred_at: "1984-01-01".to_date)
+    expect(learning_hour).to_not be_valid
+    expect(learning_hour.errors[:occurred_at]).to eq(["is not valid: Occurred on Date cannot be prior to 1/1/1989."])
+  end
+
   it "does not require learning_hour_topic if casa_org learning_hour_topic disabled" do
     learning_hour = build_stubbed(:learning_hour, learning_hour_topic: nil)
     expect(learning_hour).to be_valid

--- a/spec/models/mileage_rate_spec.rb
+++ b/spec/models/mileage_rate_spec.rb
@@ -21,6 +21,30 @@ RSpec.describe MileageRate, type: :model do
   end
 
   context "#effective_date" do
+    it "cannot be before 1/1/1989" do
+      mileage_rate = build_stubbed(:mileage_rate, effective_date: "1984-01-01".to_date)
+      expect(mileage_rate).to_not be_valid
+      expect(mileage_rate.errors[:effective_date]).to eq(["cannot be prior to 1/1/1989."])
+    end
+
+    it "cannot be more than one year in the future" do
+      mileage_rate = build_stubbed(:mileage_rate, effective_date: 367.days.from_now)
+      expect(mileage_rate).to_not be_valid
+      expect(mileage_rate.errors[:effective_date]).to eq(["must not be more than one year in the future."])
+    end
+
+    it "is valid in the past after 1/1/1989" do
+      mileage_rate = build_stubbed(:mileage_rate, effective_date: "1997-08-29".to_date)
+      expect(mileage_rate).to be_valid
+      expect(mileage_rate.errors[:effective_date]).to eq([])
+    end
+
+    it "is valid today" do
+      mileage_rate = build_stubbed(:mileage_rate, effective_date: DateTime.now)
+      expect(mileage_rate).to be_valid
+      expect(mileage_rate.errors[:effective_date]).to eq([])
+    end
+
     it "is unique within is_active and casa_org" do
       effective_date = Date.new(2020, 1, 1)
       casa_org = create(:casa_org)

--- a/spec/models/other_duty_spec.rb
+++ b/spec/models/other_duty_spec.rb
@@ -14,4 +14,30 @@ RSpec.describe OtherDuty, type: :model do
     other_duty.creator = nil
     expect { other_duty.save!(validate: false) }.to raise_error ActiveRecord::NotNullViolation
   end
+
+  describe "occurred_at validation" do
+    it "is not valid before 1989" do
+      other_duty = OtherDuty.new(occurred_at: "1984-01-01".to_date)
+      expect(other_duty.valid?).to be false
+      expect(other_duty.errors[:occurred_at]).to eq(["is not valid. Occured on date cannot be prior to 1/1/1989."])
+    end
+
+    it "is not valid more than 1 year in the future" do
+      other_duty = OtherDuty.new(occurred_at: 367.days.from_now)
+      expect(other_duty.valid?).to be false
+      expect(other_duty.errors[:occurred_at]).to eq(["is not valid. Occured on date must be within one year from today."])
+    end
+
+    it "is valid within one year in the future" do
+      other_duty = OtherDuty.new(occurred_at: 6.months.from_now)
+      other_duty.valid?
+      expect(other_duty.errors[:occurred_at]).to eq([])
+    end
+
+    it "is valid in the past after 1989" do
+      other_duty = OtherDuty.new(occurred_at: "1997-08-29".to_date)
+      other_duty.valid?
+      expect(other_duty.errors[:occurred_at]).to eq([])
+    end
+  end
 end

--- a/spec/models/placement_spec.rb
+++ b/spec/models/placement_spec.rb
@@ -6,4 +6,30 @@ RSpec.describe Placement, type: :model do
   it { is_expected.to belong_to(:placement_type) }
   it { is_expected.to belong_to(:creator) }
   it { is_expected.to belong_to(:casa_case) }
+
+  context "placement_started_at" do
+    it "cannot be before 1/1/1989" do
+      placement = build_stubbed(:placement, placement_started_at: "1984-01-01".to_date)
+      expect(placement).to_not be_valid
+      expect(placement.errors[:placement_started_at]).to eq(["cannot be prior to 1/1/1989."])
+    end
+
+    it "cannot be more than one year in the future" do
+      placement = build_stubbed(:placement, placement_started_at: 367.days.from_now)
+      expect(placement).to_not be_valid
+      expect(placement.errors[:placement_started_at]).to eq(["must not be more than one year in the future."])
+    end
+
+    it "is valid in the past after 1/1/1989" do
+      placement = build_stubbed(:placement, placement_started_at: "1997-08-29".to_date)
+      expect(placement).to be_valid
+      expect(placement.errors[:placement_started_at]).to eq([])
+    end
+
+    it "is valid today" do
+      placement = build_stubbed(:placement, placement_started_at: DateTime.now)
+      expect(placement).to be_valid
+      expect(placement.errors[:placement_started_at]).to eq([])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe User, type: :model do
     it "requires date of birth to be in the past" do
       user = build(:user, date_of_birth: 10.days.from_now)
       expect(user.valid?).to be false
+      expect(user.errors[:base]).to eq([" Date of birth must be in the past."])
+    end
+
+    it "requires date of birth to be no earlier than 1/1/1920" do
+      user = build(:user, date_of_birth: "1919-12-31".to_date)
+      expect(user.valid?).to be false
+      expect(user.errors[:base]).to eq([" Date of birth must be on or after 1/1/1920."])
     end
 
     it "has an empty old_emails array when initialized" do

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe Volunteer, type: :model do
     context "there are volunteers whose birthdays are not next month" do
       let!(:volunteer1) { create(:volunteer, date_of_birth: Date.new(1990, 9, 1)) }
       let!(:volunteer2) { create(:volunteer, date_of_birth: Date.new(1998, 10, 15)) }
-      let!(:volunteer3) { create(:volunteer, date_of_birth: Date.new(1919, 12, 1)) }
+      let!(:volunteer3) { create(:volunteer, date_of_birth: Date.new(1920, 12, 1)) }
 
       it { is_expected.to be_empty }
     end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -207,7 +207,14 @@ RSpec.describe "/casa_cases", type: :request do
 
             expect(response.content_type).to eq("application/json; charset=utf-8")
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(response.body).to eq(["Case number can't be blank", "Birth month year youth can't be blank", "Casa case contact types : At least one contact type must be selected"].to_json)
+            expected_response_body = [
+              "Birth month year youth can't be blank",
+              "Birth month year youth is not valid: Youth's Birth Month & Year cannot be a future date.",
+              "Birth month year youth is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989.",
+              "Case number can't be blank",
+              "Casa case contact types : At least one contact type must be selected"
+            ].to_json
+            expect(response.body).to eq(expected_response_body)
           end
         end
 

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -263,7 +263,12 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
         it "renders a successful response (i.e. to display the 'new' template)" do
           post casa_case_court_dates_path(casa_case), params: {court_date: invalid_attributes}
           expect(response).to be_successful
-          expect(assigns[:court_date].errors.full_messages).to eq ["Date can't be blank"]
+          expected_errors = [
+            "Date can't be blank",
+            "Date is not valid. Court date must be within one year from today.",
+            "Date is not valid. Court date cannot be prior to 1/1/1989."
+          ].freeze
+          expect(assigns[:court_date].errors.full_messages).to eq expected_errors
         end
       end
     end
@@ -304,7 +309,12 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
         patch casa_case_court_date_path(casa_case, court_date), params: {court_date: invalid_attributes}
 
         expect(response).to be_successful
-        expect(assigns[:court_date].errors.full_messages).to eq ["Date can't be blank"]
+        expected_errors = [
+          "Date can't be blank",
+          "Date is not valid. Court date must be within one year from today.",
+          "Date is not valid. Court date cannot be prior to 1/1/1989."
+        ].freeze
+        expect(assigns[:court_date].errors.full_messages).to eq expected_errors
       end
     end
 

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "casa_cases/new", type: :system do
         contact_type_group = create(:contact_type_group, casa_org: casa_org)
         contact_type = create(:contact_type, contact_type_group: contact_type_group)
         case_number = "12345"
-        court_date = 21.days.from_now
 
         sign_in admin
         visit root_path
@@ -18,6 +17,7 @@ RSpec.describe "casa_cases/new", type: :system do
         click_on "New Case"
 
         travel_to Time.zone.local(2020, 12, 1) do
+          court_date = 21.days.from_now
           fourteen_years = (Date.today.year - 14).to_s
           fill_in "Case number", with: case_number
 

--- a/spec/views/supervisors/index.html.erb_spec.rb
+++ b/spec/views/supervisors/index.html.erb_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe "supervisors/index", type: :view do
       casa_case1 = create(:casa_case,
         case_number: "123",
         active: true,
-        birth_month_year_youth: Date.new(1900))
+        birth_month_year_youth: "1999-01-01".to_date)
       casa_case2 = create(:casa_case,
         case_number: "456",
         active: false,
-        birth_month_year_youth: Date.new(2100))
+        birth_month_year_youth: "2024-01-01".to_date)
       assign :casa_cases, [casa_case1, casa_case2]
       assign :supervisors, []
       assign :available_volunteers, []


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5646 

### What changed, and _why_?
Added date validations to avoid bad dates like 6/1/20000:

CourtDate

- [x] date - no earlier than 1/1/1989. No later than 1 year in the future.
- [x] court_report_due_date - ignored

CasaCase

- [x] birth_month_year_youth —> range from 1989 to today
- [x] court_report_due_date —> ignored
- [x] court_report_submitted_at —> set by app
- [x] date_in_care —> range is from 1989 to today

CaseContact

- [x] occurred_at —> already validates can’t be in future, added 1989 minimum

LearningHour

- [x] occurred_at —> already validates can’t be in future, added 1989 minimum

MileageRate

- [x] effective_date —>  no earlier than 1/1/1989. No later than 1 year in the future.

OtherDuties

- [x] occurred_at —> no earlier than 1/1/1989. No later than 1 year in the future.

PlacementsStartedAt

- [x] Placement_started_at —> no earlier than 1/1/1989. No later than 1 year in the future.

User

- [x] date_of_birth —> range from 1920 to today

UserReminderTime - added by https://github.com/rubyforgood/casa/pull/3735 but not used anywhere. Currently no orgs use SMS anyways so we are fine ignoring this
case_contact_types —> ignored
no_contact_made —> ignored

### How is this **tested**? (please write tests!) 💖💪
Updated specs for models and manually tested UI.

### Screenshots please :)
Sample validation for new court dates:
![image](https://github.com/rubyforgood/casa/assets/725/2549470c-7f92-4f85-9b53-2477aa8796ce)

### Feelings gif (optional)
😀 😀
![Ruby for Good 2024! 😀 😀 ](https://rubyforgood.org/assets/img/logos/classic-logo.png)

Worked on by @yyelleww70 and @marc .