### PR TITLE
5864- Fixing the Double click error

### DIFF
--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -25,14 +25,13 @@
               type="button"
               data-bs-toggle="collapse"
               data-bs-target="#filter-card-body"
-              aria-expanded="<%= params[:filterrific].present? %>>"
+              aria-expanded="false"
               aria-controls="filter-card-body">
         <div class="h4">Show / Hide</div>
       </button>
     </div>
 
-  <% collapse_class = params[:filterrific] ? "" : "collapse" %>
-    <div class="card-content mb-10 ml-20 <%= collapse_class %>" id="filter-card-body">
+    <div class="card-content mb-10 ml-20 collapse" id="filter-card-body">
       <div class="row">
         <div class="col-12">
           <h3 class="mt-10"><label>Draft status</label></h3>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5864 

### What changed, and _why_?
The Filter Modal was not closing even when clicked on button to hide. The problem there was a syntax error and also a validation which resulted true always. these events were led to this error.

And also from user perspective , Once the user clicks on  Filter button  inside the modal  after reloading the page with new results the filter modal should be closed as size of it is huge (it occupies total view port) and  makes the user to scrollnup
 to see what the  results are after applying filters. if he is not satisfied he need to scroll up again and vary the filter inputs. If the filter closes on default on page load, user can see the results right on top of page without scrolling up and can vary filter inputs by opening modal by just clicking on Show / Hide button if he wants to change anything.

This is just my input





