### PR TITLE
Flaky test resolution

### DIFF
--- a/spec/system/banners/new_spec.rb
+++ b/spec/system/banners/new_spec.rb
@@ -15,18 +15,16 @@ RSpec.describe "Banners", :js, type: :system do
     check "Active?"
     fill_in_rich_text_area "banner_content", with: "Please fill out this survey."
     click_on "Submit"
-
-    visit banners_path
+    expect(page).to have_current_path(banners_path)
     expect(page).to have_text("Volunteer Survey Announcement")
 
-    visit banners_path
     within "#banners" do
       click_on "Edit", match: :first
     end
     fill_in "Name", with: "Better Volunteer Survey Announcement"
     click_on "Submit"
 
-    visit banners_path
+    expect(page).to have_current_path(banners_path)
     expect(page).to have_text("Better Volunteer Survey Announcement")
 
     visit root_path
@@ -44,17 +42,14 @@ RSpec.describe "Banners", :js, type: :system do
     fill_in_rich_text_area "banner_content", with: "Please fill out this survey."
     click_on "Submit"
 
-    visit banners_path
+    expect(page).to have_current_path(banners_path)
     expect(page).to have_text("Expiring Announcement")
-
-    visit banners_path
     within "#banners" do
       click_on "Edit", match: :first
     end
     fill_in "banner_expires_at", with: 2.days.from_now.strftime("%m%d%Y\t%I%M%P")
     click_on "Submit"
-
-    visit banners_path
+    expect(page).to have_current_path(banners_path)
     expect(page).to have_text("Expiring Announcement")
 
     visit root_path
@@ -71,7 +66,7 @@ RSpec.describe "Banners", :js, type: :system do
     fill_in_rich_text_area "banner_content", with: "Please fill out this survey."
     click_on "Submit"
 
-    visit banners_path
+    expect(page).to have_current_path(new_banner_path)
     expect(page).not_to have_text("Announcement not created")
   end
 
@@ -93,8 +88,8 @@ RSpec.describe "Banners", :js, type: :system do
         check "Active?"
         fill_in_rich_text_area "banner_content", with: "New active banner content."
         click_on "Submit"
+        expect(page).to have_current_path(banners_path)
 
-        visit banners_path
         within("table#banners") do
           already_existing_banner_row = find("tr", text: active_banner.name)
 
@@ -118,7 +113,7 @@ RSpec.describe "Banners", :js, type: :system do
         fill_in_rich_text_area "banner_content", with: "New active banner content."
         click_on "Submit"
 
-        visit banners_path
+        expect(page).to have_current_path(banners_path)
 
         within("table#banners") do
           already_existing_banner_row = find("tr", text: active_banner.name)

--- a/spec/system/bulk_court_dates/new_spec.rb
+++ b/spec/system/bulk_court_dates/new_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "bulk_court_dates/new", type: :system do
     within ".top-page-actions" do
       click_on "Create"
     end
+    expect(page).to have_current_path(new_bulk_court_date_path)
 
     visit casa_case_path(casa_case)
     expect(page).to have_content(hearing_type.name)

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe "Edit CASA Case", type: :system do
       # uncheck all contact type options
       select_all_el.click
       within ".ts-dropdown-content" do
-        expect(page).not_to have_css(".form-check-input--checked")
         expect(page).to have_css(".form-check-input--unchecked", count: 3)
+        expect(page).not_to have_css(".form-check-input--checked")
       end
       # check all contact type options
       select_all_el.click
       within ".ts-dropdown-content" do
-        expect(page).not_to have_css("input.form-check-input--unchecked")
         expect(page).to have_css("input.form-check-input--checked", count: 3)
+        expect(page).not_to have_css("input.form-check-input--unchecked")
       end
 
       # unselect contact_type from dropdown
@@ -247,14 +247,14 @@ RSpec.describe "Edit CASA Case", type: :system do
       # uncheck all contact type options
       select_all_el.click
       within ".ts-dropdown-content" do
-        expect(page).not_to have_css(".form-check-input--checked")
         expect(page).to have_css(".form-check-input--unchecked", count: 2)
+        expect(page).not_to have_css(".form-check-input--checked")
       end
       # check all contact type options
       select_all_el.click
       within ".ts-dropdown-content" do
-        expect(page).not_to have_css("input.form-check-input--unchecked")
         expect(page).to have_css("input.form-check-input--checked", count: 2)
+        expect(page).not_to have_css("input.form-check-input--unchecked")
       end
       # since all contact type options checked, don't need to select one
       within ".top-page-actions" do

--- a/spec/system/case_contacts/additional_expenses_spec.rb
+++ b/spec/system/case_contacts/additional_expenses_spec.rb
@@ -49,8 +49,11 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     fill_expense_fields 5.34, "Lunch"
     uncheck "Request travel or other reimbursement"
 
-    expect { click_on "Submit" }
-      .to change(CaseContact.active, :count).by(1)
+    expect do
+      click_on "Submit"
+
+      expect(page).to have_text("Case contact successfully created.")
+    end.to change(CaseContact.active, :count).by(1)
 
     case_contact = CaseContact.active.last
     expect(case_contact.additional_expenses).to be_empty
@@ -58,8 +61,7 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     expect(case_contact.want_driving_reimbursement).to be false
   end
 
-  # TODO: Fix this test
-  xit "can remove an expense" do
+  it "can remove an expense" do
     subject
     fill_in_contact_details
     check "Request travel or other reimbursement"
