### PR TITLE
5795- Modal closing  error in export filter fixed

### DIFF
--- a/app/views/reports/_filter.html.erb
+++ b/app/views/reports/_filter.html.erb
@@ -5,6 +5,7 @@
         <div class="modal-header px-0 border-0">
           <h5 class="text-bold">Filter Exported Columns</h5>
           <button
+            type="button"
             class="border-0 bg-transparent h1"
             data-bs-dismiss="modal">
             <i class="lni lni-cross-circle"></i>


### PR DESCRIPTION
Resolves #5795

changed the button type to 'button'. It was defaulted to 'submit' and making the form submit when pressed on it








