### PR TITLE
Add new_case_contact_table feature flag

### DIFF
--- a/app/controllers/case_contacts/case_contacts_new_design_controller.rb
+++ b/app/controllers/case_contacts/case_contacts_new_design_controller.rb
@@ -1,5 +1,6 @@
 class CaseContacts::CaseContactsNewDesignController < ApplicationController
   include LoadsCaseContacts
+  before_action :check_feature_flag
 
   def index
     load_case_contacts
@@ -11,5 +12,13 @@ class CaseContacts::CaseContactsNewDesignController < ApplicationController
     datatable = CaseContactDatatable.new case_contacts, params
 
     render json: datatable
+  end
+
+  private
+
+  def check_feature_flag
+    unless Flipper.enabled?(:new_case_contact_table)
+      redirect_to case_contacts_path, alert: "This feature is not available."
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,11 @@ Rails.application.routes.draw do
 
   get "case_contacts/leave", to: "case_contacts#leave", as: "leave_case_contacts_form"
   get "case_contacts/drafts", to: "case_contacts#drafts"
-  get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index"
+  
+  # Feature flag for new case contact table design
+  get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index", constraints: lambda { |request|
+    Flipper.enabled?(:new_case_contact_table)
+  }
   resources :case_contacts, except: %i[create update show], concerns: %i[with_datatable] do
     member do
       post :restore

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,9 +94,7 @@ Rails.application.routes.draw do
   get "case_contacts/drafts", to: "case_contacts#drafts"
 
   # Feature flag for new case contact table design
-  get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index", constraints: lambda { |request|
-    Flipper.enabled?(:new_case_contact_table)
-  }
+  get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index"
   resources :case_contacts, except: %i[create update show], concerns: %i[with_datatable] do
     member do
       post :restore

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,7 @@ Rails.application.routes.draw do
 
   get "case_contacts/leave", to: "case_contacts#leave", as: "leave_case_contacts_form"
   get "case_contacts/drafts", to: "case_contacts#drafts"
-  
+
   # Feature flag for new case contact table design
   get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index", constraints: lambda { |request|
     Flipper.enabled?(:new_case_contact_table)

--- a/spec/controllers/concerns/loads_case_contacts_spec.rb
+++ b/spec/controllers/concerns/loads_case_contacts_spec.rb
@@ -12,4 +12,37 @@ RSpec.describe LoadsCaseContacts do
     expect(host.private_instance_methods)
       .to include(:load_case_contacts, :current_organization_groups, :all_case_contacts)
   end
+
+  describe "integration with Flipper flags", type: :request do
+    let(:organization) { create(:casa_org) }
+    let(:admin) { create(:casa_admin, casa_org: organization) }
+    let!(:casa_case) { create(:casa_case, casa_org: organization) }
+    let!(:case_contact) { create(:case_contact, :active, casa_case: casa_case) }
+
+    before { sign_in admin }
+
+    context "when new_case_contact_table flag is enabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(true)
+      end
+
+      it "loads case contacts successfully through the new design controller" do
+        get case_contacts_new_design_path
+        expect(response).to have_http_status(:success)
+        expect(assigns(:filtered_case_contacts)).to be_present
+      end
+    end
+
+    context "when new_case_contact_table flag is disabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(false)
+      end
+
+      it "does not load case contacts and redirects instead" do
+        get case_contacts_new_design_path
+        expect(response).to redirect_to(case_contacts_path)
+        expect(assigns(:filtered_case_contacts)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6493

### What changed, and _why_?

Added a feature flag to enable and disable the new case contact table. This feature flag guards the route and the controller.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Existing specs have been updated to test cases when the feature flag is enabled and disabled.

- `spec/controllers/concerns/loads_case_contacts_spec.rb`
- `spec/requests/case_contacts/case_contacts_new_design_spec.rb`

_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
