### PR TITLE
CaseGroups request spec & custom policy generator

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -1,7 +1,6 @@
 blueprints/api/v1/session_blueprint.rb
 channels/application_cable/channel.rb
 channels/application_cable/connection.rb
-controllers/case_groups_controller.rb
 controllers/concerns/court_date_params.rb
 controllers/followup_reports_controller.rb
 controllers/learning_hour_topics_controller.rb

--- a/app/controllers/case_groups_controller.rb
+++ b/app/controllers/case_groups_controller.rb
@@ -52,6 +52,6 @@ class CaseGroupsController < ApplicationController
   end
 
   def set_case_group
-    @case_group = CaseGroup.find(params[:id])
+    @case_group = policy_scope(CaseGroup).find(params[:id])
   end
 end

--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -12,6 +12,10 @@ class AllCasaAdmin < ApplicationRecord
   def supervisor?
     false
   end
+
+  def volunteer?
+    false
+  end
 end
 
 # == Schema Information

--- a/app/models/all_casa_admin.rb
+++ b/app/models/all_casa_admin.rb
@@ -4,6 +4,14 @@ class AllCasaAdmin < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, invite_for: 1.weeks
+
+  def casa_admin?
+    false
+  end
+
+  def supervisor?
+    false
+  end
 end
 
 # == Schema Information

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -57,8 +57,6 @@ class ApplicationPolicy
       user.casa_org == record
     when CasaAdmin, CasaCase, Volunteer, Supervisor, HearingType, ContactTypeGroup, ContactTopic
       user.casa_org == record.casa_org
-    when CaseGroup
-      user.casa_org == record.casa_org
     when CourtDate, CaseContact, CaseAssignment
       user.casa_org == record&.casa_case&.casa_org
     when LearningHour

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -48,7 +48,7 @@ class ApplicationPolicy
   end
 
   def is_admin?
-    user.casa_admin?
+    user&.casa_admin?
   end
 
   def same_org?
@@ -56,6 +56,8 @@ class ApplicationPolicy
     when CasaOrg
       user.casa_org == record
     when CasaAdmin, CasaCase, Volunteer, Supervisor, HearingType, ContactTypeGroup, ContactTopic
+      user.casa_org == record.casa_org
+    when CaseGroup
       user.casa_org == record.casa_org
     when CourtDate, CaseContact, CaseAssignment
       user.casa_org == record&.casa_case&.casa_org
@@ -76,16 +78,16 @@ class ApplicationPolicy
 
   def is_admin_same_org?
     # eventually everything should use this
-    user.casa_admin? && same_org?
+    user&.casa_admin? && same_org?
   end
 
   def is_supervisor?
-    user.supervisor?
+    user&.supervisor?
   end
 
   def is_supervisor_same_org?
     # eventually everything should use this
-    user.supervisor? && same_org?
+    is_supervisor? && same_org?
   end
 
   def is_volunteer? # deprecated in favor of is_volunteer_same_org?

--- a/app/policies/case_group_policy.rb
+++ b/app/policies/case_group_policy.rb
@@ -1,0 +1,44 @@
+class CaseGroupPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      case user
+      when CasaAdmin, Supervisor
+        scope.where(casa_org: @user.casa_org)
+      when Volunteer
+        # REMOVE IF NOT APPLICABLE (just an example, doesn't work for all cases)
+        # scope.assigned_to_user(@user)
+        scope.none
+      else
+        scope.none
+      end
+    end
+  end
+
+  def index?
+    is_admin? || is_supervisor?
+  end
+
+  def new?
+    admin_or_supervisor_same_org?
+  end
+
+  def show?
+    admin_or_supervisor_same_org?
+  end
+
+  def create?
+    admin_or_supervisor_same_org?
+  end
+
+  def edit?
+    admin_or_supervisor_same_org?
+  end
+
+  def update?
+    admin_or_supervisor_same_org?
+  end
+
+  def destroy?
+    admin_or_supervisor_same_org?
+  end
+end

--- a/app/policies/case_group_policy.rb
+++ b/app/policies/case_group_policy.rb
@@ -5,8 +5,6 @@ class CaseGroupPolicy < ApplicationPolicy
       when CasaAdmin, Supervisor
         scope.where(casa_org: @user.casa_org)
       when Volunteer
-        # REMOVE IF NOT APPLICABLE (just an example, doesn't work for all cases)
-        # scope.assigned_to_user(@user)
         scope.none
       else
         scope.none

--- a/app/policies/case_group_policy.rb
+++ b/app/policies/case_group_policy.rb
@@ -39,4 +39,8 @@ class CaseGroupPolicy < ApplicationPolicy
   def destroy?
     admin_or_supervisor_same_org?
   end
