### PR TITLE
BUG: no validation for email in new fund request form

### DIFF
--- a/app/models/fund_request.rb
+++ b/app/models/fund_request.rb
@@ -1,4 +1,5 @@
 class FundRequest < ApplicationRecord
+  validates :submitter_email, presence: true
 end
 
 # == Schema Information

--- a/app/views/fund_requests/new.html.erb
+++ b/app/views/fund_requests/new.html.erb
@@ -11,9 +11,16 @@
 <!-- ========== card start ========== -->
 <div class="card-style mb-50">
   <%= form_with(model: @fund_request, local: true, url: casa_case_fund_request_path(@casa_case), method: :post) do |form| %>
+
+    <% if @fund_request.errors.any? %>
+      <% @fund_request.errors.full_messages.each do |msg| %>
+        <p><%= msg %></p>
+      <% end %>
+    <% end %>
+
     <div class="input-style-1">
-      <%= form.label :submitter_email, "Your email" %>
-      <%= form.text_field :submitter_email, class: "form-control", required: true, value: current_user.email %>
+    <%= form.label :submitter_email, "Your email" %>
+      <%= form.email_field :submitter_email, class: "form-control", required: false, value: current_user.email %>
     </div>
 
     <div class="input-style-1">

--- a/spec/models/fund_request_spec.rb
+++ b/spec/models/fund_request_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe FundRequest, type: :model do
+  it { is_expected.to validate_presence_of(:submitter_email) }
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves [#6281](https://github.com/rubyforgood/casa/issues/6281)

### What changed, and _why_?
Added validation for email because previously user can submit the fund request with any input.

Before:
![image](https://github.com/user-attachments/assets/1a763ef6-ac44-413c-b5e0-2c09c3092756)

After:
![image](https://github.com/user-attachments/assets/e271619b-2540-4977-ab26-298ef0e79122)


### How is this **tested**? (please write rspec and jest tests!) 💖💪
I've added test cases for the same.

### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
