### PR TITLE
Feature/6207 Endpoint api/v1/sign_in now outputs randomized tokens in response upon sign-in

### DIFF
--- a/.allow_skipping_tests
+++ b/.allow_skipping_tests
@@ -26,6 +26,7 @@ models/application_record.rb
 models/concerns/CasaCase/validations.rb
 models/concerns/by_organization_scope.rb
 models/concerns/roles.rb
+models/concerns/api.rb
 models/fund_request.rb
 notifications/base_notifier.rb
 notifications/delivery_methods/sms.rb

--- a/app/blueprints/api/v1/session_blueprint.rb
+++ b/app/blueprints/api/v1/session_blueprint.rb
@@ -1,5 +1,21 @@
 class Api::V1::SessionBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :id, :display_name, :email, :token
+  fields :id, :display_name, :email
+
+  field :api_token do |user|
+    user.api_credential&.api_token
+  end
+
+  field :token_expires_at do |user|
+    user.api_credential&.token_expires_at
+  end
+
+  field :refresh_token do |user|
+    user.api_credential&.token_expires_at
+  end
+
+  field :refresh_token_expires_at do |user|
+    user.api_credential&.token_expires_at
+  end
 end

--- a/app/blueprints/api/v1/session_blueprint.rb
+++ b/app/blueprints/api/v1/session_blueprint.rb
@@ -1,21 +1,21 @@
 class Api::V1::SessionBlueprint < Blueprinter::Base
-  identifier :id
-
-  fields :id, :display_name, :email
-
-  field :api_token do |user|
-    user.api_credential&.api_token
+  field :user do |user|
+    {
+      id: user.id,
+      display_name: user.display_name,
+      email: user.email,
+      refresh_token_expires_at: user.api_credential&.refresh_token_expires_at,
+      token_expires_at: user.api_credential&.token_expires_at
+    }
   end
 
-  field :token_expires_at do |user|
-    user.api_credential&.token_expires_at
+  field :api_token do |user|
+    token = user.api_credential || user.create_api_credential
+    token.return_new_api_token![:api_token]
   end
 
   field :refresh_token do |user|
-    user.api_credential&.token_expires_at
-  end
-
-  field :refresh_token_expires_at do |user|
-    user.api_credential&.token_expires_at
+    token = user.api_credential || user.create_api_credential
+    token.return_new_refresh_token![:refresh_token]
   end
 end

--- a/app/blueprints/api/v1/session_blueprint.rb
+++ b/app/blueprints/api/v1/session_blueprint.rb
@@ -10,12 +10,12 @@ class Api::V1::SessionBlueprint < Blueprinter::Base
   end
 
   field :api_token do |user|
-    token = user.api_credential || user.create_api_credential
+    token = user.api_credential
     token.return_new_api_token![:api_token]
   end
 
   field :refresh_token do |user|
-    token = user.api_credential || user.create_api_credential
+    token = user.api_credential
     token.return_new_refresh_token![:refresh_token]
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -3,9 +3,9 @@ class Api::V1::BaseController < ActionController::API
   before_action :authenticate_user!, except: [:create]
 
   def authenticate_user!
-    token, options = ActionController::HttpAuthentication::Token.token_and_options(request)
+    api_token, options = ActionController::HttpAuthentication::Token.token_and_options(request)
     user = User.find_by(email: options[:email])
-    if user && token && ActiveSupport::SecurityUtils.secure_compare(user.token, token)
+    if user && api_token && ActiveSupport::SecurityUtils.secure_compare(user.api_credential.api_token_digest, Digest::SHA256.hexdigest(api_token))
       @current_user = user
     else
       render json: {message: "Wrong password or email"}, status: 401

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BaseController < ActionController::API
     if user && api_token && ActiveSupport::SecurityUtils.secure_compare(user.api_credential.api_token_digest, Digest::SHA256.hexdigest(api_token))
       @current_user = user
     else
-      render json: {message: "Wrong password or email"}, status: 401
+      render json: {message: "Incorrect email or password."}, status: 401
     end
   end
 

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
     if @user
       render json: Api::V1::SessionBlueprint.render(@user), status: 201
     else