+
+  def same_org?
+    user&.casa_org.present? && user&.casa_org == record&.casa_org
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module Casa
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks mailers])
+    config.autoload_lib(ignore: %w[assets generators tasks mailers])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,38 @@
+# Allows rails generators (scaffold/controller) to use custom policy generator.
+# Arguments for rails generators will be passed to the policy generator.
+# Options will be shown in the help text for the rails generators,
+# including the option to skip the policy generator (--skip-policy).
+module PolicyGenerator
+  module ControllerGenerator
+    extend ActiveSupport::Concern
+
+    included do
+      hook_for :policy, in: nil, default: true, type: :boolean do |generator|
+        # use actions from controller invocation
+        invoke generator, [name.singularize, *actions]
+      end
+    end
+  end
+
+  module ScaffoldControllerGenerator
+    extend ActiveSupport::Concern
+
+    included do
+      hook_for :policy, in: nil, default: true, type: :boolean do |generator|
+        # prevent attribute arguments (name:string) being confused with actions
+        scaffold_actions = %w[index new create show edit update destroy]
+        invoke generator, [name.singularize, *scaffold_actions]
+      end
+    end
+  end
+end
+
+module ActiveModel
+  class Railtie < Rails::Railtie
+    generators do |app|
+      Rails::Generators.configure! app.config.generators
+      Rails::Generators::ControllerGenerator.include PolicyGenerator::ControllerGenerator
+      Rails::Generators::ScaffoldControllerGenerator.include PolicyGenerator::ScaffoldControllerGenerator
+    end
+  end
+end

--- a/lib/generators/rails/policy/USAGE
+++ b/lib/generators/rails/policy/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generates a pundit policy and corresponding spec.
+
+Example:
+    bin/rails generate policy CasaThing
+
+    This will create:
+        - app/policies/casa_thing_policy.rb
+        - spec/policies/casa_thing_policy_spec.rb

--- a/lib/generators/rails/policy/policy_generator.rb
+++ b/lib/generators/rails/policy/policy_generator.rb
@@ -1,0 +1,20 @@
+# NOTE: Rails namespace in order to be able to called from rails generators (see initializers/generators.rb)
+class Rails::PolicyGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path("templates", __dir__)
+
+  remove_class_option :skip_namespace
+  remove_class_option :skip_collision_check
+
+  argument :actions, type: :array, banner: "action action",
+    default: %w[index new show create edit update destroy]
+  class_option :headless, type: :boolean, default: false,
+    desc: "Policy for non-model routes (dashboard, collection, etc)"
+
+  def create_policy
+    template "policy.rb", File.join("app/policies", class_path, "#{file_name}_policy.rb")
+  end
+
+  def create_policy_spec
+    template "policy_spec.rb", File.join("spec/policies", class_path, "#{file_name}_policy_spec.rb")
+  end
+end

--- a/lib/generators/rails/policy/policy_generator.rb
+++ b/lib/generators/rails/policy/policy_generator.rb
@@ -5,8 +5,8 @@ class Rails::PolicyGenerator < Rails::Generators::NamedBase
   remove_class_option :skip_namespace
   remove_class_option :skip_collision_check
 
-  argument :actions, type: :array, banner: "action action",
-    default: %w[index new show create edit update destroy]
+  argument :actions, type: :array, banner: "action action", default: []
+
   class_option :headless, type: :boolean, default: false,
     desc: "Policy for non-model routes (dashboard, collection, etc)"
 

--- a/lib/generators/rails/policy/templates/policy.rb.tt
+++ b/lib/generators/rails/policy/templates/policy.rb.tt
@@ -1,0 +1,52 @@
+<%- module_namespacing do -%>
+class <%= class_name %>Policy < ApplicationPolicy
+<%- if options[:headless] -%>
+  # Headless policy (used when no corresponding ActiveRecord/Model):
+  # - use `authorize(:<%= singular_name %>, :action?)` in controller actions
+  # - see https://github.com/varvet/pundit#headless-policies
+  def initialize(user, _record)
+    @user = user
+  end
+<%- else -%>
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      case user
+      when CasaAdmin, Supervisor
+        scope.where(casa_org: @user.casa_org)
+      when Volunteer
+        # REMOVE IF NOT APPLICABLE (just an example, doesn't work for all cases)
+        # scope.assigned_to_user(@user)
+        scope.none
+      else
+        scope.none
+      end
+    end
+  end
+<%- end -%>
+<%- user_example = "is_admin? || is_supervisor?" -%>
+<%- record_example = "admin_or_supervisor_same_org?" -%>
+<%- if actions.empty? -%>
+
+  # No actions specified, Example usage:
+  # def index?
+  #   <%= user_example %>
+  # end
+  #
+  # def show?
+  #   <%= record_example %>
+  # end
+<%- end -%>
+<%- actions.each do |action| -%>
+
+  <%- if action == "index" -%>
+  def index?
+    <%= user_example %>
+  end
+  <%- else -%>
+  def <%= action %>?
+    <%= options[:headless] ? user_example :  record_example %>
+  end
+  <%- end -%>
+<%- end -%>
+end
+<% end -%>

