### PR TITLE
Fix flaky CaseContactReportSpec

### DIFF
--- a/spec/models/case_contact_report_spec.rb
+++ b/spec/models/case_contact_report_spec.rb
@@ -409,9 +409,15 @@ RSpec.describe CaseContactReport, type: :model do
     end
 
     it "includes topic answers in csv rows" do
-      expect(csv[0].fields).to eq ["Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2"]
-      expect(csv[1].fields).to eq [nil,                     "Ans Contact 2 Topic 2"]
-      expect(csv[2].fields).to eq [nil,                     nil]
+      expected_rows = [
+        # ['Used topic 1',        'Used topic 2'] (header)
+        ["Ans Contact 1 Topic 1", "Ans Contact 1 Topic 2"],
+        [nil,                     "Ans Contact 2 Topic 2"],
+        [nil,                     nil]
+      ]
+      csv.by_row.each do |row|
+        expect(expected_rows).to include(row.fields)
+      end
     end
 
     context "when court topics are not requested" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
No issue - flaky spec seen in PR CI runs. ([here](https://github.com/rubyforgood/casa/actions/runs/10113566490/job/27970214915?pr=5946) and [here](https://github.com/rubyforgood/casa/actions/runs/10100601593/job/27932322976?pr=5944), for example)

### What changed, and _why_?
Changed spec to look for row in array of expected results rather than check each row.  Spec previously assumed created_at ordering, but the report does not explicitly enforce an order, afaik.

I ran full suite of a known bad seed (24693), and these changes passed.