### PR TITLE
Case contact form 'create another' checkbox

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,7 +101,7 @@ class ApplicationController < ActionController::Base
 
   def store_referring_location
     if request.referer && !request.referer.end_with?("users/sign_in")
-      session[:return_to] = request.referer
+      session[:return_to] = request.referer unless params[:ignore_referer]
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -100,8 +100,8 @@ class ApplicationController < ActionController::Base
   end
 
   def store_referring_location
-    if request.referer && !request.referer.end_with?("users/sign_in")
-      session[:return_to] = request.referer unless params[:ignore_referer]
+    if request.referer && !request.referer.end_with?("users/sign_in") && params[:ignore_referer].blank?
+      session[:return_to] = request.referer
     end
   end
 

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -83,7 +83,7 @@ class CaseContacts::FormController < ApplicationController
     update_volunteer_address(@case_contact)
     flash[:notice] = message
     if @case_contact.metadata["create_another"]
-      redirect_to new_case_contact_path(params: {draft_case_ids:})
+      redirect_to new_case_contact_path(params: {draft_case_ids:, ignore_referrer: true})
     else
       redirect_back_to_referer(fallback_location: case_contacts_path(success: true))
     end

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -77,7 +77,7 @@ class CaseContacts::FormController < ApplicationController
     else
       message = "Case #{"contact".pluralize(draft_case_ids.count)} successfully created."
       create_additional_case_contacts(@case_contact)
-      first_casa_case_id = draft_case_ids.slice(0)
+      first_casa_case_id = draft_case_ids.first
       @case_contact.update(status: "active", draft_case_ids: [first_casa_case_id], casa_case_id: first_casa_case_id)
     end
     update_volunteer_address(@case_contact)

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -83,7 +83,7 @@ class CaseContacts::FormController < ApplicationController
     update_volunteer_address(@case_contact)
     flash[:notice] = message
     if @case_contact.metadata["create_another"]
-      redirect_to new_case_contact_path(params: {draft_case_ids:, ignore_referrer: true})
+      redirect_to new_case_contact_path(params: {draft_case_ids:, ignore_referer: true})
     else
       redirect_back_to_referer(fallback_location: case_contacts_path(success: true))
     end

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -71,17 +71,22 @@ class CaseContacts::FormController < ApplicationController
   def finish_editing
     message = ""
     send_reimbursement_email(@case_contact)
+    draft_case_ids = @case_contact.draft_case_ids
     if @case_contact.active?
       message = @case_contact.decorate.form_updated_message
     else
-      message = "Case #{"contact".pluralize(@case_contact.draft_case_ids.count)} successfully created."
+      message = "Case #{"contact".pluralize(draft_case_ids.count)} successfully created."
       create_additional_case_contacts(@case_contact)
-      first_casa_case_id = @case_contact.draft_case_ids.slice(0)
+      first_casa_case_id = draft_case_ids.slice(0)
       @case_contact.update(status: "active", draft_case_ids: [first_casa_case_id], casa_case_id: first_casa_case_id)
     end
     update_volunteer_address(@case_contact)
     flash[:notice] = message
-    redirect_back_to_referer(fallback_location: case_contacts_path(success: true))
+    if @case_contact.metadata["create_another"]
+      redirect_to new_case_contact_path(params: {draft_case_ids:})
+    else
+      redirect_back_to_referer(fallback_location: case_contacts_path(success: true))
+    end
   end
 
   def send_reimbursement_email(case_contact)

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -32,7 +32,7 @@ class CaseContactsController < ApplicationController
   end
 
   def new
-    store_referring_location unless params[:ignore_referrer]
+    store_referring_location
     authorize CaseContact
 
     # - If there are cases defined in the params, select those cases

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -35,10 +35,6 @@ class CaseContactsController < ApplicationController
     store_referring_location
     authorize CaseContact
 
-    # - If there are cases defined in the params, select those cases
-    #   - as in coming from the case page, or previous case contact 'create another' option
-    # - If there is only one case, select that case
-    # - If there are no hints, let them select their case
     casa_cases = policy_scope(current_organization.casa_cases)
     draft_case_ids = set_draft_case_ids(params, casa_cases)
 
@@ -133,13 +129,16 @@ class CaseContactsController < ApplicationController
   end
 
   def set_draft_case_ids(params, casa_cases)
+    # Use case(s) from params if present
     if params[:draft_case_ids].present?
       params[:draft_case_ids]
     elsif params.dig(:case_contact, :casa_case_id).present?
       casa_cases.where(id: params.dig(:case_contact, :casa_case_id)).pluck(:id)
     elsif casa_cases.count == 1
+      # If there is only one case for user, select that case
       [casa_cases.first.id]
     else
+      # Otherwise, let user select cases
       []
     end
   end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -36,7 +36,7 @@ class CaseContactsController < ApplicationController
     authorize CaseContact
 
     casa_cases = policy_scope(current_organization.casa_cases)
-    draft_case_ids = set_draft_case_ids(params, casa_cases)
+    draft_case_ids = build_draft_case_ids(params, casa_cases)
 
     @case_contact = CaseContact.create_with_answers(current_organization,
       creator: current_user, draft_case_ids: draft_case_ids)
@@ -128,7 +128,7 @@ class CaseContactsController < ApplicationController
     end
   end
 
-  def set_draft_case_ids(params, casa_cases)
+  def build_draft_case_ids(params, casa_cases)
     # Use case(s) from params if present
     if params[:draft_case_ids].present?
       params[:draft_case_ids]

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -40,16 +40,7 @@ class CaseContactsController < ApplicationController
     # - If there is only one case, select that case
     # - If there are no hints, let them select their case
     casa_cases = policy_scope(current_organization.casa_cases)
