### PR TITLE
Add extra day to case contact date validation

### DIFF
--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -15,8 +15,9 @@ class CaseContact < ApplicationRecord
     message: "can't be prior to #{I18n.l(MINIMUM_DATE)}.",
     allow_nil: true
   }
+  # NOTE: 'extra' day is a temporary fix for user selecting current date, but this validation failing
   validates :occurred_at, comparison: {
-    less_than: Date.tomorrow,
+    less_than: Time.zone.tomorrow + 1.day,
     message: :cant_be_future,
     allow_nil: true
   }


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #5860 

### What changed, and _why_?
Addresses (temporarily?) issue where validation failed when user selected current day in browser. 

Date could now be wrong (tomorrow) for those situations, however. Also changes Date.tomorrow to Time.zone.tomorrow to possibly to mitigate that.

### How is this **tested**? (please write tests!) 💖💪
Current tests only.  Cannot find a decent solution for setting capybara browser driver timezones to tests the difference between browser and server. Possibly could add request spec sending date as browser would send... but unsure how to account for TimeZone differences there?