### PR TITLE
Add "Enable Other Duties" as Organization Feature

### DIFF
--- a/app/controllers/casa_org_controller.rb
+++ b/app/controllers/casa_org_controller.rb
@@ -51,6 +51,7 @@ class CasaOrgController < ApplicationController
       :court_report_template,
       :show_driving_reimbursement,
       :additional_expenses_enabled,
+      :other_duties_enabled,
       :twilio_account_sid,
       :twilio_phone_number,
       :twilio_api_key_sid,

--- a/app/models/casa_org.rb
+++ b/app/models/casa_org.rb
@@ -158,6 +158,7 @@ end
 #  footer_links                :string           default([]), is an Array
 #  learning_topic_active       :boolean          default(FALSE)
 #  name                        :string           not null
+#  other_duties_enabled        :boolean          default(TRUE)
 #  show_driving_reimbursement  :boolean          default(TRUE)
 #  show_fund_request           :boolean          default(FALSE)
 #  slug                        :string

--- a/app/policies/other_duty_policy.rb
+++ b/app/policies/other_duty_policy.rb
@@ -9,11 +9,11 @@ class OtherDutyPolicy < UserPolicy
   end
 
   def index?
-    admin_or_supervisor_or_volunteer?
+    admin_or_supervisor_or_volunteer? && casa_org_other_duties_enabled?
   end
 
   def new?
-    user.volunteer?
+    user.volunteer? && casa_org_other_duties_enabled?
   end
 
   def create?
@@ -21,10 +21,14 @@ class OtherDutyPolicy < UserPolicy
   end
 
   def edit?
-    user.volunteer? && record.creator == user
+    user.volunteer? && record.creator == user && casa_org_other_duties_enabled?
   end
 
   def update?
     edit?
+  end
+
+  def casa_org_other_duties_enabled?
+    user.casa_org.other_duties_enabled
   end
 end

--- a/app/views/casa_org/edit.html.erb
+++ b/app/views/casa_org/edit.html.erb
@@ -51,6 +51,10 @@
       <%= form.label :learning_topic_active, "Enable Learning Topic", class: 'form-check-label mb-2' %>
     </div>
     <div class="form-check checkbox-style mb-20">
+      <%= form.check_box :other_duties_enabled, class: 'form-check-input' %>
+      <%= form.label :other_duties_enabled, "Enable Other Duties", class: 'form-check-label mb-2' %>
+    </div>
+    <div class="form-check checkbox-style mb-20">
       <%= form.check_box :twilio_enabled, class: 'form-check-input accordionTwilio' %>
       <%= form.label :twilio_enabled, "Enable Twilio", class: 'form-check-label mb-2' %>
     </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -23,7 +23,7 @@
         <ul>
           <%= render(Sidebar::LinkComponent.new(title: "Supervisors", icon: "network", path: supervisors_path, render_check: policy(Supervisor).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Volunteers", icon: "heart-filled", path: volunteers_path, render_check: policy(Volunteer).index?)) %>
-          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.casa_admin? || (current_user.supervisor? && policy(OtherDuty).index?))) %>
+          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: (current_user.casa_admin? || current_user.supervisor?) && policy(OtherDuty).index?)) %>
           <!-- Renders Cases for Volunteers -->
           <%= render(Sidebar::GroupComponent.new(title: cases_index_title, icon: "folder", render_check: current_user.volunteer?)) do |group| %>
             <% group.with_link(title: "All", path: casa_cases_path, nav_item: false) %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -23,7 +23,7 @@
         <ul>
           <%= render(Sidebar::LinkComponent.new(title: "Supervisors", icon: "network", path: supervisors_path, render_check: policy(Supervisor).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Volunteers", icon: "heart-filled", path: volunteers_path, render_check: policy(Volunteer).index?)) %>
-          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.casa_admin? || current_user.supervisor?)) %>
+          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.casa_admin? || (current_user.supervisor? && policy(OtherDuty).index?))) %>
           <!-- Renders Cases for Volunteers -->
           <%= render(Sidebar::GroupComponent.new(title: cases_index_title, icon: "folder", render_check: current_user.volunteer?)) do |group| %>
             <% group.with_link(title: "All", path: casa_cases_path, nav_item: false) %>