-    draft_case_ids =
-      if params[:draft_case_ids].present?
-        params[:draft_case_ids]
-      elsif params.dig(:case_contact, :casa_case_id).present?
-        casa_cases.where(id: params.dig(:case_contact, :casa_case_id)).pluck(:id)
-      elsif casa_cases.count == 1
-        [casa_cases.first.id]
-      else
-        []
-      end
+    draft_case_ids = set_draft_case_ids(params, casa_cases)
 
     @case_contact = CaseContact.create_with_answers(current_organization,
       creator: current_user, draft_case_ids: draft_case_ids)
@@ -138,6 +129,18 @@ class CaseContactsController < ApplicationController
       @case_contact = authorize(current_organization.case_contacts.find(params[:id]))
     else
       redirect_to authenticated_user_root_path
+    end
+  end
+
+  def set_draft_case_ids(params, casa_cases)
+    if params[:draft_case_ids].present?
+      params[:draft_case_ids]
+    elsif params.dig(:case_contact, :casa_case_id).present?
+      casa_cases.where(id: params.dig(:case_contact, :casa_case_id)).pluck(:id)
+    elsif casa_cases.count == 1
+      [casa_cases.first.id]
+    else
+      []
     end
   end
 end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -32,7 +32,7 @@ class CaseContactsController < ApplicationController
   end
 
   def new
-    store_referring_location
+    store_referring_location unless params[:ignore_referrer]
     authorize CaseContact
 
     # - If there are cases defined in the params, select those cases

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -35,12 +35,15 @@ class CaseContactsController < ApplicationController
     store_referring_location
     authorize CaseContact
 
-    # - If there are cases defined in the params, select those cases (often coming from the case page)
+    # - If there are cases defined in the params, select those cases
+    #   - as in coming from the case page, or previous case contact 'create another' option
     # - If there is only one case, select that case
     # - If there are no hints, let them select their case
     casa_cases = policy_scope(current_organization.casa_cases)
     draft_case_ids =
-      if params.dig(:case_contact, :casa_case_id).present?
+      if params[:draft_case_ids].present?
+        params[:draft_case_ids]
+      elsif params.dig(:case_contact, :casa_case_id).present?
         casa_cases.where(id: params.dig(:case_contact, :casa_case_id)).pluck(:id)
       elsif casa_cases.count == 1
         [casa_cases.first.id]

--- a/app/decorators/contact_type_decorator.rb
+++ b/app/decorators/contact_type_decorator.rb
@@ -13,6 +13,6 @@ class ContactTypeDecorator < Draper::Decorator
   def last_time_used_with_cases(casa_case_ids)
     last_contact = CaseContact.joins(:contact_types).where(casa_case_id: casa_case_ids, contact_types: {id: object.id}).order(occurred_at: :desc).first
 
-    last_contact.nil? ? "never" : "#{time_ago_in_words(last_contact.occurred_at)} ago"
+    last_contact&.occurred_at.blank? ? "never" : "#{time_ago_in_words(last_contact.occurred_at)} ago"
   end
 end

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -147,6 +147,9 @@ class CaseContact < ApplicationRecord
 
   scope :no_drafts, ->(checked) { (checked == 1) ? where(status: "active") : all }
 
