### PR TITLE
5847 surface common filters

### DIFF
--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   static targets = ['collapsible']
 
   initialize () {
-    const isCollapsed = sessionStorage.getItem('filtersCollapsed') === 'true'
+    const isCollapsed = window.sessionStorage.getItem('filtersCollapsed') === 'true'
 
     if (isCollapsed) {
       this.collapsibleTarget.classList.add('collapse')
@@ -24,6 +24,6 @@ export default class extends Controller {
 
     this.collapsible.toggle()
 
-    sessionStorage.setItem('filtersCollapsed', isCollapsed ? 'false' : 'true')
+    window.sessionStorage.setItem('filtersCollapsed', isCollapsed ? 'false' : 'true')
   }
 }

--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from '@hotwired/stimulus'
+import { Collapse } from 'bootstrap'
+
+// Connects to data-controller="collapse"
+export default class extends Controller {
+  static targets = ['collapsible']
+
+  initialize () {
+    const isCollapsed = sessionStorage.getItem('filtersCollapsed') === 'true'
+
+    if (isCollapsed) {
+      this.collapsibleTarget.classList.add('collapse')
+    } else {
+      this.collapsibleTarget.classList.add('collapse', 'show')
+    }
+  }
+
+  connect () {
+    this.collapsible = Collapse.getOrCreateInstance(this.collapsibleTarget, { toggle: false })
+  }
+
+  toggle () {
+    const isCollapsed = !this.collapsibleTarget.classList.contains('show')
+
+    this.collapsible.toggle()
+
+    sessionStorage.setItem('filtersCollapsed', isCollapsed ? 'false' : 'true')
+  }
+}

--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -6,12 +6,12 @@ export default class extends Controller {
   static targets = ['collapsible']
 
   initialize () {
-    const isCollapsed = window.sessionStorage.getItem('filtersCollapsed') === 'true'
+    const isExpanded = window.sessionStorage.getItem('filtersCollapsed') === 'false'
 
-    if (isCollapsed) {
-      this.collapsibleTarget.classList.add('collapse')
-    } else {
+    if (isExpanded) {
       this.collapsibleTarget.classList.add('collapse', 'show')
+    } else {
+      this.collapsibleTarget.classList.add('collapse')
     }
   }
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -8,11 +8,13 @@ import AlertController from './alert_controller'
 
 import AutosaveController from './autosave_controller'
 
+import CollapseController from './collapse_controller'
+
+import CourtOrderFormController from './court_order_form_controller'
+
 import DisableFormController from './disable_form_controller'
 
 import DismissController from './dismiss_controller'
-
-import CourtOrderFormController from './court_order_form_controller'
 
 import HelloController from './hello_controller'
 
@@ -31,9 +33,10 @@ import SidebarGroupController from './sidebar_group_controller'
 import TruncatedTextController from './truncated_text_controller'
 application.register('alert', AlertController)
 application.register('autosave', AutosaveController)
+application.register('collapse', CollapseController)
+application.register('court-order-form', CourtOrderFormController)
 application.register('disable-form', DisableFormController)
 application.register('dismiss', DismissController)
-application.register('court-order-form', CourtOrderFormController)
 application.register('hello', HelloController)
 application.register('icon-toggle', IconToggleController)
 application.register('multiple-select', MultipleSelectController)

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -43,9 +43,9 @@
           </div>
         </div>
         <div class="select-style-1 mb-0">
-          <div class="select-position pr-5">
-            <%= f.label :sorted_by %>
-            <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: "select-style-1 mb-0 bg-white"}) %>
+          <%= f.label :sorted_by %>
+          <div class="select-position">
+            <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: ""}) %>
           </div>
         </div>
         <div>
@@ -99,27 +99,30 @@
             </div>
           </div>
         </div>
-        <div class="row align-items-end select-style-1 mb-10">
+        <div class="row align-items-end  mb-10">
           <div class="col-12">
             <h3>Other filters</h3>
           </div>
-          <div class="col-md-6 select-position pr-5">
+          <div class="col-md-6 select-style-1 pr-5">
             <%= f.label :contact_medium %>
-            <%= f.select(:contact_medium, options_from_collection_for_select(contact_mediums, "value", "label"),
-                                        {include_blank: "Display all"},
-                                        {class: "select-style-1"}) %>
+            <div class="select-position">
+              <%= f.select(:contact_medium, options_from_collection_for_select(contact_mediums, "value", "label"),
+                                          {include_blank: "Display all"}) %>
+            </div>
           </div>
-          <div class="col-md-3 select-position pr-5">
+          <div class="col-md-3 select-style-1 pr-5">
             <%= f.label :want_driving_reimbursement %>
