### PR TITLE
fix: delete boilerplate favicon on login page

### DIFF
--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -4,10 +4,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link
-    rel="shortcut icon"
-    href="assets/images/favicon.svg"
-    type="image/x-icon">
   <title>CASA Volunteer Tracker</title>
 
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>


### PR DESCRIPTION
Previously, network tools show a 404 getting /users/assets/images/favicon.svg on /users/sign_in, and some tests intermittently failed with this 404. Delete the extraneous favicon link from devise boilerplate to let the normal favicon work on the login screen.

Fixes test flake at
https://github.com/rubyforgood/casa/wiki/Flaky-tests#suspected-testing-tool-crash

### What github issue is this PR for, if any?
Resolves [flaky test at ](https://github.com/rubyforgood/casa/wiki/Flaky-tests#suspected-testing-tool-crash). The test reports sometimes failing with `No route matches [GET] "/users/assets/images/favicon.svg"`.

### What changed, and _why_?

The devise-generated view at `app/views/layouts/devise.html.erb` had its own favicon, which would make 404s on the page, and these 404s would fail some tests. Deleting this link tag lets the normal favicon present on other pages work.

Note: I initially tried using `href="<%= asset_path("favicon.svg")%."` instead, but `favicon.svg` is committed directly at `public/assets/images/favicon.svg`, so Rails doesn't seem to actually have an asset path for it. I don't know why this was done, so I don't want to undo it. The file at `public/assets/images/favicon.svg` does not seem to be the right favicon for the project.

### How is this **tested**? (please write tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 

On `main`, in dev tools, you can see a 404 on `GET http://0.0.0.0:3000/users/assets/images/favicon.svg`. On this branch, the favicon loads and is the expected CASA logo.

I'm happy to add an automated test for this, but I wasn't sure where one belonged.

One important note is that during testing, I was not able to make the failure described at https://github.com/rubyforgood/casa/wiki/Flaky-tests#suspected-testing-tool-crash happen on purpose, so this is a bit of a speculative fix. But it _does_ fix a 404 that was happening during local development, and that currently happens in prod on https://casavolunteertracking.org/users/sign_in

### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 

Before:
- browser tab: <img width="243" alt="image" src="https://github.com/user-attachments/assets/0bdbd470-4c22-4529-b94a-c56f02e8c7be" />
- network tools: <img width="870" alt="image" src="https://github.com/user-attachments/assets/8e852297-57b6-4ead-b427-c5efd034323c" />


After:
- browser tab: <img width="230" alt="image" src="https://github.com/user-attachments/assets/40b86170-10f3-4fec-a8c5-9da2991ee4b2" />

- network tools: <img width="870" alt="image" src="https://github.com/user-attachments/assets/cc188bd8-dc81-4d90-949e-727d32019398" />


