### PR TITLE
5906 update renders for turbo

### DIFF
--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -12,7 +12,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
       service.create!
       redirect_to all_casa_admins_casa_org_path(@casa_org), notice: "New admin created successfully"
     rescue ActiveRecord::RecordInvalid
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
       @casa_admin.filter_old_emails!(@casa_admin.email)
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path(@casa_org), notice: notice
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -39,7 +39,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
 
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was activated. They have been sent an email."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -50,7 +50,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
 
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was deactivated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/all_casa_admins/casa_orgs_controller.rb
+++ b/app/controllers/all_casa_admins/casa_orgs_controller.rb
@@ -25,7 +25,7 @@ class AllCasaAdmins::CasaOrgsController < AllCasaAdminsController
       end
     else
       respond_to do |format|
-        format.html { render :new }
+        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -30,7 +30,7 @@ class AllCasaAdminsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid
       respond_to do |format|
-        format.html { render :new }
+        format.html { render :new, status: :unprocessable_entity }
 
         format.json do
           render json: @all_casa_admin.errors.full_messages, status: :unprocessable_entity
@@ -53,7 +53,7 @@ class AllCasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -78,7 +78,7 @@ class AllCasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -35,7 +35,7 @@ class BannersController < ApplicationController
 
     redirect_to banners_path
   rescue
-    render :new
+    render :new, status: :unprocessable_entity
   end
 
   def update
@@ -48,7 +48,7 @@ class BannersController < ApplicationController
 
     redirect_to banners_path
   rescue
-    render :edit
+    render :edit, status: :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/bulk_court_dates_controller.rb
+++ b/app/controllers/bulk_court_dates_controller.rb
@@ -15,7 +15,7 @@ class BulkCourtDatesController < ApplicationController
     case_group_id = params[:court_date][:case_group_id]
     if case_group_id.empty?
       @court_date = build_court_date_with_error_message
-      render :new
+      render :new, status: :unprocessable_entity
       return
     end
 
@@ -26,7 +26,7 @@ class BulkCourtDatesController < ApplicationController
 
     if court_date_with_error
       @court_date = court_date_with_error
-      render :new
+      render :new, status: :unprocessable_entity
     else
       redirect_to new_bulk_court_date_path, notice: "#{court_dates.size} #{"court date".pluralize(court_dates.size)} created!"
     end

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -26,7 +26,7 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -59,7 +59,7 @@ class CasaAdminsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid
       respond_to do |format|
-        format.html { render :new }
+        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: service.casa_admin.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -81,7 +81,7 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -100,7 +100,7 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -59,7 +59,7 @@ class CasaCasesController < ApplicationController
       set_contact_types
       @empty_court_date = court_date_unknown?
       respond_to do |format|
-        format.html { render :new }
+        format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -79,7 +79,7 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -101,7 +101,7 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
       end
     end
@@ -123,7 +123,7 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/casa_org_controller.rb
+++ b/app/controllers/casa_org_controller.rb
@@ -28,7 +28,7 @@ class CasaOrgController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -53,7 +53,7 @@ class CaseAssignmentsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @case_assignment.errors.full_messages, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/case_groups_controller.rb
+++ b/app/controllers/case_groups_controller.rb
@@ -19,7 +19,7 @@ class CaseGroupsController < ApplicationController
     if @case_group.save
       redirect_to case_groups_path, notice: "Case group created!"
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class CaseGroupsController < ApplicationController
     if @case_group.update(case_group_params)
       redirect_to case_groups_path, notice: "Case group updated!"
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/checklist_items_controller.rb
+++ b/app/controllers/checklist_items_controller.rb
@@ -13,7 +13,7 @@ class ChecklistItemsController < ApplicationController
       set_checklist_updated_date(@hearing_type)
       redirect_to edit_hearing_type_path(@hearing_type), notice: "Checklist item was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -25,7 +25,7 @@ class ChecklistItemsController < ApplicationController
       set_checklist_updated_date(@hearing_type)
       redirect_to edit_hearing_type_path(@hearing_type), notice: "Checklist item was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/contact_type_groups_controller.rb
