### PR TITLE
fix: deprecated docker-compose

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,13 +32,13 @@ jobs:
           mkdir -p tmp/downloads
           chmod 777 tmp tmp/downloads
       - name: docker UP
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: db:reset
-        run: docker-compose exec -T web rails db:reset
+        run: docker compose exec -T web rails db:reset
       - name: compile assets
-        run: docker-compose exec -T web bundle exec rails assets:precompile
+        run: docker compose exec -T web bundle exec rails assets:precompile
       - name: Test
-        run: docker-compose exec -T web bundle exec rspec spec --fail-fast
+        run: docker compose exec -T web bundle exec rspec spec --fail-fast
 
       - name: Archive selenium screenshots
         if: ${{ failure() }}


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #XXXX

### What changed, and _why_?


### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
