### PR TITLE
Feature/6210 - Endpoint API remember_me option

### DIFF
--- a/app/blueprints/api/v1/session_blueprint.rb
+++ b/app/blueprints/api/v1/session_blueprint.rb
@@ -14,8 +14,12 @@ class Api::V1::SessionBlueprint < Blueprinter::Base
     token.return_new_api_token![:api_token]
   end
 
-  field :refresh_token do |user|
+  field :refresh_token do |user, options|
     token = user.api_credential
-    token.return_new_refresh_token![:refresh_token]
+    if options[:remember_me]
+      token.return_new_refresh_token!(true)[:refresh_token]
+    else
+      token.return_new_refresh_token!(false)[:refresh_token]
+    end
   end
 end

--- a/app/controllers/api/v1/users/sessions_controller.rb
+++ b/app/controllers/api/v1/users/sessions_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
   def create
     load_resource
     if @user
-      render json: Api::V1::SessionBlueprint.render(@user), status: 201
+      render json: Api::V1::SessionBlueprint.render(@user, remember_me: user_params[:remember_me]), status: 201
     else
       render json: {message: "Incorrect email or password."}, status: 401
     end
@@ -27,7 +27,7 @@ class Api::V1::Users::SessionsController < Api::V1::BaseController
   private
 
   def user_params
-    params.permit(:email, :password)
+    params.permit(:email, :password, :remember_me)
   end
 
   def load_resource

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -22,8 +22,13 @@ class ApiCredential < ApplicationRecord
     {api_token: new_token}
   end
 
-  def return_new_refresh_token!
+  def return_new_refresh_token! (remember_me)
     new_token = generate_refresh_token
+    if remember_me
+      update_column(:refresh_token_expires_at, 1.year.from_now)
+    else
+      update_column(:refresh_token_expires_at, 30.days.from_now)
+    end
     update_column(:refresh_token_digest, refresh_token_digest)
     {refresh_token: new_token}
   end

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -22,7 +22,7 @@ class ApiCredential < ApplicationRecord
     {api_token: new_token}
   end
 
-  def return_new_refresh_token! (remember_me)
+  def return_new_refresh_token!(remember_me)
     new_token = generate_refresh_token
     if remember_me
       update_column(:refresh_token_expires_at, 1.year.from_now)

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ApiCredential, type: :model do
   describe "#generate_refresh_token_with_rememberme" do
     it "updates token to be valid for 1 year" do
       api_credential.refresh_token_digest
-      refresh_token = api_credential.return_new_refresh_token!(true)[:refresh_token]
+      api_credential.return_new_refresh_token!(true)[:refresh_token]
 
       expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(1.year.from_now)
     end
@@ -131,9 +131,9 @@ RSpec.describe ApiCredential, type: :model do
   describe "#generate_refresh_token_without_rememberme" do
     it "updates token to be valid for 30 days" do
       api_credential.refresh_token_digest
-      refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
+      api_credential.return_new_refresh_token!(false)[:refresh_token]
 
-    expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(30.days.from_now)
+      expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(30.days.from_now)
     end
   end
 end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -118,20 +118,22 @@ RSpec.describe ApiCredential, type: :model do
       expect(api_credential.refresh_token_digest).to be_nil
     end
   end
-  describe "#generate_refresh_token_with_rememberme" do
-  it "updates token to be valid for 1 year" do
-    api_credential.refresh_token_digest
-    refresh_token = api_credential.return_new_refresh_token!(true)[:refresh_token]
 
-    expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(1.year.from_now)
+  describe "#generate_refresh_token_with_rememberme" do
+    it "updates token to be valid for 1 year" do
+      api_credential.refresh_token_digest
+      refresh_token = api_credential.return_new_refresh_token!(true)[:refresh_token]
+
+      expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(1.year.from_now)
+    end
   end
-end
+
   describe "#generate_refresh_token_without_rememberme" do
-  it "updates token to be valid for 30 days" do
-    api_credential.refresh_token_digest
-    refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
+    it "updates token to be valid for 30 days" do
+      api_credential.refresh_token_digest
+      refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
 
     expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(30.days.from_now)
+    end
   end
-end
 end

--- a/spec/models/api_credential_spec.rb
+++ b/spec/models/api_credential_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ApiCredential, type: :model do
 
   describe "#authenticate_refresh_token" do
     it "returns true for a valid refresh_token" do
-      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
       expect(api_credential.authenticate_refresh_token(refresh_token)).to be true
     end
 
@@ -47,13 +47,13 @@ RSpec.describe ApiCredential, type: :model do
   describe "#return_new_refresh_token!" do
     it "updates the refresh_token digest" do
       old_digest = api_credential.refresh_token_digest
-      api_credential.return_new_refresh_token![:refresh_token]
+      api_credential.return_new_refresh_token!(false)[:refresh_token]
       api_credential.reload
       expect(api_credential.refresh_token_digest).not_to eq(old_digest)
     end
 
     it "sets a new refresh_token" do
-      new_token = api_credential.return_new_refresh_token![:refresh_token]
+      new_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
 
       expect(new_token).not_to be_nil
     end
@@ -95,7 +95,7 @@ RSpec.describe ApiCredential, type: :model do
   describe "#generate_refresh_token" do
     it "creates a secure hashed refresh_token" do
       api_credential.refresh_token_digest
-      refresh_token = api_credential.return_new_refresh_token![:refresh_token]
+      refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
 
       expect(api_credential.refresh_token_digest).to eq(Digest::SHA256.hexdigest(refresh_token))
     end
@@ -112,10 +112,26 @@ RSpec.describe ApiCredential, type: :model do
 
   describe "#revoke_refresh_token" do
     it "sets refresh token to nil" do
-      api_credential.return_new_refresh_token![:refresh_token]
+      api_credential.return_new_refresh_token!(false)[:refresh_token]
       api_credential.revoke_refresh_token
 
       expect(api_credential.refresh_token_digest).to be_nil
     end
   end
+  describe "#generate_refresh_token_with_rememberme" do
+  it "updates token to be valid for 1 year" do
+    api_credential.refresh_token_digest
+    refresh_token = api_credential.return_new_refresh_token!(true)[:refresh_token]
+
+    expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(1.year.from_now)
+  end
+end
+  describe "#generate_refresh_token_without_rememberme" do
+  it "updates token to be valid for 30 days" do
+    api_credential.refresh_token_digest
+    refresh_token = api_credential.return_new_refresh_token!(false)[:refresh_token]
+
+    expect(api_credential.refresh_token_expires_at).to be_within(1.minutes).of(30.days.from_now)
+  end
+end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6210

### What changed, and _why_?
Add remember_me parameter to API endpoint to update refresh token expiry to 1 year. 
- Update return_new_refresh_token to include boolean parameter
- Permit remember_me boolean param in controller and pass to blueprint to retrieve a refresh token with updated expiry date

Why? 
Users have the option for the refresh token to expire after 1 yr instead of 30 days for extended sessions.

### How is this **tested**? (please write tests!) 💖💪
2 tests for both return_new_refresh_token(true) and return_new_refresh_token(false) - spec/models/api_credential_spec.rb
Tested API endpoint with curl.

### Screenshots please :)
![IMG_5212](https://github.com/user-attachments/assets/979be44c-15a3-4d28-a8c9-64244fcb4c72)

