### PR TITLE
[6199] BUG: case contacts showing for unassigned volunteers

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -10,6 +10,7 @@ ignore:
   - Rails/TimeZone
 - app/controllers/case_contacts_controller.rb:
   - Rails/LexicallyScopedActionFilter
+  - Style/HashSlice
 - app/controllers/checklist_items_controller.rb:
   - Rails/TimeZone
 - app/controllers/court_dates_controller.rb:
@@ -806,6 +807,7 @@ ignore:
 - spec/requests/case_contacts_spec.rb:
   - RSpec/MultipleMemoizedHelpers
   - RSpec/MultipleExpectations
+  - RSpec/LetSetup
   - RSpec/PendingWithoutReason
 - spec/requests/case_court_reports_spec.rb:
   - RSpec/ContextWording
@@ -1161,7 +1163,6 @@ ignore:
   - RSpec/MultipleExpectations
   - RSpec/PredicateMatcher
   - RSpec/ContextWording
-  - RSpec/PendingWithoutReason
 - spec/system/case_contacts/index_spec.rb:
   - RSpec/LetSetup
   - RSpec/MultipleMemoizedHelpers
@@ -1174,7 +1175,6 @@ ignore:
   - RSpec/MultipleExpectations
   - RSpec/NamedSubject
   - RSpec/ExampleLength
-  - RSpec/PendingWithoutReason
   - RSpec/NestedGroups
   - Rails/Date
 - spec/system/case_court_reports/index_spec.rb:

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -21,6 +21,7 @@ class CaseContactsController < ApplicationController
 
     @pagy, @filtered_case_contacts = pagy(@filterrific.find)
     case_contacts = CaseContact.case_hash_from_cases(@filtered_case_contacts)
+    case_contacts = case_contacts.select { |k, _v| current_user.casa_cases.pluck(:id).include?(k) } if current_user.volunteer?
     case_contacts = case_contacts.select { |k, _v| k == params[:casa_case_id].to_i } if params[:casa_case_id].present?
 
     @presenter = CaseContactPresenter.new(case_contacts)

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe "/case_contacts", type: :request do
         expect(page).to include("60 minutes")
         expect(page).not_to include("3 hours")
       end
-
     end
   end
 

--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe "/case_contacts", type: :request do
         expect(page).not_to include(past_contact.creator.display_name)
       end
     end
+
+    context "when logged in as a volunteer" do
+      let(:assigned_case) { create(:casa_case, :with_one_case_assignment, casa_org: organization) }
+      let(:unassigned_case) { casa_case }
+      let(:volunteer) { assigned_case.assigned_volunteers.first }
+      let!(:assigned_case_contact) { create(:case_contact, casa_case: assigned_case, creator: volunteer) }
+      let!(:unassigned_case_contact) { create(:case_contact, casa_case: unassigned_case, creator: volunteer, duration_minutes: 180) }
+
+      before { sign_in volunteer }
+
+      it "returns only currently assigned cases" do
+        page = request.parsed_body.to_html
+        expect(page).to include("60 minutes")
+        expect(page).not_to include("3 hours")
+      end
+
+    end
   end
 
   describe "GET /new" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6199 

### What changed, and _why_?
Added an filtering step in the `case_contacts` controller for the index if a volunteer is logged in to only pass on case contacts for assigned cases to the view. 
Volunteers should not be seeing case contacts for cases no longer assigned to them.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
A test was added where a volunteer is logged in and is the creator of two case contacts, one for an assigned case (with a duration of 180 minutes) and one for a case that is not assigned to them (with factory default duration of 60 min). The test checks the page for the presence of "60 minutes" and omission of "3 hours". 


### Screenshots please :)
URL when logged in as a volunteer: http://127.0.0.1:3000/case_contacts

Before:
<img width="1141" alt="Screenshot 2025-03-21 at 1 32 32 PM" src="https://github.com/user-attachments/assets/1311b4a6-0ab6-4805-8695-b76f2055ecfd" />

Case contacts included without a Case No heading (meaning it's been unassigned.)

After:
<img width="1129" alt="Screenshot 2025-03-21 at 1 32 58 PM" src="https://github.com/user-attachments/assets/978be1ee-780c-4550-8999-f9e5fd42ebce" />

Orphaned case contacts no longer display below assigned case case contacts.

### Feelings gif (optional)
![I don't know what's happening](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExemtoa2R6dHRwaXRtcWJtOHQzejhteTc0bjBja2lvaThtdjRuNXA0eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMPj8P20jjOqZ5C/giphy.gif)
