### PR TITLE
Local-friendly RSpec setup

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,8 @@ Rails.application.configure do
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
+  # cach classes on CI, but enable reloading for local work (bin/rspec)
+  config.enable_reloading = ENV["CI"].blank?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # recommended that you enable it in continuous integration systems to ensure eager
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
-  # cach classes on CI, but enable reloading for local work (bin/rspec)
+  # cache classes on CI, but enable reloading for local work (bin/rspec)
   config.enable_reloading = ENV["CI"].blank?
 
   # Configure public file server for tests with Cache-Control for performance.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,7 +65,13 @@ RSpec.configure do |config|
 
   config.example_status_persistence_file_path = "#{::Rails.root}/tmp/persistent_examples.txt"
 
+  # Filter backtraces to gems that are not under our control.
+  # Can override using `--backtrace` option to rspec to see full backtraces.
   config.filter_rails_from_backtrace!
+  config.filter_gems_from_backtrace(*%w[
+    bootsnap capybara factory_bot puma rack railties shoulda-matchers
+    sprockets-rails pundit
+  ])
 
   config.disable_monkey_patching!
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
No Issue, concerns local development only.

### What changed, and _why_?
Prior to change, running `bin/rspec` locally would produce following error in my (mac) environment:
```sh
lib/ruby/gems/3.2.0/gems/spring-4.2.1/lib/spring/application.rb:105:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
```
(Note I did not do what the above error says to do, that was the 'old' way to do it before Rails 7.1, I guess rspec hasn't updated the error?)

So, the only way to run a specific spec or file was to use focus tag (`fit`, `fdescribe`, etc...) while running `bin/rails spec`, which runs javascript/css builds each run - annoying if running backed / not changing javascript/css.  The focus tag could also be forgotten about and committed.

This change allows copy/pasting lines from failure notifications, for example, `bin/rspec path/to/file.rb:23`. Used ENV["CI"] so that CI test run speed is not affected.

Also made a change that filters gems from backtrace of spec failures, which aren't very useful. Typically, I only want to see trace of files we have control over. This can be overridden by passing option to rspec `bin/rspec --backtrace`. I added a comment to that effect.