### PR TITLE
fix: qa notification bugs

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,4 @@
 class NotificationsController < ApplicationController
-  skip_before_action :authenticate_user!
-  skip_after_action :verify_authorized
-
   def index
     @deploy_time = Health.instance.latest_deploy_time
     @notifications = current_user.notifications.includes([:event]).newest_first


### PR DESCRIPTION
A recent PR removed the authorization step at the `/notifications` page, this resulted in issues where unauthorized requests would hit the index page but they don't have the required values to actually show the page.

```plaintext
 NoMethodError · undefined method `notifications' for nil:NilClass @notifications = current_user.notifications.includes([:event]).newest_first ^^^^^^^^^^^^^^
app/controllers/notifications_controller.rb:7 index
  def index
    @deploy_time = Health.instance.latest_deploy_time
    @notifications = current_user.notifications.includes([:event]).newest_first
    @patch_notes = PatchNote.notes_available_for_user(current_user)
  end
```