### PR TITLE
Clean up CaseAssignmentsController#show_or_hide_contacts and corresponding skipped spec

### DIFF
--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -66,11 +66,8 @@ class CaseAssignmentsController < ApplicationController
 
     flash_message = "Old Case Contacts created by #{volunteer.display_name} #{@case_assignment.hide_old_contacts? ? "are now visible" : "were successfully hidden"}."
 
-    if !@case_assignment.active && @case_assignment.update(hide_old_contacts: !@case_assignment.hide_old_contacts?)
-      redirect_to after_action_path(casa_case), notice: flash_message
-    else
-      render :edit
-    end
+    @case_assignment.toggle!(:hide_old_contacts)
+    redirect_to after_action_path(casa_case), notice: flash_message
   end
 
   def reimbursement

--- a/app/lib/importers/case_importer.rb
+++ b/app/lib/importers/case_importer.rb
@@ -57,12 +57,12 @@ class CaseImporter < FileImporter
 
     volunteer_assignment_list.each do |volunteer|
       # Expecting an array of length 0 or 1
-      assignment = casa_case.case_assignments.where(volunteer: volunteer)
+      assignments = casa_case.case_assignments.where(volunteer: volunteer)
 
-      if assignment.empty?
+      if assignments.empty?
         casa_case.volunteers << volunteer
-      elsif !assignment[0].active
-        assignment[0].update(active: true)
+      elsif assignments[0].inactive?
+        assignments[0].update(active: true)
       end
     end
   end

--- a/app/models/case_assignment.rb
+++ b/app/models/case_assignment.rb
@@ -14,6 +14,8 @@ class CaseAssignment < ApplicationRecord
     where("updated_at > ?", 1.week.ago).where(active: false).where(volunteer_id: volunteer_id)
   end
 
+  def inactive? = !active?
+
   private
 
   def assignee_must_be_volunteer

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -57,7 +57,7 @@ class ApplicationPolicy
       user.casa_org == record
     when CasaAdmin, CasaCase, Volunteer, Supervisor, HearingType, ContactTypeGroup, ContactTopic
       user.casa_org == record.casa_org
-    when CourtDate, CaseContact
+    when CourtDate, CaseContact, CaseAssignment
       user.casa_org == record&.casa_case&.casa_org
     when LearningHour
       user.casa_org == record&.user&.casa_org

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -29,11 +29,11 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def hide_contacts?
-    !record.active? && !record.hide_old_contacts? && admin_or_supervisor?
+    show_or_hide_contacts? && !record.hide_old_contacts?
   end
 
   def show_or_hide_contacts?
-    admin_or_supervisor? && same_org?
+    !record.active? && admin_or_supervisor? && same_org?
   end
 
   def same_org?

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -31,8 +31,4 @@ class CaseAssignmentPolicy < ApplicationPolicy
   def show_or_hide_contacts?
     record.inactive? && admin_or_supervisor? && same_org?
   end
-
-  def same_org?
-    user.casa_org_id == record.casa_case.casa_org_id
-  end
 end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -28,10 +28,6 @@ class CaseAssignmentPolicy < ApplicationPolicy
     admin_or_supervisor? && same_org?
   end
 
-  def hide_contacts?
-    show_or_hide_contacts? && !record.hide_old_contacts?
-  end
-
   def show_or_hide_contacts?
     !record.active? && admin_or_supervisor? && same_org?
   end

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -29,7 +29,7 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def show_or_hide_contacts?
-    !record.active? && admin_or_supervisor? && same_org?
+    record.inactive? && admin_or_supervisor? && same_org?
   end
 
   def same_org?

--- a/app/policies/case_assignment_policy.rb
+++ b/app/policies/case_assignment_policy.rb
@@ -17,18 +17,18 @@ class CaseAssignmentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    admin_or_supervisor? && same_org?
+    admin_or_supervisor_same_org?
   end
 
   def unassign?
-    record.active? && admin_or_supervisor? && same_org?
+    record.active? && admin_or_supervisor_same_org?
   end
 
   def reimbursement?
-    admin_or_supervisor? && same_org?
+    admin_or_supervisor_same_org?
   end
 
   def show_or_hide_contacts?
-    record.inactive? && admin_or_supervisor? && same_org?
+    record.inactive? && admin_or_supervisor_same_org?
   end
 end

--- a/app/views/casa_cases/_volunteer_assignment.html.erb
+++ b/app/views/casa_cases/_volunteer_assignment.html.erb
@@ -56,16 +56,16 @@
                         method: :patch,
                         class: "btn btn-outline-success" %>
             <% end %>
-            <% if (policy(assignment).hide_contacts?) %>
-              <%= button_to("Hide Old Contacts",
-                        show_hide_contacts_case_assignment_path(assignment),
-                        method: :patch,
-                        class: "btn btn-outline-secondary text-wrap") %>
-            <% else %>
+            <% if assignment.hide_old_contacts? %>
               <%= button_to("Show Old Contacts",
                         show_hide_contacts_case_assignment_path(assignment),
                         method: :patch,
                         class: "btn btn-outline-warning text-wrap") %>
+            <% else %>
+              <%= button_to("Hide Old Contacts",
+                        show_hide_contacts_case_assignment_path(assignment),
+                        method: :patch,
+                        class: "btn btn-outline-secondary text-wrap") %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/volunteers/_manage_cases.erb
+++ b/app/views/volunteers/_manage_cases.erb
@@ -26,7 +26,7 @@
                   <td>
                     <% if @volunteer.active? && assignment.casa_case.active? && assignment.active? %>
                       Volunteer is <%= render BadgeComponent.new(text: "Active", type: :success) %>