+  scope :with_metadata_pair, ->(key, value) { where("metadata -> ? @> ?::jsonb", key.to_s, value.to_s) }
+  scope :used_create_another, -> { with_metadata_pair(:create_another, true) }
+
   filterrific(
     default_filter_params: {sorted_by: "occurred_at_desc"},
     available_filters: [

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -24,11 +24,9 @@ class CaseContactParameters < SimpleDelegator
     if params.dig(:case_contact, :miles_driven)
       new_params[:miles_driven] = convert_miles_driven(params)
     end
-
-    create_another_param = params.dig(:case_contact, :metadata, :create_another)
-    if create_another_param.present?
-      # "0" or "1" (from checkbox) will not be cast to boolean because metadata is jsonb
-      new_params[:metadata][:create_another] = ActiveRecord::Type::Boolean.new.cast create_another_param
+    if params.dig(:case_contact, :metadata, :create_another)
+      new_params[:metadata][:create_another] =
+        ActiveRecord::Type::Boolean.new.cast params[:case_contact][:metadata][:create_another]
     end
 
     super(new_params)

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -14,6 +14,7 @@ class CaseContactParameters < SimpleDelegator
         :volunteer_address,
         contact_type_ids: [],
         draft_case_ids: [],
+        metadata: %i[create_another],
         additional_expenses_attributes: %i[id other_expense_amount other_expenses_describe _destroy],
         contact_topic_answers_attributes: %i[id value selected]
       )
@@ -22,6 +23,12 @@ class CaseContactParameters < SimpleDelegator
     end
     if params.dig(:case_contact, :miles_driven)
       new_params[:miles_driven] = convert_miles_driven(params)
+    end
+
+    create_another_param = params.dig(:case_contact, :metadata, :create_another)
+    if create_another_param.present?
+      # "0" or "1" (from checkbox) will not be cast to boolean because metadata is jsonb
+      new_params[:metadata][:create_another] = ActiveRecord::Type::Boolean.new.cast create_another_param
     end
 
     super(new_params)

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -1,6 +1,7 @@
 # Calculate values when using case contact parameters
 class CaseContactParameters < SimpleDelegator
   def initialize(params)
+    params = normalize_params(params)
     new_params =
       params.require(:case_contact).permit(
         :duration_minutes,
@@ -18,21 +19,32 @@ class CaseContactParameters < SimpleDelegator
         additional_expenses_attributes: %i[id other_expense_amount other_expenses_describe _destroy],
         contact_topic_answers_attributes: %i[id value selected]
       )
-    if params.dig(:case_contact, :duration_minutes)
-      new_params[:duration_minutes] = convert_duration_minutes(params)
-    end
-    if params.dig(:case_contact, :miles_driven)
-      new_params[:miles_driven] = convert_miles_driven(params)
-    end
-    if params.dig(:case_contact, :metadata, :create_another)
-      new_params[:metadata][:create_another] =
-        ActiveRecord::Type::Boolean.new.cast params[:case_contact][:metadata][:create_another]
-    end
 
     super(new_params)
   end
 
   private
+
+  def normalize_params(params)
+    if params.dig(:case_contact, :metadata)
+      params[:case_contact][:metadata] = convert_metadata(params[:case_contact][:metadata])
+    end
+    if params.dig(:case_contact, :duration_minutes)
+      params[:case_contact][:duration_minutes] = convert_duration_minutes(params)
+    end
+    if params.dig(:case_contact, :miles_driven)
+      params[:case_contact][:miles_driven] = convert_miles_driven(params)
+    end
+
+    params
+  end
+
+  def convert_metadata(metadata)
+    if metadata["create_another"]
+      metadata["create_another"] = ActiveRecord::Type::Boolean.new.cast metadata["create_another"]
+    end
+    metadata
+  end
 
   def convert_duration_minutes(params)
     duration_hours = params[:case_contact][:duration_hours].to_i

--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -101,10 +101,10 @@
         <%= form.fields_for :metadata do |metadata_form| %>
           <%= metadata_form.check_box :create_another, class: "form-check-input" %>
           <%= metadata_form.label :create_another, class: "form-check-label" do %>
-            <i class="lni lni-question-circle" data-toggle="tooltip" data-placemnet="top"
+            Create Another
+            <i class="lni lni-question-circle" data-toggle="tooltip" data-placement="top"
               title="Start a new contact for the same case(s) after submitting.">
             </i>
-            Create Another
           <% end %>
         <% end %>
       </div>

--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -97,7 +97,7 @@
     <% end %>
 
     <div class="actions mb-10 case-contacts-form-buttons">
-      <div class="case-contacts-form-options checkbox-style flex-grow-1">
+      <div class="case-contacts-form-options checkbox-style pt-1">
         <%= form.fields_for :metadata do |metadata_form| %>
           <%= metadata_form.check_box :create_another, class: 'form-check-input ' %>
           <%= metadata_form.label :create_another,  "Create Another", class: 'form-check-label ' %>

--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -100,7 +100,7 @@
       <div class="checkbox-style pt-1">
         <%= form.fields_for :metadata do |metadata_form| %>
           <%= metadata_form.check_box :create_another, class: "form-check-input" %>
-          <%= metadata_form.label :create_another, class: "form-check-label" do %>
+          <%= metadata_form.label :create_another, class: "form-check-label d-inline align-bottom" do %>
             Create Another
             <i class="lni lni-question-circle" data-toggle="tooltip" data-placement="top"
               title="Start a new contact for the same case(s) after submitting.">

--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -97,10 +97,15 @@
     <% end %>
 
     <div class="actions mb-10 case-contacts-form-buttons">
-      <div class="case-contacts-form-options checkbox-style pt-1">
+      <div class="checkbox-style pt-1">
         <%= form.fields_for :metadata do |metadata_form| %>
-          <%= metadata_form.check_box :create_another, class: 'form-check-input ' %>
-          <%= metadata_form.label :create_another,  "Create Another", class: 'form-check-label ' %>
+          <%= metadata_form.check_box :create_another, class: "form-check-input" %>
+          <%= metadata_form.label :create_another, class: "form-check-label" do %>
+            <i class="lni lni-question-circle" data-toggle="tooltip" data-placemnet="top"
+              title="Start a new contact for the same case(s) after submitting.">
+            </i>
+            Create Another
+          <% end %>
         <% end %>
       </div>
       <%= link_to previous_wizard_path(case_contact_id: @case_contact.id), class: "btn-sm main-btn primary-btn-outline btn-hover" do %>

--- a/app/views/case_contacts/form/expenses.html.erb
+++ b/app/views/case_contacts/form/expenses.html.erb
@@ -97,6 +97,12 @@
     <% end %>
 
     <div class="actions mb-10 case-contacts-form-buttons">
+      <div class="case-contacts-form-options checkbox-style flex-grow-1">
+        <%= form.fields_for :metadata do |metadata_form| %>
+          <%= metadata_form.check_box :create_another, class: 'form-check-input ' %>
+          <%= metadata_form.label :create_another,  "Create Another", class: 'form-check-label ' %>
+        <% end %>
+      </div>
       <%= link_to previous_wizard_path(case_contact_id: @case_contact.id), class: "btn-sm main-btn primary-btn-outline btn-hover" do %>
         Back
       <% end %>

--- a/spec/decorators/contact_type_decorator_spec.rb
+++ b/spec/decorators/contact_type_decorator_spec.rb
@@ -20,8 +20,12 @@ RSpec.describe ContactTypeDecorator do
   end
 
   describe "last_time_used_with_cases" do
+    let(:casa_case_ids) { [] }
+
+    subject { contact_type.decorate.last_time_used_with_cases casa_case_ids }
+
     context "with empty array" do
-      it { expect(contact_type.decorate.last_time_used_with_cases([])).to eq "never" }
+      it { is_expected.to eq "never" }
     end
 
     context "with cases" do
@@ -38,10 +42,19 @@ RSpec.describe ContactTypeDecorator do
 
         it "is the most recent case contact" do
           case_contact1.contact_types << contact_type
-          expect(contact_type.decorate.last_time_used_with_cases(casa_case_ids)).to eq "4 days ago"
+          expect(subject).to eq "4 days ago"
 
           case_contact2.contact_types << contact_type
           expect(contact_type.decorate.last_time_used_with_cases(casa_case_ids)).to eq "3 days ago"
+        end
+
+        context "when case_contact occurred_at is nil" do
+          let(:case_contact1) { build :case_contact, casa_case: casa_case, occurred_at: nil }
+
+          it "returns 'never'" do
+            case_contact1.contact_types << contact_type
+            expect(subject).to eq "never"
+          end
         end
       end
     end

--- a/spec/models/case_contact_spec.rb
+++ b/spec/models/case_contact_spec.rb
@@ -547,6 +547,20 @@ RSpec.describe CaseContact, type: :model do
         end
       end
     end
+
+    describe ".used_create_another" do
+      let!(:scope_case_contact) { create(:case_contact, metadata: {"create_another" => true}) }
+      let!(:false_case_contact) { create(:case_contact, metadata: {"create_another" => false}) }
+      let!(:empty_meta_case_contact) { create(:case_contact) }
+
+      subject { described_class.used_create_another }
+
+      it "returns only the case contacts with the metadata key 'create_another' set to true" do
+        expect(subject).to include(scope_case_contact)
+        expect(subject).not_to include(false_case_contact)
+        expect(subject).not_to include(empty_meta_case_contact)
+      end
+    end
   end
 
   describe "#contact_groups_with_types" do

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -415,11 +415,15 @@ RSpec.describe "CaseContacts::Forms", type: :request do
         end
 
         context "when create_another option is truthy" do
+          let(:draft_case_ids) { case_contact.draft_case_ids }
+
           before { params[:case_contact][:metadata] = {create_another: "1"} }
 
-          it "redirects to contact form with the same draft_case_id" do
+          it "redirects to contact form with the same draft_case_id, ignore_referrer" do
             expect(request).to have_http_status :redirect
-            expect(request).to redirect_to new_case_contact_path(draft_case_ids: case_contact.draft_case_ids)
+            expect(request).to redirect_to(
+              new_case_contact_path draft_case_ids:, ignore_referrer: true
+            )
           end
         end
 
@@ -461,10 +465,12 @@ RSpec.describe "CaseContacts::Forms", type: :request do
           context "when create_another option is truthy" do
             before { params[:case_contact][:metadata] = {create_another: "1"} }
 
-            it "redirects to new contact with the same draft_case_ids" do
+            it "redirects to new contact with the same draft_case_ids, ignore_referrer" do
               draft_case_ids = case_contact.draft_case_ids
               expect(request).to have_http_status :redirect
-              expect(request).to redirect_to new_case_contact_path(draft_case_ids:)
+              expect(request).to redirect_to(
+                new_case_contact_path draft_case_ids:, ignore_referrer: true
+              )
             end
           end
         end

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -419,10 +419,10 @@ RSpec.describe "CaseContacts::Forms", type: :request do
 
           before { params[:case_contact][:metadata] = {create_another: "1"} }
 
-          it "redirects to contact form with the same draft_case_id, ignore_referrer" do
+          it "redirects to contact form with the same draft_case_id, ignore_referer" do
             expect(request).to have_http_status :redirect
             expect(request).to redirect_to(
-              new_case_contact_path(draft_case_ids:, ignore_referrer: true)
+              new_case_contact_path(draft_case_ids:, ignore_referer: true)
             )
           end
         end
@@ -465,11 +465,11 @@ RSpec.describe "CaseContacts::Forms", type: :request do
           context "when create_another option is truthy" do
             before { params[:case_contact][:metadata] = {create_another: "1"} }
 
-            it "redirects to new contact with the same draft_case_ids, ignore_referrer" do
+            it "redirects to new contact with the same draft_case_ids, ignore_referer" do
               draft_case_ids = case_contact.draft_case_ids
               expect(request).to have_http_status :redirect
               expect(request).to redirect_to(
-                new_case_contact_path(draft_case_ids:, ignore_referrer: true)
+                new_case_contact_path(draft_case_ids:, ignore_referer: true)
               )
             end
           end

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -409,7 +409,19 @@ RSpec.describe "CaseContacts::Forms", type: :request do
           end
         end
 
-        it { is_expected.to have_http_status(:redirect) }
+        it "redirects to referrer (fallback) page" do
+          expect(request).to have_http_status :redirect
+          expect(request).to redirect_to case_contacts_path(success: true)
+        end
+
+        context "when create_another option is truthy" do
+          before { params[:case_contact][:metadata] = {create_another: "1"} }
+
+          it "redirects to contact form with the same draft_case_id" do
+            expect(request).to have_http_status :redirect
+            expect(request).to redirect_to new_case_contact_path(draft_case_ids: case_contact.draft_case_ids)
+          end
+        end
 
         context "with multiple cases selected" do
           let!(:other_casa_case) { create(:casa_case, casa_org: organization) }
@@ -439,6 +451,21 @@ RSpec.describe "CaseContacts::Forms", type: :request do
             case_contact.reload
             expect(case_contact.draft_case_ids.count).to eq 1
             expect(case_contact.draft_case_ids).to eq [casa_case.id]
+          end
+
+          it "redirects to referrer (fallback) page" do
+            expect(request).to have_http_status :redirect
+            expect(request).to redirect_to case_contacts_path(success: true)
+          end
+
+          context "when create_another option is truthy" do
+            before { params[:case_contact][:metadata] = {create_another: "1"} }
+
+            it "redirects to new contact with the same draft_case_ids" do
+              draft_case_ids = case_contact.draft_case_ids
+              expect(request).to have_http_status :redirect
+              expect(request).to redirect_to new_case_contact_path(draft_case_ids:)
+            end
           end
         end
       end

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe "CaseContacts::Forms", type: :request do
           it "redirects to contact form with the same draft_case_id, ignore_referrer" do
             expect(request).to have_http_status :redirect
             expect(request).to redirect_to(
-              new_case_contact_path draft_case_ids:, ignore_referrer: true
+              new_case_contact_path(draft_case_ids:, ignore_referrer: true)
             )
           end
         end
@@ -469,7 +469,7 @@ RSpec.describe "CaseContacts::Forms", type: :request do
               draft_case_ids = case_contact.draft_case_ids
               expect(request).to have_http_status :redirect
               expect(request).to redirect_to(
-                new_case_contact_path draft_case_ids:, ignore_referrer: true
+                new_case_contact_path(draft_case_ids:, ignore_referrer: true)
               )
             end
           end

--- a/spec/system/case_contacts/create_spec.rb
+++ b/spec/system/case_contacts/create_spec.rb
@@ -131,13 +131,13 @@ RSpec.describe "case_contacts/create", type: :system, js: true do
       sign_in volunteer
     end
 
-    it "should create a case contact" do
+    it "should skip expenses step and create a case contact" do
       visit case_contacts_path
 
       click_on "New Case Contact"
       complete_details_page(case_numbers: [casa_case.case_number], medium: "In Person", contact_made: true, hours: 1, minutes: 45)
       complete_notes_page(click_continue: false)
-
+      expect(page).to have_text("Step 2 of 2")
       click_on "Submit"
 
       expect(page).to have_text "Case contact successfully created"

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -134,5 +134,24 @@ you are trying to set the address for both of them. This is not currently possib
 
       expect(CaseContact.last.notes).to eq "Hello world"
     end
+
+    context "when 'Create Another' option is checked" do
+      it "redirects to new contact with the same draft_case_ids", js: true do
+        case_contact = create(:case_contact, duration_minutes: 105, casa_case: casa_case, creator: volunteer)
+        sign_in volunteer
+        visit edit_case_contact_path(case_contact)
+
+        complete_details_page(contact_made: true, medium: "Letter")
+        complete_notes_page
+        fill_in_expenses_page
+
+        check "Create Another"
+        expect { click_on "Submit" }.to change { CaseContact.count }.by(1)
+
+        expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
+        expect(page).to have_text "Step 1 of 3"
+        expect(page).to have_text casa_case.case_number
+      end
+    end
   end
 end

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -148,7 +148,6 @@ you are trying to set the address for both of them. This is not currently possib
         check "Create Another"
         expect { click_on "Submit" }.to change { CaseContact.count }.by(1)
 
-        expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
         expect(page).to have_text "Step 1 of 3"
         expect(page).to have_text casa_case.case_number
       end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -224,8 +224,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
       before { create_contact_types casa_org }
 
       it "redirects to the new CaseContact form with the same case selected" do
-        visit new_case_contact_path(case_contact: {casa_case_id: casa_case.id})
-        expect(page).to have_text case_number
+        visit new_case_contact_path
         complete_details_page(
           case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
           medium: "In Person", occurred_on: Date.today, hours: 1, minutes: 45

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -1,87 +1,119 @@
 require "rails_helper"
 require "action_view"
 
-RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
+RSpec.describe "case_contacts/new", type: :system, js: true do
   include ActionView::Helpers::SanitizeHelper
 
+  let(:casa_org) { build :casa_org }
+  let(:casa_case) { create :casa_case, :with_case_assignments, casa_org: }
+  let(:case_number) { casa_case.case_number }
+  let(:contact_type_group) { build :contact_type_group, casa_org: }
+  let!(:school_contact_type) { create :contact_type, contact_type_group:, name: "School" }
+  let!(:therapist_contact_type) { create :contact_type, contact_type_group:, name: "Therapist" }
+
+  before { sign_in user }
+
+  subject { visit new_case_contact_path casa_case }
+
   context "when admin" do
-    it "does not display empty or hidden contact type groups; can create CaseContact", js: true do
-      organization = build(:casa_org)
-      admin = create(:casa_admin, casa_org: organization)
-      casa_case = create(:casa_case, :with_case_assignments, casa_org: organization)
-      contact_type_group = build(:contact_type_group, casa_org: organization)
-      build(:contact_type_group, name: "Empty", casa_org: organization)
-      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
+    let(:user) { create :casa_admin, casa_org: }
+
+    it "does not display empty or hidden contact type groups; can create CaseContact" do
+      build(:contact_type_group, name: "Empty", casa_org:)
+      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org:)
       create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
-      school = create(:contact_type, name: "School", contact_type_group: contact_type_group)
-      therapist = create(:contact_type, name: "Therapist", contact_type_group: contact_type_group)
 
-      sign_in admin
-
-      visit casa_case_path(casa_case.id)
-
+      visit casa_case_path(casa_case)
       # assert to wait for page loading, to reduce flakiness
       expect(page).to have_text("CASA Case Details")
-
       # does not show empty contact type groups
       expect(page).to_not have_text("Empty")
-
       # does not show contact type groups with only hidden contact types
       expect(page).to_not have_text("Hidden")
 
       click_on "New Case Contact"
-      complete_details_page(case_numbers: [], contact_types: %w[School Therapist], contact_made: true, medium: "Video", occurred_on: Date.new(2020, 4, 5), hours: 1, minutes: 45)
+      complete_details_page(
+        case_numbers: [], contact_types: %w[School Therapist], contact_made: true,
+        medium: "Video", occurred_on: Date.new(2020, 4, 5), hours: 1, minutes: 45
+      )
       complete_notes_page
       fill_in_expenses_page
 
       expect {
         click_on "Submit"
       }.to change(CaseContact.where(status: "active"), :count).by(1)
-      expect(CaseContact.first.casa_case_id).to eq casa_case.id
-      expect(CaseContact.first.contact_types).to match_array([school, therapist])
-      expect(CaseContact.first.duration_minutes).to eq 105
+      contact = CaseContact.last
+      expect(contact.casa_case_id).to eq casa_case.id
+      expect(contact.contact_types.map(&:name)).to include("School", "Therapist")
+      expect(contact.duration_minutes).to eq 105
     end
   end
 
   context "volunteer user" do
-    let(:volunteer) { create(:volunteer, :with_casa_cases) }
-    let(:volunteer_casa_case_one) { volunteer.casa_cases.first }
+    let(:volunteer) { create :volunteer, :with_single_case, casa_org: }
+    let(:user) { volunteer }
+    let(:casa_case) { volunteer.casa_cases.first }
 
-    before(:each) do
-      sign_in volunteer
-      allow(Flipper).to receive(:enabled?).with(:show_additional_expenses).and_return(true)
+    it "saves entered details" do
+      subject
+
+      complete_details_page(
+        case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
+        medium: "In Person", occurred_on: Date.today, hours: 1, minutes: 45
+      )
+      complete_notes_page(notes: "Hello world")
+      fill_in_expenses_page(miles: 50, want_reimbursement: true, address: "123 Example St")
+      expect {
+        click_on "Submit"
+      }.to change { CaseContact.where(status: "active").count }.by(1)
+
+      case_contact = casa_case.case_contacts.last
+      aggregate_failures do
+        # associations
+        expect(case_contact.casa_case).to eq casa_case
+        expect(case_contact.creator).to eq user
+        expect(case_contact.contact_types.map(&:name)).to include("School", "Therapist")
+        # entered details
+        expect(case_contact.duration_minutes).to eq 105
+        expect(case_contact.contact_made).to be true
+        expect(case_contact.medium_type).to eq "in-person"
+        expect(case_contact.want_driving_reimbursement).to be true
+        expect(case_contact.miles_driven).to eq 50
+        expect(case_contact.draft_case_ids).to eq [casa_case.id]
+        expect(case_contact.volunteer_address).to eq "123 Example St"
+        expect(case_contact.occurred_at).to eq Date.today
+        expect(case_contact.notes).to eq "Hello world"
+        # other fields
+        expect(case_contact.reimbursement_complete).to be false
+        expect(case_contact.status).to eq "active"
+        expect(case_contact.metadata).to be_present
+      end
     end
 
-    it "is successful without a. Miles Driven or driving reimbursement", js: true do
-      allow(Flipper).to receive(:enabled?).with(:show_additional_expenses).and_return(false)
-      organization = build(:casa_org)
-      build(:contact_type_group, name: "Empty", casa_org: organization)
-      grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org: organization)
-      build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
-      create_contact_types(volunteer_casa_case_one.casa_org)
+    it "is successful without 'miles_driven' or 'want_driving_reimbursement'" do
+      subject
 