+++ b/app/controllers/contact_type_groups_controller.rb
@@ -14,7 +14,7 @@ class ContactTypeGroupsController < ApplicationController
     if @contact_type_group.save
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type Group was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -27,7 +27,7 @@ class ContactTypeGroupsController < ApplicationController
     if @contact_type_group.update(contact_type_group_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type Group was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/contact_types_controller.rb
+++ b/app/controllers/contact_types_controller.rb
@@ -14,7 +14,7 @@ class ContactTypesController < ApplicationController
     if @contact_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -27,7 +27,7 @@ class ContactTypesController < ApplicationController
     if @contact_type.update(contact_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -38,7 +38,7 @@ class CourtDatesController < ApplicationController
     if @court_date.save && @casa_case.save
       redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -47,7 +47,7 @@ class CourtDatesController < ApplicationController
     if @court_date.update(court_date_params(@casa_case))
       redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/fund_requests_controller.rb
+++ b/app/controllers/fund_requests_controller.rb
@@ -15,7 +15,7 @@ class FundRequestsController < ApplicationController
       FundRequestMailer.send_request(nil, @fund_request).deliver
       redirect_to casa_case_path(@casa_case), notice: "Fund Request was sent for case #{@casa_case.case_number}"
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/hearing_types_controller.rb
+++ b/app/controllers/hearing_types_controller.rb
@@ -14,7 +14,7 @@ class HearingTypesController < ApplicationController
     if @hearing_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Hearing Type was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -27,7 +27,7 @@ class HearingTypesController < ApplicationController
     if @hearing_type.update(hearing_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Hearing Type was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/judges_controller.rb
+++ b/app/controllers/judges_controller.rb
@@ -14,7 +14,7 @@ class JudgesController < ApplicationController
     if @judge.save
       redirect_to edit_casa_org_path(current_organization), notice: "Judge was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -27,7 +27,7 @@ class JudgesController < ApplicationController
     if @judge.update(judge_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Judge was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/learning_hour_topics_controller.rb
+++ b/app/controllers/learning_hour_topics_controller.rb
@@ -18,7 +18,7 @@ class LearningHourTopicsController < ApplicationController
     if @learning_hour_topic.save
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Topic was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class LearningHourTopicsController < ApplicationController
     if @learning_hour_topic.update(learning_hour_topic_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Topic was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/learning_hour_types_controller.rb
+++ b/app/controllers/learning_hour_types_controller.rb
@@ -18,7 +18,7 @@ class LearningHourTypesController < ApplicationController
     if @learning_hour_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -28,7 +28,7 @@ class LearningHourTypesController < ApplicationController
     if @learning_hour_type.update(learning_hour_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully updated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/learning_hours_controller.rb
+++ b/app/controllers/learning_hours_controller.rb
@@ -24,7 +24,7 @@ class LearningHoursController < ApplicationController
       if @learning_hour.save
         format.html { redirect_to learning_hours_path, notice: "New entry was successfully created." }
       else
-        format.html { render :new, status: 404 }
+        format.html { render :new, status: :unprocessable_entity }
       end
     end
   end
@@ -39,7 +39,7 @@ class LearningHoursController < ApplicationController
       if @learning_hour.update(update_learning_hours_params)
         format.html { redirect_to learning_hour_path(@learning_hour), notice: "Entry was successfully updated." }
       else
-        format.html { render :edit, status: 404 }
+        format.html { render :edit, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/mileage_rates_controller.rb
+++ b/app/controllers/mileage_rates_controller.rb
@@ -18,7 +18,7 @@ class MileageRatesController < ApplicationController
     if @mileage_rate.save
       redirect_to mileage_rates_path
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -32,7 +32,7 @@ class MileageRatesController < ApplicationController
     if @mileage_rate.update(mileage_rate_params)
       redirect_to mileage_rates_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -35,7 +35,7 @@ class SupervisorsController < ApplicationController
       sms_status = deliver_sms_to @supervisor, body_msg
       redirect_to edit_supervisor_path(@supervisor), notice: sms_acct_creation_notice("supervisor", sms_status)
     else
-      render new_supervisor_path
+      render new_supervisor_path, status: :unprocessable_entity
     end
   end
 
@@ -55,7 +55,7 @@ class SupervisorsController < ApplicationController
       @supervisor.filter_old_emails!(@supervisor.email)
       redirect_to edit_supervisor_path(@supervisor), notice: notice
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,19 +16,19 @@ class UsersController < ApplicationController
       flash[:success] = "Profile was successfully updated."
       redirect_to edit_users_path
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
   def add_language
     if @language.nil?
       @user.errors.add(:language_id, "can not be blank. Please select a language before adding.")
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     if current_user.languages.include?(@language)
       @user.errors.add(:language_id, "#{@language.name} is already in your languages list.")
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     current_user.languages << @language
@@ -54,11 +54,11 @@ class UsersController < ApplicationController
   def update_password
     unless valid_user_password
       @user.errors.add(:base, "Current password is incorrect")
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     unless update_user_password
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     bypass_sign_in(@user) if @user == true_user
@@ -72,11 +72,11 @@ class UsersController < ApplicationController
   def update_email
     unless valid_user_password
       @user.errors.add(:base, "Current password is incorrect")
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     unless update_user_email
-      return render "edit"
+      return render "edit", status: :unprocessable_entity
     end
 
     bypass_sign_in(@user) if @user == true_user

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -41,7 +41,7 @@ class VolunteersController < ApplicationController
       sms_status = deliver_sms_to @volunteer, body_msg
       redirect_to edit_volunteer_path(@volunteer), notice: sms_acct_creation_notice("volunteer", sms_status)
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -58,7 +58,7 @@ class VolunteersController < ApplicationController
       @volunteer.filter_old_emails!(@volunteer.email)
       redirect_to edit_volunteer_path(@volunteer), notice: notice
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -73,7 +73,7 @@ class VolunteersController < ApplicationController
         redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated. They have been sent an email."
       end
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -82,7 +82,7 @@ class VolunteersController < ApplicationController
     if @volunteer.deactivate
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "All-Casa Admin" do
       it "renders new page" do
         expect { subject }.not_to change(CasaAdmin, :count)
 
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template "casa_admins/new"
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe "All-Casa Admin" do
 
       it "renders new page" do
         subject
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template "casa_admins/edit"
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe "All-Casa Admin" do
 
       it "renders edit page" do
         subject
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template "casa_admins/edit"
       end
     end
@@ -168,7 +168,7 @@ RSpec.describe "All-Casa Admin" do
 
       it "renders edit page" do
         subject
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template "casa_admins/edit"
       end
     end

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "/all_casa_admins", type: :request do
             email: ""
           }
         }
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template "all_casa_admins/new"
       end
 
@@ -132,7 +132,7 @@ RSpec.describe "/all_casa_admins", type: :request do
       it "does not update the all_casa_admin" do
         other_admin = create(:all_casa_admin)
         patch all_casa_admins_path, params: {all_casa_admin: {email: other_admin.email}}
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unprocessable_entity)
 
         expect(admin.email).to_not eq "newemail@example.com"
       end
@@ -201,7 +201,7 @@ RSpec.describe "/all_casa_admins", type: :request do
       it "does not update the all_casa_admin password" do
         subject
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(admin.reload.valid_password?("newpassword")).to be false
       end
 

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -231,9 +231,9 @@ RSpec.describe "/casa_cases", type: :request do
             ).by(0)
           end
 
-          it "renders a successful response (i.e. to display the 'new' template)" do
+          it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
             post casa_cases_url, params: {casa_case: invalid_attributes}
-            expect(response).to be_successful
+            expect(response).to have_http_status(:unprocessable_entity)
           end
 
           it "also respond to json", :aggregate_failures do
@@ -271,9 +271,9 @@ RSpec.describe "/casa_cases", type: :request do
             )
           end
 
-          it "renders a successful response (i.e. to display the 'new' template)" do
+          it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
             post casa_cases_url, params: {casa_case: invalid_params}
-            expect(response).to be_successful
+            expect(response).to have_http_status(:unprocessable_entity)
           end
         end
       end
@@ -329,9 +329,9 @@ RSpec.describe "/casa_cases", type: :request do
       end
 
       context "with invalid parameters" do
-        it "renders a successful response displaying the edit template" do
+        it "renders an unprocessable entity response displaying the edit template" do
           patch casa_case_url(casa_case), params: {casa_case: invalid_attributes}
-          expect(response).to be_successful
+          expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it "also responds as json", :aggregate_failures do

--- a/spec/requests/casa_org_spec.rb
+++ b/spec/requests/casa_org_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "CasaOrg", type: :request do
       end
 
       context "and html format" do
-        it { is_expected.to be_successful }
+        it { is_expected.to have_http_status(:unprocessable_entity) }
 
         it "renders the edit template" do
           expect(request.body).to match(/error_explanation/)

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -260,9 +260,9 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
           end.to change(CourtDate, :count).by(0)
         end
 
-        it "renders a successful response (i.e. to display the 'new' template)" do
+        it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
           post casa_case_court_dates_path(casa_case), params: {court_date: invalid_attributes}
-          expect(response).to be_successful
+          expect(response).to have_http_status(:unprocessable_entity)
           expected_errors = [
             "Date can't be blank",
             "Date is not valid. Court date must be within one year from today.",
@@ -305,10 +305,10 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
     end
 
     context "with invalid parameters" do
-      it "renders a successful response displaying the edit template" do
+      it "renders an unprocessable entity response displaying the edit template" do
         patch casa_case_court_date_path(casa_case, court_date), params: {court_date: invalid_attributes}
 
-        expect(response).to be_successful
+        expect(response).to have_http_status(:unprocessable_entity)
         expected_errors = [
           "Date can't be blank",
           "Date is not valid. Court date must be within one year from today.",

--- a/spec/requests/fund_requests_spec.rb
+++ b/spec/requests/fund_requests_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe FundRequestsController, type: :request do
           end
         end
 
-        context "with in valid params" do
+        context "with invalid params" do
           it "does not create fund request or call mailer" do
             volunteer = create(:volunteer, :with_casa_cases)
             casa_case = volunteer.casa_cases.first
@@ -170,7 +170,7 @@ RSpec.describe FundRequestsController, type: :request do
               }
             }.to_not change(FundRequest, :count)
 
-            expect(response).to be_successful
+            expect(response).to have_http_status(:unprocessable_entity)
           end
         end
       end

--- a/spec/requests/mileage_rates_spec.rb
+++ b/spec/requests/mileage_rates_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "/mileage_rates", type: :request do
         expect {
           post mileage_rates_path, params: params
         }.to_not change { MileageRate.count }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe "/mileage_rates", type: :request do
         expect {
           post mileage_rates_path, params: params
         }.to_not change { MileageRate.count }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
@@ -140,7 +140,7 @@ RSpec.describe "/mileage_rates", type: :request do
       it "does not update a mileage rate" do
         patch mileage_rate_path(mileage_rate), params: params
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:unprocessable_entity)
 
         mileage_rate.reload
         expect(mileage_rate.amount).to eq(10.11)

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "/supervisors", type: :request do
         it "gracefully fails" do
           patch supervisor_path(supervisor), params: {supervisor: {email: other_supervisor.email}}
 
-          expect(response).to be_successful
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -426,7 +426,7 @@ RSpec.describe "/users", type: :request do
         patch add_language_users_path(volunteer), params: {
           language_id: ""
         }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("Please select a language before adding.")
       end
     end
@@ -449,7 +449,7 @@ RSpec.describe "/users", type: :request do
       end
 
       it "should notify the user that the language is already in their list" do
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include("#{language.name} is already in your languages list.")
       end
     end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe "/volunteers", type: :request do
           post volunteers_url, params: params
         }.to change(Volunteer, :count).by(0)
           .and change(ActionMailer::Base.deliveries, :count).by(0)
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
@@ -262,7 +262,7 @@ RSpec.describe "/volunteers", type: :request do
         patch volunteer_path(volunteer), params: {
           volunteer: {email: other_volunteer.email, display_name: "New Name", phone_number: "+15463457898"}
         }
-        expect(response).to have_http_status(:success) # Re-renders form
+        expect(response).to have_http_status(:unprocessable_entity)
 
         volunteer.reload
         expect(volunteer.display_name).to_not eq "New Name"


### PR DESCRIPTION
### What github issue is this PR for, if any?
This does not resolve #5906, but is the first part in completing it.

### What changed, and _why_?
Turbo expects all form failures to return 422 (unprocessable entity). This used to not be required in Rails, so many renders from form failures just returned 200 by default. This PR adds 422 to all render messages in controllers for form failures.

Beyond the Turbo requirement, this is a better practice and should not break any old behavior.

### How is this **tested**? (please write tests!) 💖💪
I update tests that are affected by the changed message. Many tests were asserting for `were_successful` or similar but now they properly expect 422. 


### Screenshots please :)
Note the response in the network tab:
![image](https://github.com/user-attachments/assets/1d602e88-b531-4cb8-aa0b-1945cbed7bde)