### PR TITLE
Fix All CASA Admin "Change Password" button

### DIFF
--- a/app/views/all_casa_admins/edit.html.erb
+++ b/app/views/all_casa_admins/edit.html.erb
@@ -19,13 +19,13 @@
 
       <div class="actions">
         <%= form.button "Update Profile", type: "submit", class: "main-btn primary-btn btn-hover" %>
-        <button class="main-btn primary-btn btn-hover" id="accordionExample" type="button" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+        <button class="main-btn primary-btn btn-hover" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
           Change Password
         </button>
       </div>
     <% end %>
     <br>
-    <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+    <div id="collapseOne" class="collapse" aria-labelledby="headingOne">
       <%= form_with(model: @user, scope: :all_casa_admin, url: {action: "update_password"}, method: :patch) do |f| %>
         <div class="input-style-1">
           <%= f.label :password, "Password" %><br>

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AllCasaAdmin edit page', type: :system do
+  let(:admin) { create(:all_casa_admin) }
+
+  before do
+    sign_in admin
+    visit edit_all_casa_admins_path
+  end
+
+  it "shows the password section only after clicking 'Change Password'", :aggregate_failures, :js do
+    expect_password_section_hidden
+
+    # Click the Change Password button
+    click_button 'Change Password'
+
+    # Password section should now be visible
+    expect_password_section_visible
+  end
+
+  private
+
+  def expect_password_section_hidden
+    expect(page).to have_selector('#collapseOne.collapse:not(.show)', visible: :all)
+  end
+
+  def expect_password_section_visible
+    expect(page).to have_selector('#collapseOne.collapse.show')
+    expect(page).to have_field('all_casa_admin[password]')
+    expect(page).to have_field('all_casa_admin[password_confirmation]')
+    expect(page).to have_button('Update Password')
+  end
+end

--- a/spec/system/all_casa_admins/edit_spec.rb
+++ b/spec/system/all_casa_admins/edit_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'AllCasaAdmin edit page', type: :system do
+RSpec.describe "AllCasaAdmin edit page", type: :system do
   let(:admin) { create(:all_casa_admin) }
 
   before do
@@ -14,7 +14,7 @@ RSpec.describe 'AllCasaAdmin edit page', type: :system do
     expect_password_section_hidden
 
     # Click the Change Password button
-    click_button 'Change Password'
+    click_button "Change Password"
 
     # Password section should now be visible
     expect_password_section_visible
@@ -23,13 +23,13 @@ RSpec.describe 'AllCasaAdmin edit page', type: :system do
   private
 
   def expect_password_section_hidden
-    expect(page).to have_selector('#collapseOne.collapse:not(.show)', visible: :all)
+    expect(page).to have_selector("#collapseOne.collapse:not(.show)", visible: :all)
   end
 
   def expect_password_section_visible
-    expect(page).to have_selector('#collapseOne.collapse.show')
-    expect(page).to have_field('all_casa_admin[password]')
-    expect(page).to have_field('all_casa_admin[password_confirmation]')
-    expect(page).to have_button('Update Password')
+    expect(page).to have_selector("#collapseOne.collapse.show")
+    expect(page).to have_field("all_casa_admin[password]")
+    expect(page).to have_field("all_casa_admin[password_confirmation]")
+    expect(page).to have_button("Update Password")
   end
 end

--- a/spec/system/all_casa_admins/password_change_spec.rb
+++ b/spec/system/all_casa_admins/password_change_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AllCasaAdmin password change', type: :system do
+  let(:admin) { create(:all_casa_admin, email: 'all_casa_admin1@example.com', password: '12345678') }
+
+  before do
+    sign_in admin
+    visit edit_all_casa_admins_path
+    click_button 'Change Password'
+  end
+
+  it 'shows error when password fields are blank', :aggregate_failures, :js do
+    click_button 'Update Password'
+    expect(page).to have_selector('#error_explanation.alert')
+    expect(page).to have_text("Password can't be blank")
+  end
+
+  it "shows error when password confirmation doesn't match", :aggregate_failures, :js do
+    fill_in 'all_casa_admin[password]', with: 'newpassword'
+    fill_in 'all_casa_admin[password_confirmation]', with: 'wrongconfirmation'
+    click_button 'Update Password'
+    expect(page).to have_selector('#error_explanation.alert')
+    expect(page).to have_text("Password confirmation doesn't match Password")
+  end
+
+  it 'shows success flash when password is updated', :aggregate_failures, :js do
+    fill_in 'all_casa_admin[password]', with: 'newpassword'
+    fill_in 'all_casa_admin[password_confirmation]', with: 'newpassword'
+    click_button 'Update Password'
+    expect(page).to have_selector('.header-flash')
+    expect(page).to have_text("Password was successfully updated.")
+  end
+end