@@ -40,7 +40,7 @@
           <% end %>
           <%= render(Sidebar::LinkComponent.new(title: "Learning Hours", icon: "timer", path: learning_hours_path, render_check: policy(LearningHour).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Emancipation Checklist(s)", icon: "list", path: emancipation_checklists_path, render_check: current_user.serving_transition_aged_youth?)) %>
-          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.volunteer?)) %>
+          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.volunteer? && policy(OtherDuty).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Banners", icon: "flag", path: banners_path, render_check: policy(:application).see_banner_page?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Generate Court Reports", icon: "paperclip", path: case_court_reports_path, render_check: policy(:application).see_court_reports_page? && current_user.volunteer?)) %>
           <%= render(Sidebar::GroupComponent.new(title: "Group Actions", icon: "list", render_check: !current_user.volunteer?)) do |group| %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -23,7 +23,7 @@
         <ul>
           <%= render(Sidebar::LinkComponent.new(title: "Supervisors", icon: "network", path: supervisors_path, render_check: policy(Supervisor).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Volunteers", icon: "heart-filled", path: volunteers_path, render_check: policy(Volunteer).index?)) %>
-          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: (current_user.casa_admin? || current_user.supervisor?) && policy(OtherDuty).index?)) %>
+          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: policy(OtherDuty).index?)) %>
           <!-- Renders Cases for Volunteers -->
           <%= render(Sidebar::GroupComponent.new(title: cases_index_title, icon: "folder", render_check: current_user.volunteer?)) do |group| %>
             <% group.with_link(title: "All", path: casa_cases_path, nav_item: false) %>