-      visit new_case_contact_path(volunteer_casa_case_one.id)
-
-      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: Date.new(2020, 0o4, 0o6), hours: 1, minutes: 45)
+      complete_details_page(
+        case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
+        medium: "In Person", occurred_on: Date.new(2020, 0o4, 0o6), hours: 1, minutes: 45
+      )
       complete_notes_page(notes: "Hello world")
       fill_in_expenses_page
+      expect { click_on "Submit" }.to change { CaseContact.where(status: "active").count }.by(1)
 
-      click_on "Submit"
-
-      expect(volunteer_casa_case_one.case_contacts.length).to eq(1)
-      case_contact = volunteer_casa_case_one.case_contacts.first
-      expect(case_contact.casa_case_id).to eq volunteer_casa_case_one.id
-      expect(case_contact.contact_types.map(&:name)).to include "School"
-      expect(case_contact.contact_types.map(&:name)).to include "Therapist"
+      case_contact = casa_case.case_contacts.last
+      expect(case_contact.casa_case_id).to eq casa_case.id
+      expect(case_contact.contact_types.map(&:name)).to include("School", "Therapist")
       expect(case_contact.duration_minutes).to eq 105
     end
 
-    it "autosaves notes", js: true do
-      create_contact_types(volunteer_casa_case_one.casa_org)
+    it "autosaves notes" do
+      subject
 
