### PR TITLE
Wait for page load before database load

### DIFF
--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -27,16 +27,15 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
 
       click_on "Submit"
 
-      case_contact.reload
       expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
+      case_contact.reload
       expect(case_contact.casa_case_id).to eq casa_case.id
       expect(case_contact.duration_minutes).to eq 105
       expect(case_contact.medium_type).to eq "letter"
       expect(case_contact.contact_made).to be true
     end
 
-    # TODO: Fix this test
-    xit "admin successfully edits case contact with mileage reimbursement" do
+    it "admin successfully edits case contact with mileage reimbursement" do
       visit edit_case_contact_path(case_contact)
 
       complete_details_page(case_numbers: [], contact_types: [], contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: "04/04/2020")
@@ -44,8 +43,9 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
       fill_in_expenses_page(miles: 10, want_reimbursement: true, address: "123 str")
 
       click_on "Submit"
-      case_contact.reload
       expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
+      case_contact.reload
+      volunteer.address&.reload
       expect(case_contact.casa_case.volunteers[0]).to eq volunteer
       expect(volunteer.address&.content).to eq "123 str"
       expect(case_contact.casa_case_id).to eq casa_case.id
@@ -63,14 +63,10 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
       visit edit_case_contact_path(case_contact)
 
       complete_details_page(case_numbers: [], contact_types: [], contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: "04/04/2020")
-      complete_notes_page
 
       check "Request travel or other reimbursement"
       expect(page).to have_field("case_contact_volunteer_address", disabled: true)
       expect(page).to have_text("There are two or more volunteers assigned to this case and you are trying to set the address for both of them. This is not currently possible.")
-
-      click_on "Submit"
-      expect(case_contact.reload.volunteer_address).to be_blank
     end
 
     context "when user is part of a different organization" do
@@ -112,8 +108,9 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     fill_in_expenses_page(miles: 50, want_reimbursement: true, address: "123 Form St")
     click_on "Submit"
 
-    case_contact.reload
     expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
+    case_contact.reload
+    case_contact.contact_topic_answers&.reload
     expect(case_contact.duration_minutes).to eq 65
     expect(case_contact.medium_type).to eq "letter"
     expect(case_contact.contact_made).to be true
@@ -128,7 +125,7 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     expect(case_contact.volunteer_address).to eq "123 Form St"
   end
 
-  xit "is successful with mileage reimbursement on" do # TODO make test not flaky
+  it "is successful with mileage reimbursement on" do
     visit edit_case_contact_path(case_contact)
 
     complete_details_page(contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: "04/04/2020")
@@ -137,9 +134,9 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
 
     click_on "Submit"
 
+    expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
     case_contact.reload
     volunteer.reload
-    expect(page).to have_text "Case contact created at #{case_contact.created_at.strftime("%-I:%-M %p on %m-%e-%Y")}, was successfully updated."
     expect(volunteer.address.content).to eq "123 str"
     expect(case_contact.casa_case_id).to eq casa_case.id
     expect(case_contact.duration_minutes).to eq 105


### PR DESCRIPTION
### What changed, and _why_?
 - Check for the database update after the page is loaded to avoid race condition.
 - Also deleted optional filling out of form fields
```
complete_notes_page
```
 - removed 
```
      click_on "Submit"
      expect(case_contact.reload.volunteer_address).to be_blank
```
because the steps were irrelevant to the test