--- a/spec/system/all_casa_admins/password_change_spec.rb
+++ b/spec/system/all_casa_admins/password_change_spec.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'AllCasaAdmin password change', type: :system do
-  let(:admin) { create(:all_casa_admin, email: 'all_casa_admin1@example.com', password: '12345678') }
+RSpec.describe "AllCasaAdmin password change", type: :system do
+  let(:admin) { create(:all_casa_admin, email: "all_casa_admin1@example.com", password: "12345678") }
 
   before do
     sign_in admin
     visit edit_all_casa_admins_path
-    click_button 'Change Password'
+    click_button "Change Password"
   end
 
-  it 'shows error when password fields are blank', :aggregate_failures, :js do
-    click_button 'Update Password'
-    expect(page).to have_selector('#error_explanation.alert')
+  it "shows error when password fields are blank", :aggregate_failures, :js do
+    click_button "Update Password"
+    expect(page).to have_selector("#error_explanation.alert")
     expect(page).to have_text("Password can't be blank")
   end
 
   it "shows error when password confirmation doesn't match", :aggregate_failures, :js do
-    fill_in 'all_casa_admin[password]', with: 'newpassword'
-    fill_in 'all_casa_admin[password_confirmation]', with: 'wrongconfirmation'
-    click_button 'Update Password'
-    expect(page).to have_selector('#error_explanation.alert')
+    fill_in "all_casa_admin[password]", with: "newpassword"
+    fill_in "all_casa_admin[password_confirmation]", with: "wrongconfirmation"
+    click_button "Update Password"
+    expect(page).to have_selector("#error_explanation.alert")
     expect(page).to have_text("Password confirmation doesn't match Password")
   end
 
-  it 'shows success flash when password is updated', :aggregate_failures, :js do
-    fill_in 'all_casa_admin[password]', with: 'newpassword'
-    fill_in 'all_casa_admin[password_confirmation]', with: 'newpassword'
-    click_button 'Update Password'
-    expect(page).to have_selector('.header-flash')
+  it "shows success flash when password is updated", :aggregate_failures, :js do
+    fill_in "all_casa_admin[password]", with: "newpassword"
+    fill_in "all_casa_admin[password_confirmation]", with: "newpassword"
+    click_button "Update Password"
+    expect(page).to have_selector(".header-flash")
     expect(page).to have_text("Password was successfully updated.")
   end
 end

--- a/spec/views/all_casa_admins/edit.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/edit.html.erb_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'all_casa_admins/edit', type: :view do
+RSpec.describe "all_casa_admins/edit", type: :view do
   let(:user) { build_stubbed(:all_casa_admin) }
 
   before do
@@ -10,53 +10,53 @@ RSpec.describe 'all_casa_admins/edit', type: :view do
     render
   end
 
-  it 'renders the edit profile form', :aggregate_failures do
+  it "renders the edit profile form", :aggregate_failures do
     expect(rendered).to have_selector("form[action='#{all_casa_admins_path}'][method='post']")
-    expect(rendered).to have_field('all_casa_admin[email]')
-    expect(rendered).to have_button('Update Profile')
+    expect(rendered).to have_field("all_casa_admin[email]")
+    expect(rendered).to have_button("Update Profile")
   end
 
-  it 'renders the change password collapse section, hidden by default', :aggregate_failures do
-    expect(rendered).to have_selector('#collapseOne.collapse')
+  it "renders the change password collapse section, hidden by default", :aggregate_failures do
+    expect(rendered).to have_selector("#collapseOne.collapse")
     expect(rendered).not_to include('class="collapse show"')
-    expect(rendered).to have_field('all_casa_admin[password]')
-    expect(rendered).to have_field('all_casa_admin[password_confirmation]')
-    expect(rendered).to have_button('Update Password')
+    expect(rendered).to have_field("all_casa_admin[password]")
+    expect(rendered).to have_field("all_casa_admin[password_confirmation]")
+    expect(rendered).to have_button("Update Password")
   end
 
-  context 'when there are error and flash messages' do
+  context "when there are error and flash messages" do
     before do
       user.errors.add(:email, "can't be blank")
-      flash[:notice] = 'Profile updated'
+      flash[:notice] = "Profile updated"
       render
     end
 
-    it 'renders error and flash messages partials', :aggregate_failures do
-      expect(rendered).to have_selector('#error_explanation.alert')
+    it "renders error and flash messages partials", :aggregate_failures do
+      expect(rendered).to have_selector("#error_explanation.alert")
       expect(rendered).to have_text("can't be blank")
-      expect(rendered).to have_selector('.header-flash')
-      expect(rendered).to have_text('Profile updated')
+      expect(rendered).to have_selector(".header-flash")
+      expect(rendered).to have_text("Profile updated")
     end
   end
 
-  context 'when submitting the password change form' do
+  context "when submitting the password change form" do
     before do
       sign_in user
       assign(:user, user)
       render
     end
 
-    it 'shows error when password fields are blank', :aggregate_failures do
+    it "shows error when password fields are blank", :aggregate_failures do
       user.errors.add(:password, "can't be blank")
       render
-      expect(rendered).to have_selector('#error_explanation.alert')
+      expect(rendered).to have_selector("#error_explanation.alert")
       expect(rendered).to have_text("can't be blank")
     end
 
