### PR TITLE
bug(case_contact): fixed the order of case contacts

### DIFF
--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -42,6 +42,12 @@ async function fireSwalFollowupAlert () {
   })
 }
 
+$(document).on('turbo:load', function() {
+  $('.filter-form').on('change', '.filter-input', function() {
+    $(this).closest('form').submit();
+  });
+});
+
 $(() => { // JQuery's callback for the DOM loading
   $('[data-toggle="tooltip"]').tooltip()
   $('.followup-button').on('click', displayFollowupAlert)

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -42,11 +42,11 @@ async function fireSwalFollowupAlert () {
   })
 }
 
-$(document).on('turbo:load', function() {
-  $('.filter-form').on('change', '.filter-input', function() {
-    $(this).closest('form').submit();
-  });
-});
+$(document).on('turbo:load', function () {
+  $('.filter-form').on('change', '.filter-input', function () {
+    $(this).closest('form').submit()
+  })
+})
 
 $(() => { // JQuery's callback for the DOM loading
   $('[data-toggle="tooltip"]').tooltip()

--- a/app/views/case_contacts/index.html.erb
+++ b/app/views/case_contacts/index.html.erb
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-<%= form_for_filterrific @filterrific, url: case_contacts_path, html: {class: "my-4"},
+<%= form_for_filterrific @filterrific, url: case_contacts_path, html: {class: "my-4 filter-form"}, remote: true,
   data: {turbo: true, turbo_frame: :case_contacts, turbo_action: :advance } do |f| %>
   <%= hidden_field_tag 'casa_case_id', params[:casa_case_id] %>
 
@@ -38,18 +38,15 @@
           <div class="select-style-1 mb-0">
             <%= f.label :sorted_by %>
             <div class="select-position">
-              <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: ""}) %>
+              <%= f.select(:sorted_by, @filterrific.select_options[:sorted_by], {}, {class: "filter-input"}) %>
             </div>
           </div>
           <div class="form-check checkbox-style">
-            <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type" %>
+            <%= f.check_box :no_drafts, class: "form-check-input case-contact-contact-type filter-input" %>
             <label class="form-check-label" for="filterrific_no_drafts">Hide drafts</label>
           </div>
         </div>
         <div>
-          <%= button_tag( :class=> "btn-sm main-btn dark-btn") do %>
-            <i class="lni lni-funnel mr-10"></i> Filter
-          <% end %>
           <%= link_to("Reset filters", reset_filterrific_url,
             class: "btn-sm main-btn dark-btn-outline btn-hove",
             data: { turbo: true, turbo_frame: :case_contacts, turbo_action: :advance }) %>
@@ -65,11 +62,11 @@
         </div>
         <div class="col-sm-6 input-style-1">
           <%= f.label "Starting from", for: "filterrific_occurred_starting_at" %>
-          <%= f.date_field(:occurred_starting_at, class: "") %>
+          <%= f.date_field(:occurred_starting_at, class: "filter-input") %>
         </div>
         <div class="col-sm-6 input-style-1">
           <%= f.label "Ending at", for: "filterrific_occurred_ending_at" %>
-          <%= f.date_field(:occurred_ending_at, class: "") %>
+          <%= f.date_field(:occurred_ending_at, class: "filter-input") %>
         </div>
       </div>
       <div class="row mb-4">
@@ -84,7 +81,7 @@
                     <div class="form-check checkbox-style">
                       <%=
                       f.check_box :contact_type,
-                        {multiple: true, class: "form-check-input case-contact-contact-type"},
+                        {multiple: true, class: "form-check-input case-contact-contact-type filter-input"},
                         contact_type.id,
                         nil
                       %>
