### PR TITLE
Add button for new case contact

### DIFF
--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -7,7 +7,7 @@
     </div>
     <div class="col-md-6">
       <div class="breadcrumb-wrapper mb-30 text-end">
-        <%= link_to new_case_contact_path, 
+        <%= link_to new_case_contact_path,
             class: "main-btn btn-sm primary-btn btn-hover ml-3",
             aria: { label: "Create new case contact" } do %>
           <i class="lni lni-plus"></i>


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6501 

### What changed, and _why_?
Added a `+ new case contact` button to the new design of the case contacts table. This button takes the user to the already-existing "new case contact" form.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
**to be added**

_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 

<img width="1908" height="956" alt="Screenshot 2025-11-12 at 11 32 59" src="https://github.com/user-attachments/assets/d5d0fdbf-f0e9-46f6-900b-7343d47ea5f0" />