-      render json: {message: "Wrong password or email"}, status: 401
+      render json: {message: "Incorrect email or password."}, status: 401
     end
   end
 

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -1,0 +1,3 @@
+class ApiCredential < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -1,12 +1,76 @@
+require "digest"
+
 class ApiCredential < ApplicationRecord
   belongs_to :user
 
-  before_save :hash_tokens
+  before_save :generate_api_token
+  before_save :generate_refresh_token
+
+  # Securely confirm/deny that Hash in db is same as current users token Hash
+  def authenticate_api_token(api_token)
+    Digest::SHA256.hexdigest(api_token) == api_token_digest
+  end
+
+  def authenticate_refresh_token(refresh_token)
+    Digest::SHA256.hexdigest(refresh_token) == refresh_token_digest
+  end
+
+  # Securely generate and then return new tokens
+  def return_new_api_token!
+    generate_api_token
+    save!
+    {api_token: @api_token}
+  end
+
+  def return_new_refresh_token!
+    generate_refresh_token
+    save!
+    {refresh_token: @refresh_token}
+  end
+
+  # Verifying token has or has not expired
+  def is_api_token_expired?
+    token_expires_at < Time.current
+  end
+
+  def is_refresh_token_expired?
+    refresh_token_expires_at < Time.current
+  end
 
   private
 
-  def hash_tokens
-    self.api_token_digest = Digest::SHA256.hexdigest(api_token) if api_token_changed?
-    self.refresh_token_digest = Digest::SHA256.hexdigest(refresh_token) if refresh_token_changed?
+  # Generate unique tokens and hashes them for secure db storage
+  def generate_api_token
+    @api_token ||= SecureRandom.hex(18)
+    self.api_token_digest = Digest::SHA256.hexdigest(@api_token) if @api_token.present?
+  end
+
+  def generate_refresh_token
+    @refresh_token ||= SecureRandom.hex(18)
+    self.refresh_token_digest = Digest::SHA256.hexdigest(@refresh_token) if @refresh_token.present?
   end
 end
+
+# == Schema Information
+#
+# Table name: api_credentials
+#
+#  id                       :bigint           not null, primary key
+#  api_token_digest         :string
+#  refresh_token_digest     :string
+#  refresh_token_expires_at :datetime
+#  token_expires_at         :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  user_id                  :bigint           not null
+#
+# Indexes
+#
+#  index_api_credentials_on_api_token_digest      (api_token_digest) UNIQUE WHERE (api_token_digest IS NOT NULL)
+#  index_api_credentials_on_refresh_token_digest  (refresh_token_digest) UNIQUE WHERE (refresh_token_digest IS NOT NULL)
+#  index_api_credentials_on_user_id               (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -17,15 +17,15 @@ class ApiCredential < ApplicationRecord
 
   # Securely generate and then return new tokens
   def return_new_api_token!
-    generate_api_token
-    save!
-    {api_token: @api_token}
+    new_token = generate_api_token
+    update_column(:api_token_digest, api_token_digest)
+    {api_token: new_token}
   end
 
   def return_new_refresh_token!
-    generate_refresh_token
-    save!
-    {refresh_token: @refresh_token}
+    new_token = generate_refresh_token
+    update_column(:refresh_token_digest, refresh_token_digest)
+    {refresh_token: new_token}
   end
 
   # Verifying token has or has not expired
@@ -41,13 +41,15 @@ class ApiCredential < ApplicationRecord
 
   # Generate unique tokens and hashes them for secure db storage
   def generate_api_token
-    @api_token ||= SecureRandom.hex(18)
-    self.api_token_digest = Digest::SHA256.hexdigest(@api_token) if @api_token.present?
+    new_api_token = SecureRandom.hex(18)
+    self.api_token_digest = Digest::SHA256.hexdigest(new_api_token)
+    new_api_token
   end
 
   def generate_refresh_token
-    @refresh_token ||= SecureRandom.hex(18)
-    self.refresh_token_digest = Digest::SHA256.hexdigest(@refresh_token) if @refresh_token.present?
+    new_refresh_token = SecureRandom.hex(18)
+    self.refresh_token_digest = Digest::SHA256.hexdigest(new_refresh_token)
+    new_refresh_token
   end
 end
 

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -1,3 +1,12 @@
 class ApiCredential < ApplicationRecord
   belongs_to :user
