### PR TITLE
CaseContact status enum changes

### DIFF
--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -20,7 +20,7 @@ class CaseContacts::FormController < ApplicationController
 
   def update
     authorize @case_contact
-    params[:case_contact][:status] = step.to_s if !@case_contact.active?
+    params[:case_contact][:status] = CaseContact.statuses[step]  if !@case_contact.active?
     remove_unwanted_contact_types
     remove_nil_draft_ids
 

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -20,7 +20,7 @@ class CaseContacts::FormController < ApplicationController
 
   def update
     authorize @case_contact
-    params[:case_contact][:status] = CaseContact.statuses[step]  if !@case_contact.active?
+    params[:case_contact][:status] = CaseContact.statuses[step] if !@case_contact.active?
     remove_unwanted_contact_types
     remove_nil_draft_ids
 

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -117,7 +117,7 @@ class CaseContactsController < ApplicationController
   end
 
   def case_contact_drafts
-    CaseContact.where(creator: current_user).where.not(status: "active")
+    CaseContact.where(creator: current_user).not_active
   end
 
   def set_case_contact

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -47,7 +47,12 @@ class CaseContact < ApplicationRecord
   # Corresponds to the steps in the controller, so validations for certain columns can happen at those steps.
   # These steps must be listed in order and have an html template in case_contacts/form.
   FORM_STEPS = %i[details notes expenses].freeze
-  enum status: (%w[started active] + FORM_STEPS.map(&:to_s)).zip((%w[started active] + FORM_STEPS.map(&:to_s))).to_h
+  enum :status,
+    started: "started",
+    active: "active",
+    details: "details",
+    notes: "notes",
+    expenses: "expenses"
 
   def active_or_details?
     status == "details" || active?

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -162,7 +162,7 @@ class CaseContact < ApplicationRecord
     where(casa_case_id: case_ids) if case_ids.present?
   }
 
-  scope :no_drafts, ->(checked) { (checked == 1) ? where(status: "active") : all }
+  scope :no_drafts, ->(checked) { (checked == 1) ? active : all }
 
   scope :with_metadata_pair, ->(key, value) { where("metadata -> ? @> ?::jsonb", key.to_s, value.to_s) }
   scope :used_create_another, -> { with_metadata_pair(:create_another, true) }

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -62,6 +62,10 @@ class CaseContact < ApplicationRecord
     status == "expenses" || active?
   end
 
+  def active_or_notes?
+    status == "notes" || active?
+  end
+
   accepts_nested_attributes_for :additional_expenses, reject_if: :all_blank, allow_destroy: true
   validates_associated :additional_expenses
 

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -49,12 +49,13 @@ class CaseContact < ApplicationRecord
   FORM_STEPS = %i[details notes expenses].freeze
   # note: enum defines methods (active?) and scopes (.active, .not_active) for each member
   # integer column would make db queries faster
-  enum :status,
+  enum :status, {
     started: "started",
     active: "active",
     details: "details",
     notes: "notes",
     expenses: "expenses"
+  }, validate: true
 
   def active_or_details?
     details? || active?

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -45,8 +45,10 @@ class CaseContact < ApplicationRecord
   after_save_commit ::CaseContactMetadataCallback.new
 
   # Corresponds to the steps in the controller, so validations for certain columns can happen at those steps.
-  # These steps must be listed in order and have an html template in case_contacts/form.
+  # These steps must be listed in order, have an html template in case_contacts/form, & be listed in the status enum
   FORM_STEPS = %i[details notes expenses].freeze
+  # note: enum defines methods (active?) and scopes (.active, .not_active) for each member
+  # integer column would make db queries faster
   enum :status,
     started: "started",
     active: "active",
@@ -55,15 +57,15 @@ class CaseContact < ApplicationRecord
     expenses: "expenses"
 
   def active_or_details?
-    status == "details" || active?
+    details? || active?
   end
 
   def active_or_expenses?
-    status == "expenses" || active?
+    expenses? || active?
   end
 
   def active_or_notes?