-            <%= f.select(:want_driving_reimbursement, @presenter.boolean_select_options,
-                                                    {include_blank: "Display all"},
-                                                    {class: "select-style-1"}) %>
+            <div class="select-position">
+              <%= f.select(:want_driving_reimbursement, @presenter.boolean_select_options,
+                                                      {include_blank: "Display all"}) %>
+            </div>
           </div>
-          <div class="col-md-3 select-position pr-5">
+          <div class="col-md-3 select-style-1 pr-5">
             <%= f.label :contact_made %>
-            <%= f.select(:contact_made, @presenter.boolean_select_options,
-                                      {include_blank: "Display all"},
-                                      {class: "select-style-1"}) %>
+            <div class="select-position">
+              <%= f.select(:contact_made, @presenter.boolean_select_options,
+                                        {include_blank: "Display all"}) %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -18,7 +18,6 @@
 <%= form_for_filterrific @filterrific, url: case_contacts_path, html: {class: "my-4"} do |f| %>
   <%= hidden_field_tag 'casa_case_id', params[:casa_case_id] %>
 
-
   <div class="card-style">
     <div class="card-content">
       <div class="d-flex justify-content-between align-items-center">
@@ -34,18 +33,16 @@
         </button>
       </div>
       <div class="d-flex flex-wrap justify-content-between align-items-end gap-3 mb-4">
-        <div class="">
-          <div class="">
-            <div class="form-check checkbox-style">
-              <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type" %>
-              <label class="form-check-label" for="filterrific_no_drafts">Hide drafts</label>
+        <div class="d-flex flex-column gap-3">
+          <div class="select-style-1 mb-0">
+            <%= f.label :sorted_by %>
+            <div class="select-position">
+              <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: ""}) %>
             </div>
           </div>
-        </div>
-        <div class="select-style-1 mb-0">
-          <%= f.label :sorted_by %>
-          <div class="select-position">
-            <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: ""}) %>
+          <div class="form-check checkbox-style">
+            <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type" %>
+            <label class="form-check-label" for="filterrific_no_drafts">Hide drafts</label>
           </div>
         </div>
         <div>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -18,14 +18,14 @@
 <%= form_for_filterrific @filterrific, url: case_contacts_path, html: {class: "my-4"} do |f| %>
   <%= hidden_field_tag 'casa_case_id', params[:casa_case_id] %>
 
-  <div class="card-style">
+  <div class="card-style" data-controller="collapse">
     <div class="card-content">
       <div class="d-flex justify-content-between align-items-center">
         <div class="h4 btn-lg">Filter by</div>
         <button href="#"
                 class="btn btn-lg btn-link"
                 type="button"
-                data-bs-toggle="collapse"
+                data-action="collapse#toggle"
                 data-bs-target="#filter-card-body"
                 aria-expanded="<%= params[:filterrific].present? %>>"
                 aria-controls="filter-card-body">
@@ -54,8 +54,7 @@
       </div>
     </div>
 
-    <% collapse_class = params[:filterrific] ? "collapse show" : "collapse" %>
-    <div class="card-content mb-10 ml-20 <%= collapse_class %>" id="filter-card-body">
+    <div class="card-content mb-10 ml-20 collapse" id="filter-card-body" data-collapse-target="collapsible">
         <div class="row">
           <div class="col-12">
             <h3 class="mt-10"><label>Date of contact</label></h3>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -15,35 +15,50 @@
   </div>
 </div>
 
-<%= form_for_filterrific @filterrific, url: case_contacts_path do |f| %>
+<%= form_for_filterrific @filterrific, url: case_contacts_path, html: {class: "my-4"} do |f| %>
   <%= hidden_field_tag 'casa_case_id', params[:casa_case_id] %>
-  <div class="card-style my-4">
-    <div class="card-content d-flex justify-content-between align-items-end">
-      <div class="h4 btn-lg">Filter by</div>
-      <button href="#"
-              class="btn btn-lg btn-link"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#filter-card-body"
-              aria-expanded="<%= params[:filterrific].present? %>>"
-              aria-controls="filter-card-body">
-        <div class="h4">Show / Hide</div>
-      </button>
-    </div>
 