-                    <% elsif @volunteer.active? && assignment.casa_case.active? && !assignment.active? %>
+                    <% elsif @volunteer.active? && assignment.casa_case.active? && assignment.inactive? %>
                       Volunteer is <%= render BadgeComponent.new(text: "Unassigned", type: :danger) %>
                     <% elsif @volunteer.active? %>
                       Case was deactivated

--- a/spec/policies/case_assignment_policy_spec.rb
+++ b/spec/policies/case_assignment_policy_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe CaseAssignmentPolicy do
       end
     end
 
-    context "when the case_assignment is inactive" do
+    context "when the case_assignment is active" do
       describe "it does not allow any user to show/hide contacts" do
         it { is_expected.not_to permit(casa_admin, case_assignment) }
         it { is_expected.not_to permit(supervisor, case_assignment) }

--- a/spec/policies/case_assignment_policy_spec.rb
+++ b/spec/policies/case_assignment_policy_spec.rb
@@ -67,11 +67,12 @@ RSpec.describe CaseAssignmentPolicy do
     context "when an admin" do
       context "in the same organization" do
         it "allows user to show or hide contacts" do
-          is_expected.to permit(casa_admin, case_assignment)
+          is_expected.to permit(casa_admin, case_assignment_inactive)
         end
       end
       context "in a different organization" do
         it "does not allow user to show or hide contacts" do
+          other_case_assignment.update(active: false)
           is_expected.not_to permit(casa_admin, other_case_assignment)
         end
       end
@@ -80,11 +81,12 @@ RSpec.describe CaseAssignmentPolicy do
     context "when a supervisor" do
       context "in the same organization" do
         it "allows user to show or hide contacts" do
-          is_expected.to permit(supervisor, case_assignment)
+          is_expected.to permit(supervisor, case_assignment_inactive)
         end
       end
       context "in a different organization" do
         it "does not allow user to show or hide contacts" do
+          other_case_assignment.update(active: false)
           is_expected.not_to permit(supervisor, other_case_assignment)
         end
       end
@@ -92,7 +94,15 @@ RSpec.describe CaseAssignmentPolicy do
 
     context "when a volunteer" do
       it "does not allow user to show or hide contacts" do
-        is_expected.not_to permit(volunteer, case_assignment)
+        is_expected.not_to permit(volunteer, case_assignment_inactive)
+      end
+    end
+
+    context "when the case_assignment is inactive" do
+      describe "it does not allow any user to show/hide contacts" do
+        it { is_expected.not_to permit(casa_admin, case_assignment) }
+        it { is_expected.not_to permit(supervisor, case_assignment) }
+        it { is_expected.not_to permit(volunteer, case_assignment) }
       end
     end
   end

--- a/spec/requests/case_assignments_spec.rb
+++ b/spec/requests/case_assignments_spec.rb
@@ -307,16 +307,18 @@ RSpec.describe "/case_assignments", type: :request do
       end
     end
 
+    # Note: we don't expect this endpoint to be exposed in the UI if the case is inactive
     context "when the case_assignment is active" do
       let(:assignment) { create(:case_assignment, casa_case: casa_case, volunteer: volunteer, active: true) }
 
-      xit "does not toggle contacts visibility" do
-        # TODO: fix controller as it is trying to render a template that does not exist
+      it "does not toggle contacts visibility" do
         expect { request }.not_to change { assignment.reload.hide_old_contacts? }
       end
 
-      xit "renders the edit page?" do
-        # TODO: fix controller as it is trying to render a template that does not exist
+      it "redirects to root with an authorization failure message" do
+        request
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to match "not authorized"
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5669 and #5670 

### What changed, and _why_?
In addressing issue #5669, it seemed that this endpoint should only be called for in inactive case_assignment. If that premise holds, then we no longer need the `else` conditional that attempts to `render :edit`, which would actually result in an error since this controller doesn't support an edit action or view.

That error was only surfacing in a spec that had been skipped.

If my hypothesis holds, then we can:
* Disallow access to this endpoint via policy if the case_assignment is inactive
* Remove the conditional and lways toggle :hide_old_contacts if authorized
* Change policy and request specs accordingly

### Note
Please verify my hypothesis on this! -- That the ability to show/hide old contacts should not be accessible on an active case_assignment (for any role).

### How is this **tested**? (please write tests!) 💖💪
* This change was motivated by trying to revive a skipped spec, which i believe this PR does.
* The changes to policies also have spec coverage.
* However i haven't reviewed whether we need additional coverage at an integration level.

Steps to test:
* Log in as an admin
* Edit a case with a volunteer assigned
* Unassign the volunteer (bottom of the form)
* Scroll back down to the bottom of the form
* A 'Hide old contacts' button should be visible
* Click it
    * should show a message at the top that contacts are hidden
    * button should now read 'Show old contacts'
    * clicking it again should show another message and toggle state.

### Screenshots please :)
No user facing changes. Here's a screenshot of the bottom of the Case Edit form where the show/hide old contacts page lives:
![Screenshot 2024-06-03 at 12 07 21](https://github.com/rubyforgood/casa/assets/8330/4093b9ea-4b10-497c-9401-c6e5fe7d59b6)