-    status == "notes" || active?
+    notes? || active?
   end
 
   accepts_nested_attributes_for :additional_expenses, reject_if: :all_blank, allow_destroy: true

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -48,14 +48,14 @@ class CaseContact < ApplicationRecord
   # These steps must be listed in order, have an html template in case_contacts/form, & be listed in the status enum
   FORM_STEPS = %i[details notes expenses].freeze
   # note: enum defines methods (active?) and scopes (.active, .not_active) for each member
-  # integer column would make db queries faster
+  # string values for wizard form steps, integer column would make db queries faster
   enum :status, {
     started: "started",
     active: "active",
     details: "details",
     notes: "notes",
     expenses: "expenses"
-  }, validate: true
+  }, validate: true, default: :started
 
   def active_or_details?
     details? || active?

--- a/spec/callbacks/case_contact_metadata_callback_spec.rb
+++ b/spec/callbacks/case_contact_metadata_callback_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CaseContactMetadataCallback do
     end
 
     context "case contact is in started status" do
-      let(:case_contact) { create(:case_contact, status: "started", created_at: past) }
+      let(:case_contact) { create(:case_contact, :started, created_at: past) }
 
       context "updates to started status" do
         before { case_contact.update(status: "started") }
@@ -59,7 +59,7 @@ RSpec.describe CaseContactMetadataCallback do
     end
 
     context "case contact is in details status" do
-      let(:case_contact) { create(:case_contact, status: "details", created_at: past) }
+      let(:case_contact) { create(:case_contact, :details, created_at: past) }
 
       context "updates to details status" do
         before { case_contact.update(status: "details") }
@@ -89,7 +89,7 @@ RSpec.describe CaseContactMetadataCallback do
     end
 
     context "case contact is in notes status" do
-      let(:case_contact) { create(:case_contact, status: "notes", created_at: past) }
+      let(:case_contact) { create(:case_contact, :notes, created_at: past) }
 
       context "updates to notes status" do
         before { case_contact.update(status: "notes") }
@@ -111,7 +111,7 @@ RSpec.describe CaseContactMetadataCallback do
     end
 
     context "case contact is in expenses status" do
-      let!(:case_contact) { create(:case_contact, status: "expenses", created_at: past) }
+      let!(:case_contact) { create(:case_contact, :expenses, created_at: past) }
 
       context "updates to expenses status" do
         before { case_contact.update(status: "expenses") }

--- a/spec/factories/case_contacts.rb
+++ b/spec/factories/case_contacts.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     contact_types { [create(:contact_type)] }
     duration_minutes { 60 }
-    occurred_at { Time.zone.now }
+    occurred_at { Time.zone.today }
     contact_made { false }
     medium_type { CaseContact::CONTACT_MEDIUMS.first }
     want_driving_reimbursement { false }

--- a/spec/factories/case_contacts.rb
+++ b/spec/factories/case_contacts.rb
@@ -1,8 +1,15 @@
 FactoryBot.define do
-  # note: uses enum status column, see:
+  # NOTE: FactoryBot automatically creates traits for a model's enum attributes
   # https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#enum-traits
+  # For example, CaseContact status enum includes `active: "active"` state, so following already defined:
+  # trait :active do
+  #   status { "active" }
+  # end
+  # ALSO, we can use any trait within other traits:
+  # https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#traits-within-traits
+  # So, rather than `status { "active" }` - use enum trait like so:
   factory :case_contact do
-    active
+    active # use the `:active` enum trait
     association :creator, factory: :user
     casa_case
 
@@ -34,7 +41,7 @@ FactoryBot.define do
     end
 
     trait :started_status do
-      started
+      started # enum trait
 
       casa_case { nil }
       draft_case_ids { [] }
@@ -46,7 +53,7 @@ FactoryBot.define do
     end
 
     trait :details_status do
-      details
+      details # enum trait
 
       casa_case { nil }
       draft_case_ids { [1] }
@@ -55,7 +62,7 @@ FactoryBot.define do
     end
 
     trait :notes_status do
