### PR TITLE
Add Court Topics to Case Contact CSV export

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -19,7 +19,7 @@ class CasaCasesController < ApplicationController
       format.html {}
       format.csv do
         case_contacts = @casa_case.decorate.case_contacts_ordered_by_occurred_at
-        csv = CaseContactsExportCsvService.new(case_contacts).perform
+        csv = CaseContactsExportCsvService.new(case_contacts, CaseContactReport::COLUMNS).perform
         send_data csv, filename: case_contact_csv_name(case_contacts)
       end
       format.xlsx do

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -138,6 +138,10 @@ class CaseContact < ApplicationRecord
     where(casa_case_id: case_ids) if case_ids.present?
   }
 
+  scope :with_court_topics, ->() {
+    left_joins(contact_topic_answers: [:contact_topic])
+  }
+
   scope :no_drafts, ->(checked) { (checked == 1) ? where(status: "active") : all }
 
   filterrific(

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -138,8 +138,8 @@ class CaseContact < ApplicationRecord
     where(casa_case_id: case_ids) if case_ids.present?
   }
 
-  scope :with_court_topics, ->() {
-    left_joins(contact_topic_answers: [:contact_topic])
+  scope :has_court_topics, -> {
+    joins(contact_topic_answers: [:contact_topic])
   }
 
   scope :no_drafts, ->(checked) { (checked == 1) ? where(status: "active") : all }

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -138,10 +138,6 @@ class CaseContact < ApplicationRecord
     where(casa_case_id: case_ids) if case_ids.present?
   }
 
-  scope :has_court_topics, -> {
-    joins(contact_topic_answers: [:contact_topic])
-  }
-
   scope :no_drafts, ->(checked) { (checked == 1) ? where(status: "active") : all }
 
   filterrific(

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -30,6 +30,8 @@ class CaseContactReport
   def filtered_columns(args)
     if args[:filtered_csv_cols].present?
       args[:filtered_csv_cols].select { |_key, value| value == "true" }.keys.map(&:to_sym)
+    else
+      COLUMNS
     end
   end
 
@@ -48,7 +50,6 @@ class CaseContactReport
     :creator_name,
     :supervisor_name,
     :case_contact_notes,
-    :court_topics,
+    :court_topics
   ]
-
 end

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -25,7 +25,6 @@ class CaseContactReport
       .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
       .with_casa_case(args[:casa_case_ids])
-      .with_court_topics
   end
 
   def filtered_columns(args)

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -32,4 +32,22 @@ class CaseContactReport
       args[:filtered_csv_cols].select { |_key, value| value == "true" }.keys.map(&:to_sym)
     end
   end
+
+  COLUMNS = [
+    :internal_contact_number,
+    :duration_minutes,
+    :contact_types,
+    :contact_made,
+    :contact_medium,
+    :occurred_at,
+    :added_to_system_at,
+    :miles_driven,
+    :wants_driving_reimbursement,
+    :casa_case_number,
+    :creator_email,
+    :creator_name,
+    :supervisor_name,
+    :case_contact_notes,
+  ]
+
 end

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -25,6 +25,7 @@ class CaseContactReport
       .contact_type(args[:contact_type_ids])
       .contact_type_groups(args[:contact_type_group_ids])
       .with_casa_case(args[:casa_case_ids])
+      .with_court_topics
   end
 
   def filtered_columns(args)

--- a/app/models/case_contact_report.rb
+++ b/app/models/case_contact_report.rb
@@ -48,6 +48,7 @@ class CaseContactReport
     :creator_name,
     :supervisor_name,
     :case_contact_notes,
+    :court_topics,
   ]
 
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -20,10 +20,10 @@ class CaseContactsExportCsvService
     end
   end
 
-  def self.fixed_columns(case_contact)
+  def fixed_column_values(case_contact)
     # Note: these header labels are for stakeholders and do not match the
     # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