--- a/lib/generators/rails/policy/templates/policy_spec.rb.tt
+++ b/lib/generators/rails/policy/templates/policy_spec.rb.tt
@@ -1,0 +1,136 @@
+require "<%= File.exist?("spec/rails_helper.rb") ? "rails_helper" : "spec_helper" %>"
+
+<%- headless_actions = options[:headless] ? actions : actions.select { |action| action.to_s.match?(/index/) } -%>
+<%- headless_methods = headless_actions.map { |action| ":#{action}?" }.join(", ") -%>
+<%- record_actions = actions - headless_actions -%>
+<%- record_methods = record_actions.map { |action| ":#{action}?" }.join(", ") -%>
+RSpec.describe <%= class_name %>Policy, type: :policy do
+  let(:casa_org) { create :casa_org }
+  let(:volunteer) { create :volunteer, casa_org: }
+  let(:supervisor) { create :supervisor, casa_org: }
+  let(:casa_admin) { create :casa_admin, casa_org: }
+  let(:all_casa_admin) { create :all_casa_admin }
+<%- unless options[:headless] -%>
+
+  # may need to modify factory/create other records to assign org
+  let(:<%= singular_name %>) { create :<%= singular_name %>, casa_org: }
+  # modify to assign to volunteer user or remove
+  let(:volunteer_<%= singular_name %>) { create :<%= singular_name %>, casa_org:, volunteer: }
+<%- end -%>
+
+  subject { described_class }
+
+<%- unless record_actions.empty? -%>
+  # split actions into different `permissions` block for different behavior
+  permissions <%= record_methods %> do
+    it "does not permit a nil user" do
+      expect(described_class).not_to permit(nil, <%= singular_name %>)
+    end
+
+    it "does not permit a volunteer" do
+      expect(described_class).not_to permit(volunteer, <%= singular_name %>)
+    end
+
+    it "permits a volunteer assigned to the <%= human_name.downcase %>" do
+      expect(described_class).to permit(volunteer, volunteer_<%= singular_name %>)
+    end
+
+    it "permits a supervisor" do
+      expect(described_class).to permit(supervisor, <%= singular_name %>)
+    end
+
+    it "does not permit a supervisor for a different casa org" do
+      other_org_supervisor = create :supervisor, casa_org: create(:casa_org)
+      expect(described_class).not_to permit(other_org_supervisor, <%= singular_name %>)
+    end
+
+    it "permits a casa admin" do
+      expect(described_class).to permit(casa_admin, <%= singular_name %>)
+    end
+
+    it "does not permit a casa admin for a different casa org" do
+      other_org_casa_admin = create :casa_admin, casa_org: create(:casa_org)
+      expect(described_class).not_to permit(other_org_casa_admin, <%= singular_name %>)
+    end
+
+    it "does not permit an all casa admin" do
+      expect(described_class).not_to permit(all_casa_admin, <%= singular_name %>)
+    end
+  end
+<%- end -%>
+<%- unless headless_actions.empty? -%>
+
+  # split actions into different `permissions` block for different behavior
+  permissions <%= headless_methods %> do
+    it "does not permit a nil user" do
+      expect(described_class).not_to permit(nil, :<%= singular_name %>)
+    end
+
+    it "does not permit a volunteer" do
+      expect(described_class).not_to permit(volunteer, :<%= singular_name %>)
+    end
+
+    it "permits a supervisor" do
+      expect(described_class).to permit(supervisor, :<%= singular_name %>)
+    end
+
+    it "permits a casa admin" do
+      expect(described_class).to permit(casa_admin, :<%= singular_name %>)
+    end
+
+    it "does not permit an all casa admin" do
+      expect(described_class).not_to permit(all_casa_admin, :<%= singular_name %>)
+    end
+  end
+<%- end -%>
+<%- unless options[:headless] -%>
+
+  describe ".scope" do
+    subject { described_class::Scope.new user, <%= class_name %>.all }
+
+    describe "#resolve" do
+      let!(:casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: }
+      let!(:other_casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: create(:casa_org) }
+
+      subject { super().resolve }
+
+      context "when user is a visitor" do
+        let(:user) { nil }
+
+        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+      end
+
+      context "when user is a volunteer" do
+        let(:user) { volunteer }
+        let!(:user_<%= singular_name %>) { volunteer_<%= singular_name %> }
+
+        it { is_expected.to include(user_<%= singular_name %>) }
+        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+      end
+
+      context "when user is a supervisor" do
+        let(:user) { supervisor }
+
+        it { is_expected.to include(casa_org_<%= singular_name %>) }
+        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+      end
+
+      context "when user is a casa_admin" do
+        let(:user) { casa_admin }
+
+        it { is_expected.to include(casa_org_<%= singular_name %>) }
+        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+      end
+
+      context "when user is an all_casa_admin" do
+        let(:user) { all_casa_admin }
+
+        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+      end
+    end
+  end
+<%- end -%>
+end

