### PR TITLE
Speed up docker multi stage balance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,14 @@ FROM ruby:3.2.2-alpine AS builder
 RUN apk update && apk upgrade && apk add --update --no-cache \
   build-base \
   curl-dev \
-  nodejs \
   postgresql-dev \
-  tzdata \
-  vim \
-  yarn && rm -rf /var/cache/apk/*
+  tzdata
 
 ARG RAILS_ROOT=/usr/src/app/
 WORKDIR $RAILS_ROOT
 
-COPY package*.json yarn.lock $RAILS_ROOT
-RUN yarn install --check-files
-
 COPY Gemfile* $RAILS_ROOT
 RUN bundle install
-
-COPY . .
-RUN yarn build && yarn build:css
 
 ### BUILD STEP DONE ###
 
@@ -38,7 +29,10 @@ RUN apk update && apk upgrade && apk add --update --no-cache \
 
 WORKDIR $RAILS_ROOT
 
-COPY --from=builder $RAILS_ROOT $RAILS_ROOT
+COPY . .
+RUN yarn install
+RUN yarn build && yarn build:css
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 EXPOSE 3000


### PR DESCRIPTION
### What changed, and _why_?
Moved all yarn actions to the second stage of the build. Bundle takes the most time and having anything run synchronously with bundle takes longer.
```
Benchmarks
    (current)
        casa-web                           latest    c611b7f38df0   9 hours ago   696MB
        selenium/standalone-chrome-debug   latest    aaf43463c572   2 years ago   1.11GB
        postgres                           12.5      5fa7773911d6   3 years ago   314MB

        real	4m16.865s
        user	0m8.035s
        sys	0m4.681s

        Github: [8m53s, 11m 17s] 5 runs

    (Balanced Multi-stage Build)
        casa-web                           latest    ff9941b85870   About a minute ago   732MB
        selenium/standalone-chrome-debug   latest    aaf43463c572   2 years ago          1.11GB
        postgres                           12.5      5fa7773911d6   3 years ago          314MB

        real	3m18.398s
        user	0m8.306s
        sys	0m4.210s

        Github: [8m 31s, 8m 51s] 5 runs
```

### How is this **tested**? (please write tests!) 💖💪
Opened the webapp locally
CI here