-    {
+    mappings = {
       internal_contact_number: case_contact.id,
       duration_minutes: case_contact.report_duration_minutes,
       contact_types: case_contact.report_contact_types,
@@ -39,14 +39,12 @@ class CaseContactsExportCsvService
       supervisor_name: case_contact.creator&.supervisor&.display_name,
       case_contact_notes: case_contact.notes
     }
+
+    mappings.slice(*filtered_columns).values
   end
 
   def fixed_column_headers
     filtered_columns.excluding(:court_topics).map(&:to_s).map(&:titleize)
-  end
-
-  def fixed_column_values(case_contact)
-    CaseContactsExportCsvService.fixed_columns(case_contact).slice(*filtered_columns).values
   end
 
   def court_topic_answers(case_contact)

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -53,8 +53,9 @@ class CaseContactsExportCsvService
   def court_topics
     @base_scope
       .has_court_topics
-      .select("contact_topics_contact_topic_answers.question")
+      .select("contact_topics_contact_topic_answers.id", "contact_topics_contact_topic_answers.question")
       .distinct
+      .order("contact_topics_contact_topic_answers.id")
       .map(&:question)
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -11,8 +11,7 @@ class CaseContactsExportCsvService
 
   def perform
     CSV.generate(headers: true) do |csv|
-      filtered_columns.delete(:court_topics)
-      csv << filtered_columns.map(&:to_s).map(&:titleize) + court_topics
+      csv << filtered_columns.excluding(:court_topics).map(&:to_s).map(&:titleize) + court_topics
       if case_contacts.present?
         case_contacts.decorate.each do |case_contact|
           csv << fixed_column_values(case_contact) + court_topic_answers(case_contact)
@@ -47,10 +46,14 @@ class CaseContactsExportCsvService
   end
 
   def court_topic_answers(case_contact)
+    return [] unless filtered_columns.include?(:court_topics)
+
     case_contact.contact_topic_answers.map(&:value)
   end
 
   def court_topics
+    return [] unless filtered_columns.include?(:court_topics)
+
     @base_scope
       .has_court_topics
       .select("contact_topics_contact_topic_answers.id", "contact_topics_contact_topic_answers.question")

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -3,10 +3,11 @@ require "csv"
 class CaseContactsExportCsvService
   attr_reader :case_contacts, :filtered_columns
 
-  def initialize(case_contacts, filtered_columns = nil)
+  def initialize(case_contacts_scope, filtered_columns = nil)
     @filtered_columns = filtered_columns || CaseContactReport::COLUMNS
+    @base_scope = case_contacts_scope
 
-    @case_contacts = case_contacts.preload({creator: :supervisor}, :contact_types, :casa_case)
+    @case_contacts = case_contacts_scope.preload({creator: :supervisor}, :contact_types, :casa_case)
   end
 
   def perform
@@ -43,6 +44,6 @@ class CaseContactsExportCsvService
   end
 
   def court_topics()
-    ContactTopic.pluck(:question)
+    @base_scope.pluck("contact_topics_contact_topic_answers.question")
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -4,7 +4,7 @@ class CaseContactsExportCsvService
   attr_reader :case_contacts, :filtered_columns
 
   def initialize(case_contacts, filtered_columns = nil)
-    @filtered_columns = filtered_columns || CaseContactsExportCsvService.DATA_COLUMNS.keys
+    @filtered_columns = filtered_columns || CaseContactReport::COLUMNS
 
     @case_contacts = case_contacts.preload({creator: :supervisor}, :contact_types, :casa_case)
   end
@@ -14,30 +14,31 @@ class CaseContactsExportCsvService
       csv << filtered_columns.map(&:to_s).map(&:titleize)
       if case_contacts.present?
         case_contacts.decorate.each do |case_contact|
-          csv << CaseContactsExportCsvService.DATA_COLUMNS(case_contact).slice(*filtered_columns).values
+          csv << CaseContactsExportCsvService.fixed_columns(case_contact).slice(*filtered_columns).values
         end
       end
     end
   end
 
-  def self.DATA_COLUMNS(case_contact = nil)
+  def self.fixed_columns(case_contact)
     # Note: these header labels are for stakeholders and do not match the
     # Rails DB names in all cases, e.g. added_to_system_at header is case_contact.created_at
     {
-      internal_contact_number: case_contact&.id,
-      duration_minutes: case_contact&.report_duration_minutes,
-      contact_types: case_contact&.report_contact_types,
-      contact_made: case_contact&.report_contact_made,
-      contact_medium: case_contact&.medium_type,
-      occurred_at: I18n.l(case_contact&.occurred_at, format: :full, default: nil),
-      added_to_system_at: case_contact&.created_at,
-      miles_driven: case_contact&.miles_driven,
-      wants_driving_reimbursement: case_contact&.want_driving_reimbursement,
-      casa_case_number: case_contact&.casa_case&.case_number,
-      creator_email: case_contact&.creator&.email,
-      creator_name: case_contact&.creator&.display_name,
-      supervisor_name: case_contact&.creator&.supervisor&.display_name,
-      case_contact_notes: case_contact&.notes
+      internal_contact_number: case_contact.id,
+      duration_minutes: case_contact.report_duration_minutes,
+      contact_types: case_contact.report_contact_types,
+      contact_made: case_contact.report_contact_made,
+      contact_medium: case_contact.medium_type,
+      occurred_at: I18n.l(case_contact.occurred_at, format: :full, default: nil),
+      added_to_system_at: case_contact.created_at,
+      miles_driven: case_contact.miles_driven,
+      wants_driving_reimbursement: case_contact.want_driving_reimbursement,
+      casa_case_number: case_contact.casa_case&.case_number,
+      creator_email: case_contact.creator&.email,
+      creator_name: case_contact.creator&.display_name,
+      supervisor_name: case_contact.creator&.supervisor&.display_name,
+      case_contact_notes: case_contact.notes,
+      court_topics: nil
     }
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -11,7 +11,8 @@ class CaseContactsExportCsvService
 
   def perform
     CSV.generate(headers: true) do |csv|
-      csv << filtered_columns.map(&:to_s).map(&:titleize)
+      filtered_columns.delete(:court_topics)
+      csv << filtered_columns.map(&:to_s).map(&:titleize) + court_topics
       if case_contacts.present?
         case_contacts.decorate.each do |case_contact|
           csv << CaseContactsExportCsvService.fixed_columns(case_contact).slice(*filtered_columns).values
@@ -37,8 +38,11 @@ class CaseContactsExportCsvService
       creator_email: case_contact.creator&.email,
       creator_name: case_contact.creator&.display_name,
       supervisor_name: case_contact.creator&.supervisor&.display_name,
-      case_contact_notes: case_contact.notes,
-      court_topics: nil
+      case_contact_notes: case_contact.notes
     }
