### PR TITLE
fix: add draft ids to seeded case contacts

### DIFF
--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -163,7 +163,8 @@ class DbPopulator
       miles_driven: rng.rand(5..40),
       want_driving_reimbursement: random_true_false,
       contact_made: random_true_false,
-      notes: note_generator
+      notes: note_generator,
+      draft_case_ids: [casa_case&.id]
     )
   end
 


### PR DESCRIPTION
The seeder for case contacts does not set `draft_case_ids` resulting in seeded case contacts not showing up on the case contacts index page. This is a fix for that to match the factory.