### PR TITLE
Allows volunteer assignment on case creation

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -167,7 +167,6 @@ class CasaCasesController < ApplicationController
   def casa_case_create_params
     create_params = casa_case_params
     create_params = create_params.except(:court_dates_attributes) if court_date_unknown?
-    create_params = create_params.except(:case_assignments_attributes) unless assigned_volunteer?
     create_params.except(:empty_court_date)
   end
 
@@ -190,9 +189,5 @@ class CasaCasesController < ApplicationController
 
   def court_date_unknown?
     casa_case_params[:empty_court_date] == "1"
-  end
-
-  def assigned_volunteer?
-    casa_case_params[:case_assignments_attributes] && casa_case_params[:case_assignments_attributes]["0"][:volunteer_id].present?
   end
 end

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -48,6 +48,7 @@ class CasaCase < ApplicationRecord
   accepts_nested_attributes_for :casa_case_contact_types
   accepts_nested_attributes_for :court_dates
   accepts_nested_attributes_for :volunteers
+  accepts_nested_attributes_for :case_assignments
 
   has_many :case_court_orders, -> { order "id asc" }, dependent: :destroy
   accepts_nested_attributes_for :case_court_orders, reject_if: :all_blank, allow_destroy: true

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -48,7 +48,7 @@ class CasaCase < ApplicationRecord
   accepts_nested_attributes_for :casa_case_contact_types
   accepts_nested_attributes_for :court_dates
   accepts_nested_attributes_for :volunteers
-  accepts_nested_attributes_for :case_assignments
+  accepts_nested_attributes_for :case_assignments, reject_if: proc { |attributes| attributes['volunteer_id'].blank? }
 
   has_many :case_court_orders, -> { order "id asc" }, dependent: :destroy
   accepts_nested_attributes_for :case_court_orders, reject_if: :all_blank, allow_destroy: true

--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -48,7 +48,7 @@ class CasaCase < ApplicationRecord
   accepts_nested_attributes_for :casa_case_contact_types
   accepts_nested_attributes_for :court_dates
   accepts_nested_attributes_for :volunteers
-  accepts_nested_attributes_for :case_assignments, reject_if: proc { |attributes| attributes['volunteer_id'].blank? }
+  accepts_nested_attributes_for :case_assignments, reject_if: proc { |attributes| attributes["volunteer_id"].blank? }
 
   has_many :case_court_orders, -> { order "id asc" }, dependent: :destroy
   accepts_nested_attributes_for :case_court_orders, reject_if: :all_blank, allow_destroy: true

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -114,9 +114,7 @@
           <%= form.fields_for :case_assignments, casa_case.case_assignments.new do |caf| %>
             <%= caf.label :volunteer_id, "Assign a Volunteer" %>
             <div class="select-position">
-              <%= caf.select :volunteer_id,
-                             @casa_case.unassigned_volunteers.map { |v| [v.display_name, v.id] },
-                             prompt: "Please select a volunteer" %>
+              <%= caf.collection_select(:volunteer_id, @casa_case.unassigned_volunteers, :id, :display_name, prompt: "Please select a volunteer") %>
             </div>
           <% end %>
         </div>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -109,14 +109,18 @@
         <label for="casa_case_contact_type_ids">Contact Types</label>
         <%= render "case_contacts/form/contact_types", form: form, options: @contact_types, selected_items: @selected_contact_type_ids, casa_cases: [@casa_case] %>
       <% end %>
-      <div class="select-style-1">
-        <%= form.label :assigned_volunteer_id, "Assign a Volunteer" %>
-        <div class="select-position">
-          <%= form.select :assigned_volunteer_id,
-                          @casa_case.unassigned_volunteers.map { |v| [v.display_name, v.id] },
-                          prompt: "Please select a volunteer" %>
+      <% unless casa_case.persisted? %>
+        <div class="select-style-1">
+          <%= form.fields_for :case_assignments, casa_case.case_assignments.new do |caf| %>
+            <%= caf.label :volunteer_id, "Assign a Volunteer" %>
+            <div class="select-position">
+              <%= caf.select :volunteer_id,
+                             @casa_case.unassigned_volunteers.map { |v| [v.display_name, v.id] },
+                             prompt: "Please select a volunteer" %>
+            </div>
+          <% end %>
         </div>
-      </div>
+      <% end %>
       <br>
       <div class="actions-cc">
         <% if casa_case.active %>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -114,8 +114,7 @@
         <div class="select-position">
           <%= form.select :assigned_volunteer_id,
                           @casa_case.unassigned_volunteers.map { |v| [v.display_name, v.id] },
-                          prompt: "Please select a volunteer"
-          %>
+                          prompt: "Please select a volunteer" %>
         </div>
       </div>
       <br>