-      visit new_case_contact_path(volunteer_casa_case_one.id)
-
-      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(
+        case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
+        medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45
+      )
       expect(CaseContact.last.notes).not_to eq "Hello world"
 
       complete_notes_page(notes: "Hello world", click_continue: false)
@@ -93,12 +125,13 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
       expect(CaseContact.last.notes).to eq "Hello world"
     end
 
-    it "submits the form when no note was added", js: true do
-      create_contact_types(volunteer_casa_case_one.casa_org)
+    it "submits the form when no note was added" do
+      subject
 
-      visit new_case_contact_path
-
-      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(
+        case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
+        medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45
+      )
       complete_notes_page(notes: "")
       fill_in_expenses_page
 
@@ -109,12 +142,13 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
       expect(CaseContact.first.notes).to eq ""
     end
 
-    it "submits the form when note is added", js: true do
-      create_contact_types(volunteer_casa_case_one.casa_org)
+    it "submits the form when note is added" do
+      subject
 
-      visit new_case_contact_path
-
-      complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School Therapist], contact_made: true, medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      complete_details_page(
+        case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
+        medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45
+      )
       complete_notes_page(notes: "This is the note")
       fill_in_expenses_page
 
@@ -126,11 +160,12 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
     end
 
     context "with invalid inputs" do
