### PR TITLE
fix: prevent 500 if attempting to unassign supervisor twice

### DIFF
--- a/app/controllers/supervisor_volunteers_controller.rb
+++ b/app/controllers/supervisor_volunteers_controller.rb
@@ -17,8 +17,8 @@ class SupervisorVolunteersController < ApplicationController
   def unassign
     authorize :supervisor_volunteer
     volunteer = Volunteer.find(params[:id])
-    supervisor = volunteer.supervisor_volunteer.supervisor
     if unassign_volunteers_supervisor(volunteer)
+      supervisor = volunteer.supervisor_volunteer.supervisor
       flash[:notice] = "#{volunteer.display_name} was unassigned from #{supervisor.display_name}."
     else
       flash[:alert] = "Something went wrong. Please try again."


### PR DESCRIPTION
If an admin attempts to unassign a supervisor when they have already been unassigned it returns a 500 error. This way it will just return a flash message about an issue.