### PR TITLE
feat: remove timeout from case_contacts_count test

### DIFF
--- a/spec/models/casa_org_spec.rb
+++ b/spec/models/casa_org_spec.rb
@@ -100,15 +100,6 @@ RSpec.describe CasaOrg, type: :model do
     end
   end
 
-  describe "user_count" do
-    let(:org) { create(:casa_org) }
-    subject(:count) { org.user_count }
-    before do
-      2.times { create(:user, casa_org: org) }
-    end
-    it { is_expected.to eq 2 }
-  end
-
   describe "generate_defaults" do
     let(:org) { create(:casa_org) }
     let(:fake_topics) { [{"question" => "Test Title", "details" => "Test details"}] }

--- a/spec/models/casa_org_spec.rb
+++ b/spec/models/casa_org_spec.rb
@@ -109,18 +109,6 @@ RSpec.describe CasaOrg, type: :model do
     it { is_expected.to eq 2 }
   end
 
-  describe "case_contacts_count" do
-    let(:org) { create(:casa_org) }
-    subject(:count) { org.case_contacts_count }
-    before do
-      5.times do
-        casa_case = create(:casa_case, casa_org: org)
-        3.times { create(:case_contact, casa_case: casa_case) }
-      end
-    end
-    it { is_expected.to eq 15 }
-  end
-
   describe "generate_defaults" do
     let(:org) { create(:casa_org) }
     let(:fake_topics) { [{"question" => "Test Title", "details" => "Test details"}] }


### PR DESCRIPTION
The following tests:

```rb
  describe "user_count" do
    let(:org) { create(:casa_org) }
    subject(:count) { org.user_count }
    before do
      2.times { create(:user, casa_org: org) }
    end
    it { is_expected.to eq 2 }
  end

  describe "case_contacts_count" do
    let(:org) { create(:casa_org) }
    subject(:count) { org.case_contacts_count }
    before do
      5.times do
        casa_case = create(:casa_case, casa_org: org)
        3.times { create(:case_contact, casa_case: casa_case) }
      end
    end
    it { is_expected.to eq 15 }
  end
```

for the following methods:

```rb
  def case_contacts_count
    case_contacts.count
  end

  def user_count
    users.count
  end
```

are very low value and seem to cause timeouts in parallel rspec testing. I want to remove them.