### PR TITLE
fix: flaky scope spec due to order

### DIFF
--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe CaseContact, type: :model do
 
       context "when parameter is not nil" do
         it "returns contacts with the given casa case ids" do
-          expect(described_class.with_casa_case(casa_case.id)).to eq(case_contacts)
+          expect(described_class.with_casa_case(casa_case.id)).to match_array(case_contacts)
         end
       end
     end


### PR DESCRIPTION
Order issue in test

```plaintext
1) CaseContact scopes .with_casa_case when parameter is not nil returns contacts with the given casa case ids
     Failure/Error: expect(described_class.with_casa_case(casa_case.id)).to eq(case_contacts)

       expected: [#<CaseContact id: 48, creator_id: 431, casa_case_id: 251, duration_minutes: 60, occurred_at: "2024-0...e_ids: [251], volunteer_address: nil, metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.936Z"}}>]
            got: #<ActiveRecord::Relation [#<CaseContact id: 49, creator_id: 432, casa_case_id: 251, duration_minutes:..._ids: [251], volunteer_address: nil, metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.901Z"}}>]>

       (compared using ==)

       Diff:
       @@ -1,4 +1,58 @@
       -[#<CaseContact id: 48, creator_id: 431, casa_case_id: 251, duration_minutes: 60, occurred_at: "2024-07-24 20:20:42.899155577 +0000", created_at: "2024-07-24 20:20:42.901033000 +0000", updated_at: "2024-07-24 20:20:42.901033000 +0000", contact_made: false, medium_type: "in-person", miles_driven: 0, want_driving_reimbursement: false, notes: nil, deleted_at: nil, reimbursement_complete: false, status: "active", draft_case_ids: [251], volunteer_address: nil, metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.901Z"}}>,
       - #<CaseContact id: 49, creator_id: 432, casa_case_id: 251, duration_minutes: 60, occurred_at: "2024-07-24 20:20:42.916053003 +0000", created_at: "2024-07-24 20:20:42.918594000 +0000", updated_at: "2024-07-24 20:20:42.918594000 +0000", contact_made: false, medium_type: "in-person", miles_driven: 0, want_driving_reimbursement: false, notes: nil, deleted_at: nil, reimbursement_complete: false, status: "active", draft_case_ids: [251], volunteer_address: nil, metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.918Z"}}>,
       - #<CaseContact id: 50, creator_id: 433, casa_case_id: 251, duration_minutes: 60, occurred_at: "2024-07-24 20:20:42.933153864 +0000", created_at: "2024-07-24 20:20:42.936136000 +0000", updated_at: "2024-07-24 20:20:42.936136000 +0000", contact_made: false, medium_type: "in-person", miles_driven: 0, want_driving_reimbursement: false, notes: nil, deleted_at: nil, reimbursement_complete: false, status: "active", draft_case_ids: [251], volunteer_address: nil, metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.936Z"}}>]
       +[#<CaseContact:0x00007f61084cb7e0
       +  id: 49,
       +  creator_id: 432,
       +  casa_case_id: 251,
       +  duration_minutes: 60,
       +  occurred_at: Wed, 24 Jul 2024 20:20:42.916053000 UTC +00:00,
       +  created_at: Wed, 24 Jul 2024 20:20:42.918594000 UTC +00:00,
       +  updated_at: Wed, 24 Jul 2024 20:20:42.918594000 UTC +00:00,
       +  contact_made: false,
       +  medium_type: "in-person",
       +  miles_driven: 0,
       +  want_driving_reimbursement: false,
       +  notes: nil,
       +  deleted_at: nil,
       +  reimbursement_complete: false,
       +  status: "active",
       +  draft_case_ids: [251],
       +  volunteer_address: nil,
       +  metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.918Z"}}>,
       + #<CaseContact:0x00007f61084cb6a0
       +  id: 50,
       +  creator_id: 433,
       +  casa_case_id: 251,
       +  duration_minutes: 60,
       +  occurred_at: Wed, 24 Jul 2024 20:20:42.933153000 UTC +00:00,
       +  created_at: Wed, 24 Jul 2024 20:20:42.936136000 UTC +00:00,
       +  updated_at: Wed, 24 Jul 2024 20:20:42.936136000 UTC +00:00,
       +  contact_made: false,
       +  medium_type: "in-person",
       +  miles_driven: 0,
       +  want_driving_reimbursement: false,
       +  notes: nil,
       +  deleted_at: nil,
       +  reimbursement_complete: false,
       +  status: "active",
       +  draft_case_ids: [251],
       +  volunteer_address: nil,
       +  metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.936Z"}}>,
       + #<CaseContact:0x00007f61084cb560
       +  id: 48,
       +  creator_id: 431,
       +  casa_case_id: 251,
       +  duration_minutes: 60,
       +  occurred_at: Wed, 24 Jul 2024 20:20:42.899155000 UTC +00:00,
       +  created_at: Wed, 24 Jul 2024 20:20:42.901033000 UTC +00:00,
       +  updated_at: Wed, 24 Jul 2024 20:20:42.901033000 UTC +00:00,
       +  contact_made: false,
       +  medium_type: "in-person",
       +  miles_driven: 0,
       +  want_driving_reimbursement: false,
       +  notes: nil,
       +  deleted_at: nil,
       +  reimbursement_complete: false,
       +  status: "active",
       +  draft_case_ids: [251],
       +  volunteer_address: nil,
       +  metadata: {"status"=>{"active"=>"2024-07-24T20:20:42.901Z"}}>]
     # ./spec/models/case_contact_spec.rb:546:in `block (5 levels) in <top (required)>'
     # ./spec/rails_helper.rb:93:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:75:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/timeout-0.4.1/lib/timeout.rb:170:in `timeout'
     # ./spec/rails_helper.rb:74:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```