### PR TITLE
Feature/6222 - Endpoint /api/v1/users/sign_out revokes access token and refresh token on request

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::BaseController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
-  before_action :authenticate_user!, except: [:create]
+  before_action :authenticate_user!, except: [:create, :destroy]
 
   def authenticate_user!
     api_token, options = ActionController::HttpAuthentication::Token.token_and_options(request)

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
       render json: {message: "Signed out successfully."}, status: 200
     else
       render json: {message: "An error occured when signing out."}, status: 401
-      return
+      nil
     end
   end
 

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -9,10 +9,10 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
   end
 
   def destroy
-    # fetch refresh token from request header
-    refresh_token = request.headers["Authorization"]&.split(" ")&.last
-    # find user's api credentials by refresh token
-    api_credential = ApiCredential.find_by(refresh_token_digest: Digest::SHA256.hexdigest(refresh_token))
+    # fetch access token from request header
+    api_token = request.headers["Authorization"]&.split(" ")&.last
+    # find user's api credentials by access token
+    api_credential = ApiCredential.find_by(api_token_digest: Digest::SHA256.hexdigest(api_token))
     # set api and refresh tokens to nil; otherwise render 401
     if api_credential
       api_credential.revoke_api_token

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -15,8 +15,8 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
     api_credential = ApiCredential.find_by(refresh_token_digest: Digest::SHA256.hexdigest(refresh_token))
     # set api and refresh tokens to nil; otherwise render 401
     if api_credential
-      api_credential.revoke_token("api_token")
-      api_credential.revoke_token("refresh_token")
+      api_credential.revoke_api_token
+      api_credential.revoke_refresh_token
       render json: {message: "Signed out successfully."}, status: 200
     else
       render json: {message: "An error occured when signing out."}, status: 401

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -8,6 +8,22 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
     end
   end
 
+  def destroy
+    # fetch refresh token from request header
+    refresh_token = request.headers["Authorization"]&.split(" ")&.last
+    # find user's api credentials by refresh token
+    api_credential = ApiCredential.find_by(refresh_token_digest: Digest::SHA256.hexdigest(refresh_token))
+    # set api and refresh tokens to nil; otherwise render 401
+    if api_credential
+      api_credential.revoke_token("api_token")
+      api_credential.revoke_token("refresh_token")
+      render json: {message: "Signed out successfully."}, status: 200
+    else
+      render json: {message: "An error occured when signing out."}, status: 401
+      return
+    end
+  end
+
   private
 
   def user_params

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -37,6 +37,19 @@ class ApiCredential < ApplicationRecord
     refresh_token_expires_at < Time.current
   end
 
+  # clear tokens
+  # token argument takes in two strings: api_token and refresh_token
+  def revoke_token(token)
+    if (token == "api_token")
+      update_columns(api_token_digest: nil)
+    elsif (token == "refresh_token")
+      update_columns(refresh_token_digest: nil)
+    else
+      return nil
+    end
+    return token
+  end
+
   private
 
   # Generate unique tokens and hashes them for secure db storage

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -37,17 +37,12 @@ class ApiCredential < ApplicationRecord
     refresh_token_expires_at < Time.current
   end
 
-  # clear tokens
-  # token argument takes in two strings: api_token and refresh_token
-  def revoke_token(token)
-    if (token == "api_token")
-      update_columns(api_token_digest: nil)
-    elsif (token == "refresh_token")
-      update_columns(refresh_token_digest: nil)
-    else
-      return nil
-    end
-    return token
+  def revoke_api_token
+    update_columns(api_token_digest: nil)
+  end
+
+  def revoke_refresh_token
+    update_columns(refresh_token_digest: nil)
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :users do
         post "sign_in", to: "sessions#create"
-        # get 'sign_out', to: 'sessions#destroy'
+        delete "sign_out", to: "sessions#destroy"
       end
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -147,3 +147,4 @@ rescue => e
   Rails.logger.error { "Caught error during db seed emancipation_options_prune, continuing. Message: #{e}" }
 end
 load(Rails.root.join("db/seeds/placement_data.rb"))
+load(Rails.root.join("db/seeds/api_credential_data.rb"))

--- a/db/seeds/api_credential_data.rb
+++ b/db/seeds/api_credential_data.rb
@@ -1,0 +1,6 @@
+ApiCredential.destroy_all
+users = User.all
+
+users.each do |user|
+  ApiCredential.create!(user: user, api_token_digest: Digest::SHA256.hexdigest(SecureRandom.hex(18)), refresh_token_digest: Digest::SHA256.hexdigest(SecureRandom.hex(18)))
+end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -100,4 +100,20 @@ RSpec.describe ApiCredential, type: :model do
       expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
     end
   end
