### PR TITLE
Flaky specs: Use travel_back when travel_to is used

### DIFF
--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe NotificationsHelper do
       notification_created_before_deploy_a.update_attribute(:created_at, 2.days.ago - 1.hour)
       notification_created_before_deploy_b.update_attribute(:created_at, 3.days.ago)
     end
+    after { travel_back }
 
     describe "#notifications_after_and_including_deploy" do
       let(:notifications_after_and_including_deploy) { helper.notifications_after_and_including_deploy(Noticed::Notification.all) }

--- a/spec/lib/tasks/supervisor_weekly_digest_spec.rb
+++ b/spec/lib/tasks/supervisor_weekly_digest_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SupervisorWeeklyDigest do
           create(:supervisor, active: true)
           create(:supervisor, active: false)
         end
+        after { travel_back }
 
         it "only sends to active supervisor" do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
@@ -25,6 +26,8 @@ RSpec.describe SupervisorWeeklyDigest do
         travel_to Time.zone.local(2021, 9, 29, 12, 0, 0) # not monday
         create(:supervisor, active: true)
       end
+
+      after { travel_back }
 
       it "does not send email" do
         expect { subject }.not_to change { ActionMailer::Base.deliveries.count }

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Banner, type: :model do
       expect(expires_at_in_eastern_time.to_s).to eq("2024-06-13 08:00:00 -0400")
 
       expect(expires_at_in_pacific_time).to eq(expires_at_in_eastern_time)
+      travel_back
     end
   end
 end

--- a/spec/models/casa_admin_spec.rb
+++ b/spec/models/casa_admin_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe CasaAdmin, type: :model do
 
       user = User.accept_invitation!(invitation_token: casa_admin.invitation_token)
       expect(user.errors.full_messages).to include("Invitation token is invalid")
+      travel_back
     end
   end
 

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -308,6 +308,7 @@ RSpec.describe CasaCase, type: :model do
       before do
         travel_to the_future
       end
+      after { travel_back }
 
       context "when the status is completed" do
         let(:court_report_status) { :completed }
@@ -367,6 +368,8 @@ RSpec.describe CasaCase, type: :model do
     before do
       travel_to Date.new(2021, 1, 1)
     end
+
+    after { travel_back }
 
     context "with a past court date" do
       it "returns the latest past court date as a formatted string" do

--- a/spec/models/case_court_report_context_spec.rb
+++ b/spec/models/case_court_report_context_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CaseCourtReportContext, type: :model do
   before do
     travel_to Date.new(2021, 1, 1)
   end
+  after { travel_back }
 
   describe "#context" do
     it "has the right shape" do

--- a/spec/models/court_date_spec.rb
+++ b/spec/models/court_date_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CourtDate, type: :model do
   before do
     travel_to Date.new(2021, 1, 1)
   end
+  after { travel_back }
 
   describe "date validation" do
     it "is not valid before 1989" do
@@ -148,6 +149,7 @@ RSpec.describe CourtDate, type: :model do
     it "contains case number and date" do
       travel_to Time.zone.local(2020, 1, 2)
       expect(subject).to eq("AAA123123 - Court Date - 2019-12-26")
+      travel_back
     end
   end
 end

--- a/spec/models/supervisor_spec.rb
+++ b/spec/models/supervisor_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Supervisor, type: :model do
 
       user = User.accept_invitation!(invitation_token: supervisor.invitation_token)
       expect(user.errors.full_messages).to include("Invitation token is invalid")
+      travel_back
     end
   end
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -392,6 +392,7 @@ RSpec.describe Volunteer, type: :model do
 
       user = User.accept_invitation!(invitation_token: volunteer.invitation_token)
       expect(user.errors.full_messages).to include("Invitation token is invalid")
+      travel_back
     end
   end
 

--- a/spec/requests/banners_spec.rb
+++ b/spec/requests/banners_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "Banners", type: :request do
 
     context "when client timezone is ahead of UTC" do
       before { travel_to Time.new(2024, 6, 1, 11, 0, 0, "+03:00") } # 08:00 UTC
+      after { travel_back }
 
       context "when submitted time is behind client but ahead of UTC" do
         let(:expires_at) { Time.new(2024, 6, 1, 9, 0, 0, "UTC") } # 12:00 +03:00
@@ -112,6 +113,7 @@ RSpec.describe "Banners", type: :request do
 
     context "when client timezone is behind UTC" do
       before { travel_to Time.new(2024, 6, 1, 11, 0, 0, "-04:00") } # 15:00 UTC
+      after { travel_back }
 
       context "when submitted time is ahead of client and ahead of UTC" do
         let(:expires_at) { Time.new(2024, 6, 1, 16, 0, 0, "UTC") } # 12:00 -04:00

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -176,6 +176,7 @@ RSpec.describe "/case_court_reports", type: :request do
       before do
         travel_to server_time
       end
+      after { travel_back }
 
       it "is different than server" do
         get request.parsed_body["link"]

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
     travel_to Date.new(2021, 1, 1)
     sign_in admin
   end
+  after { travel_back }
+
 
   describe "GET /show" do
     subject(:show) { get casa_case_court_date_path(casa_case, court_date) }

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
   end
   after { travel_back }
 
-
   describe "GET /show" do
     subject(:show) { get casa_case_court_date_path(casa_case, court_date) }
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "/notifications", type: :request do
   before do
     travel_to Date.new(2021, 1, 1)
   end
