### PR TITLE
Fix RSpec not running in GitHub Actions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -77,11 +77,12 @@ jobs:
           RUN_SIMPLECOV: true
           CC_TEST_REPORTER_ID: 31464536e34ab26588cb951d0fa6b5898abdf401dbe912fd47274df298e432ac
         run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
           RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
-          ./cc-test-reporter after-build --exit-code $?
+
+      - uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/.resultset.json
 
       - name: Archive selenium screenshots
         if: ${{ failure() }}


### PR DESCRIPTION
### What github issue is this PR for, if any?


### What changed, and _why_?

Every Github CI run was failing because, before running RSpec, the action configurations were trying to use a CodeClimate feature that is no longer supported. When accessing CodeClimate, the curl command would get a 500 error and fail the action before the test suite ran.

I have access to the new qlty.sh environment, so I added the token to the GitHub secrets for this repo as per the qlty docs.

Process:

- sign in to https://qlty.sh as self using GitHub account
- visit https://qlty.sh/gh/rubyforgood/projects/casa/pulls 
- click on "Settings" tab (see second screenshot below)
- copy qlty.sh API token for the rubyforgood casa project 
- add token to the casa project secrets as `QLTY_COVERAGE_TOKEN`

### How is this **tested**? (please write rspec and jest tests!) 💖💪

I opened a draft PR and the action actually ran the rspec tests and completed.

### Screenshots please :)

<img width="963" height="539" alt="Screenshot 2025-09-12 at 09 23 07" src="https://github.com/user-attachments/assets/c0a9789d-3d90-4353-9fb6-911e77a70d36" />

<img width="1098" height="514" alt="Screenshot 2025-09-12 at 09 32 15" src="https://github.com/user-attachments/assets/a83e7591-41d5-49f2-af7b-d030e09adba3" />


### Feelings gif (optional)

![Tom Hanks puffing his cheeks, sighing, and looking to the sky wondering](https://media2.giphy.com/media/BhyPiYtLJhIJVcTLLi/giphy-downsized.gif)
