### PR TITLE
Fix: Add local: true to invitation form to prevent blank token error

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="password-box px-4 pb-3">
   <h2 class="my-3">Send invitation</h2>
 
-  <%= form_with(model: resource, as: resource_name, url: invitation_path(resource_name), html: {method: :put}) do |f| %>
+  <%= form_with(model: resource, as: resource_name, url: invitation_path(resource_name), local: true, html: {method: :put}) do |f| %>
     <%= render "/shared/error_messages", resource: resource %>
     <%= f.hidden_field :invitation_token, readonly: true %>
 


### PR DESCRIPTION
Fixes the "Invitation token can't be blank" error that occurs when new users accept email invitations and try to set their password.

Root cause: PR #6528 refactored form_for to form_with, but form_with defaults to remote: true (AJAX submission). This causes the hidden invitation_token field to not be properly submitted with the form.

Solution: Add local: true to the form_with helper to use standard form submission instead of AJAX, ensuring the invitation_token is correctly included in the POST data.

Related to PR #6528 (form helper refactor)

### What github issue is this PR for, if any?
Resolves #XXXX

### What changed, and _why_?


### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