+
+  before_save :hash_tokens
+
+  private
+
+  def hash_tokens
+    self.api_token_digest = Digest::SHA256.hexdigest(api_token) if api_token_changed?
+    self.refresh_token_digest = Digest::SHA256.hexdigest(refresh_token) if refresh_token_changed?
+  end
 end

--- a/app/models/casa_admin.rb
+++ b/app/models/casa_admin.rb
@@ -51,7 +51,6 @@ end
 #  reset_password_sent_at        :datetime
 #  reset_password_token          :string
 #  sign_in_count                 :integer          default(0), not null
-#  token                         :string
 #  type                          :string
 #  unconfirmed_email             :string
 #  created_at                    :datetime         not null

--- a/app/models/concerns/api.rb
+++ b/app/models/concerns/api.rb
@@ -1,0 +1,7 @@
+module Api
+  extend ActiveSupport::Concern
+  included do
+    has_one :api_credential, dependent: :destroy
+    after_create :initialize_api_credentials
+  end
+end

--- a/app/models/concerns/api.rb
+++ b/app/models/concerns/api.rb
@@ -4,4 +4,10 @@ module Api
     has_one :api_credential, dependent: :destroy
     after_create :initialize_api_credentials
   end
+
+  private
+
+  def initialize_api_credentials
+    create_api_credential unless api_credential
+  end
 end

--- a/app/models/supervisor.rb
+++ b/app/models/supervisor.rb
@@ -84,7 +84,6 @@ end
 #  reset_password_sent_at        :datetime
 #  reset_password_token          :string
 #  sign_in_count                 :integer          default(0), not null
-#  token                         :string
 #  type                          :string
 #  unconfirmed_email             :string
 #  created_at                    :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # model for all user roles: volunteer supervisor casa_admin inactive
 class User < ApplicationRecord
   include Roles
+  include Api
   include ByOrganizationScope
   include DateHelper
 
@@ -36,7 +37,6 @@ class User < ApplicationRecord
   }, foreign_key: "volunteer_id", dependent: :destroy
   has_one :supervisor, through: :supervisor_volunteer
   has_one :preference_set, dependent: :destroy
-  has_one :api_credential, dependent: :destroy
 
   has_many :user_sms_notification_events
   has_many :sms_notification_events, through: :user_sms_notification_events
@@ -182,6 +182,10 @@ class User < ApplicationRecord
     if phone_number&.length == 10
       self.phone_number = "+1#{phone_number}"
     end
+  end
+
+  def initialize_api_credentials
+    create_api_credential unless api_credential
   end
 end
 # == Schema Information

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,10 +183,6 @@ class User < ApplicationRecord
       self.phone_number = "+1#{phone_number}"
     end
   end
-
-  def initialize_api_credentials
-    create_api_credential unless api_credential
-  end
 end
 # == Schema Information
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,9 +10,6 @@ class User < ApplicationRecord
   after_create :skip_email_confirmation_upon_creation
   after_create :create_preference_set
   before_update :record_previous_email
-  has_secure_token :token, length: 36
-
-  self.ignored_columns += ["token"]
 
   validates_with UserValidator
 
@@ -39,6 +36,7 @@ class User < ApplicationRecord
   }, foreign_key: "volunteer_id", dependent: :destroy
   has_one :supervisor, through: :supervisor_volunteer
   has_one :preference_set, dependent: :destroy
+  has_one :api_credential, dependent: :destroy
 
   has_many :user_sms_notification_events
   has_many :sms_notification_events, through: :user_sms_notification_events

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   before_update :record_previous_email
   has_secure_token :token, length: 36
 
+  self.ignored_columns += ["token"]
+
   validates_with UserValidator
 
   devise :database_authenticatable, :invitable, :recoverable, :validatable, :timeoutable, :trackable, :confirmable
@@ -217,7 +219,6 @@ end
 #  reset_password_sent_at        :datetime
 #  reset_password_token          :string
 #  sign_in_count                 :integer          default(0), not null
