### PR TITLE
fix: n+1 issues in case_contacts#index

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -115,7 +115,12 @@ class CaseContactsController < ApplicationController
   end
 
   def all_case_contacts
-    policy_scope(current_organization.case_contacts).includes(:creator, contact_types: :contact_type_group)
+    policy_scope(current_organization.case_contacts).includes(
+      :creator,
+      :followups,
+      :contact_types,
+      contact_topic_answers: [:contact_topic]
+    )
   end
 
   def additional_expense_params

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -240,7 +240,7 @@ class CaseContact < ApplicationRecord
   end
 
   def requested_followup
-    followups.requested.first
+    followups.find(&:requested?)
   end
 
   def should_send_reimbursement_email?

--- a/app/presenters/case_contact_presenter.rb
+++ b/app/presenters/case_contact_presenter.rb
@@ -28,6 +28,6 @@ class CaseContactPresenter < BasePresenter
     CasaOrg.includes(:casa_cases)
       .references(:casa_cases)
       .find_by(id: current_user.casa_org_id)
-      .casa_cases.includes(:case_contacts)
+      .casa_cases
   end
 end

--- a/app/views/casa_cases/show.html.erb
+++ b/app/views/casa_cases/show.html.erb
@@ -130,14 +130,14 @@
           <%= render(partial: "case_contacts/case_contact",
                     collection: @casa_case.decorate
                       .case_contacts_ordered_by_occurred_at
-                      .includes(contact_types: [:contact_type_group])
+                      .includes(:contact_types)
                       .grab_all(current_user),
                     as: :contact) %>
         <% else %>
           <%= render(partial: "case_contacts/case_contact",
                     collection: @casa_case.decorate
                       .case_contacts_filtered_by_active_assignment_ordered_by_occurred_at
-                      .includes(contact_types: [:contact_type_group])
+                      .includes(:contact_types)
                       .grab_all(current_user),
                     as: :contact) %>
         <% end %>


### PR DESCRIPTION
`CaseContactsController#index` was our worst page according to scout.

![image](https://github.com/rubyforgood/casa/assets/14540596/5ed34341-1cae-47c8-ae20-06c4bab03a6b)
![image](https://github.com/rubyforgood/casa/assets/14540596/b48c7bbe-a186-42de-936e-4fb6ed21d394)

This was mainly because we had 2 N+1 queries:
![image](https://github.com/rubyforgood/casa/assets/14540596/7ef87810-46cf-4512-b59f-f05ed6579285)

Those have been fixed.