### PR TITLE
feat: quiet sass deprecation warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Keep this locked to 1.77.6 until
+      # bootstrap 5.3.4 is out to silence
+      # sass deprecation warnings
+      - dependency-name: "sass"
+        versions: ["1.77.*", "1.78.*"]
 
   - package-ecosystem: "bundler"
     directory: "/"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",
     "popper.js": "^1.16.1",
-    "sass": "^1.77.8",
+    "sass": "1.77.6",
     "select2": "^4.0.13",
     "select2-bootstrap-5-theme": "^1.3.0",
     "stimulus-rails-nested-form": "^4.1.0",

--- a/spec/requests/all_casa_admins/casa_orgs_spec.rb
+++ b/spec/requests/all_casa_admins/casa_orgs_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe "AllCasaAdmin::CasaOrgs", type: :request do
         expect { post_create }.to change(ContactTopic, :count).by(2)
 
         casa_org = CasaOrg.last
-        expect(casa_org.contact_topics.map(&:question)).to eq contact_topics.map { |t| t["question"] }
-        expect(casa_org.contact_topics.map(&:details)).to eq contact_topics.map { |t| t["details"] }
+        expect(casa_org.contact_topics.map(&:question)).to match_array(contact_topics.map { |t| t["question"] })
+        expect(casa_org.contact_topics.map(&:details)).to match_array(contact_topics.map { |t| t["details"] })
         expect(casa_org.contact_topics.pluck(:active)).to be_all true
       end
 

--- a/spec/views/notifications/index.html.erb_spec.rb
+++ b/spec/views/notifications/index.html.erb_spec.rb
@@ -43,10 +43,12 @@ RSpec.describe "notifications/index", type: :view do
         notifications_html = Nokogiri::HTML5(rendered).css(".list-group-item")
         patch_note_index = notifications_html.index { |node| node.text.include?("Patch Notes") }
 
-        expect(notifications_html[0].text).to match(/User \d+ has flagged a Case Contact that needs follow up/)
-        expect(notifications_html[1].text).to match(/Your case CINA-\d+ is a transition aged youth/)
-        expect(notifications_html[2].text).to match(/Your youth, case number: CINA-\d+ has a birthday next month/)
-        expect(patch_note_index).to eq(3)
+        aggregate_failures do
+          expect(notifications_html[0].text).to match(/User \d+ has flagged a Case Contact that needs follow up/)
+          expect(notifications_html[1].text).to match(/Your case CINA-\d+ is a transition aged youth/)
+          expect(notifications_html[2].text).to match(/Your youth, case number: CINA-\d+ has a birthday next month/)
+          expect(patch_note_index).to eq(3)
+        end
       end
 
       it "has all notifications created before the deploy date below the patch note" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -5136,10 +5136,10 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.77.8:
-  version "1.77.8"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.77.8.tgz#9f18b449ea401759ef7ec1752a16373e296b52bd"
-  integrity sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==
+sass@1.77.6:
+  version "1.77.6"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.77.6.tgz#898845c1348078c2e6d1b64f9ee06b3f8bd489e4"
+  integrity sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
We have a lot of these in the app atm:

```plaintext
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ┌──> node_modules/bootstrap/scss/_type.scss
40  │       font-weight: $display-font-weight;
    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    ┌──> node_modules/bootstrap/scss/vendor/_rfs.scss
136 │ ┌     @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}) {
137 │ │       @content;
138 │ │     }
    │ └─── nested rule
    ╵
    node_modules/bootstrap/scss/_type.scss 40:5  @import
    bootstrap/scss/bootstrap.scss 17:9           @use
    app/assets/stylesheets/application.scss 3:1  root stylesheet

```
This is because sass added those in 1.77.7 but bootstrap is not up to date to that yet.

Thus, we will pin sass to 1.77.6 until bootstrap 5.3.4 is out to silence sass deprecation warnings.

See this issue on bootstrap for details: https://github.com/twbs/bootstrap/issues/40621
