### PR TITLE
fix: relax case contact date validation

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -16,7 +16,7 @@ class CaseContact < ApplicationRecord
     allow_nil: true
   }
   validates :occurred_at, comparison: {
-    less_than: Date.tomorrow,
+    less_than: 2.day.from_now,
     message: :cant_be_future,
     allow_nil: true
   }


### PR DESCRIPTION
Temporary fix to allow users to make same day case contacts despite time-zone issues.