@@ -81,6 +83,7 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
       expect(page).to have_field(class: "expense-amount-input", count: 2)
 
       click_on "Submit"
+      expect(page).to have_text('Case contact successfully created.')
     }
       .to change(CaseContact.active, :count).by(1)
       .and change(AdditionalExpense, :count).by(2)

--- a/spec/system/case_contacts/additional_expenses_spec.rb
+++ b/spec/system/case_contacts/additional_expenses_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
       expect(page).to have_field(class: "expense-amount-input", count: 2)
 
       click_on "Submit"
-      expect(page).to have_text('Case contact successfully created.')
+      expect(page).to have_text("Case contact successfully created.")
     }
       .to change(CaseContact.active, :count).by(1)
       .and change(AdditionalExpense, :count).by(2)

--- a/spec/system/case_contacts/contact_topic_answers_spec.rb
+++ b/spec/system/case_contacts/contact_topic_answers_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
       fill_in "Additional Notes", with: "This is a fake a topic answer."
 
       expect do
-        click_on "Submit";
+        click_on "Submit"
         # Force wait for capybara round trip before asserting the database was updated
-        expect(page).to have_text 'successfully created'
+        expect(page).to have_text "successfully created"
       end.to change(CaseContact.active, :count).by(1)
 
       contact = CaseContact.active.last

--- a/spec/system/case_contacts/contact_topic_answers_spec.rb
+++ b/spec/system/case_contacts/contact_topic_answers_spec.rb
@@ -139,7 +139,11 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
 
       fill_in "Additional Notes", with: "This is a fake a topic answer."
 
-      expect { click_on "Submit" }.to change(CaseContact.active, :count).by(1)
+      expect do
+        click_on "Submit";
+        # Force wait for capybara round trip before asserting the database was updated
+        expect(page).to have_text 'successfully created'
+      end.to change(CaseContact.active, :count).by(1)
 
       contact = CaseContact.active.last
       expect(contact.contact_topic_answers).to be_empty

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Case Groups", :js, type: :system do
     find("#case_group_name").click
 
     click_on "Submit"
-
-    visit case_groups_path
+    # Wait for capybara to follow the redirect before asserting anything else
+    expect(page).to have_current_path(case_groups_path)
     expect(page).to have_text("A family")
 
     within "#case-groups" do
@@ -28,9 +28,10 @@ RSpec.describe "Case Groups", :js, type: :system do
     end
     fill_in "Name", with: "Another family"
     click_on "Submit"
-
-    visit case_groups_path
+    # Wait for capybara to follow the redirect before asserting anything else
+    expect(page).to have_current_path(case_groups_path)
     expect(page).to have_text("Another family")
+
   end
 
   it "remove from a case group" do
@@ -49,7 +50,7 @@ RSpec.describe "Case Groups", :js, type: :system do
 
     click_on "Submit"
 
-    visit case_groups_path
+    expect(page).to have_current_path(case_groups_path)
     expect(page).to have_text(casa_case1.case_number)
     expect(page).to have_text(casa_case2.case_number)
 
@@ -62,7 +63,7 @@ RSpec.describe "Case Groups", :js, type: :system do
     end
     click_on "Submit"
 
-    visit case_groups_path
+    expect(page).to have_current_path(case_groups_path)
     expect(page).to have_text(casa_case1.case_number)
     expect(page).not_to have_text(casa_case2.case_number)
   end
@@ -80,7 +81,7 @@ RSpec.describe "Case Groups", :js, type: :system do
     find("#case_group_name").click
     click_on "Submit"
 
-    visit case_groups_path
+    expect(page).to have_current_path(case_groups_path)
     click_on "New Case Group"
     fill_in "Name", with: "A Family "
     find(".ts-control > input").click

--- a/spec/system/case_groups/case_groups_spec.rb
+++ b/spec/system/case_groups/case_groups_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe "Case Groups", :js, type: :system do
     # Wait for capybara to follow the redirect before asserting anything else
     expect(page).to have_current_path(case_groups_path)
     expect(page).to have_text("Another family")
-
   end
 
   it "remove from a case group" do


### PR DESCRIPTION
### What github issue is this PR for, if any?

This fixes some flaky tests.
* Fixes one that was listed as TODO in a comment
* Fixes a few tests that we noticed in local dev envs at the RfG 2025 events

This also speeds up test times for `spec/system/casa_cases/edit_spec.rb`

### What changed, and _why_?

This addresses two main types of changes
* When expecting a controller to do something via a headless browser actions, assert a UI change you expect to see before asserting the DB was updated or navigating the browser to a different page
  * On fast machines, it's possible to navigate away before the browser has finished sending its request
  * In many of these cases, the `visit` call was unneeded because the page to visit was already the page that the controller redirects to
* When asserting in sequence a series of page content matchers (CSS based or otherwise) are valid and not expecting the page to change between assertions, put at least one positive `.to` assertions before any `.not_to` assertions whenever practicable. 
  * If the negative page content matchers are first, Capybara would wait for the full length of its maximum wait time to be extra sure the content doesn't show up at the very last second
  * Getting this wrong can easily double the time Capybara waits to make sure the page is correct before passing the test.
 
Using `expect(page).to have_current_path(expected_path)` does count as putting a positive assertion first that helps with not doubling the wait time . The `have_current_path` matcher was intentionally written with this goal in mind.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

I tested it locally repeatedly and the edited tests pass reliably.

### Feelings gif (optional)
![a turtle attempting to walk up a playground slide](https://media3.giphy.com/media/mAwCycImTr7JC/giphy.gif)
