### PR TITLE
Fixed court report dropdown

### DIFF
--- a/app/assets/stylesheets/pages/casa_cases.scss
+++ b/app/assets/stylesheets/pages/casa_cases.scss
@@ -175,10 +175,15 @@ body.casa_cases-show {
   background: transparent;
   border: 1px solid #e5e5e5;
   border-radius: 10px;
-  padding: 8px;
+  padding: 4px;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
+}
+
+// removes select2 dropdown default border
+span.select2-selection.select2-selection--single {
+  border: none;
 }
 
 .select-wrapper {

--- a/app/javascript/src/casa_case.js
+++ b/app/javascript/src/casa_case.js
@@ -159,6 +159,11 @@ function handleModalClose () {
   $('#case-selection').val(null).trigger('change')
 }
 
+// re-initialized for setting modal as dropdownParent
+function handleDropdownSelection () {
+  $('#case-selection').select2();
+}
+
 $(() => { // JQuery's callback for the DOM loading
   $('button.copy-court-button').on('click', copyOrdersFromCaseWithConfirmation)
 
@@ -178,6 +183,8 @@ $(() => { // JQuery's callback for the DOM loading
   // modal id is defined in _generate_docx.html.erb so would like to be able to implement modal close logic in that file
   // but not sure how to
   $('#generate-docx-report-modal').on('hidden.bs.modal', () => handleModalClose())
+  
+  $('#generate-docx-report-modal').on('shown.bs.modal', () => handleDropdownSelection())
 
   $('#btnGenerateReport').on('click', handleGenerateReport)
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6461

### What changed, and _why_?

Scroll was added as a option for dropdown modal of court reports, the dropdown didn't had proper scrolling present and was unresponsive once used.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Tested by running `spec/system/case_court_reports/index_spec.rb`


### Screenshots please :)

- Image before changes 
<img width="500" height="500" alt="Screenshot from 2025-08-05 18-55-40" src="https://github.com/user-attachments/assets/dcf7e7c4-0201-4d04-864a-15dfd6f1f1d9" />

- Image after changes
<img width="500" height="500" alt="Screenshot from 2025-08-05 18-54-56" src="https://github.com/user-attachments/assets/5608a812-d470-4df1-b30b-7909eccb7e01" />
<img width="500" height="500" alt="Screenshot from 2025-08-05 18-55-06" src="https://github.com/user-attachments/assets/d62aac4f-9d3d-4c01-9ccb-7fddf6775c0c" />