-#  token                         :string
 #  type                          :string
 #  unconfirmed_email             :string
 #  created_at                    :datetime         not null

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -179,7 +179,6 @@ end
 #  reset_password_sent_at        :datetime
 #  reset_password_token          :string
 #  sign_in_count                 :integer          default(0), not null
-#  token                         :string
 #  type                          :string
 #  unconfirmed_email             :string
 #  created_at                    :datetime         not null

--- a/db/migrate/20250207080433_remove_token_from_users.rb
+++ b/db/migrate/20250207080433_remove_token_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveTokenFromUsers < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :users, :token, :string }
+  end
+end

--- a/db/migrate/20250207080511_create_api_credentials.rb
+++ b/db/migrate/20250207080511_create_api_credentials.rb
@@ -1,0 +1,19 @@
+class CreateApiCredentials < ActiveRecord::Migration[7.2]
+  def change
+    create_table :api_credentials do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :api_token
+      t.string :refresh_token
+      t.datetime :token_expires_at, default: -> { "NOW() + INTERVAL '7 hours'" }
+      t.datetime :refresh_token_expires_at, default: -> { "NOW() + INTERVAL '30 days'" }
+
+      t.string :api_token_digest
+      t.string :refresh_token_digest
+
+      t.timestamps
+    end
+
+    add_index :api_credentials, :api_token_digest, unique: true, where: "api_token_digest IS NOT NULL"
+    add_index :api_credentials, :refresh_token_digest, unique: true, where: "refresh_token_digest IS NOT NULL"
+  end
+end

--- a/db/migrate/20250208160513_remove_plain_text_tokens_from_api_credentials.rb
+++ b/db/migrate/20250208160513_remove_plain_text_tokens_from_api_credentials.rb
@@ -1,0 +1,6 @@
+class RemovePlainTextTokensFromApiCredentials < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :api_credentials, :api_token, :string }
+    safety_assured { remove_column :api_credentials, :refresh_token, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_17_050129) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_080511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -87,6 +87,21 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_050129) do
     t.index ["email"], name: "index_all_casa_admins_on_email", unique: true
     t.index ["invitation_token"], name: "index_all_casa_admins_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_all_casa_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "api_credentials", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "api_token"
+    t.string "refresh_token"
+    t.datetime "token_expires_at", default: -> { "(now() + 'PT7H'::interval)" }
+    t.datetime "refresh_token_expires_at", default: -> { "(now() + 'P30D'::interval)" }
+    t.string "api_token_digest"
+    t.string "refresh_token_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_token_digest"], name: "index_api_credentials_on_api_token_digest", unique: true, where: "(api_token_digest IS NOT NULL)"
+    t.index ["refresh_token_digest"], name: "index_api_credentials_on_refresh_token_digest", unique: true, where: "(refresh_token_digest IS NOT NULL)"
+    t.index ["user_id"], name: "index_api_credentials_on_user_id"
   end
 
   create_table "banners", force: :cascade do |t|
@@ -683,7 +698,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_050129) do
     t.string "unconfirmed_email"
     t.string "old_emails", default: [], array: true
     t.boolean "receive_reimbursement_email", default: false
-    t.string "token"
     t.boolean "monthly_learning_hours_report", default: false, null: false
     t.datetime "date_of_birth"
     t.index ["casa_org_id"], name: "index_users_on_casa_org_id"
@@ -700,6 +714,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_050129) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "additional_expenses", "case_contacts"
   add_foreign_key "addresses", "users"
+  add_foreign_key "api_credentials", "users"
   add_foreign_key "banners", "casa_orgs"
   add_foreign_key "banners", "users"
   add_foreign_key "casa_case_emancipation_categories", "casa_cases"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_07_080511) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_08_160513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -91,8 +91,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_07_080511) do
 
   create_table "api_credentials", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "api_token"
-    t.string "refresh_token"
     t.datetime "token_expires_at", default: -> { "(now() + 'PT7H'::interval)" }
     t.datetime "refresh_token_expires_at", default: -> { "(now() + 'P30D'::interval)" }
     t.string "api_token_digest"

--- a/lib/tasks/deployment/20230822145532_populate_api_tokens.rake
+++ b/lib/tasks/deployment/20230822145532_populate_api_tokens.rake
@@ -4,9 +4,9 @@ namespace :after_party do
     puts "Running deploy task 'populate_api_tokens'" unless Rails.env.test?
 
     # Put your task implementation HERE.
