### PR TITLE
fix: Prevent uniqueness validation error when updating case contact t…

### DIFF
--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -165,7 +165,7 @@ class CaseContacts::FormController < ApplicationController
   # Deletes the current associations (from the join table) only if the submitted form body has the parameters for
   # the contact_type ids.
   def remove_unwanted_contact_types
-    @case_contact.contact_types.clear if params.dig(:case_contact, :contact_type_ids)
+    @case_contact.case_contact_contact_types.destroy_all if params.dig(:case_contact, :contact_type_ids)
   end
 
   def remove_nil_draft_ids

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -234,6 +234,19 @@ RSpec.describe "CaseContacts::Forms", type: :request do
         case_contact.reload
         expect(case_contact.contact_type_ids).to contain_exactly(contact_types.first.id)
       end
+
+      it "allows re-assigning the same contact type without uniqueness validation error" do
+        # This test prevents regression of Bugsnag error:
+        # "Validation failed: Case contact has already been taken"
+        case_contact.update!(contact_type_ids: [contact_types.first.id])
+        expect(case_contact.contact_type_ids).to contain_exactly(contact_types.first.id)
+
+        # Re-submit form with same contact type (simulates user editing and saving)
+        request
+
+        case_contact.reload
+        expect(case_contact.contact_type_ids).to contain_exactly(contact_types.first.id)
+      end
     end
 
     context "when contact topic answers in params" do


### PR DESCRIPTION
…ypes

Fixes Bugsnag error "Validation failed: Case contact has already been taken"
(Error URL: https://api.bugsnag.com/projects/5f370b68136a4b0010d15364/events/6924fd6f015b929d46570000)

The issue occurred when updating case contacts with contact types. The remove_unwanted_contact_types method used contact_types.clear which marks records for deletion in memory but doesn't immediately execute DELETE statements. When the subsequent update attempted to create new join records, the old records still existed in the database, triggering the uniqueness validation on CaseContactContactType.

Changed to use destroy_all which immediately deletes records from the database, ensuring old contact type associations are fully removed before new ones are created.

Added regression test to prevent this issue from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What github issue is this PR for, if any?
Resolves #XXXX

### What changed, and _why_?


### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
