### PR TITLE
Bug: clear contact types in update

### DIFF
--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -24,7 +24,7 @@ class CaseContacts::FormController < ApplicationController
     respond_to do |format|
       format.html do
         params[:case_contact][:status] = CaseContact.statuses[step] if !@case_contact.active?
-        if @case_contact.update(case_contact_params)
+        if @case_contact.update_cleaning_contact_types(case_contact_params)
           finish_editing
         else
           prepare_form
@@ -32,7 +32,7 @@ class CaseContacts::FormController < ApplicationController
         end
       end
       format.json do
-        if @case_contact.update(case_contact_params)
+        if @case_contact.update_cleaning_contact_types(case_contact_params)
           render json: @case_contact, status: :ok
         else
           render json: @case_contact.errors.full_messages, status: :unprocessable_entity


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6117

### What changed, and _why_?
See Issue and/or [bugsnag](https://api.bugsnag.com/projects/5f370b68136a4b0010d15364/events/674f2ae7010d308b50b10000), which I cannot access.

Used the existing `CaseContact#update_cleaning_contact_types` method to clear contact types before update (within a transaction). I am just guessing that this is why that method exists, to prevent the CaseContactContactType `validates :case_contact_id, uniqueness: {scope: :contact_type_id` from causing this issue.  There is probably a 'better' way to handle these, but without more info about the data or how to reproduce, I just wanted to try something quick.

### How is this **tested**? (please write tests!) 💖💪
I could not reproduce the issue in the new/edit system specs. I don't know exactly what is happening with the production data. So this is current specs only.