-      notes
+      notes # enum trait
 
       casa_case { nil }
       draft_case_ids { [1] }
@@ -63,7 +70,7 @@ FactoryBot.define do
     end
 
     trait :expenses_status do
-      expenses
+      expenses # enum trait
 
       draft_case_ids { [1] }
     end

--- a/spec/factories/case_contacts.rb
+++ b/spec/factories/case_contacts.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
+  # note: uses enum status column, see:
+  # https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#enum-traits
   factory :case_contact do
+    active
     association :creator, factory: :user
     casa_case
 
@@ -10,7 +13,6 @@ FactoryBot.define do
     medium_type { CaseContact::CONTACT_MEDIUMS.first }
     want_driving_reimbursement { false }
     deleted_at { nil }
-    status { "active" }
     draft_case_ids { [casa_case&.id] }
 
     trait :multi_line_note do
@@ -32,6 +34,8 @@ FactoryBot.define do
     end
 
     trait :started_status do
+      started
+
       casa_case { nil }
       draft_case_ids { [] }
       medium_type { nil }
@@ -39,27 +43,29 @@ FactoryBot.define do
       duration_minutes { nil }
       notes { nil }
       miles_driven { 0 }
-      status { "started" }
     end
 
     trait :details_status do
+      details
+
       casa_case { nil }
       draft_case_ids { [1] }
       notes { nil }
       miles_driven { 0 }
-      status { "details" }
     end
 
     trait :notes_status do
+      notes
+
       casa_case { nil }
       draft_case_ids { [1] }
       miles_driven { 0 }
-      status { "notes" }
     end
 
     trait :expenses_status do
+      expenses
+
       draft_case_ids { [1] }
-      status { "expenses" }
     end
 
     after(:create) do |case_contact, evaluator|

--- a/spec/policies/case_contact_policy_spec.rb
+++ b/spec/policies/case_contact_policy_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe CaseContactPolicy do
       end
 
       context "case_contact is not a draft" do
-        let(:case_contact) { build_stubbed(:case_contact, status: "active", creator: volunteer) }
+        let(:case_contact) { build_stubbed(:case_contact, :active, creator: volunteer) }
 
         it { is_expected.not_to permit(volunteer, case_contact) }
       end
@@ -117,7 +117,7 @@ RSpec.describe CaseContactPolicy do
       end
 
       context "case_contact is not a draft" do
-        let(:case_contact) { build_stubbed(:case_contact, status: "active", creator: build_stubbed(:volunteer)) }
+        let(:case_contact) { build_stubbed(:case_contact, :active, creator: build_stubbed(:volunteer)) }
 
         it { is_expected.not_to permit(volunteer, case_contact) }
       end

--- a/spec/services/deployment/backfill_case_contact_started_metadata_service_spec.rb
+++ b/spec/services/deployment/backfill_case_contact_started_metadata_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Deployment::BackfillCaseContactStartedMetadataService do
     let(:case_contact) { create(:case_contact) }
 
     context "when a case contact has status started metadata" do
-      let!(:case_contact) { create(:case_contact, created_at: past, status: "started") }
+      let!(:case_contact) { create(:case_contact, :started, created_at: past) }
 
       it "does not change metadata" do
         described_class.new.backfill_metadata

--- a/spec/system/case_contacts/additional_expenses_spec.rb
+++ b/spec/system/case_contacts/additional_expenses_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1).and change(AdditionalExpense, :count).by(1)
+      }.to change(CaseContact.active, :count).by(1).and change(AdditionalExpense, :count).by(1)
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
       complete_details_page(contact_made: true)
@@ -108,7 +108,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
       expect(page).to have_text("Add Another Expense")
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1).and change(AdditionalExpense, :count).by(2)
+      }.to change(CaseContact.active, :count).by(1).and change(AdditionalExpense, :count).by(2)
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
       complete_details_page(contact_made: true)
