### PR TITLE
feat: add functionality for volunteer to delete drafts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        groups: ["[0, 1, 2]", "[3, 4, 5]", "[6, 7, 8]", "[9, 10, 11]"]
+        groups: ["[0, 1, 2, 3]", "[4, 5, 6, 7]", "[8, 9, 10, 11]"]
     uses: ./.github/workflows/rspec_parallel.yml
     secrets: inherit
     with:
       groups: ${{ matrix.groups }}
       group_count: 12 # the total number of test groups, must match the groups listed in the matrix.groups
-      parallel_processes_count: 3 # the number of parallel processes to run tests in worker, must match the size of the
+      parallel_processes_count: 4 # the number of parallel processes to run tests in worker, must match the size of the
       # inner arrays in the matrix.groups
   combine_and_report:
     if: ${{ !cancelled() }}

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -66,7 +66,7 @@ class CaseContactsController < ApplicationController
   end
 
   def destroy
-    authorize CaseContact
+    authorize @case_contact
 
     @case_contact.destroy
     flash[:notice] = "Contact is successfully deleted."

--- a/app/policies/case_contact_policy.rb
+++ b/app/policies/case_contact_policy.rb
@@ -7,6 +7,10 @@ class CaseContactPolicy < ApplicationPolicy
     is_creator? || admin_or_supervisor?
   end
 
+  def destroy?
+    admin_or_supervisor? || (is_creator? && is_draft?)
+  end
+
   def additional_expenses_allowed?
     FeatureFlagService.is_enabled?(FeatureFlagService::SHOW_ADDITIONAL_EXPENSES_FLAG) &&
       current_organization.additional_expenses_enabled
@@ -16,8 +20,6 @@ class CaseContactPolicy < ApplicationPolicy
   alias_method :new?, :admin_or_supervisor_or_volunteer?
   alias_method :show?, :is_creator_or_casa_admin?
   alias_method :drafts?, :admin_or_supervisor_or_volunteer?
-  alias_method :create?, :is_creator_or_casa_admin?
-  alias_method :destroy?, :admin_or_supervisor?
   alias_method :update?, :is_creator_or_supervisor_or_casa_admin?
   alias_method :edit?, :is_creator_or_supervisor_or_casa_admin?
   alias_method :restore?, :is_admin?
@@ -43,6 +45,10 @@ class CaseContactPolicy < ApplicationPolicy
   end
 
   private
+
+  def is_draft?
+    !record.active?
+  end
 
   def is_creator?
     record.creator == user

--- a/spec/policies/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy_spec.rb
@@ -90,13 +90,37 @@ RSpec.describe CaseContactPolicy do
     end
   end
 
-  permissions :create?, :destroy? do
+  permissions :destroy? do
     it "allows casa_admins" do
       is_expected.to permit(casa_admin, case_contact)
     end
 
-    it "does not allow volunteers" do
-      is_expected.not_to permit(volunteer, case_contact)
+    context "when volunteer is assigned" do
+      context "case_contact is a draft" do
+        let(:case_contact) { build_stubbed(:case_contact, :started_status, creator: volunteer) }
+
+        it { is_expected.to permit(volunteer, case_contact) }
+      end
+
+      context "case_contact is not a draft" do
+        let(:case_contact) { build_stubbed(:case_contact, status: "active", creator: volunteer) }
+
+        it { is_expected.not_to permit(volunteer, case_contact) }
+      end
+    end
+
+    context "when volunteer is not assigned" do
+      context "case_contact is a draft" do
+        let(:case_contact) { build_stubbed(:case_contact, :started_status, creator: build_stubbed(:volunteer)) }
+
+        it { is_expected.not_to permit(volunteer, case_contact) }
+      end
+
+      context "case_contact is not a draft" do
+        let(:case_contact) { build_stubbed(:case_contact, status: "active", creator: build_stubbed(:volunteer)) }
+
+        it { is_expected.not_to permit(volunteer, case_contact) }
+      end
     end
   end
 end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         [
           create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday - 1),
           create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.yesterday),
-          create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today)
+          create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today),
+          create(:case_contact, :started_status, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.today,
+            contact_types: [create(:contact_type, name: "DRAFT Case Contact")])
         ]
       end
 
@@ -32,6 +34,22 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         sign_in volunteer
         visit case_contacts_path
         expect(page).to have_no_link("Bob Loblaw")
+      end
+
+      it "allows the volunteer to delete a draft they created" do
+        case_contacts
+        sign_in volunteer
+        visit case_contacts_path
+
+        card = find(".container-fluid.mb-1", text: "DRAFT Case Contact")
+        expect(card).to_not be_nil
+
+        within_element(card) do
+          expect(card).to have_text("Draft")
+          click_link "Delete"
+        end
+
+        expect(page).to_not have_css(".container-fluid.mb-1", text: "DRAFT Case Contact")
       end
 
       it "displays the contact type groups" do


### PR DESCRIPTION
Fixes #5846

Volunteers are having issues draft case contacts polluting their list of case contacts. 

Often times they will start a case contacts (thus creating a draft). Then they will leave forget about it and complete the case contact by creating a new one. Now they are stuck with useless drafts that pollute their list of case contacts. 

This PR enables volunteers to delete the case contacts that are still in draft status if they are the creators of said case contact.

![image](https://github.com/rubyforgood/casa/assets/14540596/75ae5648-ce93-4af0-a249-efe01cf09215)