+  end
+
+  def court_topics()
+    ContactTopic.pluck(:question)
   end
 end

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -16,7 +16,7 @@ class CaseContactsExportCsvService
       csv << filtered_columns.map(&:to_s).map(&:titleize) + court_topics
       if case_contacts.present?
         case_contacts.decorate.each do |case_contact|
-          csv << CaseContactsExportCsvService.fixed_columns(case_contact).slice(*filtered_columns).values
+          csv << fixed_column_values(case_contact) + court_topic_answers(case_contact)
         end
       end
     end
@@ -41,6 +41,14 @@ class CaseContactsExportCsvService
       supervisor_name: case_contact.creator&.supervisor&.display_name,
       case_contact_notes: case_contact.notes
     }
+  end
+
+  def fixed_column_values(case_contact)
+    CaseContactsExportCsvService.fixed_columns(case_contact).slice(*filtered_columns).values
+  end
+
+  def court_topic_answers(case_contact)
+    case_contact.contact_topic_answers.map(&:value)
   end
 
   def court_topics

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -6,8 +6,7 @@ class CaseContactsExportCsvService
   def initialize(case_contacts_scope, filtered_columns = nil)
     @filtered_columns = filtered_columns || CaseContactReport::COLUMNS
     @base_scope = case_contacts_scope
