### PR TITLE
feat: add timeout and concurrency limit to rspec GH action

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,10 +10,14 @@ on:
   pull_request:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rspec:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       RAILS_ENV: test
 


### PR DESCRIPTION
We occasionally have timeouts with our RSpec Github Action. Lets save the planet a little and cancel it if it goes too long (20 mins)