### PR TITLE
feat: add timing metadata for case contacts

### DIFF
--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -23,7 +23,8 @@ class CaseContacts::FormController < ApplicationController
     params[:case_contact][:status] = step.to_s if !@case_contact.active?
     remove_unwanted_contact_types
     remove_nil_draft_ids
-    if @case_contact.update(case_contact_params)
+
+    if CaseContactUpdateService.new(@case_contact).update_attrs(case_contact_params)
       respond_to do |format|
         format.html {
           if step == steps.last

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -320,6 +320,7 @@ end
 #  draft_case_ids             :integer          default([]), is an Array
 #  duration_minutes           :integer
 #  medium_type                :string
+#  metadata                   :jsonb
 #  miles_driven               :integer          default(0), not null
 #  notes                      :string
 #  occurred_at                :datetime

--- a/app/services/case_contact_update_service.rb
+++ b/app/services/case_contact_update_service.rb
@@ -1,0 +1,28 @@
+class CaseContactUpdateService
+  attr_reader :case_contact
+
+  def initialize(case_contact)
+    @case_contact = case_contact
+  end
+
+  def update_attrs(new_attrs)
+    old_attrs = case_contact.as_json
+
+    result = case_contact.update(new_attrs)
+    update_status_metadata(old_attrs, new_attrs) if result
+
+    result
+  end
+
+  private
+
+  def update_status_metadata(old_attrs, new_attrs)
+    return if old_attrs[:status] == new_attrs[:status]
+
+    metadata = case_contact.metadata
+    metadata["status"] ||= {}
+    metadata["status"][new_attrs[:status]] = Time.zone.now
+
+    case_contact.update(metadata: metadata)
+  end
+end

--- a/db/migrate/20240716194609_add_metadata_to_case_contacts.rb
+++ b/db/migrate/20240716194609_add_metadata_to_case_contacts.rb
@@ -1,0 +1,5 @@
+class AddMetadataToCaseContacts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :case_contacts, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_22_020203) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_194609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -203,6 +203,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_22_020203) do
     t.string "status", default: "started"
     t.integer "draft_case_ids", default: [], array: true
     t.string "volunteer_address"
+    t.jsonb "metadata", default: {}
     t.index ["casa_case_id"], name: "index_case_contacts_on_casa_case_id"
     t.index ["creator_id"], name: "index_case_contacts_on_creator_id"
     t.index ["deleted_at"], name: "index_case_contacts_on_deleted_at"