+
+  describe "#revoke_token" do
+    it "sets api token to nil" do
+      api_token = api_credential.return_new_api_token![:api_token]
+      api_credential.revoke_token(api_token)
+
+      expect(api_credential.api_token_digest).to be_nil
+    end
+
+    it "sets refresh token to nil" do
+      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      api_credential.revoke_token(refresh_token)
+
+      expect(api_credential.refresh_token_digest).to be_nil
+    end
+  end
 end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe ApiCredential, type: :model do
 
   describe "#revoke_api_token" do
     it "sets api token to nil" do
-      api_token = api_credential.return_new_api_token![:api_token]
+      api_credential.return_new_api_token![:api_token]
       api_credential.revoke_api_token
 
       expect(api_credential.api_token_digest).to be_nil
@@ -112,7 +112,7 @@ RSpec.describe ApiCredential, type: :model do
 
   describe "#revoke_refresh_token" do
     it "sets refresh token to nil" do
-      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      api_credential.return_new_refresh_token![:refresh_token]
       api_credential.revoke_refresh_token
 
       expect(api_credential.refresh_token_digest).to be_nil

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -101,23 +101,21 @@ RSpec.describe ApiCredential, type: :model do
     end
   end
 
-  describe "#revoke_token" do
+  describe "#revoke_api_token" do
     it "sets api token to nil" do
       api_token = api_credential.return_new_api_token![:api_token]
-      api_credential.revoke_token("api_token")
+      api_credential.revoke_api_token
 
       expect(api_credential.api_token_digest).to be_nil
     end
+  end
 
+  describe "#revoke_refresh_token" do
     it "sets refresh token to nil" do
       refresh_token = api_credential.return_new_refresh_token![:refresh_token]
-      api_credential.revoke_token("refresh_token")
+      api_credential.revoke_refresh_token
 
       expect(api_credential.refresh_token_digest).to be_nil
-    end
-
-    it "returns nil if token is not found" do
-      expect(api_credential.revoke_token("invalid_token")).to be_nil
     end
   end
 end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -104,16 +104,20 @@ RSpec.describe ApiCredential, type: :model do
   describe "#revoke_token" do
     it "sets api token to nil" do
       api_token = api_credential.return_new_api_token![:api_token]
-      api_credential.revoke_token(api_token)
+      api_credential.revoke_token("api_token")
 
       expect(api_credential.api_token_digest).to be_nil
     end
 
     it "sets refresh token to nil" do
       refresh_token = api_credential.return_new_refresh_token![:refresh_token]
-      api_credential.revoke_token(refresh_token)
+      api_credential.revoke_token("refresh_token")
 
       expect(api_credential.refresh_token_digest).to be_nil
+    end
+
+    it "returns nil if token is not found" do
+      expect(api_credential.revoke_token("invalid_token")).to be_nil
     end
   end
 end

--- a/spec/requests/api/v1/users/sessions_spec.rb
+++ b/spec/requests/api/v1/users/sessions_spec.rb
@@ -41,4 +41,37 @@ RSpec.describe "sessions API", type: :request do
       end
     end
   end
+
+  path "/api/v1/users/sign_out" do
+    delete "Signs out a user" do
+      tags "Sessions"
+      produces "application/json"
+      parameter name: :Authorization, in: :header, type: :string, required: true
+
+      let(:casa_org) { create(:casa_org) }
+      let(:volunteer) { create(:volunteer, casa_org: casa_org) }
+      let(:api_credential) { create(:api_credential, user: volunteer) }
+      let(:refresh_token) { api_credential.return_new_refresh_token![:refresh_token] }
+
+      response "200", "user signed out" do
+        let(:Authorization) { "Bearer #{refresh_token}" }
+        schema "$ref" => "#/components/schemas/sign_out"
+        run_test! do |response|
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response.body).to eq({message: "Signed out successfully."}.to_json)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      response "401", "unauthorized" do
+        let(:Authorization) { "Bearer foo" }
+        schema "$ref" => "#/components/schemas/sign_out"
+        run_test! do |response|
+          expect(response.content_type).to eq("application/json; charset=utf-8")
+          expect(response.body).to eq({message: "An error occured when signing out."}.to_json)
+          expect(response.status).to eq(401)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/users/sessions_spec.rb
+++ b/spec/requests/api/v1/users/sessions_spec.rb
@@ -1,6 +1,9 @@
 require "swagger_helper"
 
 RSpec.describe "sessions API", type: :request do
+  let(:casa_org) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: casa_org) }
+
   path "/api/v1/users/sign_in" do
     post "Signs in a user" do
       tags "Sessions"
@@ -14,9 +17,6 @@ RSpec.describe "sessions API", type: :request do
         },
         required: %w[email password]
       }