--- a/lib/generators/rails/policy/templates/policy_spec.rb.tt
+++ b/lib/generators/rails/policy/templates/policy_spec.rb.tt
@@ -2,8 +2,10 @@ require "<%= File.exist?("spec/rails_helper.rb") ? "rails_helper" : "spec_helper
 
 <%- headless_actions = options[:headless] ? actions : actions.select { |action| action.to_s.match?(/index/) } -%>
 <%- headless_methods = headless_actions.map { |action| ":#{action}?" }.join(", ") -%>
+<%- headless_methods = ":index?" if actions.empty? -%>
 <%- record_actions = actions - headless_actions -%>
 <%- record_methods = record_actions.map { |action| ":#{action}?" }.join(", ") -%>
+<%- record_methods = ":show?" if actions.empty? -%>
 RSpec.describe <%= class_name %>Policy, type: :policy do
   let(:casa_org) { create :casa_org }
   let(:volunteer) { create :volunteer, casa_org: }
@@ -12,17 +14,26 @@ RSpec.describe <%= class_name %>Policy, type: :policy do
   let(:all_casa_admin) { create :all_casa_admin }
 <%- unless options[:headless] -%>
 
-  # may need to modify factory/create other records to assign org
+  # may need to create other records/modify factory to assign org
   let(:<%= singular_name %>) { create :<%= singular_name %>, casa_org: }
-  # modify to assign to volunteer user or remove
+  # modify to assign to volunteer user or remove if not applicable
   let(:volunteer_<%= singular_name %>) { create :<%= singular_name %>, casa_org:, volunteer: }
 <%- end -%>
 
   subject { described_class }
 
-<%- unless record_actions.empty? -%>
-  # split actions into different `permissions` block for different behavior
+  # NOTE: `permissions :action_one?, :action_two?, :action_three? do` for same behavior per method
+<%- unless options[:headless] -%>
+  # - may need to move collection methods to the other permissions block, this generator only checks for 'index',
+<%- end -%>
+
+<%- if actions.empty? -%>
+  # TODO: No actions were specified, replace show/index examples with actual policy methods & remove unused
+
+<%- end -%>
+<%- unless record_methods.empty? -%>
   permissions <%= record_methods %> do
+    # Usage for action(s) on a single record (check user and record info to authorize)
     it "does not permit a nil user" do
       expect(described_class).not_to permit(nil, <%= singular_name %>)
     end
@@ -58,10 +69,10 @@ RSpec.describe <%= class_name %>Policy, type: :policy do
     end
   end
 <%- end -%>
-<%- unless headless_actions.empty? -%>
+<%- unless headless_methods.empty? -%>
 
-  # split actions into different `permissions` block for different behavior
   permissions <%= headless_methods %> do
+    # Usage for action(s) on a collection of records (no single record to authorize, check user only)
     it "does not permit a nil user" do
       expect(described_class).not_to permit(nil, :<%= singular_name %>)
     end

--- a/lib/generators/rails/policy/templates/policy_spec.rb.tt
+++ b/lib/generators/rails/policy/templates/policy_spec.rb.tt
@@ -85,51 +85,47 @@ RSpec.describe <%= class_name %>Policy, type: :policy do
 <%- end -%>
 <%- unless options[:headless] -%>
 
-  describe ".scope" do
-    subject { described_class::Scope.new user, <%= class_name %>.all }
+  describe "Scope#resolve" do
+    let!(:casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: }
+    let!(:other_casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: create(:casa_org) }
 
-    describe "#resolve" do
-      let!(:casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: }
-      let!(:other_casa_org_<%= singular_name %>) { create :<%= singular_name %>, casa_org: create(:casa_org) }
+    subject { described_class::Scope.new(user, <%= class_name %>.all).resolve }
 
-      subject { super().resolve }
+    context "when user is a visitor" do
+      let(:user) { nil }
 
-      context "when user is a visitor" do
-        let(:user) { nil }
+      it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+      it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+    end
 
