### PR TITLE
fix: parallel timeout improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 20
     env:
       RAILS_ENV: test
+      TEST_MAX_DURATION: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,7 +38,7 @@ jobs:
       - name: compile assets
         run: docker-compose exec -T web bundle exec rails assets:precompile
       - name: Test
-        run: docker-compose exec -T web bundle exec rspec spec --format documentation
+        run: docker-compose exec -T web bundle exec rspec spec --fail-fast
 
       - name: Archive selenium screenshots
         if: ${{ failure() }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 20
     env:
       RAILS_ENV: test
+      TEST_MAX_DURATION: 60
 
     services:
       db:

--- a/.github/workflows/rspec_parallel.yml
+++ b/.github/workflows/rspec_parallel.yml
@@ -21,9 +21,9 @@ jobs:
   rspec_parallel:
     name: RSpec Groups ${{ inputs.groups }}
     runs-on: ubuntu-latest
-    timeout-minutes: 4
     env:
       RAILS_ENV: test
+      TEST_MAX_DURATION: 45
       BUNDLE_WITHOUT: "development"
       CI_TOTAL_JOBS: ${{ inputs.group_count }}
       CI_JOB_INDEX: ${{ inputs.groups }}
@@ -110,12 +110,10 @@ jobs:
           RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec parallel_rspec \
           -n "${CI_TOTAL_JOBS}" \
           --only-group "${CI_JOB_INDEX}" \
-          --runtime-log old_parallel_runtime.log \
-          --verbose ./spec
+          --runtime-log old_parallel_runtime.log ./spec
 
           # echo 'Tests completed. Uploading to Code Climate'
           # ./cc-test-reporter after-build --exit-code $?
-          # cat tmp/spec_summary.log
 
       - name: Compress reports
         if: ${{ !cancelled() }}

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,5 +1,4 @@
 --format RspecJunitFormatter --out tmp/reports/rspec_<%= ENV["GROUPS_UNDERSCORE"] %>_<%= ENV["TEST_ENV_NUMBER"] %>.xml
---format ParallelTests::RSpec::VerboseLogger
+--format ParallelTests::RSpec::SummaryLogger
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime.log
---format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log
 --format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,4 +76,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = false
+
+  # https://github.com/rails/rails/issues/48468
+  config.active_job.queue_adapter = :test
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,15 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
+  config.around :each do |example|
+    # If timeout is not set it will run without a timeout
+    Timeout.timeout(ENV["TEST_MAX_DURATION"].to_i) do
+      example.run
+    end
+  rescue Timeout::Error
+    raise StandardError.new "\"#{example.full_description}\" in #{example.location} timed out."
+  end
+
   config.around :each, :disable_bullet do |example|
     Bullet.raise = false
     example.run


### PR DESCRIPTION
Created an ENV variable `TEST_MAX_DURATION`. If set the max time each test can take will equal that max duration in seconds. If it takes longer the test will fail with an error.

Additionally docker will not fail fast in CI. That test suite is intended to be supplemental. If it is failing, we gain no additional insight compared to the regular RSpec suite. 