### PR TITLE
[5894] Fix VolunteersController#edit N+1 issues

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -5,14 +5,14 @@ module UiHelper
     [
       [
         "Not Assigned",
-        CasaCase
+        CasaCase.eager_load([:assigned_volunteers])
           .not_assigned(@volunteer.casa_org).active
           .uniq { |casa_case| casa_case.case_number }
           .map { |casa_case| ["#{casa_case.case_number} - #{volunteer_badge(casa_case, current_user)}".html_safe, casa_case.id] }
       ],
       [
         "Assigned",
-        CasaCase
+        CasaCase.eager_load([:assigned_volunteers])
           .actively_assigned_excluding_volunteer(@volunteer)
           .uniq { |casa_case| casa_case.case_number }
           .map { |casa_case| ["#{casa_case.case_number} - #{volunteer_badge(casa_case, current_user)}".html_safe, casa_case.id] }

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -97,7 +97,7 @@ class Volunteer < User
   end
 
   def case_assignments_with_cases
-    case_assignments.includes(:casa_case)
+    case_assignments.includes(casa_case: :assigned_volunteers)
   end
 
   def has_supervisor?


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5894

### What changed, and _why_?
When editing a Volunteer, an N+1 query occurred.
After the changes, it doesn't happen an the code is faster.

### How is this **tested**? (please write tests!) 💖💪
N+1 queries are tested with Bullet gem, a message is shown in the console

<img width="1511" alt="Add to your query" src="https://github.com/user-attachments/assets/f841d825-ea0d-4615-8d53-b107d4c7b85a">



### Screenshots please :)
Previous queries
<img width="1512" alt="Antes" src="https://github.com/user-attachments/assets/6c4f7af3-d35b-4e36-a13a-fc85a1f8b2a9">
Actual queries
<img width="1511" alt="Captura de pantalla 2024-10-04 a las 16 15 12" src="https://github.com/user-attachments/assets/2ef9df22-336c-47b2-b5eb-7c50819e5f9a">
