### PR TITLE
Added table name and styling to volunteers without supervisors table

### DIFF
--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -122,7 +122,7 @@
 <div class="tables-wrapper">
   <div class="row">
     <div class="col-lg-12">
-      <div class="card-style">
+      <div class="card-style mb-30">
         <div class="title mb-30">
           <h2>Volunteers without Supervisors</h2>
         </div>

--- a/app/views/supervisors/index.html.erb
+++ b/app/views/supervisors/index.html.erb
@@ -122,14 +122,17 @@
 <div class="tables-wrapper">
   <div class="row">
     <div class="col-lg-12">
-      <div class="card-style mb-30">
+      <div class="card-style">
+        <div class="title mb-30">
+          <h2>Volunteers without Supervisors</h2>
+        </div>
         <% if @available_volunteers.any? %>
           <div class="table-wrapper table-responsive">
             <table id="active_volunteers" class="table">
               <thead>
               <tr>
-                <th><h6>Active volunteers not assigned to supervisors</h6></th>
-                <th><h6>Assigned to Case(s)</h6></th>
+                <th>Active volunteers not assigned to supervisors</th>
+                <th>Assigned to Case(s)</th>
               </tr>
               <!-- end table row-->
               </thead>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6025 

### What changed, and _why_?
Added a table name to the table that shows active volunteers without supervisors. The title is `Volunteers without Supervisors`. Changed the styling of this table to match the other tables in the supervisors page.

### Screenshots please :)
![Screenshot from 2024-09-09 20-57-26](https://github.com/user-attachments/assets/9fc6f9a8-b95e-44bf-bf5d-589af49375b6)