-        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
-        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
-      end
+    context "when user is a volunteer" do
+      let(:user) { volunteer }
+      let!(:user_<%= singular_name %>) { volunteer_<%= singular_name %> }
 
-      context "when user is a volunteer" do
-        let(:user) { volunteer }
-        let!(:user_<%= singular_name %>) { volunteer_<%= singular_name %> }
+      it { is_expected.to include(user_<%= singular_name %>) }
+      it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+      it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+    end
 
-        it { is_expected.to include(user_<%= singular_name %>) }
-        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
-        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
-      end
+    context "when user is a supervisor" do
+      let(:user) { supervisor }
 
-      context "when user is a supervisor" do
-        let(:user) { supervisor }
+      it { is_expected.to include(casa_org_<%= singular_name %>) }
+      it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+    end
 
-        it { is_expected.to include(casa_org_<%= singular_name %>) }
-        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
-      end
+    context "when user is a casa_admin" do
+      let(:user) { casa_admin }
 
-      context "when user is a casa_admin" do
-        let(:user) { casa_admin }
+      it { is_expected.to include(casa_org_<%= singular_name %>) }
+      it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
+    end
 
-        it { is_expected.to include(casa_org_<%= singular_name %>) }
-        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
-      end
+    context "when user is an all_casa_admin" do
+      let(:user) { all_casa_admin }
 
-      context "when user is an all_casa_admin" do
-        let(:user) { all_casa_admin }
-
-        it { is_expected.not_to include(casa_org_<%= singular_name %>) }
-        it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
-      end
+      it { is_expected.not_to include(casa_org_<%= singular_name %>) }
+      it { is_expected.not_to include(other_casa_org_<%= singular_name %>) }
     end
   end
 <%- end -%>

--- a/spec/factories/case_groups.rb
+++ b/spec/factories/case_groups.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       casa_cases = if evaluator.casa_cases.present?
         evaluator.casa_cases
       elsif case_group.case_group_memberships.empty?
-        build_list(:casa_case, evaluator.case_count)
+        build_list(:casa_case, evaluator.case_count, casa_org: case_group.casa_org)
       else
         []
       end

--- a/spec/factories/case_groups.rb
+++ b/spec/factories/case_groups.rb
@@ -2,12 +2,17 @@ FactoryBot.define do
   factory :case_group do
     transient do
       case_count { 1 }
+      casa_cases { [] }
     end
     casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:name) { |n| "Family #{n}" }
 
     after(:build) do |case_group, evaluator|
-      if case_group.case_group_memberships.empty?
+      if evaluator.casa_cases.size > 0
+        evaluator.casa_cases.each do |casa_case|
+          case_group.case_group_memberships.build(casa_case: casa_case)
+        end
+      elsif case_group.case_group_memberships.empty?
         evaluator.case_count.times do
           case_group.case_group_memberships.build(casa_case: create(:casa_case))
         end

--- a/spec/factories/case_groups.rb
+++ b/spec/factories/case_groups.rb
@@ -2,20 +2,21 @@ FactoryBot.define do
   factory :case_group do
     transient do
       case_count { 1 }
-      casa_cases { [] }
+      casa_cases { nil }
     end
     casa_org { CasaOrg.first || create(:casa_org) }
     sequence(:name) { |n| "Family #{n}" }
 
     after(:build) do |case_group, evaluator|
-      if evaluator.casa_cases.size > 0
-        evaluator.casa_cases.each do |casa_case|
-          case_group.case_group_memberships.build(casa_case: casa_case)
-        end
+      casa_cases = if evaluator.casa_cases.present?
+        evaluator.casa_cases
       elsif case_group.case_group_memberships.empty?
-        evaluator.case_count.times do
-          case_group.case_group_memberships.build(casa_case: create(:casa_case))
-        end
+        build_list(:casa_case, evaluator.case_count)
+      else
+        []
+      end
+      casa_cases.each do |casa_case|
+        case_group.case_group_memberships.build(casa_case: casa_case)
       end
     end
   end

--- a/spec/policies/case_group_policy_spec.rb
+++ b/spec/policies/case_group_policy_spec.rb
@@ -70,51 +70,47 @@ RSpec.describe CaseGroupPolicy, type: :policy do
     end
   end
 
-  describe ".scope" do
-    subject { described_class::Scope.new user, CaseGroup.all }
+  describe "Scope#resolve" do
+    let!(:casa_org_case_group) { create :case_group, casa_org: }
+    let!(:other_casa_org_case_group) { create :case_group, casa_org: create(:casa_org) }
 
-    describe "#resolve" do
-      let!(:casa_org_case_group) { create :case_group, casa_org: }
-      let!(:other_casa_org_case_group) { create :case_group, casa_org: create(:casa_org) }
+    subject { described_class::Scope.new(user, CaseGroup.all).resolve }
 