-      it "re-renders the form with errors, but preserving all previously entered selections", js: true do
-        create_contact_types(volunteer_casa_case_one.casa_org)
-
-        visit new_case_contact_path
-        complete_details_page(case_numbers: [volunteer_casa_case_one.case_number], contact_types: %w[School], contact_made: true, medium: nil, occurred_on: "04/04/2020", hours: 1, minutes: 45)
+      it "re-renders the form with errors, but preserving all previously entered selections" do
+        subject
+        complete_details_page(
+          case_numbers: [case_number], contact_types: %w[School], contact_made: true, medium: nil,
+          occurred_on: "04/04/2020", hours: 1, minutes: 45
+        )
         expect(page).to have_text("Medium type can't be blank")
 
         choose_medium("In Person")
@@ -142,31 +177,25 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
     end
 
     context "with no contact types set for the volunteer's cases" do
-      let(:org) { build(:casa_org) }
-      let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: org) }
+      before { expect(casa_case.contact_types).to be_empty }
 
-      it "renders all of the org's contact types", js: true do
-        create_contact_types(org)
-
-        visit new_case_contact_path
+      it "renders all of the org's contact types" do
+        subject
 
         find("#case_contact_contact_type_ids-ts-control").click
-        expect(page).to have_text("Attorney")
         expect(page).to have_text("School")
         expect(page).to have_text("Therapist")
       end
     end
 
     context "with specific contact types allowed for the volunteer's cases" do
