### PR TITLE
Update GH Workflow TOC Generator

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -6,3 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/toc-generator@v4
+        with:
+          CREATE_PR: true
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          CHECK_ONLY_DEFAULT_BRANCH: true

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -11,5 +11,3 @@ jobs:
       - uses: technote-space/toc-generator@v4
         with:
           CREATE_PR: true
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          CHECK_ONLY_DEFAULT_BRANCH: true

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - main
 name: TOC Generator
 jobs:
   generateTOC:


### PR DESCRIPTION
### What github issue is this PR for, if any?
n/a

### What changed, and _why_?
The TOC Generator step in GitHub actions sometimes tries to run against branches that no longer exist and fails. This config update should have it only check/run against the main branch.

This update also has the TOC Generator create a PR for readme changes instead of pushing them directly.

### How is this **tested**? (please write tests!) 💖💪
Need to see how this runs in GitHub actions.

### Feelings gif (optional)
😀 😀 
First time collaborating with @FireLemons! 🎉