### PR TITLE
Fix selenium web mock errors

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,11 +3,7 @@ require "support/stubbed_requests/webmock_helper"
 
 RSpec.describe ApplicationController, type: :controller do
   let(:volunteer) { create(:volunteer) }
-  # add domains to blacklist you want to stub
-  blacklist = ["api.short.io"]
-  web_mock = WebMockHelper.new(blacklist)
-  web_mock.stub_network_connection
-  # stub application controller methods
+
   controller do
     def index
       render plain: "hello there..."

--- a/spec/lib/tasks/case_contact_types_reminder_spec.rb
+++ b/spec/lib/tasks/case_contact_types_reminder_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe CaseContactTypesReminder do
     WebMockHelper.twilio_success_stub
     WebMockHelper.twilio_success_stub_messages_60_days
     WebMockHelper.short_io_stub_localhost
-    WebMock.disable_net_connect!
   end
 
   context "volunteer with uncontacted contact types, sms notifications on, and no reminder in last quarter" do

--- a/spec/lib/tasks/no_contact_made_reminder_spec.rb
+++ b/spec/lib/tasks/no_contact_made_reminder_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe NoContactMadeReminder do
     WebMockHelper.twilio_success_stub
     WebMockHelper.twilio_no_contact_made_stub
     WebMockHelper.short_io_stub_localhost
-    WebMock.disable_net_connect!
   end
 
   context "volunteer with no contact made in past 2 weeks in case contact" do

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Volunteer, type: :model do
     before do
       stub_const("Volunteer::COURT_REPORT_SUBMISSION_REMINDER", 7.days)
       WebMockHelper.short_io_court_report_due_date_stub
-      WebMock.disable_net_connect!
     end
 
     it "sends one mailer" do

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -456,6 +456,7 @@ RSpec.describe "/casa_admins", type: :request do
       it "does not send SMS when Twilio has an error" do
         org = create(:casa_org, twilio_account_sid: "articuno31", twilio_enabled: true)
         admin = build(:casa_admin, casa_org: org)
+        short_io_stub = WebMockHelper.short_io_stub_sms
         twilio_activation_error_stub = WebMockHelper.twilio_activation_error_stub("admin")
         params = attributes_for(:casa_admin)
         params[:phone_number] = "+12222222222"
@@ -463,6 +464,7 @@ RSpec.describe "/casa_admins", type: :request do
         sign_in admin
         post casa_admins_path, params: {casa_admin: params}
 
+        expect(short_io_stub).to have_been_requested.times(2) # TODO: why is this called at all?
         expect(twilio_activation_error_stub).to have_been_requested.times(1)
         expect(response).to have_http_status(:redirect)
         follow_redirect!
@@ -474,10 +476,12 @@ RSpec.describe "/casa_admins", type: :request do
         admin = build(:casa_admin, casa_org: org)
         params = attributes_for(:casa_admin)
         params[:phone_number] = "+12222222222"
+        short_io_stub = WebMockHelper.short_io_stub_sms
 
         sign_in admin
         post casa_admins_path, params: {casa_admin: params}
 
+        expect(short_io_stub).to have_been_requested.times(2) # TODO: why is this called at all?
         expect(response).to have_http_status(:redirect)
         follow_redirect!
         expect(flash[:notice]).to match(/New admin created successfully./)

--- a/spec/services/court_report_due_sms_reminder_service_spec.rb
+++ b/spec/services/court_report_due_sms_reminder_service_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe CourtReportDueSmsReminderService do
     before :each do
       WebMockHelper.short_io_court_report_due_date_stub
       WebMockHelper.twilio_court_report_due_date_stub
-      WebMock.disable_net_connect!
     end
 
     context "when sending sms reminder" do

--- a/spec/services/no_contact_made_sms_reminder_service_spec.rb
+++ b/spec/services/no_contact_made_sms_reminder_service_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe NoContactMadeSmsReminderService do
     before :each do
       WebMockHelper.short_io_stub_localhost
       WebMockHelper.twilio_no_contact_made_stub
-      WebMock.disable_net_connect!
     end
 
     context "when sending sms reminder" do

--- a/spec/services/short_url_service_spec.rb
+++ b/spec/services/short_url_service_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ShortUrlService do
   describe "short.io API" do
     before :each do
       WebMockHelper.short_io_stub
-      WebMock.disable_net_connect!
     end
 
     it "returns a successful response with correct http request" do

--- a/spec/services/sms_reminder_service_spec.rb
+++ b/spec/services/sms_reminder_service_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe SmsReminderService do
     before :each do
       WebMockHelper.short_io_stub_localhost
       WebMockHelper.twilio_no_contact_made_stub
-      WebMock.disable_net_connect!
     end
 
     context "when sending sms reminder" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,11 +27,6 @@ if ENV["RUN_SIMPLECOV"]
 end
 
 RSpec.configure do |config|
-  # webmock gem disables net connections globally by default and so need to allow net connections before each test
-  config.before(:each) do
-    WebMock.allow_net_connect!
-  end
-
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/stubbed_requests/twilio_api.rb
+++ b/spec/support/stubbed_requests/twilio_api.rb
@@ -59,7 +59,7 @@ module TwilioAPI
       .to_return(body: "{\"error_code\":null, \"status\":\"sent\", \"body\":\"Your court report is due on #{court_due_date}. Generate a court report to complete & submit here: https://42ni.short.gy/jzTwdF\"}")
   end
 
-  def twilio_no_contact_made_stub(resousne = "")
+  def twilio_no_contact_made_stub(resource = "")
     WebMock.stub_request(:post, "https://api.twilio.com/2010-04-01/Accounts/articuno34/Messages.json")
       .with(
         body: {"Body" => "It's been two weeks since you've tried reaching 'test'. Try again! https://42ni.short.gy/jzTwdF", "From" => "+15555555555", "To" => "+12222222222"},

--- a/spec/support/stubbed_requests/webmock_helper.rb
+++ b/spec/support/stubbed_requests/webmock_helper.rb
@@ -4,20 +4,4 @@ require "support/stubbed_requests/twilio_api"
 class WebMockHelper
   extend ShortIOAPI
   extend TwilioAPI
-
-  def initialize(blacklist)
-    @blacklist = blacklist
-  end
-
-  def stub_network_connection
-    WebMock.disable_net_connect!(allow: allowed_sites)
-  end
-
-  private
-
-  def allowed_sites
-    lambda { |uri|
-      @blacklist.none? { |site| uri.host.include?(site) }
-    }
-  end
 end


### PR DESCRIPTION
Fixes https://github.com/rubyforgood/casa/wiki/Flaky-tests#rspec-failure-outside-of-tests-x40 (hopefully)

The previous behavior in terms of making API calls in the application was allowing all external calls in tests

```rb
RSpec.configure do |config|
  # webmock gem disables net connections globally by default and so need to allow net connections before each test
  config.before(:each) do
    WebMock.allow_net_connect!
  end
...
end
```

and blacklisting certain requests if the tests were making those calls.

```rb
  # add domains to blacklist you want to stub
  blacklist = ["api.twilio.com", "api.short.io"]
  web_mock = WebMockHelper.new(blacklist)
  web_mock.stub_network_connection
```

This resulted in several issues:
- some tests were not blacklisting all the calls they should have been so we were making 3rd party calls in our specs (woops)
- some tests were not returns the allow_list back to the default state which resulted in localhost calls failing

I have changed the strategy to deny all exertnal calls (except localhost and docker). All requests will needed to be stubbed using WebMock.