### PR TITLE
Case contact details ux improvements 5896 

### DIFF
--- a/app/decorators/contact_type_decorator.rb
+++ b/app/decorators/contact_type_decorator.rb
@@ -17,7 +17,7 @@ class ContactTypeDecorator < Draper::Decorator
   end
 
   def last_contact_timestamp(casa_case_ids)
-    last_contact = CaseContact.joins(:contact_types).where(casa_case_id: casa_case_ids, contact_types: { id: object.id }).order(occurred_at: :desc).first
+    last_contact = CaseContact.joins(:contact_types).where(casa_case_id: casa_case_ids, contact_types: {id: object.id}).order(occurred_at: :desc).first
     last_contact&.occurred_at || Time.at(0)
   end
 end

--- a/app/decorators/contact_type_decorator.rb
+++ b/app/decorators/contact_type_decorator.rb
@@ -15,4 +15,9 @@ class ContactTypeDecorator < Draper::Decorator
 
     last_contact.nil? ? "never" : "#{time_ago_in_words(last_contact.occurred_at)} ago"
   end
+
+  def last_contact_timestamp(casa_case_ids)
+    last_contact = CaseContact.joins(:contact_types).where(casa_case_id: casa_case_ids, contact_types: { id: object.id }).order(occurred_at: :desc).first
+    last_contact&.occurred_at || Time.at(0)
+  end
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -18,6 +18,7 @@ class CaseContact < ApplicationRecord
   validate :reimbursement_only_when_miles_driven, if: :active_or_expenses?
   validate :volunteer_address_when_reimbursement_wanted, if: :active_or_expenses?
   validate :volunteer_address_is_valid, if: :active_or_expenses?
+  validates :contact_type_ids, presence: true, if: :active_or_details?
 
   belongs_to :creator, class_name: "User"
   has_one :supervisor_volunteer, -> {

--- a/app/views/case_contacts/form/_contact_types.html.erb
+++ b/app/views/case_contacts/form/_contact_types.html.erb
@@ -3,7 +3,7 @@
   <%= render(Form::MultipleSelectComponent.new(
     form: form,
     name: :contact_type_ids,
-    options: options.decorate.map { |ct| ct.hash_for_multi_select_with_cases(casa_cases&.pluck(:id)) },
+    options: options.decorate.sort_by { |ct| ct.last_contact_timestamp(casa_cases.pluck(:id)) }.reverse.map { |ct| ct.hash_for_multi_select_with_cases(casa_cases.pluck(:id)) },
     selected_items: selected_items,
     render_option_subtext: true
   )) %>

--- a/app/views/case_contacts/form/details.html.erb
+++ b/app/views/case_contacts/form/details.html.erb
@@ -19,9 +19,9 @@
     </div>
 
     <div id="enter-contact-details" class="card-style-1 pl-25 mb-10">
-      <h4 class="mb-3"><label>3. Record contact details</label><span class="red-letter"> *</span></h4>
+      <h4 class="mb-3"><label>3. Record contact details</label></h4>
       <div class="">
-        <h5 classs="mb-3"><label>a. Was contact made?</label></h5>
+        <h5 classs="mb-3"><label>a. Was contact made?</label><span class="red-letter"> *</span></h5>
         <div class="form-check radio-style mb-20">
           <%= form.radio_button :contact_made, true,
             checked: @case_contact.contact_made,
@@ -41,7 +41,7 @@
       </div>
 
       <div class="field contact-medium form-group">
-        <h5 classs="mb-3"><label>b. How was contact made?</label></h5>
+        <h5 classs="mb-3"><label>b. How was contact made?</label><span class="red-letter"> *</span></h5>
         <%= form.collection_radio_buttons(:medium_type, contact_mediums, 'value', 'label') do |b| %>
           <div class="form-check radio-style mb-20">
             <%= b.radio_button(class: ["form-check-input", "case-contacts-form-checkbox"]) %>

--- a/spec/decorators/contact_type_decorator_spec.rb
+++ b/spec/decorators/contact_type_decorator_spec.rb
@@ -61,5 +61,4 @@ RSpec.describe ContactTypeDecorator do
       end
     end
   end
-
 end

--- a/spec/decorators/contact_type_decorator_spec.rb
+++ b/spec/decorators/contact_type_decorator_spec.rb
@@ -46,4 +46,20 @@ RSpec.describe ContactTypeDecorator do
       end
     end
   end
+
+  describe "last_contact_timestamp" do
+    context "with empty array" do
+      it { expect(contact_type.decorate.last_contact_timestamp([])).to eq Time.at(0) }
+    end
+
+    context "with cases" do
+      let(:casa_case) { create(:casa_case, casa_org: casa_org) }
+      let(:casa_case_ids) { [casa_case.id] }
+
+      context "with no case contacts" do
+        it { expect(contact_type.decorate.last_contact_timestamp([])).to eq Time.at(0) }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5896 

### What changed, and _why_?

3 main changes were made to the UX around creating contact details in order to improve UX and create a better experience for recorder.  

- [x] Marked "Was contact made?" and "How was contact made?" as required by adding asterisks instead of marking "Record Contact Details" as mandatory. This ensures User knows what specific fields needed to be added to complete submission.
- [x] Add server side validation NOT client side (required JavaScript) to the fields. Currently if there is an error it reloads the page and you must scroll all the way down. The scrolling feature was not modified.
- [x] Contact Type Selection: Sort the options in the dropdown by recency where contact types that were never used remain at the bottom of the options.


### How is this **tested**? (please write tests!) 💖💪
added rspec testing to case_contact_decorator spec to test new method


### Screenshots please :)
<img width="660" alt="Screenshot 2024-07-16 at 9 33 21 PM" src="https://github.com/user-attachments/assets/4ba8e6c5-04ad-4cce-b91b-5c65425b032d">

![Screenshot 2024-07-14 at 4 34 52 PM](https://github.com/user-attachments/assets/4a90be68-3e0a-41ad-a231-e48931a6068e)

![Screenshot 2024-07-14 at 4 34 23 PM](https://github.com/user-attachments/assets/1abf6154-17c9-4616-8e84-f7256918aede)