-  <% collapse_class = params[:filterrific] ? "" : "collapse" %>
-    <div class="card-content mb-10 ml-20 <%= collapse_class %>" id="filter-card-body">
-      <div class="row">
-        <div class="col-12">
-          <h3 class="mt-10"><label>Draft status</label></h3>
-        </div>
-        <div class="col-md-4">
-          <div class="form-check checkbox-style">
-            <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type" %>
-            <label class="form-check-label" for="filterrific_no_drafts">Hide drafts</label>
+
+  <div class="card-style">
+    <div class="card-content">
+      <div class="d-flex justify-content-between align-items-center">
+        <div class="h4 btn-lg">Filter by</div>
+        <button href="#"
+                class="btn btn-lg btn-link"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#filter-card-body"
+                aria-expanded="<%= params[:filterrific].present? %>>"
+                aria-controls="filter-card-body">
+          <div class="h4">Expand / Hide</div>
+        </button>
+      </div>
+      <div class="d-flex flex-wrap justify-content-between align-items-end gap-3 mb-4">
+        <div class="">
+          <div class="">
+            <div class="form-check checkbox-style">
+              <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type" %>
+              <label class="form-check-label" for="filterrific_no_drafts">Hide drafts</label>
+            </div>
           </div>
         </div>
+        <div class="select-style-1 mb-0">
+          <div class="select-position pr-5">
+            <%= f.label :sorted_by %>
+            <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: "select-style-1 mb-0 bg-white"}) %>
+          </div>
+        </div>
+        <div>
+          <%= button_tag( :class=> "btn-sm main-btn dark-btn") do %>
+            <i class="lni lni-funnel mr-10"></i> Filter
+          <% end %>
+          <%= link_to("Reset filters", reset_filterrific_url, class: "btn-sm main-btn dark-btn-outline btn-hove") %>
+        </div>
       </div>
+    </div>
+
+    <% collapse_class = params[:filterrific] ? "" : "collapse" %>
+    <div class="card-content mb-10 ml-20 <%= collapse_class %>" id="filter-card-body">
         <div class="row">
           <div class="col-12">
             <h3 class="mt-10"><label>Date of contact</label></h3>
@@ -106,18 +121,6 @@
                                       {include_blank: "Display all"},
                                       {class: "select-style-1"}) %>
           </div>
-        </div>
-        <div class="row select-style-1">
-          <div class="col-md-6 select-position pr-5">
-            <%= f.label :sorted_by %>
-            <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: "select-style-1"}) %>
-          </div>
-        </div>
-        <div>
-          <%= button_tag( :class=> "btn-sm main-btn dark-btn") do %>
-            <i class="lni lni-funnel mr-10"></i> Filter
-          <% end %>
-          <%= link_to("Reset filters", reset_filterrific_url, class: "btn-sm main-btn dark-btn-outline btn-hove") %>
         </div>
       </div>
     </div>

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -54,7 +54,7 @@
       </div>
     </div>
 
-    <% collapse_class = params[:filterrific] ? "" : "collapse" %>
+    <% collapse_class = params[:filterrific] ? "collapse show" : "collapse" %>
     <div class="card-content mb-10 ml-20 <%= collapse_class %>" id="filter-card-body">
         <div class="row">
           <div class="col-12">

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
 
             sign_in volunteer
             visit case_contacts_path
-            click_button "Show / Hide"
+            click_button "Expand / Hide"
 
             fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday
             fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
@@ -167,7 +167,7 @@ RSpec.describe "case_contacts/index", js: true, type: :system do
         expect(page).to_not have_text("Case 1 Notes")
 
         # filtering to only show case 2
-        click_button "Show / Hide"
+        click_button "Expand / Hide"
         fill_in "filterrific_occurred_starting_at", with: Time.zone.yesterday
         fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
         click_button "Filter"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5847 

### What changed, and _why_?
- Moved the `Sorted by` and `Hide drafts` filter options outside of the collapsable area of the form element, so that they display regardless of filter menu collapse status.
- Fixed the positioning of the form select pseudo icons by refactoring the HTML syntax around the select elements
- Changed the filter-card-body collapse class logic to, fix a bug where the "Expand / show" button did not respond to the first click after filtering. This change accounts for how Bootstrap implements its version of collapse.

### How is this **tested**? (please write tests!) 💖💪
I did not add any new tests, since this was only a matter of changing options that are collapsed. However, I did update the button text and the tests that expected the old text.

I can add some system tests to check that the "sticky" options are always displayed if that is desired.

### Screenshots please :)
<img width="1592" alt="SCR-20240629-swmf" src="https://github.com/rubyforgood/casa/assets/81536479/8d8e51e1-1c90-4eb1-b2f6-78e3c81a609c">
<img width="1592" alt="SCR-20240629-swrz" src="https://github.com/rubyforgood/casa/assets/81536479/977a5fda-a595-47e5-9f22-54b578874166">

### Feelings gif (optional)
Instead of a gif, I asked ChatGPT to write a haiku about Bootstrap.
ブートストラップ
制約を感じて
自由を求め