### PR TITLE
Fix: Expand width of errors alert on edit user page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,7 +9,7 @@
       <div class="card-style mb-30">
         <div class="card-body">
           <%= form_for @user, as: :user, url: users_path do |form| %>
-            <div class="alert-box danger-alert">
+            <div class="alert-box danger-alert flex-grow>
               <%= render "/shared/error_messages", resource: @user %>
             </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,7 +9,7 @@
       <div class="card-style mb-30">
         <div class="card-body">
           <%= form_for @user, as: :user, url: users_path do |form| %>
-            <div class="alert-box danger-alert flex-grow>
+            <div class="mb-30">
               <%= render "/shared/error_messages", resource: @user %>
             </div>
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5178

### What changed, and _why_?
The edit user page has an alert that displays the shared error messages template. This seemed to have double wrapped the alert in the `alert-box` and `danger_alert` classes.

<img width="1194" alt="Screenshot 2024-07-30 at 5 00 08 PM" src="https://github.com/user-attachments/assets/94fd7b7a-aa33-4c80-a65e-90a4ec011159">

There was a couple ways to achieve a fix here. One was to edit the shared errors messages page but that would have had implications in the other 36 references

<img width="395" alt="Screenshot 2024-07-30 at 5 01 09 PM" src="https://github.com/user-attachments/assets/b655d774-ad64-4bc3-91ee-9afbac6a3dbc">

It appears since the styles were double wrapped we can just remove the top level on the edit page thus only affecting that page in this change while also adding the desired padding

Achieving the request of the ticket of

> Make the error shown below the width of the parent container with some margin.


### How is this **tested**? (please write tests!) 💖💪

This was tested using the browser to replicate different widths. I wasn't aware of any actual unit or e2e tests that would cover this type of style change feel free to correct me though.


### Screenshots please :)
<img width="1099" alt="Screenshot 2024-07-30 at 5 14 30 PM" src="https://github.com/user-attachments/assets/7c431641-ac01-4b1f-bb4e-7d884acbf7d0">
<img width="1093" alt="Screenshot 2024-07-30 at 5 14 35 PM" src="https://github.com/user-attachments/assets/daf819ec-d6be-4c35-bf82-5172cc79170b">
<img width="548" alt="Screenshot 2024-07-30 at 5 14 39 PM" src="https://github.com/user-attachments/assets/34b5d004-61dd-46de-b140-f5424ad3ca81">