-
-    @case_contacts = case_contacts_scope.preload({creator: :supervisor}, :contact_types, :casa_case)
+    @case_contacts = case_contacts_scope.preload({creator: :supervisor}, :contact_types, :casa_case, :contact_topic_answers)
   end
 
   def perform

--- a/app/services/case_contacts_export_csv_service.rb
+++ b/app/services/case_contacts_export_csv_service.rb
@@ -43,7 +43,11 @@ class CaseContactsExportCsvService
     }
   end
 
-  def court_topics()
-    @base_scope.pluck("contact_topics_contact_topic_answers.question")
+  def court_topics
+    @base_scope
+      .has_court_topics
+      .select("contact_topics_contact_topic_answers.question")
+      .distinct
+      .map(&:question)
   end
 end

--- a/app/views/reports/_filter.html.erb
+++ b/app/views/reports/_filter.html.erb
@@ -16,7 +16,7 @@
               Select columns:
             </h6>
             <%= form.fields_for :filtered_csv_cols do |ff| %>
-              <% CaseContactsExportCsvService.DATA_COLUMNS.keys.each_with_index do |column, index| %>
+              <% CaseContactReport::COLUMNS.each_with_index do |column, index| %>
                 <div class="form-check checkbox-style m-2">
                   <%= ff.check_box column, { class: "form-check-input", checked: true }, true, false %>
                   <%= ff.label column, column.to_s.titleize, class: "form-check-label" %>

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -30,18 +30,21 @@ RSpec.describe CaseContactReport, type: :model do
       expect(case_contact_data[1]).to eq("60")
     end
 
-    example "with court topics" do
+    it "with court topics" do
       used_topic = create(:contact_topic, question: "Used topic")
       unused_topic = create(:contact_topic, question: "Unused topic")
 
-      contact = create(:case_contact)
-      create(:contact_topic_answer, case_contact: contact, contact_topic: used_topic)
+      first_contact = create(:case_contact)
+      second_contact = create(:case_contact)
+      create(:contact_topic_answer, case_contact: first_contact, contact_topic: used_topic)
+      create(:contact_topic_answer, case_contact: second_contact, contact_topic: used_topic)
 
       csv = described_class.new.to_csv
-      parsed_csv = CSV.parse(csv, headers: true)
+      headers = CSV.parse(csv, headers: true).headers
 
-      expect(parsed_csv.headers).to include(used_topic.question)
-      expect(parsed_csv.headers).not_to include(unused_topic.question)
+      expect(headers).not_to include(unused_topic.question)
+      expect(headers).to include(used_topic.question)
+      expect(headers.select { |header| header == used_topic.question }.size).to be 1
     end
   end
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe CaseContactReport, type: :model do
       expect(parsed_csv.headers.length).to eq(case_contact_data.length)
       expect(case_contact_data[1]).to eq("60")
     end
+
+    example "with court topics" do
+      contact = create(:case_contact)
+      topic = create(:contact_topic, question: "How are you?")
+      create(:contact_topic_answer, case_contact: contact, contact_topic: topic)
+
+      csv = described_class.new.to_csv
+      parsed_csv = CSV.parse(csv, headers: true)
+
+      expect(parsed_csv.headers).not_to include("Court Topics")
+      expect(parsed_csv.headers).to include("How are you?")
+    end
   end
 
   describe "CSV body serialization" do

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -5,11 +5,10 @@ RSpec.describe CaseContactReport, type: :model do
     it "matches the length of row data" do
       create(:case_contact)
       csv = described_class.new.to_csv
-      parsed_csv = CSV.parse(csv)
+      parsed_csv = CSV.parse(csv, headers: true)
 
