### PR TITLE
Display error message for unauthorized court date visit attempt

### DIFF
--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -68,7 +68,7 @@ class CourtDatesController < ApplicationController
   rescue ActiveRecord::RecordNotFound
     respond_to do |format|
       format.html { redirect_to casa_cases_path, notice: "Sorry, you are not authorized to perform this action." }
-      format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :not_found }
+      format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :unauthorized }
     end
   end
 

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -65,10 +65,10 @@ class CourtDatesController < ApplicationController
 
   def set_casa_case
     @casa_case = current_organization.casa_cases.friendly.find(params[:casa_case_id])
-    rescue ActiveRecord::RecordNotFound
-      respond_to do |format|
-        format.html { redirect_to casa_cases_path, notice: "Sorry, you are not authorized to perform this action." }
-        format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :not_found }
+  rescue ActiveRecord::RecordNotFound
+    respond_to do |format|
+      format.html { redirect_to casa_cases_path, notice: "Sorry, you are not authorized to perform this action." }
+      format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :not_found }
     end
   end
 

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -65,6 +65,11 @@ class CourtDatesController < ApplicationController
 
   def set_casa_case
     @casa_case = current_organization.casa_cases.friendly.find(params[:casa_case_id])
+    rescue ActiveRecord::RecordNotFound
+      respond_to do |format|
+        format.html { redirect_to casa_cases_path, notice: "Sorry, you are not authorized to perform this action." }
+        format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :not_found }
+    end
   end
 
   def set_court_date

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -182,7 +182,6 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
       other_case = create(:casa_case, casa_org: other_org)
 
       get edit_casa_case_court_date_path(other_case, court_date)
-      get edit_casa_case_court_date_path(other_case, court_date)
       expect(response).to redirect_to(casa_cases_path)
       expect(response.status).to match 302
       expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -188,8 +188,6 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
       expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
     end
   end
-    end
-  end
 
   describe "POST /create" do
     let(:casa_case) { create(:casa_case) }

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -182,7 +182,12 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
       other_case = create(:casa_case, casa_org: other_org)
 
       get edit_casa_case_court_date_path(other_case, court_date)
-      expect(response).to be_not_found
+      get edit_casa_case_court_date_path(other_case, court_date)
+      expect(response).to redirect_to(casa_cases_path)
+      expect(response.status).to match 302
+      expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
+    end
+  end
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6457

### What changed, and _why_?
Showing unauthorized message instead of 404 error. We were getting this error when user not authorized to view a court date either from an organization not containing the court date's parent casa case or a volunteer not assigned to the court date's parent casa case. 


### How is this **tested**? (please write rspec and jest tests!) 💖💪
Updated `spec/requests/court_dates_spec.rb`.

### Screenshots

For fix, I have used similar pattern for errors as how it's used in `app/controllers/casa_cases_controller.rb#set_casa_case` .

- Image before changes  <img width="1116" height="563" alt="Screenshot from 2025-07-23 18-56-55" src="https://github.com/user-attachments/assets/58aff565-a40b-40c0-9c43-e5a7ad4c651e" /> 
- Image after changes <img width="1796" height="512" alt="Screenshot from 2025-07-23 18-58-55" src="https://github.com/user-attachments/assets/dd189c48-757e-4663-8e15-d19b64cec9a3" /> 

