### PR TITLE
Fix #6117 handle duplicate contact types

### DIFF
--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -73,6 +73,7 @@ class CaseContacts::FormController < ApplicationController
       .joins(:casa_case_contact_types)
       .active
       .where(casa_case_contact_types: {casa_case_id: @casa_cases.pluck(:id)})
+      .distinct
 
     if case_contact_types.present?
       case_contact_types
@@ -83,6 +84,7 @@ class CaseContacts::FormController < ApplicationController
         .active
         .where(contact_type_group: {casa_org: current_organization})
         .order("contact_type_group.name ASC", :name)
+        .distinct
     end
   end
 

--- a/app/values/case_contact_parameters.rb
+++ b/app/values/case_contact_parameters.rb
@@ -36,6 +36,7 @@ class CaseContactParameters < SimpleDelegator
       params[:case_contact][:miles_driven] = convert_miles_driven(params)
     end
     params[:case_contact][:notes] = params.dig(:case_contact, :notes).presence
+    params[:case_contact][:contact_type_ids] = params[:case_contact][:contact_type_ids]&.uniq
 
     params
   end

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -212,6 +212,18 @@ RSpec.describe "CaseContacts::Forms", type: :request do
       end
     end
 
+    context "with duplicate contact type ids in params" do
+      let(:contact_type_ids) { [contact_types.first.id, contact_types.first.id] }
+
+      it "dedupes and updates the contact type ids" do
+        expect(case_contact.contact_type_ids).to be_empty
+        request
+        expect(response).to have_http_status(:redirect)
+
+        expect(case_contact.reload.contact_type_ids).to contain_exactly(contact_types.first.id)
+      end
+    end
+
     context "when contact types were previously assigned" do
       before { case_contact.update!(contact_type_ids: [contact_types.second.id]) }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6117

### What changed, and _why_?
See Issue and/or [bugsnag](https://api.bugsnag.com/projects/5f370b68136a4b0010d15364/events/674f2ae7010d308b50b10000)

Duplicate contact type ids are being shown in the form, due to a join... And if they are sent in request, it will fail because of a unique validation.

This PR:
- adds logic in CaseContactParams class to remove duplicate contact type ids in the request. This is the "main" fix.
- adds .distinct calls when contact types are queried for the form. This should prevent the form showing repeated contact types, and prevent the 'bad' request from happening. Not necessary to stop the error, but a better user experience.
- adds request spec for duplicate type ids in request params. The setup gave the same error seen in bugsnag before the fixes above were applied.

### How is this **tested**? (please write tests!) 💖💪
Third bullet point above. I didn't figure out how the production data resulted in duplication in the form, so I did not make a 'frontend' spec.