@@ -107,21 +104,21 @@
           <%= f.label :contact_medium %>
           <div class="select-position">
             <%= f.select(:contact_medium, options_from_collection_for_select(contact_mediums, "value", "label"),
-                                        {include_blank: "Display all"}) %>
+                                        {include_blank: "Display all", class: "filter-input"}) %>
           </div>
         </div>
         <div class="col-md-3 select-style-1 pr-5">
           <%= f.label :want_driving_reimbursement %>
           <div class="select-position">
             <%= f.select(:want_driving_reimbursement, @presenter.boolean_select_options,
-                                                    {include_blank: "Display all"}) %>
+                                                    {include_blank: "Display all", class: "filter-input"}) %>
           </div>
         </div>
         <div class="col-md-3 select-style-1 pr-5">
           <%= f.label :contact_made %>
           <div class="select-position">
             <%= f.select(:contact_made, @presenter.boolean_select_options,
-                                      {include_blank: "Display all"}) %>
+                                      {include_blank: "Display all", class: "filter-input"}) %>
           </div>
         </div>
       </div>

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe "case_contacts/index", :js, type: :system do
           click_on "Expand / Hide"
           select "In Person", from: "Contact medium"
 
-
           expect(page).to have_content "Other filters"
         end
       end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       end
     end
 
-    describe "filtering case contacts" do
+    describe "automated filtering case contacts" do
       describe "by date of contact" do
         it "only shows the contacts with the correct date" do
           yesterday = Time.zone.yesterday
@@ -87,8 +87,6 @@ RSpec.describe "case_contacts/index", :js, type: :system do
 
           fill_in "filterrific_occurred_starting_at", with: yesterday
           fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
-
-          click_on "Filter"
 
           expect(page).to have_no_content day_before_yesterday_display
           expect(page).to have_content yesterday_display
@@ -125,8 +123,6 @@ RSpec.describe "case_contacts/index", :js, type: :system do
 
           check "Hide drafts"
 
-          click_on "Filter"
-
           expect(page).to have_no_content "Draft"
         end
       end
@@ -143,8 +139,6 @@ RSpec.describe "case_contacts/index", :js, type: :system do
         it "does not expand menu when filtering only by sticky filter" do
           check "Hide drafts"
 
-          click_on "Filter"
-
           expect(page).to have_field "Hide drafts", type: :checkbox
           expect(page).to have_no_content "Other filters"
         end
@@ -159,7 +153,6 @@ RSpec.describe "case_contacts/index", :js, type: :system do
           click_on "Expand / Hide"
           select "In Person", from: "Contact medium"
 
-          click_on "Filter"
 
           expect(page).to have_content "Other filters"
         end
@@ -225,7 +218,7 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       click_on "Expand / Hide"
       fill_in "filterrific_occurred_starting_at", with: yesterday
       fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
-      click_on "Filter"
+
       expect(page).to have_text("Case 2 Notes")
       expect(page).to have_no_text("Case 1 Notes")
 
@@ -237,7 +230,7 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       click_on "Expand / Hide"
       fill_in "filterrific_occurred_starting_at", with: yesterday
       fill_in "filterrific_occurred_ending_at", with: Time.zone.tomorrow
-      click_on "Filter"
+
       # no contacts because we're only showing case 1 and that occurred before the filter dates
       expect(page).to have_no_text("Case 1 Notes")
       expect(page).to have_no_text("Case 2 Notes")


### PR DESCRIPTION
### What github issue is this PR for, if any?

Github issue: [Issue#6128](https://github.com/rubyforgood/casa/issues/6128)

### What changed, and _why_?

Removed the filter button from listing of case_contacts page and added automatic filter has been applied for contact list.

### How is this **tested**? (please write tests!) 💖💪
Manually tested on local enviroment for case_contact filters. 
Removed rspec code where filter has been implemented for the validation of rspec.


### Screenshots please :)
<img width="1466" alt="Screenshot 2024-12-26 at 3 03 45 PM" src="https://github.com/user-attachments/assets/70b6f94a-7b63-4952-83c2-61c8b198f213" />

https://github.com/user-attachments/assets/5e356702-bc6c-4df6-83a6-0a8986e1484e



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
😊😊