@@ -132,7 +132,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(0).and change(AdditionalExpense, :count).by(1)
+      }.to change(CaseContact.active, :count).by(0).and change(AdditionalExpense, :count).by(1)
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
       complete_details_page(contact_made: true)
@@ -181,7 +181,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1).and change(AdditionalExpense, :count).by(12)
+      }.to change(CaseContact.active, :count).by(1).and change(AdditionalExpense, :count).by(12)
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
       complete_details_page(contact_made: true)
@@ -227,7 +227,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1).and change(AdditionalExpense, :count).by(2)
+      }.to change(CaseContact.active, :count).by(1).and change(AdditionalExpense, :count).by(2)
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
       complete_details_page(contact_made: true)
@@ -240,7 +240,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(0).and change(AdditionalExpense, :count).by(-1)
+      }.to change(CaseContact.active, :count).by(0).and change(AdditionalExpense, :count).by(-1)
     end
 
     it "verifies that an additional expense without a description will cause an error", js: true do
@@ -260,7 +260,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(0).and change(AdditionalExpense, :count).by(0)
+      }.to change(CaseContact.active, :count).by(0).and change(AdditionalExpense, :count).by(0)
 
       expect(page).to have_text("error")
 
@@ -268,7 +268,7 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1).and change(AdditionalExpense, :count).by(1)
+      }.to change(CaseContact.active, :count).by(1).and change(AdditionalExpense, :count).by(1)
       expect(page).not_to have_text("error")
 
       visit edit_case_contact_path(casa_case.reload.case_contacts.last)
@@ -281,14 +281,14 @@ RSpec.describe "additional_expenses", type: :system, flipper: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(0).and change(AdditionalExpense, :count).by(0)
+      }.to change(CaseContact.active, :count).by(0).and change(AdditionalExpense, :count).by(0)
       expect(page).to have_text("error")
 
       all("input[name*='[additional_expenses_attributes]'][name$='[other_expenses_describe]']").last.fill_in(with: "2nd meal")
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(0).and change(AdditionalExpense, :count).by(1)
+      }.to change(CaseContact.active, :count).by(0).and change(AdditionalExpense, :count).by(1)
       expect(page).not_to have_text("error")
     end
   end

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1)
+      }.to change(CaseContact.active, :count).by(1)
       contact = CaseContact.last
       expect(contact.casa_case_id).to eq casa_case.id
       expect(contact.contact_types.map(&:name)).to include("School", "Therapist")
@@ -137,7 +137,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1)
+      }.to change(CaseContact.active, :count).by(1)
 
       expect(CaseContact.first.notes).to eq ""
     end
@@ -154,7 +154,7 @@ RSpec.describe "case_contacts/new", type: :system, js: true do
 
       expect {
         click_on "Submit"
-      }.to change(CaseContact.where(status: "active"), :count).by(1)
+      }.to change(CaseContact.active, :count).by(1)
 
       expect(CaseContact.first.notes).to eq "This is the note"
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?

No issue: syntax changes only. None of this is necessary.

While working on CaseContacts, I noticed the status enum was defined oddly. I started poking around. The enum is used to define `.active?`/`.started?` and not much else - doesn't use any of the other methods or scopes that come along with an enum definition. It is also a string column, which is atypical. That is for easy compatibility with the wicked wizard form steps - but standard integer column would make for faster queries.

### What changed, and _why_?

The main thing I wanted to do is define the enum in a way that makes sense. But then I kept going to see if we could better use the enum, and set things up for a transition to integer column. That won't be necessary until performance is a real-world concern. It would require migrating existing data, which could be delicate. But these changes would enable it. The definition & wizard form updates would work if the enum column was changed to an integer type.

- Explicitly define the enum (_If this is all you want to do here, I'm happy with that_)
- Use the methods and scopes that are defined by doing so
- Integrate those changes into the wizard step updates
- Integrate the enum into factories

### How is this **tested**? (please write tests!) 💖💪
Current specs. ~~Could add/modify specs for each of the enum-created scopes, will probably look at that a bit, especially if people want to do this.~~ I think the scope changes in specs are enough?