--- a/app/views/casa_cases/_form.html.erb
+++ b/app/views/casa_cases/_form.html.erb
@@ -109,6 +109,15 @@
         <label for="casa_case_contact_type_ids">Contact Types</label>
         <%= render "case_contacts/form/contact_types", form: form, options: @contact_types, selected_items: @selected_contact_type_ids, casa_cases: [@casa_case] %>
       <% end %>
+      <div class="select-style-1">
+        <%= form.label :assigned_volunteer_id, "Assign a Volunteer" %>
+        <div class="select-position">
+          <%= form.select :assigned_volunteer_id,
+                          @casa_case.unassigned_volunteers.map { |v| [v.display_name, v.id] },
+                          prompt: "Please select a volunteer"
+          %>
+        </div>
+      </div>
       <br>
       <div class="actions-cc">
         <% if casa_case.active %>

--- a/app/views/shared/_manage_volunteers.html.erb
+++ b/app/views/shared/_manage_volunteers.html.erb
@@ -30,17 +30,19 @@
       </div>
     <% end %>
     <br>
-    <h3 class="title">Assign a New Volunteer</h3>
+    <h3 class="title">Assign a Volunteer to Case</h3>
     <fieldset class="border-0" <%= 'disabled' unless available_volunteers.any? %>>
       <%= form_for assignable_obj.new, url: assign_action do |form| %>
-        <div class='form-group'>
+        <div class='form-group select-style-1'>
           <label for="<%= select_id %>" class="mt-2">Select a Volunteer</label>
-          <select id="<%= select_id %>" name="<%= select_name %>" class='form-control select-style-2 mt-1'>
-            <option value="">Please Select Volunteer</option>
-            <% available_volunteers.each do |volunteer| %>
-              <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
-            <% end %>
-          </select>
+          <div class="select-position">
+            <select id="<%= select_id %>" name="<%= select_name %>" class='form-control select-style-2 mt-1'>
+              <option value="">Please Select Volunteer</option>
+              <% available_volunteers.each do |volunteer| %>
+                <option value="<%= volunteer.id %>"><%= volunteer.display_name %></option>
+              <% end %>
+            </select>
+          </div>
         </div>
         <% if @supervisor %>
           <%= form.hidden_field :supervisor_id, :value => @supervisor.id %>

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -200,9 +200,9 @@ RSpec.describe "/casa_cases", type: :request do
 
           it "does not create a case assignment" do
             expect { post casa_cases_url, params: {casa_case: valid_attributes} }.not_to change(
-               CaseAssignment,
-               :count
-             )
+              CaseAssignment,
+              :count
+            )
           end
         end
       end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "/casa_cases", type: :request do
   let(:date_in_care) { Date.today }
   let(:organization) { build(:casa_org) }
   let(:group) { build(:contact_type_group) }
+  let(:volunteer) { create(:volunteer) }
   let(:type1) { create(:contact_type, contact_type_group: group) }
   let(:valid_attributes) do
     {
@@ -12,6 +13,7 @@ RSpec.describe "/casa_cases", type: :request do
       "date_in_care(3i)": date_in_care.day,
       "date_in_care(2i)": date_in_care.month,
       "date_in_care(1i)": date_in_care.year,
+      assigned_volunteer_id: volunteer.id,
       casa_org_id: organization.id,
       contact_type_ids: [type1.id]
     }
@@ -171,6 +173,37 @@ RSpec.describe "/casa_cases", type: :request do
           expect(response.content_type).to eq("application/json; charset=utf-8")
           expect(response).to have_http_status(:created)
           expect(response.body).to match(valid_attributes[:case_number].to_json)
+        end
+
+        context "with valid assigned_volunteer_id" do
+          it "creates a case assignment" do
+            expect { post casa_cases_url, params: {casa_case: valid_attributes} }.to change(
+              CaseAssignment,
+              :count
+            ).by(1)
+          end
+        end
+
+        context "without an assigned_volunteer_id" do
+          let(:valid_attributes) do
+            {
+              case_number: "1234",
+              birth_month_year_youth: pre_transition_aged_youth_age,
+              "date_in_care(3i)": date_in_care.day,
+              "date_in_care(2i)": date_in_care.month,
+              "date_in_care(1i)": date_in_care.year,
+              assigned_volunteer_id: nil,
+              casa_org_id: organization.id,
+              contact_type_ids: [type1.id]
+            }
+          end
+
+          it "does not create a case assignment" do
+            expect { post casa_cases_url, params: {casa_case: valid_attributes} }.not_to change(
+               CaseAssignment,
+               :count
+             )
+          end
         end
       end
 

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "/casa_cases", type: :request do
       "date_in_care(1i)": date_in_care.year,
       assigned_volunteer_id: volunteer.id,
       casa_org_id: organization.id,
-      contact_type_ids: [type1.id]
+      contact_type_ids: [type1.id],
+      case_assignments_attributes: {"0": {volunteer_id: volunteer.id.to_s}}
     }
   end
   let(:invalid_attributes) { {case_number: nil, birth_month_year_youth: nil} }

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe "casa_cases/new", type: :system do
 
           find(".ts-control").click
           find("span", text: contact_type.name).click