-      subject { super().resolve }
+    context "when user is a visitor" do
+      let(:user) { nil }
 
-      context "when user is a visitor" do
-        let(:user) { nil }
+      it { is_expected.not_to include(casa_org_case_group) }
+      it { is_expected.not_to include(other_casa_org_case_group) }
+    end
 
-        it { is_expected.not_to include(casa_org_case_group) }
-        it { is_expected.not_to include(other_casa_org_case_group) }
-      end
+    context "when user is a volunteer" do
+      let(:user) { volunteer }
+      let!(:user_case_group) { volunteer_case_group }
 
-      context "when user is a volunteer" do
-        let(:user) { volunteer }
-        let!(:user_case_group) { volunteer_case_group }
+      it { is_expected.not_to include(user_case_group) }
+      it { is_expected.not_to include(casa_org_case_group) }
+      it { is_expected.not_to include(other_casa_org_case_group) }
+    end
 
-        it { is_expected.not_to include(user_case_group) }
-        it { is_expected.not_to include(casa_org_case_group) }
-        it { is_expected.not_to include(other_casa_org_case_group) }
-      end
+    context "when user is a supervisor" do
+      let(:user) { supervisor }
 
-      context "when user is a supervisor" do
-        let(:user) { supervisor }
+      it { is_expected.to include(casa_org_case_group) }
+      it { is_expected.not_to include(other_casa_org_case_group) }
+    end
 
-        it { is_expected.to include(casa_org_case_group) }
-        it { is_expected.not_to include(other_casa_org_case_group) }
-      end
+    context "when user is a casa_admin" do
+      let(:user) { casa_admin }
 
-      context "when user is a casa_admin" do
-        let(:user) { casa_admin }
+      it { is_expected.to include(casa_org_case_group) }
+      it { is_expected.not_to include(other_casa_org_case_group) }
+    end
 
-        it { is_expected.to include(casa_org_case_group) }
-        it { is_expected.not_to include(other_casa_org_case_group) }
-      end
+    context "when user is an all_casa_admin" do
+      let(:user) { all_casa_admin }
 
-      context "when user is an all_casa_admin" do
-        let(:user) { all_casa_admin }
-
-        it { is_expected.not_to include(casa_org_case_group) }
-        it { is_expected.not_to include(other_casa_org_case_group) }
-      end
+      it { is_expected.not_to include(casa_org_case_group) }
+      it { is_expected.not_to include(other_casa_org_case_group) }
     end
   end
 end

--- a/spec/policies/case_group_policy_spec.rb
+++ b/spec/policies/case_group_policy_spec.rb
@@ -2,19 +2,16 @@ require "rails_helper"
 
 RSpec.describe CaseGroupPolicy, type: :policy do
   let(:casa_org) { create :casa_org }
-  let(:volunteer) { create :volunteer, casa_org: }
+  let(:volunteer) { create :volunteer, :with_casa_cases, casa_org: }
   let(:supervisor) { create :supervisor, casa_org: }
   let(:casa_admin) { create :casa_admin, casa_org: }
   let(:all_casa_admin) { create :all_casa_admin }
 
-  # may need to modify factory/create other records to assign org
   let(:case_group) { create :case_group, casa_org: }
-  # modify to assign to volunteer user or remove
-  let(:volunteer_case_group) { create :case_group, casa_org:, volunteer: }
+  let(:volunteer_case_group) { create :case_group, casa_org:, casa_cases: volunteer.casa_cases }
 
   subject { described_class }
 
-  # split actions into different `permissions` block for different behavior
   permissions :new?, :show?, :create?, :edit?, :update?, :destroy? do
     it "does not permit a nil user" do
       expect(described_class).not_to permit(nil, case_group)
@@ -24,8 +21,8 @@ RSpec.describe CaseGroupPolicy, type: :policy do
       expect(described_class).not_to permit(volunteer, case_group)
     end
 
-    it "permits a volunteer assigned to the case group" do
-      expect(described_class).to permit(volunteer, volunteer_case_group)
+    it "does not permit a volunteer assigned to the case group" do
+      expect(described_class).not_to permit(volunteer, volunteer_case_group)
     end
 
     it "permits a supervisor" do
@@ -51,7 +48,6 @@ RSpec.describe CaseGroupPolicy, type: :policy do
     end
   end
 
-  # split actions into different `permissions` block for different behavior
   permissions :index? do
     it "does not permit a nil user" do
       expect(described_class).not_to permit(nil, :case_group)
@@ -94,7 +90,7 @@ RSpec.describe CaseGroupPolicy, type: :policy do
         let(:user) { volunteer }
         let!(:user_case_group) { volunteer_case_group }
 
