### PR TITLE
chore: remove superfluous test code

### DIFF
--- a/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/casa_orgs/show.html.erb_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "all_casa_admins/casa_orgs/show", type: :view do
     }
 
     before do
-      allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:selected_organization).and_return(organization)
       assign :casa_org_metrics, metrics
       render

--- a/spec/views/banners/new.html.erb_spec.rb
+++ b/spec/views/banners/new.html.erb_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "banners/new", type: :view do
       current_organization = user.casa_org
       current_organization_banner = build(:banner, active: true, casa_org: current_organization)
 
-      allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:current_organization).and_return(current_organization)
       without_partial_double_verification do
         allow(view).to receive(:browser_time_zone).and_return("America/New_York")
@@ -31,7 +30,6 @@ RSpec.describe "banners/new", type: :view do
         current_organization = user.casa_org
         current_organization_banner = build(:banner, active: true, casa_org: current_organization)
 
-        allow(view).to receive(:current_user).and_return(user)
         allow(view).to receive(:current_organization).and_return(current_organization)
         without_partial_double_verification do
           allow(view).to receive(:browser_time_zone).and_return("America/New_York")
@@ -55,7 +53,6 @@ RSpec.describe "banners/new", type: :view do
         user = build_stubbed(:casa_admin)
         current_organization = user.casa_org
 
-        allow(view).to receive(:current_user).and_return(user)
         allow(view).to receive(:current_organization).and_return(current_organization)
         without_partial_double_verification do
           allow(view).to receive(:browser_time_zone).and_return("America/New_York")

--- a/spec/views/casa_admins/admins_table.html.erb_spec.rb
+++ b/spec/views/casa_admins/admins_table.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "admins_table", type: :view do
   it "allows editing admin users" do
     admin = build_stubbed :casa_admin
     enable_pundit(view, admin)
-    allow(view).to receive(:current_user).and_return(admin)
 
     assign :admins, [admin.decorate]
 

--- a/spec/views/casa_cases/new.html.erb_spec.rb
+++ b/spec/views/casa_cases/new.html.erb_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe "casa_cases/new", type: :view do
   context "while signed in as admin" do
     it "has youth birth month and year" do
       enable_pundit(view, user)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:current_organization).and_return(casa_org)
 
       assign :casa_case, build(:casa_case, casa_org: casa_org)
       assign :contact_types, casa_org.contact_types
@@ -24,8 +22,6 @@ RSpec.describe "casa_cases/new", type: :view do
   context "when trying to assign a volunteer to a case" do
     it "is able to assign volunteers" do
       enable_pundit(view, user)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:current_organization).and_return(user.casa_org)
 
       assign :casa_case, build(:casa_case, casa_org: user.casa_org)
       assign :contact_types, casa_org.contact_types

--- a/spec/views/court_dates/edit.html.erb_spec.rb
+++ b/spec/views/court_dates/edit.html.erb_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "court_dates/edit", type: :view do
     assign :court_date, court_date
 
     enable_pundit(view, user)
-    allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
   end
 

--- a/spec/views/court_dates/show.html.erb_spec.rb
+++ b/spec/views/court_dates/show.html.erb_spec.rb
@@ -52,9 +52,6 @@ RSpec.describe "court_dates/show", type: :view do
 
     assign :casa_case, court_date.casa_case
     assign :court_date, court_date
-
-    allow(view).to receive(:current_user).and_return(user)
-    allow(view).to receive(:current_organization).and_return(user.casa_org)
   end
 
   context "with court details" do

--- a/spec/views/mileage_rates/index.html.erb_spec.rb
+++ b/spec/views/mileage_rates/index.html.erb_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Index Mileage Rates", type: :view do
 
   before do
     enable_pundit(view, admin)
-    allow(view).to receive(:current_user).and_return(admin)
     sign_in admin
   end
 

--- a/spec/views/placements/edit.html.erb_spec.rb
+++ b/spec/views/placements/edit.html.erb_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "placements/edit", type: :view do
     assign :placement, placement
 
     enable_pundit(view, user)
-    allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return(user.casa_org)
     render
   end

--- a/spec/views/reimbursements/index.html.erb_spec.rb
+++ b/spec/views/reimbursements/index.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "reimbursements/index", type: :view do
   before do
     admin = build_stubbed :casa_admin
     enable_pundit(view, admin)
-    allow(view).to receive(:current_user).and_return(admin)
   end
 
   it "does not have any translation missing classes" do

--- a/spec/views/volunteers/index.html.erb_spec.rb
+++ b/spec/views/volunteers/index.html.erb_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "volunteers", type: :view do
 
   before do
     enable_pundit(view, user)
-    allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:current_organization).and_return user.casa_org
     assign :volunteers, [volunteer]
     sign_in user


### PR DESCRIPTION
### What changed, and _why_?

In the process of working on #6491, I noticed that there was extra view spec setup code that I had copy-pasted into my new view specs.

Turned out to be superfluous, so I tried take the same code out everywhere else it appeared. These are the tests where that could be done safely!

### How is this **tested**?
 
Deleted code, Rspec suite still passes: ✅ 

### Screenshots please :)

<img width="125" height="33" alt="image" src="https://github.com/user-attachments/assets/f441d247-1866-447d-8038-97a38c4b6034" />

