### PR TITLE
fix: incorrect followup urls

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -61,7 +61,6 @@ class CaseContactsController < ApplicationController
 
   def edit
     authorize @case_contact
-    current_user.notifications.unread.where(id: params[:notification_id]).mark_as_read
     redirect_to case_contact_form_path(CaseContact::FORM_STEPS.first, case_contact_id: @case_contact.id)
   end
 

--- a/app/notifications/followup_notifier.rb
+++ b/app/notifications/followup_notifier.rb
@@ -24,7 +24,7 @@ class FollowupNotifier < BaseNotifier
   end
 
   def url
-    edit_case_contact_path(params[:followup].id, notification_id: id)
+    edit_case_contact_path(params[:followup].case_contact_id)
   end
 
   private

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -84,23 +84,6 @@ RSpec.describe "/case_contacts", type: :request do
     end
 
     it { is_expected.to have_http_status(:redirect) }
-
-    describe "unread notification" do
-      let(:followup) { create(:followup, case_contact: case_contact, creator: admin) }
-
-      subject(:request) do
-        get edit_case_contact_url(case_contact, notification_id: admin.notifications.first.id)
-
-        response
-      end
-
-      before { FollowupResolvedNotifier.with(followup: followup, created_by: admin).deliver(followup.creator) }
-
-      it "is marked as read" do
-        request
-        expect(admin.notifications.unread).to eq([])
-      end
-    end
   end
 
   describe "DELETE /destroy" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -131,7 +131,9 @@ RSpec.describe "/notifications", type: :request do
       it "redirects to the notification event URL" do
         post mark_as_read_notification_path(notification)
 
-        expect(response).to redirect_to(notification.event.url)
+        case_contact_url = edit_case_contact_path(CaseContact.last)
+
+        expect(response).to redirect_to(case_contact_url)
       end
     end
 


### PR DESCRIPTION
The mark_as_read action was not redirecting to the case contact that it was marking as read.

Since we have this mark as read controller action it no longer makes sense to mark a followup to a case contact as read when editing the case contact.