### PR TITLE
Rubocop config tune up

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 require:
-  - rubocop-capybara
   - rubocop-factory_bot
+
+plugins:
+  - rubocop-capybara
   - rubocop-rspec
   - rubocop-rspec_rails
 

--- a/spec/system/static/index_spec.rb
+++ b/spec/system/static/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "static/index", type: :system do
   context "when visiting the CASA volunteer landing page", :js do
     describe "when all organizations have logos" do
       before do
-        3.times { create(:casa_org, :with_logo, display_name: "CASA of Awesome") }
+        create_list(:casa_org, 3, :with_logo, display_name: "CASA of Awesome")
         visit root_path
       end
 

--- a/spec/system/volunteers/index_spec.rb
+++ b/spec/system/volunteers/index_spec.rb
@@ -175,13 +175,7 @@ RSpec.describe "view all volunteers", :js, type: :system do
     # These tests are very flaky do to the use of datatables on this page.
     # If the page is switched over to Hotwire, should try to re-instate these tests.
     describe "Manage Volunteers button" do
-      let!(:volunteers) {
-        [
-          create(:volunteer, casa_org: organization),
-          create(:volunteer, casa_org: organization),
-          create(:volunteer, casa_org: organization)
-        ]
-      }
+      let!(:volunteers) { create_list(:volunteer, 3, casa_org: organization) }
 
       before do
         sign_in admin
@@ -229,13 +223,7 @@ RSpec.describe "view all volunteers", :js, type: :system do
     end
 
     describe "Select All Checkbox" do
-      let!(:volunteers) {
-        [
-          create(:volunteer, casa_org: organization),
-          create(:volunteer, casa_org: organization),
-          create(:volunteer, casa_org: organization)
-        ]
-      }
+      let!(:volunteers) { create_list(:volunteer, 3, casa_org: organization) }
 
       before do
         sign_in admin

--- a/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/patch_notes/index.html.erb_spec.rb
@@ -2,12 +2,7 @@ require "rails_helper"
 
 RSpec.describe "patch_notes/index", type: :view do
   let(:all_casa_admin) { build(:all_casa_admin) }
-  let!(:patch_notes) {
-    [
-      create(:patch_note),
-      create(:patch_note)
-    ]
-  }
+  let!(:patch_notes) { create_list(:patch_note, 2) }
 
   before do
     assign(:patch_notes, patch_notes)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6380 

### What changed, and _why_?

Update rubocop config file to specify "plugins" instead of "require" for the following extensions:
- rubocop-capybara
- rubocop-rspec
- rubocop-rspec_rails

This ensures all extensions are supported properly.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Manual testing 
run `bundle exec standardrb`

We now receive the following output -

```yaml
Warning: Lint/UselessAccessModifier does not support ContextCreatingMethods parameter.

Supported parameters are:

  - Enabled
  ```
  
  Before we received
  
  ```yaml
  Warning: Lint/UselessAccessModifier does not support ContextCreatingMethods parameter.

Supported parameters are:

  - Enabled
rubocop-capybara extension supports plugin, specify `plugins: rubocop-capybara` instead of `require: rubocop-capybara` in /home/runner/work/casa/casa/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /home/runner/work/casa/casa/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec_rails extension supports plugin, specify `plugins: rubocop-rspec_rails` instead of `require: rubocop-rspec_rails` in /home/runner/work/casa/casa/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
WARNING: this project is being migrated to standard gradually via `/home/runner/work/casa/casa/.standard_todo.yml` and is ignoring these files:
  app/controllers/all_casa_admins/sessions_controller.rb
  app/controllers/api/v1/base_controller.rb

  ``` 
  
![CGT](https://github.com/user-attachments/assets/9ee3abcf-dbbc-4451-8331-7089fedf1194)
