### PR TITLE
fix: authorize mark_as_read in Notification controller

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,13 +1,25 @@
 class NotificationsController < ApplicationController
+  after_action :verify_authorized
+  before_action :set_notification, only: %i[mark_as_read]
+
   def index
+    authorize Noticed::Notification, policy_class: NotificationPolicy
+
     @deploy_time = Health.instance.latest_deploy_time
     @notifications = current_user.notifications.includes([:event]).newest_first
     @patch_notes = PatchNote.notes_available_for_user(current_user)
   end
 
   def mark_as_read
-    @notification = Noticed::Notification.find(params[:id])
+    authorize @notification, policy_class: NotificationPolicy
+
     @notification.mark_as_read unless @notification.read?
     redirect_to @notification.event.url
+  end
+
+  private
+
+  def set_notification
+    @notification = Noticed::Notification.find(params[:id])
   end
 end

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -1,0 +1,9 @@
+class NotificationPolicy < ApplicationPolicy
+  def index?
+    admin_or_supervisor_or_volunteer?
+  end
+
+  def mark_as_read?
+    record&.recipient == user
+  end
+end

--- a/spec/policies/notification_policy_spec.rb
+++ b/spec/policies/notification_policy_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe NotificationPolicy, type: :policy do
+  subject { described_class }
+
+  let(:recipient) { create(:volunteer) }
+  let(:casa_admin) { create(:casa_admin) }
+  let(:volunteer) { build(:volunteer) }
+  let(:supervisor) { build(:supervisor) }
+
+  permissions :index? do
+    it "allows any volunteer" do
+      is_expected.to permit(casa_admin)
+    end
+
+    it "allows any supervisor" do
+      is_expected.to permit(supervisor)
+    end
+
+    it "allows any admin" do
+      is_expected.to permit(volunteer)
+    end
+  end
+
+  permissions :mark_as_read? do
+    let(:notification) { create(:notification, recipient: recipient) }
+
+    it "allows recipient" do
+      is_expected.to permit(recipient, notification)
+    end
+
+    it "does not allow other volunteer" do
+      is_expected.to_not permit(volunteer, notification)
+    end
+
+    it "does not permit other supervisor" do
+      is_expected.to_not permit(supervisor, notification)
+    end
+
+    it "does not permit other admin" do
+      is_expected.to_not permit(casa_admin, notification)
+    end
+  end
+end


### PR DESCRIPTION
When we upgraded Noticed we added skipping of callbacks to the NotificationsController. This resulted in issues with unauthed users hitting the notifications page.

To fix this we removed the skipping of callbacks, however, one of the callbacks being skipped was a callback to authorize the Notification. Authorization logic had never been added so now mark as read would not work.

This PR added authorization logic as well as request and policy specs for the controller.

Fixes theses errors:
https://app.bugsnag.com/ruby-for-good/casa/errors/6674487b0fc5c70008cbe9d0?filters%5Berror.status%5D=open&filters%5Bevent.since%5D=30d