-    it 'shows error when password confirmation does not match', :aggregate_failures do
+    it "shows error when password confirmation does not match", :aggregate_failures do
       user.errors.add(:password_confirmation, "doesn't match Password")
       render
-      expect(rendered).to have_selector('#error_explanation.alert')
+      expect(rendered).to have_selector("#error_explanation.alert")
       expect(rendered).to have_text("doesn't match Password")
     end
   end

--- a/spec/views/all_casa_admins/edit.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/edit.html.erb_spec.rb
@@ -38,4 +38,26 @@ RSpec.describe 'all_casa_admins/edit', type: :view do
       expect(rendered).to have_text('Profile updated')
     end
   end
+
+  context 'when submitting the password change form' do
+    before do
+      sign_in user
+      assign(:user, user)
+      render
+    end
+
+    it 'shows error when password fields are blank', :aggregate_failures do
+      user.errors.add(:password, "can't be blank")
+      render
+      expect(rendered).to have_selector('#error_explanation.alert')
+      expect(rendered).to have_text("can't be blank")
+    end
+
+    it 'shows error when password confirmation does not match', :aggregate_failures do
+      user.errors.add(:password_confirmation, "doesn't match Password")
+      render
+      expect(rendered).to have_selector('#error_explanation.alert')
+      expect(rendered).to have_text("doesn't match Password")
+    end
+  end
 end

--- a/spec/views/all_casa_admins/edit.html.erb_spec.rb
+++ b/spec/views/all_casa_admins/edit.html.erb_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'all_casa_admins/edit', type: :view do
+  let(:user) { build_stubbed(:all_casa_admin) }
+
+  before do
+    assign(:user, user)
+    render
+  end
+
+  it 'renders the edit profile form', :aggregate_failures do
+    expect(rendered).to have_selector("form[action='#{all_casa_admins_path}'][method='post']")
+    expect(rendered).to have_field('all_casa_admin[email]')
+    expect(rendered).to have_button('Update Profile')
+  end
+
+  it 'renders the change password collapse section, hidden by default', :aggregate_failures do
+    expect(rendered).to have_selector('#collapseOne.collapse')
+    expect(rendered).not_to include('class="collapse show"')
+    expect(rendered).to have_field('all_casa_admin[password]')
+    expect(rendered).to have_field('all_casa_admin[password_confirmation]')
+    expect(rendered).to have_button('Update Password')
+  end
+
+  context 'when there are error and flash messages' do
+    before do
+      user.errors.add(:email, "can't be blank")
+      flash[:notice] = 'Profile updated'
+      render
+    end
+
+    it 'renders error and flash messages partials', :aggregate_failures do
+      expect(rendered).to have_selector('#error_explanation.alert')
+      expect(rendered).to have_text("can't be blank")
+      expect(rendered).to have_selector('.header-flash')
+      expect(rendered).to have_text('Profile updated')
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6527

### What changed, and _why_?
The bug fix updates the "Change Password" button and collapse form in `app/views/all_casa_admins/edit.html.erb` to use Bootstrap 5 attributes (`data-bs-toggle`, `data-bs-target`) instead of Bootstrap 4 (`data-toggle`, `data-target`). The parent accordion reference was also removed. Previously, clicking "Change Password" did not expand the password form due to outdated attributes, preventing admins from updating their password. Now, the button correctly toggles the password form, restoring expected functionality and improving user experience.

### How is this **tested**?
**New test files added:**
- `spec/views/all_casa_admins/edit.html.erb_spec.rb` — verifies the correct rendering and behavior of the edit profile view.
- `spec/system/all_casa_admins/edit_spec.rb` — covers system-level interactions for editing admin profiles.
- `spec/system/all_casa_admins/password_change_spec.rb` — tests the password change workflow, including form expansion and successful/failed updates.

**Manual testing:**
- Navigated to `/all_casa_admins/edit` locally, confirmed the password form expands and updates work. See Loom demo and screenshots below.

**Demo**
[![dbb1b4d5e5f344b4972735dc693e5386-51f60ae5c0f4e762-full-play](https://github.com/user-attachments/assets/ba1f0776-6ed9-4851-a8ad-765963ab4d63)](https://www.loom.com/share/dbb1b4d5e5f344b4972735dc693e5386?sid=b73db727-ba6d-4050-86e2-eff011ba6bcb)

**Before:**
<img width="614" height="391" alt="Screenshot 2025-10-06 at 2 58 57 PM" src="https://github.com/user-attachments/assets/e8941a25-1f32-48d1-b6a3-42d80027ae52" />

**After:**
<img width="540" height="716" alt="Screenshot 2025-10-06 at 2 59 08 PM" src="https://github.com/user-attachments/assets/fa46213f-4b4a-4179-8bf2-8fbb0daeaa40" />

### Feelings gif
![Jim Halpert from The Office saying, "Problem solved."](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmc5MXBzdzU4ZzFzc245MjEwd2Z6MTR0cHV3dDRseTFrdGliOG1wbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Ztzt8zhmmpVPUiSNMX/giphy.gif)`