@@ -40,7 +40,6 @@
           <% end %>
           <%= render(Sidebar::LinkComponent.new(title: "Learning Hours", icon: "timer", path: learning_hours_path, render_check: policy(LearningHour).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Emancipation Checklist(s)", icon: "list", path: emancipation_checklists_path, render_check: current_user.serving_transition_aged_youth?)) %>
-          <%= render(Sidebar::LinkComponent.new(title: "Other Duties", icon: "agenda", path: other_duties_path, render_check: current_user.volunteer? && policy(OtherDuty).index?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Banners", icon: "flag", path: banners_path, render_check: policy(:application).see_banner_page?)) %>
           <%= render(Sidebar::LinkComponent.new(title: "Generate Court Reports", icon: "paperclip", path: case_court_reports_path, render_check: policy(:application).see_court_reports_page? && current_user.volunteer?)) %>
           <%= render(Sidebar::GroupComponent.new(title: "Group Actions", icon: "list", render_check: !current_user.volunteer?)) do |group| %>

--- a/db/migrate/20240610071054_add_other_duties_enabled_to_casa_org.rb
+++ b/db/migrate/20240610071054_add_other_duties_enabled_to_casa_org.rb
@@ -1,0 +1,5 @@
+class AddOtherDutiesEnabledToCasaOrg < ActiveRecord::Migration[7.1]
+  def change
+    add_column :casa_orgs, :other_duties_enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_172823) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_10_071054) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -161,6 +161,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_172823) do
     t.boolean "twilio_enabled", default: false
     t.boolean "additional_expenses_enabled", default: false
     t.boolean "learning_topic_active", default: false
+    t.boolean "other_duties_enabled", default: true
     t.index ["slug"], name: "index_casa_orgs_on_slug", unique: true
   end
 

--- a/spec/policies/other_duty_policy_spec.rb
+++ b/spec/policies/other_duty_policy_spec.rb
@@ -19,5 +19,42 @@ RSpec.describe OtherDutyPolicy do
     it "allows volunteer" do
       is_expected.to permit(volunteer)
     end
+
+    context "when other_duties_enabled is false in casa_org" do
+      before do
+        casa_admin.casa_org.other_duties_enabled = false
+        supervisor.casa_org.other_duties_enabled = false
+        volunteer.casa_org.other_duties_enabled = false
+      end
+      it "not allows casa_admins" do
+        is_expected.not_to permit(casa_admin)
+      end
+
+      it "not allows supervisors" do
+        is_expected.not_to permit(supervisor)
+      end
+
+      it "not allows volunteer" do
+        is_expected.not_to permit(volunteer)
+      end
+    end
+    context "when other_duties_enabled is true in casa_org" do
+      before do
+        casa_admin.casa_org.other_duties_enabled = true
+        supervisor.casa_org.other_duties_enabled = true
+        volunteer.casa_org.other_duties_enabled = true
+      end
+      it "not allows casa_admins" do
+        is_expected.to permit(casa_admin)
+      end
+
+      it "not allows supervisors" do
+        is_expected.to permit(supervisor)
+      end
+
+      it "not allows volunteer" do
+        is_expected.to permit(volunteer)
+      end
+    end
   end
 end

--- a/spec/policies/other_duty_policy_spec.rb
+++ b/spec/policies/other_duty_policy_spec.rb
@@ -44,15 +44,15 @@ RSpec.describe OtherDutyPolicy do
         supervisor.casa_org.other_duties_enabled = true
         volunteer.casa_org.other_duties_enabled = true
       end
-      it "not allows casa_admins" do
+      it "allows casa_admins" do
         is_expected.to permit(casa_admin)
       end
 
-      it "not allows supervisors" do
+      it "allows supervisors" do
         is_expected.to permit(supervisor)
       end
 
-      it "not allows volunteer" do
+      it "allows volunteer" do
         is_expected.to permit(volunteer)
       end
     end

--- a/spec/views/layouts/sidebar.html.erb_spec.rb
+++ b/spec/views/layouts/sidebar.html.erb_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists/0")
       expect(rendered).to_not have_link("System Settings", href: "/settings")
+      expect(rendered).to have_link("Other Duties", href: "/other_duties")
+    end
+
+    context "when casa_org other_duties_enabled is true" do
+      before do
+        user.casa_org.other_duties_enabled = true
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "renders Other Duties" do
+        expect(rendered).to have_link("Other Duties", href: "/other_duties")
+      end
+    end
+
+    context "when casa_org other_duties_enabled is false" do
+      before do
+        user.casa_org.other_duties_enabled = false
+
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "does not renders Other Duties" do
+        expect(rendered).to_not have_link("Other Duties", href: "/other_duties")
+      end
     end
   end
 
@@ -78,6 +102,30 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to_not have_link("Supervisors", href: "/supervisors")
       expect(rendered).to_not have_link("Admins", href: "/casa_admins")
       expect(rendered).to_not have_link("System Settings", href: "/settings")
+      expect(rendered).to have_link("Other Duties", href: "/other_duties")
+    end
+
+    context "when casa_org other_duties_enabled is true" do
+      before do
+        user.casa_org.other_duties_enabled = true
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "renders Other Duties" do
+        expect(rendered).to have_link("Other Duties", href: "/other_duties")
+      end
+    end
+
+    context "when casa_org other_duties_enabled is false" do
+      before do
+        user.casa_org.other_duties_enabled = false
+
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "does not renders Other Duties" do
+        expect(rendered).to_not have_link("Other Duties", href: "/other_duties")
+      end
     end
 
     context "when the volunteer does not have a transitioning case" do
@@ -143,6 +191,30 @@ RSpec.describe "layout/sidebar", type: :view do
       expect(rendered).to have_link("Generate Court Reports", href: "/case_court_reports")
       expect(rendered).to have_link("Export Data", href: "/reports")
       expect(rendered).to_not have_link("Emancipation Checklist", href: "/emancipation_checklists")
+      expect(rendered).to have_link("Other Duties", href: "/other_duties")
+    end
+
+    context "when casa_org other_duties_enabled is true" do
+      before do
+        user.casa_org.other_duties_enabled = true
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "renders Other Duties" do
+        expect(rendered).to have_link("Other Duties", href: "/other_duties")
+      end
+    end
+
+    context "when casa_org other_duties_enabled is false" do
+      before do
+        user.casa_org.other_duties_enabled = false
+
+        sign_in user
+        render partial: "layouts/sidebar"
+      end
+      it "does not renders Other Duties" do
+        expect(rendered).to_not have_link("Other Duties", href: "/other_duties")
+      end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5771

### What changed, and _why_?
Because not all orgs will use "Other Duties"  added this as a Organization Feature. The default should be "On" (check marked). Titled as "Enable Other Duties"

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 

### Screenshots please :)
![image](https://github.com/rubyforgood/casa/assets/75837235/c6fdc0d0-079c-4bcb-a0f3-53fec8fda47b)

### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