-      let(:org) { build(:casa_org) }
-      let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: org) }
+      let!(:attorney_contact_type) { create :contact_type, contact_type_group:, name: "Attorney" }
 
-      it "only renders contact types that are allowed for the volunteer's cases", js: true do
-        contact_type_group = create_contact_types(org)
-        contact_types_for_cases = contact_type_group.contact_types.reject { |ct| ct.name == "Attorney" }
-        assign_contact_types_to_cases(volunteer.casa_cases, contact_types_for_cases)
+      before { casa_case.update!(contact_types: [school_contact_type, therapist_contact_type]) }
 
-        visit new_case_contact_path
+      it "only renders contact types that are allowed for the volunteer's cases" do
+        expect(casa_org.contact_types.map(&:name)).to include("Attorney")
+        subject
 
         within find("#contact-type-id-selector") do
           find(".ts-control").click
@@ -179,37 +208,29 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
     end
 
     context "when driving reimbursement is hidden by the CASA org" do
-      let(:org) { build(:casa_org, show_driving_reimbursement: false) }
-      let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org: org) }
+      let(:casa_org) { build(:casa_org, show_driving_reimbursement: false) }
 
-      it "does not show for case_contacts" do
-        contact_type_group = create_contact_types(org)
-        contact_types_for_cases = contact_type_group.contact_types.reject { |ct| ct.name == "Attorney" }
-        assign_contact_types_to_cases(volunteer.casa_cases, contact_types_for_cases)
+      it "skips reimbursement (step 3)" do
+        subject
 
-        visit new_case_contact_path
-
-        complete_details_page(case_numbers: [volunteer.casa_cases.first.case_number], contact_types: %w[School], contact_made: true, medium: "In Person")
+        complete_details_page(
+          case_numbers: [case_number], contact_types: %w[School], contact_made: true, medium: "In Person"
+        )
         complete_notes_page(click_continue: false)
-
+        expect(page).to have_text("Step 2 of 2")
         click_on "Submit"
-
-        expect(page).not_to have_field("b. Want Driving Reimbursement")
+        expect(page).to have_text("Case contact successfully created")
       end
     end
 
     context "when driving reimbursement is hidden when volunteer not allowed to request" do
-      let(:org) { build(:casa_org, show_driving_reimbursement: true) }
-      let(:volunteer) { create(:volunteer, :with_disasllow_reimbursement, casa_org: org) }
+      let(:casa_org) { build(:casa_org, show_driving_reimbursement: true) }
+      let(:volunteer) { create(:volunteer, :with_disasllow_reimbursement, casa_org:) }
 
       it "does not show for case_contacts" do
-        contact_type_group = create_contact_types(org)
-        contact_types_for_cases = contact_type_group.contact_types.reject { |ct| ct.name == "Attorney" }
-        assign_contact_types_to_cases(volunteer.casa_cases, contact_types_for_cases)
+        subject
 
-        visit new_case_contact_path
-
-        complete_details_page(case_numbers: [volunteer.casa_cases.first.case_number], contact_types: %w[School], contact_made: true, medium: "In Person")
+        complete_details_page(case_numbers: [case_number], contact_types: %w[School], contact_made: true, medium: "In Person")
         complete_notes_page
 
         expect(page).not_to have_field("b. Want Driving Reimbursement")
@@ -293,26 +314,22 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
     end
 
     describe "differences in single vs. multiple cases" do
-      let(:volunteer) { create(:volunteer, :with_casa_cases) }
       let(:first_case) { volunteer.casa_cases.first }
 
-      before(:each) do
-        sign_in volunteer
-      end
-
       context "multiple cases" do
+        let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org:) }
         let(:second_case) { volunteer.casa_cases.second }
 
         context "case default selection" do
           it "selects no cases" do
-            visit new_case_contact_path
+            subject
 
             expect(page).not_to have_text(first_case.case_number)
             expect(page).not_to have_text(second_case.case_number)
           end
 
           it "warns user about using the back button on step 1" do
-            visit new_case_contact_path
+            subject
 
             click_on "Back"
             expect(page).to have_selector("h2", text: "Discard draft?")