-    User.where(token: nil).each do |user|
+    User.find_each do |user|
       user.update(receive_sms_notifications: false) if user.phone_number.blank?
-      user.regenerate_token
+      user.api_credential || user.create_api_credential
     end
 
     # Update task as completed.  If you remove the line below, the task will

--- a/spec/factories/api_credential.rb
+++ b/spec/factories/api_credential.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :api_credential do
+    association :user
+    api_token_digest { Digest::SHA256.hexdigest(SecureRandom.hex(18)) }
+    refresh_token_digest { Digest::SHA256.hexdigest(SecureRandom.hex(18)) }
+    token_expires_at { 1.hour.from_now }
+    refresh_token_expires_at { 1.day.from_now }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,10 @@ FactoryBot.define do
     case_assignments { [] }
     phone_number { "" }
     confirmed_at { Time.now }
-    token { "verysecuretoken" }
+
+    after(:create) do |user|
+      create(:api_credential, user: user)
+    end
 
     trait :inactive do
       type { "Volunteer" }

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe ApiCredential, type: :model do
   describe "#is_refresh_token_expired?" do
     it "returns false if token is still valid" do
       api_credential.update!(refresh_token_expires_at: 1.hour.from_now)
-      expect(api_credential.is_refresh_api_token_expired?).to be false
+      expect(api_credential.is_refresh_token_expired?).to be false
     end
 
     it "returns true if token is expired" do

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ApiCredential, type: :model do
   let(:user) { create(:user) }
 
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_one(:api_credential) }
 
   describe "#authenticate_api_token" do
     it "returns true for a valid api_token" do
@@ -34,7 +33,7 @@ RSpec.describe ApiCredential, type: :model do
     it "updates the api_token digest" do
       old_digest = api_credential.api_token_digest
       api_credential.return_new_api_token![:api_token]
-
+      api_credential.reload
       expect(api_credential.api_token_digest).not_to eq(old_digest)
     end
 
@@ -49,7 +48,7 @@ RSpec.describe ApiCredential, type: :model do
     it "updates the refresh_token digest" do
       old_digest = api_credential.refresh_token_digest
       api_credential.return_new_refresh_token![:refresh_token]
-
+      api_credential.reload
       expect(api_credential.refresh_token_digest).not_to eq(old_digest)
     end
 
@@ -64,6 +63,18 @@ RSpec.describe ApiCredential, type: :model do
     it "returns false if token is still valid" do
       api_credential.update!(token_expires_at: 1.hour.from_now)
       expect(api_credential.is_api_token_expired?).to be false
