### PR TITLE
Fix #6404: Trim whitespace from custom link text before saving

### DIFF
--- a/app/models/custom_org_link.rb
+++ b/app/models/custom_org_link.rb
@@ -6,6 +6,14 @@ class CustomOrgLink < ApplicationRecord
   validates :text, length: {maximum: TEXT_MAX_LENGTH}
   validates :active, inclusion: {in: [true, false]}
   validates :url, url: true
+
+  before_save :trim_name
+
+  private
+
+  def trim_name
+    self.text = text.strip if text.present?
+  end
 end
 
 # == Schema Information

--- a/db/migrate/20250528092341_trim_whitespace_from_custom_org_links.rb
+++ b/db/migrate/20250528092341_trim_whitespace_from_custom_org_links.rb
@@ -3,7 +3,7 @@ class TrimWhitespaceFromCustomOrgLinks < ActiveRecord::Migration[7.2]
     CustomOrgLink.find_each do |link|
       trimmed_text = link.text.strip
       link.update_columns(text: trimmed_text) if trimmed_text.present?
-    rescue StandardError => e
+    rescue => e
       Rails.logger.error("Failed to update CustomOrgLink ##{link.id}: #{e.message}")
     end
   end

--- a/db/migrate/20250528092341_trim_whitespace_from_custom_org_links.rb
+++ b/db/migrate/20250528092341_trim_whitespace_from_custom_org_links.rb
@@ -1,0 +1,14 @@
+class TrimWhitespaceFromCustomOrgLinks < ActiveRecord::Migration[7.2]
+  def up
+    CustomOrgLink.find_each do |link|
+      trimmed_text = link.text.strip
+      link.update_columns(text: trimmed_text) if trimmed_text.present?
+    rescue StandardError => e
+      Rails.logger.error("Failed to update CustomOrgLink ##{link.id}: #{e.message}")
+    end
+  end
+
+  def down
+    Rails.logger.info("Rollback not implemented for TrimWhitespaceFromCustomOrgLinks as it is a data migration")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_07_011754) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_28_092341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION

Resolves #6404 


 - Added a `before_save` callback in `CustomOrgLink` to trim whitespace from the `text` field before saving.
- Added a migration to trim whitespace from existing `CustomOrgLink` records (please review if this is desired). Used `up`/`down` methods since this is a data migration and not reversible. Tested locally to confirm it works.

![db_before](https://github.com/user-attachments/assets/cbc283b0-2382-4bcc-a10d-669ce4329010)
![DB_after](https://github.com/user-attachments/assets/ff6e8449-0888-4b30-b241-2a122850ff05)



