### PR TITLE
Fix erblint deprecation warning

### DIFF
--- a/bin/git_hooks/lint
+++ b/bin/git_hooks/lint
@@ -61,7 +61,7 @@ if test $erb_changed_count -gt 0; then
     log error "Command bundle could not be found"
     exit 1
   else
-    if ! bundle exec erblint --lint-all --autocorrect ; then
+    if ! bundle exec erb_lint --lint-all --autocorrect ; then
       log error "ERB Lint linting failed, could not fix 1 or more issues\n  See above output for more details"
       exit 1
     fi


### PR DESCRIPTION
### What changed, and _why_?
`Calling `erblint` is deprecated, please call the renamed executable `erb_lint` instead.`

### How is this **tested**? (please write tests!) 💖💪
![image](https://github.com/user-attachments/assets/09a520dc-6ffc-45ec-a795-66ca8e251506) 