### PR TITLE
Enable Scout error monitoring in production config

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -22,6 +22,7 @@ common: &defaults
 
 production:
   <<: *defaults
+  errors_enabled: true
 
 development:
   <<: *defaults


### PR DESCRIPTION
<img width="1199" height="539" alt="Screenshot 2025-09-05 at 7 52 18 PM" src="https://github.com/user-attachments/assets/cc6d5c4c-c624-42ed-84d1-ef14da5380ab" />
We are excited to announce that Scout's Error Monitoring is now in Beta! Easily find errors by type and by endpoint all in one place. 


To enable error reporting please use either of these two methods:


1. In your config/scout_apm.yml set `errors_enabled: true` 
2. Or you can set the environment variable SCOUT_ERRORS_ENABLED=true

 

Once you have deployed, you will see the Errors tab on the homepage.

 

You can expect

10,000 monthly errors on our free tier.
Transparent pricing: $15/month for 100k errors, $5 for each additional 50k
30-day data retention 
Correlate logs, traces, and errors
Please send us feedback!

 

We would love to hear about your experience to help us make this feature as valuable as possible.