### PR TITLE
[5921] Show the first error messages of each attribute in forms 

### DIFF
--- a/app/models/concerns/CasaCase/validations.rb
+++ b/app/models/concerns/CasaCase/validations.rb
@@ -7,11 +7,13 @@ module CasaCase::Validations
     validates :birth_month_year_youth, presence: true
     validates :birth_month_year_youth, comparison: {
       less_than_or_equal_to: -> { Time.now.end_of_day },
-      message: "is not valid: Youth's Birth Month & Year cannot be a future date."
+      message: "is not valid: Youth's Birth Month & Year cannot be a future date.",
+      allow_nil: true
     }
     validates :birth_month_year_youth, comparison: {
       greater_than_or_equal_to: "1989-01-01".to_date,
-      message: "is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989."
+      message: "is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989.",
+      allow_nil: true
     }
 
     validates :date_in_care, comparison: {

--- a/app/models/court_date.rb
+++ b/app/models/court_date.rb
@@ -7,11 +7,13 @@ class CourtDate < ApplicationRecord
   validates :date, presence: true
   validates :date, comparison: {
     less_than_or_equal_to: -> { 1.year.from_now },
-    message: "is not valid. Court date must be within one year from today."
+    message: "is not valid. Court date must be within one year from today.",
+    allow_nil: true
   }
   validates :date, comparison: {
     greater_than_or_equal_to: "1989-01-01".to_date,
-    message: "is not valid. Court date cannot be prior to 1/1/1989."
+    message: "is not valid. Court date cannot be prior to 1/1/1989.",
+    allow_nil: true
   }
 
   has_many :case_court_orders

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -243,8 +243,6 @@ RSpec.describe "/casa_cases", type: :request do
             expect(response).to have_http_status(:unprocessable_entity)
             expected_response_body = [
               "Birth month year youth can't be blank",
-              "Birth month year youth is not valid: Youth's Birth Month & Year cannot be a future date.",
-              "Birth month year youth is not valid: Youth's Birth Month & Year cannot be prior to 1/1/1989.",
               "Case number can't be blank",
               "Casa case contact types : At least one contact type must be selected"
             ].to_json

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -264,9 +264,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
           post casa_case_court_dates_path(casa_case), params: {court_date: invalid_attributes}
           expect(response).to have_http_status(:unprocessable_entity)
           expected_errors = [
-            "Date can't be blank",
-            "Date is not valid. Court date must be within one year from today.",
-            "Date is not valid. Court date cannot be prior to 1/1/1989."
+            "Date can't be blank"
           ].freeze
           expect(assigns[:court_date].errors.full_messages).to eq expected_errors
         end
@@ -310,9 +308,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expected_errors = [
-          "Date can't be blank",
-          "Date is not valid. Court date must be within one year from today.",
-          "Date is not valid. Court date cannot be prior to 1/1/1989."
+          "Date can't be blank"
         ].freeze
         expect(assigns[:court_date].errors.full_messages).to eq expected_errors
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5921 

### What changed, and _why_?
The issue involved multiple error messages when creating a Casa case with a blank _court date_ and/or a blank _birth month year youth_. 

I have modified the validations in casa_case model. With this partial only one error message is shown per field in the form. 

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
Replicating the previous steps in the issue:
<img width="562" alt="Captura de pantalla 2024-08-22 a las 15 47 02" src="https://github.com/user-attachments/assets/31736729-4995-4325-86da-7419a9a122a4">


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