-
-      let(:casa_org) { create(:casa_org) }
-      let(:volunteer) { create(:volunteer, casa_org: casa_org) }
 
       response "201", "user signed in" do
         let(:user) { {email: volunteer.email, password: volunteer.password} }
@@ -46,15 +46,12 @@ RSpec.describe "sessions API", type: :request do
     delete "Signs out a user" do
       tags "Sessions"
       produces "application/json"
-      parameter name: :Authorization, in: :header, type: :string, required: true
+      parameter name: :authorization, in: :header, type: :string, required: true
 
-      let(:casa_org) { create(:casa_org) }
-      let(:volunteer) { create(:volunteer, casa_org: casa_org) }
-      let(:api_credential) { create(:api_credential, user: volunteer) }
-      let(:refresh_token) { api_credential.return_new_refresh_token![:refresh_token] }
+      let(:refresh_token) { create(:api_credential, user: volunteer).return_new_refresh_token![:refresh_token] }
 
       response "200", "user signed out" do
-        let(:Authorization) { "Bearer #{refresh_token}" }
+        let(:authorization) { "Bearer #{refresh_token}" }
         schema "$ref" => "#/components/schemas/sign_out"
         run_test! do |response|
           expect(response.content_type).to eq("application/json; charset=utf-8")
@@ -64,7 +61,7 @@ RSpec.describe "sessions API", type: :request do
       end
 
       response "401", "unauthorized" do
-        let(:Authorization) { "Bearer foo" }
+        let(:authorization) { "Bearer foo" }
         schema "$ref" => "#/components/schemas/sign_out"
         run_test! do |response|
           expect(response.content_type).to eq("application/json; charset=utf-8")

--- a/spec/requests/api/v1/users/sessions_spec.rb
+++ b/spec/requests/api/v1/users/sessions_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe "sessions API", type: :request do
       produces "application/json"
       parameter name: :authorization, in: :header, type: :string, required: true
 
-      let(:refresh_token) { create(:api_credential, user: volunteer).return_new_refresh_token![:refresh_token] }
+      let(:api_token) { create(:api_credential, user: volunteer).return_new_api_token![:api_token] }
 
       response "200", "user signed out" do
-        let(:authorization) { "Bearer #{refresh_token}" }
+        let(:authorization) { "Bearer #{api_token}" }
         schema "$ref" => "#/components/schemas/sign_out"
         run_test! do |response|
           expect(response.content_type).to eq("application/json; charset=utf-8")

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -42,6 +42,12 @@ RSpec.configure do |config|
             properties: {
               message: {type: :string}
             }
+          },
+          sign_out: {
+            type: :object,
+            properties: {
+              message: {type: :string}
+            }
           }
         }
       },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -19,11 +19,16 @@ components:
             type: string
           email:
             type: string
-          api_token_expires_at:
+          token_expires_at:
             type: datetime
           refresh_token_expires_at:
             type: datetime
     login_failure:
+      type: object
+      properties:
+        message:
+          type: string
+    sign_out:
       type: object
       properties:
         message:
@@ -61,6 +66,30 @@ paths:
               required:
               - email
               - password
+  "/api/v1/users/sign_out":
+    delete:
+      summary: Signs out a user
+      tags:
+      - Sessions
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: user signed out
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/sign_out"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/sign_out"
 servers:
 - url: https://{defaultHost}
   variables:


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6222 

### What changed, and _why_?
Added /api/v1/users/sign_out endpoint so both the access and refresh tokens for that user is cleared from the api_credentials table and set to nil.

- Added request and model specs for the sign out route
- Generated and updated swagger file
- Added helper function to api credential model to clear tokens
- Added sign out to routes and session controller
- Added seed data for populating tokens in api credential table in dev environment

_Why_?: for added security - tokens should be removed from api_credentials table because user is no longer signed in.

### How is this **tested**? (please write tests!) 💖💪
`Token Destroyer Helper Function tests (2 in total)` &rarr; spec/models/api_credential_spec.rb
`Sign Out Request Test for 200 and 401 Response Cases` &rarr; spec/requests/api/v1/users/sessions_spec.rb

### Screenshots please :)
Testing sign out with postman on localhost

Steps:
First we sign in to fetch the refresh token
Lastly we sign out and pass in refresh token in the request authorization header
![Screenshot 2025-02-26 at 12 30 58 PM](https://github.com/user-attachments/assets/cfbf6490-1fdf-409e-a47e-d2391c1cdc7e)

### Feelings gif (optional)
![very strange](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcDg2eHBhNDI2MXp2aGNyeHhncDV4cHpjOTZ4aWZmdW5zcmdlbWUxNiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/aQwvKKi4Lv3t63nZl9/giphy.gif)