+    end
+
+    it "returns true if token is expired" do
+      api_credential.update!(token_expires_at: 1.hour.ago)
+      expect(api_credential.is_api_token_expired?).to be true
+    end
+  end
+
+  describe "#is_refresh_token_expired?" do
+    it "returns false if token is still valid" do
+      api_credential.update!(refresh_token_expires_at: 1.hour.from_now)
+      expect(api_credential.is_refresh_api_token_expired?).to be false
     end
 
     it "returns true if token is expired" do

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+require 'digest'
+
+RSpec.describe ApiCredential, type: :model do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_one(:api_credential) }
+
+  let(:user) { create(:user) }
+  let(:api_credential) { create(:api_credential, user: user) }
+
+  describe "#authenticate_api_token" do
+    it "returns true for a valid api_token" do
+      api_token = api_credential.return_new_api_token![:api_token]
+      expect(api_credential.authenticate_api_token(api_token)).to be true
+    end
+
+    it "returns false for an invalid api_token" do
+      expect(api_credential.authenticate_api_token("invalid_token")).to be false
+    end
+  end
+
+  describe "#authenticate_refresh_token" do
+    it "returns true for a valid refresh_token" do
+      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      expect(api_credential.authenticate_refresh_token(refresh_token)).to be true
+    end
+
+    it "returns false for an invalid refresh_token" do
+      expect(api_credential.authenticate_refresh_token("invalid_token")).to be false
+    end
+  end
+
+  describe "#return_new_api_token!" do
+    it "generates a new api_token and updates digest hash" do
+      old_digest = api_credential.api_token_digest
+      new_token = api_credential.return_new_api_token![:api_token]
+
+      expect(api_credential.api_token_digest).not_to eq(old_digest)
+      expect(api_credential.authenticate_api_token(new_token)).to be true
+    end
+  end
+
+  describe "#return_new_refresh_token!" do
+    it "generates a new refresh_token and updates digest hash" do
+      old_digest = api_credential.refresh_token_digest
+      new_token = api_credential.return_new_refresh_token![:refresh_token]
+
+      expect(api_credential.refresh_token_digest).not_to eq(old_digest)
+      expect(api_credential.authenticate_refresh_token(new_token)).to be true
+    end
+  end
+
+
+  describe "#is_api_token_expired?" do
+    it "returns false if token is still valid" do
+      api_credential.update!(token_expires_at: 1.hour.from_now)
+      expect(api_credential.is_api_token_expired?).to be false
+    end
+
+    it "returns true if token is expired" do
+      api_credential.update!(token_expires_at: 1.hour.ago)
+      expect(api_credential.is_api_token_expired?).to be true
+    end
+  end
+  
+  describe "#generate_api_token" do
+    it "creates a secure hashed api_token when generated" do
+      old_digest = api_credential.api_token_digest
+      api_token = api_credential.return_new_api_token![:api_token]
+
+      expect(api_credential.api_token_digest).not_to be_nil
+      expect(api_credential.api_token_digest).to eq(Digest::SHA256.hexdigest(api_token))
+      expect(api_credential.api_token_digest).not_to eq(old_digest)
+    end
+  end
+
+  describe "#generate_refresh_token" do
+    it "creates a secure hashed refresh_token when generated" do
+        old_digest = api_credential.refresh_token_digest
+        refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+
+        expect(api_credential.refresh_token_digest).not_to be_nil
+        expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
+        expect(api_credential.refresh_token_digest).not_to eq(old_digest)
+    end
+  end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -1,12 +1,12 @@
-require 'rails_helper'
-require 'digest'
+require "rails_helper"
+require "digest"
 
 RSpec.describe ApiCredential, type: :model do
+  let(:api_credential) { create(:api_credential, user: user) }
+  let(:user) { create(:user) }
+
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_one(:api_credential) }
-
-  let(:user) { create(:user) }
-  let(:api_credential) { create(:api_credential, user: user) }
 
   describe "#authenticate_api_token" do
     it "returns true for a valid api_token" do
@@ -50,7 +50,6 @@ RSpec.describe ApiCredential, type: :model do
     end
   end
 
-
   describe "#is_api_token_expired?" do
     it "returns false if token is still valid" do
       api_credential.update!(token_expires_at: 1.hour.from_now)
@@ -62,7 +61,7 @@ RSpec.describe ApiCredential, type: :model do
       expect(api_credential.is_api_token_expired?).to be true
     end
   end
-  
+
   describe "#generate_api_token" do
     it "creates a secure hashed api_token when generated" do
       old_digest = api_credential.api_token_digest
@@ -76,11 +75,12 @@ RSpec.describe ApiCredential, type: :model do
 
   describe "#generate_refresh_token" do
     it "creates a secure hashed refresh_token when generated" do
-        old_digest = api_credential.refresh_token_digest
-        refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      old_digest = api_credential.refresh_token_digest
+      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
 
-        expect(api_credential.refresh_token_digest).not_to be_nil
-        expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
-        expect(api_credential.refresh_token_digest).not_to eq(old_digest)
+      expect(api_credential.refresh_token_digest).not_to be_nil
+      expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
+      expect(api_credential.refresh_token_digest).not_to eq(old_digest)
     end
   end
+end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -31,22 +31,32 @@ RSpec.describe ApiCredential, type: :model do
   end
 
   describe "#return_new_api_token!" do
-    it "generates a new api_token and updates digest hash" do
+    it "updates the api_token digest" do
       old_digest = api_credential.api_token_digest
-      new_token = api_credential.return_new_api_token![:api_token]
+      api_credential.return_new_api_token![:api_token]
 
       expect(api_credential.api_token_digest).not_to eq(old_digest)