--- a/spec/services/case_contact_update_service_spec.rb
+++ b/spec/services/case_contact_update_service_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+
+RSpec.describe CaseContactUpdateService do
+  let(:updater) { described_class.new(case_contact) }
+  let(:case_contact) { create(:case_contact) }
+
+  let!(:now) { Time.zone.now }
+  let!(:one_day_ago) { 1.day.ago }
+  let!(:two_days_ago) { 2.days.ago }
+
+  before { travel_to one_day_ago }
+  after { travel_back }
+
+  describe "#update_attributes" do
+    context "case is in details status" do
+      let!(:case_contact) { create(:case_contact, status: "details", created_at: two_days_ago) }
+
+      context "status is not updated" do
+        before { updater.update_attrs({notes: "stuff"}) }
+
+        it { expect(case_contact.metadata).to eq({}) }
+        it { expect(updater.update_attrs({notes: "stuff"})).to be true }
+      end
+
+      it "does not update metadata if attrs are invalid" do
+        result = updater.update_attrs({occurred_at: 50.years.ago})
+        expect(case_contact.metadata).to eq({})
+        expect(result).to be false
+      end
+
+      context "gets updated to details" do
+        before { updater.update_attrs({status: "details"}) }
+
+        it "updates details metadata to current date" do
+          date = case_contact.metadata.dig("status", "details")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("details") }
+      end
+
+      context "gets updated to expenses" do
+        before { updater.update_attrs({status: "expenses"}) }
+
+        it "updates expenses metadata to current date" do
+          date = case_contact.metadata.dig("status", "expenses")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("expenses") }
+      end
+
+      context "gets updated to active" do
+        before { updater.update_attrs({status: "active"}) }
+
+        it "updates active metadata to current date" do
+          date = case_contact.metadata.dig("status", "active")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("active") }
+      end
+    end
+
+    context "case is in expenses status" do
+      let!(:case_contact) { create(:case_contact, status: "expenses", created_at: two_days_ago) }
+
+      context "status is not updated" do
+        before { updater.update_attrs({notes: "stuff"}) }
+
+        it { expect(case_contact.metadata).to eq({}) }
+        it { expect(updater.update_attrs({notes: "stuff"})).to be true }
+      end
+
+      it "does not update metadata if attrs are invalid" do
+        result = updater.update_attrs({occurred_at: 50.years.ago})
+        expect(case_contact.metadata).to eq({})
+        expect(result).to be false
+      end
+
+      context "gets updated to details" do
+        before { updater.update_attrs({status: "details"}) }
+
+        it "updates details metadata to current date" do
+          date = case_contact.metadata.dig("status", "details")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("details") }
+      end
+
+      context "gets updated to expenses" do
+        before { updater.update_attrs({status: "expenses"}) }
+
+        it "updates expenses metadata to current date" do
+          date = case_contact.metadata.dig("status", "expenses")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("expenses") }
+      end
+
+      context "gets updated to active" do
+        before { updater.update_attrs({status: "active"}) }
+
+        it "updates active metadata to current date" do
+          date = case_contact.metadata.dig("status", "active")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("active") }
+      end
+    end
+
+    context "case is in active status" do
+      let!(:case_contact) { create(:case_contact, status: "active", created_at: two_days_ago) }
+
+      context "status is not updated" do
+        before { updater.update_attrs({notes: "stuff"}) }
+
+        it { expect(case_contact.metadata).to eq({}) }
+        it { expect(updater.update_attrs({notes: "stuff"})).to be true }
+      end
+
+      it "does not update metadata if attrs are invalid" do
+        result = updater.update_attrs({occurred_at: 50.years.ago})
+        expect(case_contact.metadata).to eq({})
+        expect(result).to be false
+      end
+
+      context "gets updated to details" do
+        before { updater.update_attrs({status: "details"}) }
+
+        it "updates details metadata to current date" do
+          date = case_contact.metadata.dig("status", "details")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("details") }
+      end
+
+      context "gets updated to expenses" do
+        before { updater.update_attrs({status: "expenses"}) }
+
+        it "updates expenses metadata to current date" do
+          date = case_contact.metadata.dig("status", "expenses")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("expenses") }
+      end
+
+      context "gets updated to active" do
+        before { updater.update_attrs({status: "active"}) }
+
+        it "updates active metadata to current date" do
+          date = case_contact.metadata.dig("status", "active")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("active") }
+      end
+    end
+
+    context "case is in started status" do
+      let!(:case_contact) { create(:case_contact, status: "started", created_at: two_days_ago) }
+
+      context "status is not updated" do
+        before { updater.update_attrs({notes: "stuff"}) }
+
+        it { expect(case_contact.metadata).to eq({}) }
+        it { expect(updater.update_attrs({notes: "stuff"})).to be true }
+      end
+
+      it "does not update metadata if attrs are invalid" do
+        result = updater.update_attrs({occurred_at: 50.years.ago})
+        expect(case_contact.metadata).to eq({})
+        expect(result).to be false
+      end
+
+      context "gets updated to details" do
+        before { updater.update_attrs({status: "details"}) }
+
+        it "updates details metadata to current date" do
+          date = case_contact.metadata.dig("status", "details")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("details") }
+      end
+
+      context "gets updated to expenses" do
+        before { updater.update_attrs({status: "expenses"}) }
+
+        it "updates expenses metadata to current date" do
+          date = case_contact.metadata.dig("status", "expenses")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("expenses") }
+      end
+
+      context "gets updated to active" do
+        before { updater.update_attrs({status: "active"}) }
+
+        it "updates active metadata to current date" do
+          date = case_contact.metadata.dig("status", "active")
+          expect(DateTime.parse(date)).to eq(Time.zone.now)
+        end
+        it { expect(case_contact.status).to eq("active") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have been attempting to improve the Case Contact flow but we don't have good data to tell if the changes we make are improvements or not. Ex: https://github.com/rubyforgood/casa/pull/5867 changed the form to use a dropdown but a user had complaints that it slowed her down because she had to select every contact type one at a time.

This PR adds a `jsonb` field to the case contact model that will hold metadata about the model. At the moment I want to just store what time the contact got changed to each status. The goal will be to use that data to track whether the changes we make are actually causing volunteers to spend less time at each case contact state.

I am doing this as a `jsonb` field because I am not sure on the data I want to store now and in the future. I would also like this data to potentially be accessible via database query. 