-        it { is_expected.to include(user_case_group) }
+        it { is_expected.not_to include(user_case_group) }
         it { is_expected.not_to include(casa_org_case_group) }
         it { is_expected.not_to include(other_casa_org_case_group) }
       end

--- a/spec/policies/case_group_policy_spec.rb
+++ b/spec/policies/case_group_policy_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe CaseGroupPolicy, type: :policy do
+  let(:casa_org) { create :casa_org }
+  let(:volunteer) { create :volunteer, casa_org: }
+  let(:supervisor) { create :supervisor, casa_org: }
+  let(:casa_admin) { create :casa_admin, casa_org: }
+  let(:all_casa_admin) { create :all_casa_admin }
+
+  # may need to modify factory/create other records to assign org
+  let(:case_group) { create :case_group, casa_org: }
+  # modify to assign to volunteer user or remove
+  let(:volunteer_case_group) { create :case_group, casa_org:, volunteer: }
+
+  subject { described_class }
+
+  # split actions into different `permissions` block for different behavior
+  permissions :new?, :show?, :create?, :edit?, :update?, :destroy? do
+    it "does not permit a nil user" do
+      expect(described_class).not_to permit(nil, case_group)
+    end
+
+    it "does not permit a volunteer" do
+      expect(described_class).not_to permit(volunteer, case_group)
+    end
+
+    it "permits a volunteer assigned to the case group" do
+      expect(described_class).to permit(volunteer, volunteer_case_group)
+    end
+
+    it "permits a supervisor" do
+      expect(described_class).to permit(supervisor, case_group)
+    end
+
+    it "does not permit a supervisor for a different casa org" do
+      other_org_supervisor = create :supervisor, casa_org: create(:casa_org)
+      expect(described_class).not_to permit(other_org_supervisor, case_group)
+    end
+
+    it "permits a casa admin" do
+      expect(described_class).to permit(casa_admin, case_group)
+    end
+
+    it "does not permit a casa admin for a different casa org" do
+      other_org_casa_admin = create :casa_admin, casa_org: create(:casa_org)
+      expect(described_class).not_to permit(other_org_casa_admin, case_group)
+    end
+
+    it "does not permit an all casa admin" do
+      expect(described_class).not_to permit(all_casa_admin, case_group)
+    end
+  end
+
+  # split actions into different `permissions` block for different behavior
+  permissions :index? do
+    it "does not permit a nil user" do
+      expect(described_class).not_to permit(nil, :case_group)
+    end
+
+    it "does not permit a volunteer" do
+      expect(described_class).not_to permit(volunteer, :case_group)
+    end
+
+    it "permits a supervisor" do
+      expect(described_class).to permit(supervisor, :case_group)
+    end
+
+    it "permits a casa admin" do
+      expect(described_class).to permit(casa_admin, :case_group)
+    end
+
+    it "does not permit an all casa admin" do
+      expect(described_class).not_to permit(all_casa_admin, :case_group)
+    end
+  end
+
+  describe ".scope" do
+    subject { described_class::Scope.new user, CaseGroup.all }
+
+    describe "#resolve" do
+      let!(:casa_org_case_group) { create :case_group, casa_org: }
+      let!(:other_casa_org_case_group) { create :case_group, casa_org: create(:casa_org) }
+
+      subject { super().resolve }
+
+      context "when user is a visitor" do
+        let(:user) { nil }
+
+        it { is_expected.not_to include(casa_org_case_group) }
+        it { is_expected.not_to include(other_casa_org_case_group) }
+      end
+
+      context "when user is a volunteer" do
+        let(:user) { volunteer }
+        let!(:user_case_group) { volunteer_case_group }
+
+        it { is_expected.to include(user_case_group) }
+        it { is_expected.not_to include(casa_org_case_group) }
+        it { is_expected.not_to include(other_casa_org_case_group) }
+      end
+
+      context "when user is a supervisor" do
+        let(:user) { supervisor }
+
+        it { is_expected.to include(casa_org_case_group) }
+        it { is_expected.not_to include(other_casa_org_case_group) }
+      end
+
+      context "when user is a casa_admin" do
+        let(:user) { casa_admin }
+
+        it { is_expected.to include(casa_org_case_group) }
+        it { is_expected.not_to include(other_casa_org_case_group) }
+      end
+
+      context "when user is an all_casa_admin" do
+        let(:user) { all_casa_admin }
+
+        it { is_expected.not_to include(casa_org_case_group) }
+        it { is_expected.not_to include(other_casa_org_case_group) }
+      end
+    end
+  end
+end