-      expect(parsed_csv.length).to eq(2)
-      expect(parsed_csv[0].length).to eq(parsed_csv[1].length)
-      expect(parsed_csv[0]).to eq([
+      expect(parsed_csv.length).to eq(1) # one header, one row
+      expect(parsed_csv.headers).to eq([
         "Internal Contact Number",
         "Duration Minutes",
         "Contact Types",
@@ -26,7 +25,9 @@ RSpec.describe CaseContactReport, type: :model do
         "Case Contact Notes",
         "Court Topics"
       ])
-      case_contact_data = parsed_csv[1]
+
+      case_contact_data = parsed_csv.first
+      expect(parsed_csv.headers.length).to eq(case_contact_data.length)
       expect(case_contact_data[1]).to eq("60")
     end
   end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -384,6 +384,7 @@ RSpec.describe CaseContactReport, type: :model do
   end
 
   context "with court topics" do
+    # rubocop:disable Lint/ExtraSpacing
     let(:report) { described_class.new(filtered_csv_cols: {court_topics: "true"}) }
     let(:csv)    { CSV.parse(report.to_csv, headers: true) }
 
@@ -397,19 +398,20 @@ RSpec.describe CaseContactReport, type: :model do
     before do
       create(:contact_topic_answer, case_contact: contacts.first,  contact_topic: used_topic_2, value: "Ans Contact 1 Topic 2")
       create(:contact_topic_answer, case_contact: contacts.first,  contact_topic: used_topic_1, value: "Ans Contact 1 Topic 1")
-      create(:contact_topic_answer, case_contact: contacts.second, contact_topic: used_topic_1, value: "Ans Contact 2 Topic 1")
+      create(:contact_topic_answer, case_contact: contacts.second, contact_topic: used_topic_2, value: "Ans Contact 2 Topic 2")
     end
 
     it "appends headers for any topics referenced by case_contacts in the report" do
       headers = csv.headers
       expect(headers).not_to include(unused_topic.question)
       expect(headers).to include(used_topic_1.question, used_topic_2.question)
-      expect(headers.select { |header| header == used_topic_1.question }.size).to be 1
+      expect(headers.select { |header| header == used_topic_1.question }.size).to be 1 # rubocop:disable Performance/Count
     end
 
     it "includes topic answers in csv rows" do
-      expect(csv["Used topic 1"]).to eq ["Ans Contact 1 Topic 1", "Ans Contact 2 Topic 1", nil]
-      expect(csv["Used topic 2"]).to eq ["Ans Contact 1 Topic 2", nil, nil]
+      expect(csv[0].fields).to eq ["Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2"]
+      expect(csv[1].fields).to eq [nil,                     "Ans Contact 2 Topic 2"]
+      expect(csv[2].fields).to eq [nil,                     nil]
     end
 
     context "when court topics are not requested" do
@@ -425,5 +427,6 @@ RSpec.describe CaseContactReport, type: :model do
         expect(csv.first.fields).not_to include("Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2")
       end
     end
+    # rubocop:enable Lint/ExtraSpacing
   end
 end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe CaseContactReport, type: :model do
   end
 
   context "with court topics" do
-    let(:report) { described_class.new }
+    let(:report) { described_class.new(filtered_csv_cols: {court_topics: "true"}) }
     let(:csv)    { CSV.parse(report.to_csv, headers: true) }
 
     let!(:used_topic_1) { create(:contact_topic, question: "Used topic 1") }
@@ -410,6 +410,20 @@ RSpec.describe CaseContactReport, type: :model do
     it "includes topic answers in csv rows" do
       expect(csv["Used topic 1"]).to eq ["Ans Contact 1 Topic 1", "Ans Contact 2 Topic 1", nil]
       expect(csv["Used topic 2"]).to eq ["Ans Contact 1 Topic 2", nil, nil]
+    end
+
+    context "when court topics are not requested" do
+      let(:report) do
+        described_class.new(filtered_csv_cols: {
+          internal_contact_number: "true",
+          court_topics: "false"
+        })
+      end
+
+      it "omits topics in headers and rows" do
+        expect(csv.headers).not_to include(used_topic_1.question, used_topic_2.question)
+        expect(csv.first.fields).not_to include("Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2")
+      end
     end
   end
 end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe CaseContactReport, type: :model do
         "Creator Email",
         "Creator Name",
         "Supervisor Name",
-        "Case Contact Notes",
-        "Court Topics"
+        "Case Contact Notes"
       ])
 
       case_contact_data = parsed_csv.first