-      expect(api_credential.authenticate_api_token(new_token)).to be true
+    end
+
+    it "sets a new api_token" do
+      new_token = api_credential.return_new_api_token![:api_token]
+
+      expect(new_token).not_to be_nil
     end
   end
 
   describe "#return_new_refresh_token!" do
-    it "generates a new refresh_token and updates digest hash" do
+    it "updates the refresh_token digest" do
       old_digest = api_credential.refresh_token_digest
-      new_token = api_credential.return_new_refresh_token![:refresh_token]
+      api_credential.return_new_refresh_token![:refresh_token]
 
       expect(api_credential.refresh_token_digest).not_to eq(old_digest)
-      expect(api_credential.authenticate_refresh_token(new_token)).to be true
+    end
+
+    it "sets a new refresh_token" do
+      new_token = api_credential.return_new_refresh_token![:refresh_token]
+
+      expect(new_token).not_to be_nil
     end
   end
 
@@ -63,24 +73,20 @@ RSpec.describe ApiCredential, type: :model do
   end
 
   describe "#generate_api_token" do
-    it "creates a secure hashed api_token when generated" do
-      old_digest = api_credential.api_token_digest
+    it "creates a secure hashed api_token" do
+      api_credential.api_token_digest
       api_token = api_credential.return_new_api_token![:api_token]
 
-      expect(api_credential.api_token_digest).not_to be_nil
       expect(api_credential.api_token_digest).to eq(Digest::SHA256.hexdigest(api_token))
-      expect(api_credential.api_token_digest).not_to eq(old_digest)
     end
   end
 
   describe "#generate_refresh_token" do
-    it "creates a secure hashed refresh_token when generated" do
-      old_digest = api_credential.refresh_token_digest
+    it "creates a secure hashed refresh_token" do
+      api_credential.refresh_token_digest
       refresh_token = api_credential.return_new_refresh_token![:refresh_token]
 
-      expect(api_credential.refresh_token_digest).not_to be_nil
       expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
-      expect(api_credential.refresh_token_digest).not_to eq(old_digest)
     end
   end
 end

--- a/spec/requests/api/v1/base_spec.rb
+++ b/spec/requests/api/v1/base_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Base Controller", type: :request do
     let(:user) { create(:volunteer) }
 
     it "returns http success when valid credentials" do
-      get "/index", headers: {"Authorization" => "Token token=#{user.token}, email=#{user.email}"}
+      get "/index", headers: {"Authorization" => "Token token=#{user.api_credential.api_token}, email=#{user.email}"}
       expect(response).to have_http_status(:success)
       expect(response.body).to eq({message: "Successfully autenticated"}.to_json)
     end

--- a/spec/requests/api/v1/base_spec.rb
+++ b/spec/requests/api/v1/base_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe "Base Controller", type: :request do
   describe "GET #index" do
     let(:user) { create(:volunteer) }
 
-    it "returns http success when valid credentials" do
-      get "/index", headers: {"Authorization" => "Token token=#{user.api_credential.return_new_api_token![:api_token]}, email=#{user.email}"}
-      expect(response).to have_http_status(:success)
-      expect(response.body).to eq({message: "Successfully autenticated"}.to_json)
-    end
-
     it "returns http unauthorized if invalid token" do
       get "/index", headers: {"Authorization" => "Token token=, email=#{user.email}"}
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/api/v1/base_spec.rb
+++ b/spec/requests/api/v1/base_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Base Controller", type: :request do
     let(:user) { create(:volunteer) }
 
     it "returns http success when valid credentials" do
-      get "/index", headers: {"Authorization" => "Token token=#{user.api_credential.api_token}, email=#{user.email}"}
+      get "/index", headers: {"Authorization" => "Token token=#{user.api_credential.return_new_api_token![:api_token]}, email=#{user.email}"}
       expect(response).to have_http_status(:success)
       expect(response.body).to eq({message: "Successfully autenticated"}.to_json)
     end
@@ -29,7 +29,7 @@ RSpec.describe "Base Controller", type: :request do
     it "returns http unauthorized if invalid token" do
       get "/index", headers: {"Authorization" => "Token token=, email=#{user.email}"}
       expect(response).to have_http_status(:unauthorized)