--- a/spec/requests/case_groups_spec.rb
+++ b/spec/requests/case_groups_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "/case_groups", type: :request do
       it "renders new template" do
         subject
         expect(response).to have_http_status(:unprocessable_entity)
-        expect(response).to render_template(:new)
+        expect(response).to render_template(:edit)
       end
     end
   end

--- a/spec/requests/case_groups_spec.rb
+++ b/spec/requests/case_groups_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe "/case_groups", type: :request do
+  let(:casa_org) { create :casa_org }
+  let(:supervisor) { create :supervisor, casa_org: }
+  let(:user) { supervisor }
+
+  let(:casa_cases) { create_list :casa_case, 2, casa_org: }
+  let(:case_group) { create :case_group, casa_org:, casa_cases: }
+  let(:valid_attributes) { attributes_for :case_group, casa_org:, casa_case_ids: casa_cases.map(&:id) }
+  let(:invalid_attributes) do
+    valid_attributes.merge(name: nil, casa_case_ids: [])
+  end
+
+  before { sign_in user }
+
+  describe "GET /index" do
+    let!(:case_groups) { create_list :case_group, 2, casa_org: }
+
+    subject { get case_groups_path }
+
+    it "renders a successful response" do
+      subject
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:index)
+    end
+
+    it "displays information of the records" do
+      subject
+      expect(response.body).to include(*case_groups.map(&:name))
+    end
+  end
+
+  describe "GET /new" do
+    subject { get new_case_group_path }
+
+    it "renders a successful response" do
+      subject
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "POST /create" do
+    let(:params) { {case_group: valid_attributes} }
+
+    subject { post case_groups_path, params: }
+
+    it "creates new record" do
+      expect { subject }.to change(CaseGroup, :count).by(1)
+    end
+
+    it "redirects to the case group index" do
+      subject
+      expect(response).to redirect_to(case_groups_path)
+    end
+
+    context "with invalid params" do
+      let(:params) { {case_group: invalid_attributes} }
+
+      it "does not create a new record" do
+        expect { subject }.to change(CaseGroup, :count).by(0)
+      end
+
+      it "renders new template" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "GET edit" do
+    let(:case_group) { create :case_group, casa_org: }
+
+    subject { get edit_case_group_path(case_group) }
+
+    it "renders a successful response" do
+      subject
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe "PATCH /update" do
+    let(:params) { {case_group: valid_attributes} }
+
+    subject { patch case_group_path(case_group), params: }
+
+    it "updates the requested record" do
+      expect(case_group.name).not_to eq(valid_attributes[:name])
+      subject
+      case_group.reload
+      expect(case_group.name).to eq(valid_attributes[:name])
+    end
+
+    it "redirects to the updated record" do
+      subject
+      expect(response).to redirect_to(case_groups_path)
+    end
+
+    context "with invalid params" do
+      let(:params) { {case_group: invalid_attributes} }
+
+      it "renders new template" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    let!(:case_group) { create :case_group, casa_org: }
+
+    subject { delete case_group_path(case_group) }
+
+    it "destroys the requested record" do
+      expect { subject }.to change(CaseGroup, :count).by(-1)
+    end
+
+    it "redirects to the case_groups index" do
+      subject
+      expect(response).to redirect_to(case_groups_path)
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #5563

### What changed, and _why_?
- Created request specs for CaseGroups controller (they were allowed-skipped)
- CaseGroupController did not have a policy to use (but everything was built from current_organization)
- Wanted to add a policy generator since the `pundit:policy` generator is so minimal
- Created a CaseGroup policy (and spec), and refined generator based on that
- Incorporate a policy into the controller, as used in other routes
- Created hooks for rails controller and scaffold generators to ensure a policy is generated along with them

### How is this **tested**? (please write tests!) 💖💪
The request spec was created with the controller as-is, and made to pass.

Then the policy changes were made in the controller without changing specs -- with one exception: The update action redirected to new rather than traditional edit redirect. I made that change.

NOTES:
- [This commit](https://github.com/rubyforgood/casa/pull/5999/commits/43cff782e6559bbbc4f02d1fde03d3224fb5b6c6) contains the changes from generated policy to make policy spec pass.
- I also made some custom scaffold and controller request spec templates, but that may be too much to include here, I will open a separate PR for those.

### Screenshots please :)
Policy generator help:
<img width="793" alt="Screenshot 2024-08-19 at 11 24 30 PM" src="https://github.com/user-attachments/assets/0d45c39c-2c21-4bb8-b32b-b139b193bbbe">

### Feelings gif (optional)
![alt text](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGI1cWw3NWh3bmZ0ZjZ4MWU1dWozMDh2cnYxZjB6aDl4N3FuamZraSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GHdE1VNN1KknPeZqoQ/giphy.gif)