@@ -97,7 +96,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
 
         expect(report.to_csv).to eq(
-          "Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes,Court Topics\n"
+          "Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes\n"
         )
         expect(contacts.length).to eq(0)
       end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe CaseContactReport, type: :model do
   end
 
   context "with court topics" do
-    # rubocop:disable Lint/ExtraSpacing
+    # rubocop:disable Layout/ExtraSpacing
     let(:report) { described_class.new(filtered_csv_cols: {court_topics: "true"}) }
     let(:csv)    { CSV.parse(report.to_csv, headers: true) }
 
@@ -427,6 +427,6 @@ RSpec.describe CaseContactReport, type: :model do
         expect(csv.first.fields).not_to include("Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2")
       end
     end
-    # rubocop:enable Lint/ExtraSpacing
+    # rubocop:enable Layout/ExtraSpacing
   end
 end

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -31,15 +31,17 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     example "with court topics" do
+      used_topic = create(:contact_topic, question: "Used topic")
+      unused_topic = create(:contact_topic, question: "Unused topic")
+
       contact = create(:case_contact)
-      topic = create(:contact_topic, question: "How are you?")
-      create(:contact_topic_answer, case_contact: contact, contact_topic: topic)
+      create(:contact_topic_answer, case_contact: contact, contact_topic: used_topic)
 
       csv = described_class.new.to_csv
       parsed_csv = CSV.parse(csv, headers: true)
 
-      expect(parsed_csv.headers).not_to include("Court Topics")
-      expect(parsed_csv.headers).to include("How are you?")
+      expect(parsed_csv.headers).to include(used_topic.question)
+      expect(parsed_csv.headers).not_to include(unused_topic.question)
     end
   end
 

--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe CaseContactReport, type: :model do
         "Creator Email",
         "Creator Name",
         "Supervisor Name",
-        "Case Contact Notes"
+        "Case Contact Notes",
+        "Court Topics"
       ])
       case_contact_data = parsed_csv[1]
       expect(case_contact_data[1]).to eq("60")
@@ -83,7 +84,7 @@ RSpec.describe CaseContactReport, type: :model do
         contacts = report.case_contacts
 
         expect(report.to_csv).to eq(
-          "Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes\n"
+          "Internal Contact Number,Duration Minutes,Contact Types,Contact Made,Contact Medium,Occurred At,Added To System At,Miles Driven,Wants Driving Reimbursement,Casa Case Number,Creator Email,Creator Name,Supervisor Name,Case Contact Notes,Court Topics\n"
         )
         expect(contacts.length).to eq(0)
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5789 

### What changed, and _why_?
This pull request introduces changes to the service responsible for exporting case contact reports to include the court topics in the report data.

We've refactored the service to separate the logic for retrieving report headers (including court topics) from the logic for generating report data. We've introduced new methods to facilitate:

1. Retrieve all the headers
2. Retrieve the court topic headers (if requested)
3. Retrieve the court topic answers for each contact case

### Co authors 🙌🏾 !
@Jcg408 , @apocosipadrino , @solebared , @elasticspoon , @rubyforgood!

### How is this **tested**? (please write tests!) 💖💪
Checkout this branch and make sure al specs are passed.


### Screenshots please :)
http://localhost:3000/reports

![created_table](https://github.com/rubyforgood/casa/assets/33580126/9af3d598-3f15-4e26-9200-d55d8ba1cfc5)
![web_screenshot](https://github.com/rubyforgood/casa/assets/33580126/26d78ff1-e35e-4907-a336-b8fecab28044)


### Feelings gif (optional)
love it


