### PR TITLE
5260 suppress erroneous email reset warning

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -18,6 +18,20 @@ class Users::PasswordsController < Devise::PasswordsController
       notice: "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
   end
 
+  
+  def update
+    self.resource = resource_class.reset_password_by_token(resource_params)
+
+    yield resource if block_given?
+
+    if resource.errors.empty?
+      flash[:notice] = "Your password has been changed successfully."
+      redirect_to new_session_path(resource_name)
+    else
+      respond_with resource
+    end
+  end
+
   private
 
   def render_error

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -18,7 +18,6 @@ class Users::PasswordsController < Devise::PasswordsController
       notice: "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
   end
 
-  
   def update
     self.resource = resource_class.reset_password_by_token(resource_params)
 

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -123,4 +123,30 @@ RSpec.describe "Users::PasswordsController", type: :request do
       end
     end
   end
+
+  describe "PUT /update" do
+    let(:token) do
+      raw_token, enc_token = Devise.token_generator.generate(User, :reset_password_token)
+      user.update!(reset_password_token: enc_token, reset_password_sent_at: Time.current)
+      raw_token
+    end
+
+    let(:params) do
+      {
+        user: {
+          reset_password_token: token,
+          password: "newpassword123!",
+          password_confirmation: "newpassword123!"
+        }
+      }
+    end
+
+    subject(:submit_reset) { put user_password_path, params: params }
+
+    it "successfully resets the password" do
+      submit_reset
+      expect(response).to redirect_to(new_user_session_path)
+      expect(flash[:notice]).to eq("Your password has been changed successfully.")
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5260

### What changed, and _why_?

A method (`def update`) was added to override the default `Devise` behavior that was causing an erroneous warning regarding email confirmation. The users should not be given that warning as emails are automatically, manually, labeled as confirmed when an account is created. 

Now when a password is successfully updated the user will only see the success message. 

### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 

A test was added to `spec/requests/users/passwords_spec.rb`,



### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
![Screenshot from 2025-05-26 12-31-31](https://github.com/user-attachments/assets/d827471e-ac16-4b27-8024-ff06d3941b5c)


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