+          find(".ts-control").click
 
-          select "Test User", from: "casa_case[assigned_volunteer_id]"
+          select "Test User", from: "casa_case[case_assignments_attributes][0][volunteer_id]"
 
           within ".top-page-actions" do
             click_on "Create CASA Case"

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "casa_cases/new", type: :system do
       let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
       let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
       let(:volunteer_display_name) { "Test User" }
-      let!(:supervisor) { create(:supervisor, casa_org: casa_org)}
+      let!(:supervisor) { create(:supervisor, casa_org: casa_org) }
       let!(:volunteer) { create(:volunteer, display_name: volunteer_display_name, supervisor: supervisor, casa_org: casa_org) }
 
       it "is successful", js: true do

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe "casa_cases/new", type: :system do
           expect(page).to have_content("CASA case was successfully created.")
           expect(page).not_to have_content("Court Report Due Date: Thursday, 1-APR-2021") # accurate for frozen time
           expect(page).to have_content("Transition Aged Youth: Yes")
+          expect(page).to have_content(volunteer_display_name)
         end
       end
     end

--- a/spec/system/casa_cases/new_spec.rb
+++ b/spec/system/casa_cases/new_spec.rb
@@ -3,11 +3,15 @@ require "rails_helper"
 RSpec.describe "casa_cases/new", type: :system do
   context "when signed in as a Casa Org Admin" do
     context "when all fields are filled" do
+      let(:casa_org) { build(:casa_org) }
+      let(:admin) { create(:casa_admin, casa_org: casa_org) }
+      let(:contact_type_group) { create(:contact_type_group, casa_org: casa_org) }
+      let!(:contact_type) { create(:contact_type, contact_type_group: contact_type_group) }
+      let(:volunteer_display_name) { "Test User" }
+      let!(:supervisor) { create(:supervisor, casa_org: casa_org)}
+      let!(:volunteer) { create(:volunteer, display_name: volunteer_display_name, supervisor: supervisor, casa_org: casa_org) }
+
       it "is successful", js: true do
-        casa_org = build(:casa_org)
-        admin = create(:casa_admin, casa_org: casa_org)
-        contact_type_group = create(:contact_type_group, casa_org: casa_org)
-        contact_type = create(:contact_type, contact_type_group: contact_type_group)
         case_number = "12345"
 
         sign_in admin
@@ -30,6 +34,8 @@ RSpec.describe "casa_cases/new", type: :system do
 
           find(".ts-control").click
           find("span", text: contact_type.name).click
+
+          select "Test User", from: "casa_case[assigned_volunteer_id]"
 
           within ".top-page-actions" do
             click_on "Create CASA Case"

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "casa_cases/new", type: :view do
       render template: "casa_cases/new"
 
       expect(rendered).to have_content("Assign a Volunteer")
-      expect(rendered).to have_css("#casa_case_assigned_volunteer_id")
+      expect(rendered).to have_css("#casa_case_case_assignments_attributes_0_volunteer_id")
     end
   end
 end

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "casa_cases/new", type: :view do
   end
 
   context "when trying to assign a volunteer to a case" do
-    it "should not be able to assign volunteers" do
+    it "should be able to assign volunteers" do
       enable_pundit(view, user)
       allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:current_organization).and_return(user.casa_org)
@@ -32,8 +32,8 @@ RSpec.describe "casa_cases/new", type: :view do
 
       render template: "casa_cases/new"
 
-      expect(rendered).not_to have_content("Manage Volunteers")
-      expect(rendered).not_to have_css("#volunteer-assignment")
+      expect(rendered).to have_content("Assign a Volunteer")
+      expect(rendered).to have_css("#casa_case_assigned_volunteer_id")
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5757

### What changed, and _why_?

#### Major Changes

- Added an "Assign a new volunteer" dropdown to `/casa_cases/new`
- Updated controller to assign the volunteer after the case is saved

#### Minor Changes

- Updated text for volunteer assignment `/casa_cases/:id/edit` to "Assign a Volunteer to Case"
- Updated styling for volunteer assignment in `/casa_cases/:id/edit` to include the caret icon

### How is this **tested**? (please write tests!) 💖💪

Added specs to test the flow and updated existing specs to support this

Manual testing includes:

1. Creating a new case and assigning a volunteer
2. Creating a new case without assigning a volunteer


### Screenshots please :)
<img width="1214" alt="image" src="https://github.com/rubyforgood/casa/assets/15682136/23e0fda6-2f8c-41fd-aa04-9b476bfede8e">

<img width="1213" alt="image" src="https://github.com/rubyforgood/casa/assets/15682136/3f8af59b-d016-448f-95f6-d8f4cf1c49f5">

<img width="1176" alt="image" src="https://github.com/rubyforgood/casa/assets/15682136/67ab7758-9291-421b-8a23-19ba5f83897a">
