### PR TITLE
Issue 5844: Seeder other duties

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -68,6 +68,7 @@ class SeederMain
       LearningHourType,
       LearningHourTopic,
       MileageRate,
+      OtherDuty,
       Supervisor,
       SupervisorVolunteer,
       User,

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -106,6 +106,25 @@ class DbPopulator
     Volunteer.all.each { |v| v.supervisor = supervisors.sample(random: rng) }
   end
 
+  # Create other duties (Volunteer only)
+  # Increment other_duties_counter by 1 each time other duty is created
+  # Print out statement that indicates number of other duties created
+
+  def create_other_duties
+    Volunteer.map do |v|
+      2.times {
+        OtherDuty.create!(
+          creator_id: v.id, 
+          creator_type: "Volunteer", 
+          occurred_at: Faker::Date.between(from: 2.days.ago, to: Date.today), 
+          duration_minutes: rand(5..180), 
+          notes: Faker::Lorem.sentence 
+        )}
+        @other_duties_counter =+ 1
+      end
+    puts "Created #{@other_duties_counter} Other Duties."
+  end
+
   def generate_case_number
     # CINA-YY-XXXX
     years = ((DateTime.now.year - 20)..DateTime.now.year).to_a

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -54,25 +54,11 @@ class DbPopulator
     create_learning_hour_types(casa_org)
     create_learning_hour_topics(casa_org)
     create_learning_hours(casa_org)
+    create_other_duties 
     casa_org
   end
 
   private # -------------------------------------------------------------------------------------------------------
-
-  # Create other duties (only if Volunteer)
-  def create_other_duties
-    Volunteer.where.find_each do |v|
-      rand(1..5).times do 
-        OtherDuty.create!(
-          creator_id: v.id, 
-          creator_type: "Volunteer", 
-          occurred_at: Faker::Date.between(2.days.ago, Date.today), 
-          duration_minutes: rand(5..180), 
-          notes: Faker::Lorem.words(3..7)
-        )
-      end
-    end
-  end
 
   # Create 2 judges for each casa_org.
   def create_judges(casa_org)

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -19,6 +19,7 @@ class DbPopulator
     @casa_org_counter = 0
     @case_number_sequence = 1000
     @case_fourteen_years_old = case_fourteen_years_old
+    @other_duties_counter = 0 ## adds other duties counter
   end
 
   def create_all_casa_admin(email)

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -59,8 +59,8 @@ class DbPopulator
   private # -------------------------------------------------------------------------------------------------------
 
   # Create other duties (only if Volunteer)
-  def create_other_duties(casa_org)
-    Volunteer.where(casa_org: casa_org).find_each do |v|
+  def create_other_duties
+    Volunteer.where.find_each do |v|
       rand(1..5).times do 
         OtherDuty.create!(
           creator_id: v.id, 

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -58,6 +58,21 @@ class DbPopulator
 
   private # -------------------------------------------------------------------------------------------------------
 
+  # Create other duties (only if Volunteer)
+  def create_other_duties(casa_org)
+    Volunteer.where(casa_org: casa_org).find_each do |v|
+      rand(1..5).times do 
+        OtherDuty.create!(
+          creator_id: v.id, 
+          creator_type: "Volunteer", 
+          occurred_at: Faker::Date.between(2.days.ago, Date.today), 
+          duration_minutes: rand(5..180), 
+          notes: Faker::Lorem.words(3..7)
+        )
+      end
+    end
+  end
+
   # Create 2 judges for each casa_org.
   def create_judges(casa_org)
     2.times { Judge.create(name: Faker::Name.name, casa_org: casa_org) }

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -54,7 +54,7 @@ class DbPopulator
     create_learning_hour_types(casa_org)
     create_learning_hour_topics(casa_org)
     create_learning_hours(casa_org)
-    create_other_duties 
+    create_other_duties
     casa_org
   end
 
@@ -111,17 +111,18 @@ class DbPopulator
   # Print out statement that indicates number of other duties created
 
   def create_other_duties
-    Volunteer.map do |v|
+    Volunteer.find_each do |v|
       2.times {
         OtherDuty.create!(
-          creator_id: v.id, 
-          creator_type: "Volunteer", 
-          occurred_at: Faker::Date.between(from: 2.days.ago, to: Date.today), 
-          duration_minutes: rand(5..180), 
-          notes: Faker::Lorem.sentence 
-        )}
-        @other_duties_counter =+ 1
-      end
+          creator_id: v.id,
+          creator_type: "Volunteer",
+          occurred_at: Faker::Date.between(from: 2.days.ago, to: Date.today),
+          duration_minutes: rand(5..180),
+          notes: Faker::Lorem.sentence
+        )
+        @other_duties_counter = + 1
+      }
+    end
     puts "Created #{@other_duties_counter} Other Duties."
   end
 

--- a/db/seeds/db_populator.rb
+++ b/db/seeds/db_populator.rb
@@ -19,7 +19,6 @@ class DbPopulator
     @casa_org_counter = 0
     @case_number_sequence = 1000
     @case_fourteen_years_old = case_fourteen_years_old
-    @other_duties_counter = 0 ## adds other duties counter
   end
 
   def create_all_casa_admin(email)
@@ -120,10 +119,8 @@ class DbPopulator
           duration_minutes: rand(5..180),
           notes: Faker::Lorem.sentence
         )
-        @other_duties_counter = + 1
       }
     end
-    puts "Created #{@other_duties_counter} Other Duties."
   end
 
   def generate_case_number


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves [5844](https://github.com/rubyforgood/casa/issues/5844)

### What changed, and _why_?
- `@create_other_duties_counter` attr. `initialized` equal to `0`
- a private method, `create_other_duties `was created; iterates through each `Volunteer object `and creates `2` `OtherDuty `instances per volunteer
- each time `other_duty` is created it, is `incremented onto the counter` `(+= 1)`
- `prints how many other duties have been created` by string interpolating the final counter 


### How is this **tested**? (please write tests!) 💖💪
Issue does not require tests;

Tested locally in Rails Console using Volunteer and OtherDuty objects + Faker for dummy data.


### Screenshots please :)
From the console:

<img width="1081" alt="Screenshot 2024-07-08 at 8 46 40 PM" src="https://github.com/rubyforgood/casa/assets/103534307/d138052a-eb78-45df-96ee-67fa7ea27c7b">

<img width="510" alt="Screenshot 2024-07-08 at 7 36 43 PM" src="https://github.com/rubyforgood/casa/assets/103534307/bc9b676e-6f3a-4788-bd12-e726bbcb6d90">


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/

![gina linetti](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHdrNHpsN2xxMGJqbGo0eWtqOGQ2dTFmbml1YWw2a2Z5ajY1bHJmZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/sKF481S11DIYg/giphy.gif)