+  after { travel_back }
 
   describe "GET /index" do
     context "when there are no patch notes" do

--- a/spec/services/case_contacts_contact_dates_spec.rb
+++ b/spec/services/case_contacts_contact_dates_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CaseContactsContactDates do
   before do
     travel_to Date.new(2021, 6, 1)
   end
+  after { travel_back }
 
   describe "#contact_dates_details" do
     subject { described_class.new(interviewees).contact_dates_details }

--- a/spec/services/volunteer_birthday_reminder_service_spec.rb
+++ b/spec/services/volunteer_birthday_reminder_service_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe VolunteerBirthdayReminderService do
     before { travel_to(this_month_15th) }
     after { travel_back }
 
-
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: next_month)
     end

--- a/spec/services/volunteer_birthday_reminder_service_spec.rb
+++ b/spec/services/volunteer_birthday_reminder_service_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe VolunteerBirthdayReminderService do
 
   context "when today is the 15th" do
     before { travel_to(this_month_15th) }
+    after { travel_back }
+
 
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: next_month)
@@ -84,6 +86,7 @@ RSpec.describe VolunteerBirthdayReminderService do
 
   context "when today is not the 15th" do
     before { travel_to(this_month_15th + 2.days) }
+    after { travel_back }
 
     it "skips the rake task" do
       expect { send_reminders }.to change { Noticed::Notification.count }.by(0)

--- a/spec/support/shared_examples/shows_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_court_dates_links.rb
@@ -6,6 +6,7 @@ shared_examples_for "shows court dates links" do
     hearing_type = create(:hearing_type, name: "Some Hearing Name")
     _court_date_with_details = create(:court_date, :with_court_details, casa_case: casa_case, hearing_type: hearing_type)
   end
+  after { travel_back }
 
   it "shows court orders" do
     visit edit_casa_case_path(casa_case)

--- a/spec/system/bulk_court_dates/new_spec.rb
+++ b/spec/system/bulk_court_dates/new_spec.rb
@@ -40,5 +40,6 @@ RSpec.describe "bulk_court_dates/new", type: :system do
     visit casa_case_path(casa_case)
     expect(page).to have_content(hearing_type.name)
     expect(page).to have_content(court_order_text)
+    travel_back
   end
 end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "casa_cases/show", type: :system do
       sign_in user
       visit casa_case_path(casa_case.id)
     end
+    after { travel_back }
 
     context "when first arriving to 'Generate Court Report' page" do
       it "generation modal hidden" do

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "case_court_reports/index", type: :system do
     sign_in volunteer
     visit case_court_reports_path
   end
+  after { travel_back }
 
   context "when first arriving to 'Generate Court Report' page", js: true do
     it "generation modal hidden" do

--- a/spec/system/court_dates/edit_spec.rb
+++ b/spec/system/court_dates/edit_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "court_dates/edit", type: :system do
   before do
     travel_to now
   end
+  after { travel_back }
 
   context "as an admin" do
     before do

--- a/spec/system/court_dates/new_spec.rb
+++ b/spec/system/court_dates/new_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "court_dates/new", type: :system do
     visit casa_case_path(casa_case)
     click_link("Add a court date")
   end
+  after { travel_back }
 
   context "when all fields are filled" do
     it "is successful", js: true do

--- a/spec/system/court_dates/view_spec.rb
+++ b/spec/system/court_dates/view_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "court_dates/edit", type: :system do
   before do
     travel_to now
   end
+  after { travel_back }
 
   context "as a volunteer" do
     it "can download a report which focuses on the court date", js: true do

--- a/spec/system/placements/destroy_spec.rb
+++ b/spec/system/placements/destroy_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "placements/destroy", type: :system do
     visit casa_case_placements_path(casa_case, placement)
     click_on "Delete"
   end
+  after { travel_back }
 
   it "does not delete on modal close" do
     expect(page).to have_text("Delete Placement?")

--- a/spec/system/placements/edit_spec.rb
+++ b/spec/system/placements/edit_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "placements/edit", type: :system do
     visit casa_case_placement_path(casa_case, placement)
     click_link("Edit")
   end
+  after { travel_back }
 
   it "updates placement with valid form data", js: true do
     expect(page).to have_content("123")

--- a/spec/system/placements/index_spec.rb
+++ b/spec/system/placements/index_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "placements", type: :system do
     sign_in admin
     visit casa_case_placements_path(casa_case, placements)
   end
+  after { travel_back }
 
   it "displays all placements for org" do
     expect(page).to have_text("Reunification")

--- a/spec/system/placements/new_spec.rb
+++ b/spec/system/placements/new_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "placements/new", type: :system do
     visit casa_case_placements_path(casa_case)
     click_link("New Placement")
   end
+  after { travel_back }
 
   it "creates placement with valid form data", js: true do
     expect(page).to have_content("123")


### PR DESCRIPTION
### What github issue is this PR for, if any?
None. Fixes flaky specs.

### What changed, and _why_?
Added travel_back wherever travel_to is used.

I was seeing a lot of spec failures locally when making a change that were seemingly unrelated to my changes. This fixed them.  A lot of places where travel to was used without a travel back. (Probably an assumption that this was done automatically). Could possibly do `travel_back` in an after(:each) block in spec_helper.rb instead. Would mean doing for every test, not just time-traveling specs, and I errored on the side of being explicit. The benefit of the spec helper approach would be that it won't ever be a problem again...