@@ -341,7 +358,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
         let(:volunteer) { create(:volunteer, :with_single_case) }
 
         it "selects the only case" do
-          visit new_case_contact_path
+          subject
 
           expect(page).to have_text(first_case.case_number)
         end
@@ -353,23 +370,6 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
           expect(page).to have_selector("h1", text: "Case Contacts")
           expect(page).to have_selector("a", text: "New Case Contact")
         end
-      end
-    end
-
-    private
-
-    def create_contact_types(org)
-      create(:contact_type_group, casa_org: org).tap do |group|
-        create(:contact_type, contact_type_group: group, name: "Attorney")
-        create(:contact_type, contact_type_group: group, name: "School")
-        create(:contact_type, contact_type_group: group, name: "Therapist")
-      end
-    end
-
-    def assign_contact_types_to_cases(cases, contact_types)
-      cases.each do |c|
-        c.contact_types = contact_types
-        c.save
       end
     end
   end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -238,14 +238,8 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
     end
 
     context "when 'Create Another' is checked" do
-      let(:casa_org) { volunteer.casa_org }
-      let(:casa_case) { volunteer.casa_cases.first }
-      let(:case_number) { casa_case.case_number }
-
-      before { create_contact_types casa_org }
-
       it "redirects to the new CaseContact form with the same case selected" do
-        visit new_case_contact_path
+        subject
         complete_details_page(
           case_numbers: [case_number], contact_types: %w[School Therapist], contact_made: true,
           medium: "In Person", occurred_on: Date.today, hours: 1, minutes: 45
@@ -293,11 +287,12 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
       end
 
       context "multiple cases selected" do
+        let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org:) }
         let(:casa_case_two) { volunteer.casa_cases.second }
         let(:case_number_two) { casa_case_two.case_number }
 
         it "redirects to the new CaseContact form with the same cases selected" do
-          visit new_case_contact_path
+          subject
           complete_details_page(
             case_numbers: [case_number, case_number_two], contact_made: true, medium: "In Person"
           )

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true, flipper: true do
         complete_notes_page
 
         click_on "Submit"
-        # CaseContactsController#new should see original referrer, casa_case_path(casa_case)
+        # update should redirect to the original referrer, casa_case_path(casa_case)
         expect(page).to have_text "CASA Case Details"
         expect(page).to have_text "Case number: #{case_number}"
       end

--- a/spec/values/case_contact_parameters_spec.rb
+++ b/spec/values/case_contact_parameters_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe CaseContactParameters do
         want_driving_reimbursement: "want_driving_reimbursement",
         notes: "notes",
         contact_type_ids: [],
-        contact_topic_answers_attributes:
+        contact_topic_answers_attributes:,
+        metadata: {"create_another" => "1", "bad_key" => "bad_value"}
       )
     )
   }
@@ -25,16 +26,21 @@ RSpec.describe CaseContactParameters do
   end
 
   it "returns data" do
-    expect(subject["duration_minutes"]).to eq(62)
-    expect(subject["occurred_at"]).to eq("occurred_at")
-    expect(subject["contact_made"]).to eq("contact_made")
-    expect(subject["medium_type"]).to eq("medium_type")
-    expect(subject["miles_driven"]).to eq(123)
-    expect(subject["want_driving_reimbursement"]).to eq("want_driving_reimbursement")
-    expect(subject["notes"]).to eq("notes")
-    expect(subject["contact_type_ids"]).to eq([])
+    aggregate_failures do
+      expect(subject["duration_minutes"]).to eq(62)
+      expect(subject["occurred_at"]).to eq("occurred_at")
+      expect(subject["contact_made"]).to eq("contact_made")
+      expect(subject["medium_type"]).to eq("medium_type")
+      expect(subject["miles_driven"]).to eq(123)
+      expect(subject["want_driving_reimbursement"]).to eq("want_driving_reimbursement")
+      expect(subject["notes"]).to eq("notes")
+      expect(subject["contact_type_ids"]).to eq([])
 
-    expected_attrs = contact_topic_answers_attributes["0"].except("question")
-    expect(subject["contact_topic_answers_attributes"]["0"].to_h).to eq(expected_attrs)
+      expected_attrs = contact_topic_answers_attributes["0"].except("question")
+      expect(subject["contact_topic_answers_attributes"]["0"].to_h).to eq(expected_attrs)
+
+      expect(subject["metadata"]["create_another"]).to eq(true)
+      expect(subject["metadata"]["bad_key"]).to_not be_present
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5925  - Add "create another" option to case contact form

### What changed, and _why_?
Adds a checkbox to the last step of case contact form, which indicates user wants to create another case contact for the same case(s). After submission, if checked, the user is redirected to the case contact form's first step with the same draft_case_ids as the previously created case contact.

Also added a CaseContact scope to view how many times this has been used. There may be a more ActiveRecord-y way to deal with the jsonb?

### How is this **tested**? (please write tests!) 💖💪
- spec/requests/case_contacts/form_spec.rb tests the changes to the form controller - that requests are redirected to correct path with draft case ids param.
- system specs for CaseContact new & edit
- I refactored the specs because there was a lot of duplicate setup and misleading descriptions, sorry for the huge diff there.

### Screenshots please :)
<img width="1369" alt="Screenshot 2024-07-31 at 3 17 21 PM" src="https://github.com/user-attachments/assets/c8bff230-4f99-41f6-92e0-067fb9bb982f">

### Feelings gif (optional)
![Fred Willard playing and old timey novelty organ at a funeral from I Think You Should Leave](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDhsYjYxbWx4bWN5b2d0dXNiZXBhNm41cG1naHVlaThpd2k2MnRvdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Xv4clwvycaX62t3bAW/giphy.gif)
