### PR TITLE
Add initial test for org scoping

### DIFF
--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe SupervisorMailer, type: :mailer do
           expect(mail.body.encoded).not_to match("volunteers have not signed in or created case contacts in the last 30 days")
         end
       end
+
+      context "volunteer from different org do not show" do
+        it "display no_recent_sign_in section" do
+          expect(mail.body.encoded).to match("volunteers have not signed in or created case contacts in the last 30 days")
+          expect(mail.body.encoded).to match(volunteer.display_name)
+          expect(mail.body.encoded).not_to match(volunteer_for_other_org.display_name)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Added an initial test for organizational scoping
in the supervisor weekly email

### What github issue is this PR for, if any?
Resolves #5640

### What changed, and _why_?
[This was a fix](https://github.com/rubyforgood/casa/pull/5632/files) to remove unknown names from the weekly supervisor email

### How is this **tested**? (please write tests!) 💖💪
Running `bundle exec rspec spec/mailers/supervisor_mailer_spec.rb`
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
N/A

### Feelings gif (optional)
![alt text](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExczV2MW5kaTBoM3M0dmh3aXBiZ3JjZ2YwZGZodjNtODNsMjl1NTUxbiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/jPAdK8Nfzzwt2/giphy.gif)