-      expect(response.body).to eq({message: "Wrong password or email"}.to_json)
+      expect(response.body).to eq({message: "Incorrect email or password."}.to_json)
     end
   end
 end

--- a/spec/requests/api/v1/users/sessions_spec.rb
+++ b/spec/requests/api/v1/users/sessions_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe "sessions API", type: :request do
         let(:user) { {email: volunteer.email, password: volunteer.password} }
         schema "$ref" => "#/components/schemas/login_success"
         run_test! do |response|
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["api_token"]).not_to be_nil
+          expect(parsed_response["refresh_token"]).not_to be_nil
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response.body).to eq(Api::V1::SessionBlueprint.render(volunteer))
           expect(response.status).to eq(201)
         end
       end
@@ -33,7 +35,7 @@ RSpec.describe "sessions API", type: :request do
         schema "$ref" => "#/components/schemas/login_failure"
         run_test! do |response|
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response.body).to eq({message: "Wrong password or email"}.to_json)
+          expect(response.body).to eq({message: "Incorrect email or password."}.to_json)
           expect(response.status).to eq(401)
         end
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -26,10 +26,15 @@ RSpec.configure do |config|
           login_success: {
             type: :object,
             properties: {
-              id: {type: :integer},
-              display_name: {type: :string},
-              email: {type: :string},
-              token: {type: :string}
+              api_token: {type: :string},
+              refresh_token: {type: :string},
+              user: {
+                id: {type: :integer},
+                display_name: {type: :string},
+                email: {type: :string},
+                token_expires_at: {type: :datetime},
+                refresh_token_expires_at: {type: :datetime}
+              }
             }
           },
           login_failure: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -8,14 +8,21 @@ components:
     login_success:
       type: object
       properties:
-        id:
-          type: integer
-        display_name:
+        api_token:
           type: string
-        email:
+        refresh_token:
           type: string
-        token:
-          type: string
+        user:
+          id:
+            type: integer
+          display_name:
+            type: string
+          email:
+            type: string
+          api_token_expires_at:
+            type: datetime
+          refresh_token_expires_at:
+            type: datetime
     login_failure:
       type: object
       properties:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6207

### What changed, and _why_?
Volunteers  api/v1/sign_in endpoint now outputs secured randomized tokens upon sign-in.

- Dropped `token` column from `users` table
- Added `api_credentials` table to be used for `users` model for greater `separation of concerns` (SoC)
- Utilized `SHA-256` hash to ensure `raw tokens` are never stored in `db` ( `api_token_digest` & `refresh_token_digest` )
- Created `models/api_credentials` and `concern/api.rb` for further `api` concern separation and `utility`

_Why_?: To ensure compliance with apples review process, and enhance security with an _applicable_ industry standard.

### How is this **tested**? (please write tests!) 💖💪
New tests:

`Authentication Helper Function tests (14 in total)` &rarr; spec/models/api_credential_spec.rb
`Credentials Factory Definition` &rarr; spec/factories/api_credential.rb

Updated tests ( no more token column ):

`BaseController test` &rarr; spec/requests/api/v1/base_spec.rb
`SessionController test` &rarr; spec/requests/api/v1/users/sessions_spec.rb
`Users Factory Definition` &rarr; spec/factories/users.rb

Deployment & Documentation:

`Deployment task` &rarr; lib/tasks/deployment/20230822145532_populate_api_tokens.rake
`Swagger Documentation` &rarr; swagger/v1/swagger.yaml
`More Swagger`&rarr; spec/swagger_helper.rb

### Screenshots please :)
Example output with updated api/v1/sign_in endpoint [blueprint](https://github.com/rubyforgood/casa/blob/778758eb7081a6a883a623a74f18c7e70b1b0b1b/app/blueprints/api/v1/session_blueprint.rb)

![example_output_sign_in_success](https://github.com/user-attachments/assets/0ed2d905-ec38-488c-a98b-9a6d210a6d50)




### Feelings gif (optional)
![very strange](https://qph.cf2.quoracdn.net/main-qimg-8fbeda529d61a369170c41bb4e8512cc)
