### PR TITLE
fix: avoid leaking user emails

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -15,7 +15,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
     send_password
     redirect_to after_sending_reset_password_instructions_path_for(resource_name),
-                notice: 'If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.'
+      notice: "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
   end
 
   private
@@ -70,7 +70,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   def empty_fields_error
     @resource ||= resource
-    @resource.errors.add(:base, 'Please enter at least one field.')
+    @resource.errors.add(:base, "Please enter at least one field.")
 
     false
   end
@@ -90,7 +90,7 @@ class Users::PasswordsController < Devise::PasswordsController
   end
 
   def no_user_found_error
-    resource.errors.add(:base, 'User does not exist.')
+    resource.errors.add(:base, "User does not exist.")
 
     false
   end

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Users::PasswordsController", type: :request do
       it "shows the correct flash message" do
         request
         expect(flash[:notice]).to(
-          eq("You will receive an email or SMS with instructions on how to reset your password in a few minutes.")
+          eq("If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.")
         )
       end
 
@@ -101,7 +101,9 @@ RSpec.describe "Users::PasswordsController", type: :request do
 
       it "sets errors correctly" do
         request
-        expect(request.parsed_body.to_html).to include("User does not exist.")
+        expect(flash[:notice]).to(
+          eq("If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.")
+        )
       end
     end
 
@@ -116,7 +118,7 @@ RSpec.describe "Users::PasswordsController", type: :request do
         expect_any_instance_of(User).to receive(:send_reset_password_instructions).once
         request
         expect(flash[:notice]).to(
-          eq("You will receive an email or SMS with instructions on how to reset your password in a few minutes.")
+          eq("If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.")
         )
       end
     end

--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe "users/passwords/new", type: :system do
       fill_in "Phone number", with: user.phone_number
 
       click_on "Send me reset password instructions"
-      expect(page).to have_content "1 error prohibited this User from being saved:"
-      expect(page).to have_text("User does not exist.")
+      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
     end
 
     it "displays phone number error messages for incorrect formatting" do
@@ -35,7 +34,7 @@ RSpec.describe "users/passwords/new", type: :system do
       fill_in "Email", with: user.email
 
       click_on "Send me reset password instructions"
-      expect(page).to have_content "You will receive an email or SMS with instructions on how to reset your password in a few minutes."
+      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
     end
   end
 


### PR DESCRIPTION
Currently the password reset page informs on submission if an account exists or not. We should avoid doing this so we are not leaking info.
