### PR TITLE
Improve report generation modal

### DIFF
--- a/app/views/case_court_reports/index.html.erb
+++ b/app/views/case_court_reports/index.html.erb
@@ -47,6 +47,9 @@
   }
 
   const setTimeZone = () => {
+     if(!$('#case-selection').val()){
+      alert('Select an active case and specify the date range.');
+    }
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
     document.getElementById("user-time-zone").value = timeZone
   }

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1085,6 +1085,12 @@ h6,
     color: #262d3f;
     display: block;
     margin-bottom: 10px; }
+  .input-style-1 select{
+    width: 465px; 
+    height: 40px; 
+    border-radius: 5px;
+    border: 1px solid #4a6cf7;
+  }
   .input-style-1 input,
   .input-style-1 textarea {
     width: 100%;


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5888

### What changed, and _why_?
Currently, the dropdown input in the modal to generate court report documents is not easily visible and users don't get an alert if they try to generate a report without selecting a case.
This PR improves the modal by :

- Adding a border to the dropdown input to make it more visible.
- Used Javascript to make the select required.

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
![Add border](https://github.com/user-attachments/assets/e548a9f3-3d7c-4ea0-bc48-1eb31a927880)
