### PR TITLE
replaced :unprocessable_entity with :unprocessable_content

### DIFF
--- a/app/controllers/additional_expenses_controller.rb
+++ b/app/controllers/additional_expenses_controller.rb
@@ -8,7 +8,7 @@ class AdditionalExpensesController < ApplicationController
     if @additional_expense.save
       render json: @additional_expense.as_json, status: :created
     else
-      render json: @additional_expense.errors.as_json, status: :unprocessable_entity
+      render json: @additional_expense.errors.as_json, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -12,7 +12,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
       service.create!
       redirect_to all_casa_admins_casa_org_path(@casa_org), notice: "New admin created successfully"
     rescue ActiveRecord::RecordInvalid
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -28,7 +28,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
       @casa_admin.filter_old_emails!(@casa_admin.email)
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path(@casa_org), notice: notice
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -39,7 +39,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
 
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was activated. They have been sent an email."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -50,7 +50,7 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
 
       redirect_to edit_all_casa_admins_casa_org_casa_admin_path, notice: "Admin was deactivated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/all_casa_admins/casa_orgs_controller.rb
+++ b/app/controllers/all_casa_admins/casa_orgs_controller.rb
@@ -25,8 +25,8 @@ class AllCasaAdmins::CasaOrgsController < AllCasaAdminsController
       end
     else
       respond_to do |format|
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/all_casa_admins/patch_notes_controller.rb
+++ b/app/controllers/all_casa_admins/patch_notes_controller.rb
@@ -13,7 +13,7 @@ class AllCasaAdmins::PatchNotesController < AllCasaAdminsController
     if @patch_note.save
       render json: {status: :created, id: @patch_note.id}, status: :created
     else
-      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_entity
+      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_content
     end
   end
 
@@ -23,7 +23,7 @@ class AllCasaAdmins::PatchNotesController < AllCasaAdminsController
     if @patch_note.update(patch_note_params)
       render json: {status: :ok}
     else
-      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_entity
+      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class AllCasaAdmins::PatchNotesController < AllCasaAdminsController
     if @patch_note.destroy
       render json: {status: :ok}
     else
-      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_entity
+      render json: {errors: @patch_note.errors.full_messages.to_json}, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/all_casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins_controller.rb
@@ -30,10 +30,10 @@ class AllCasaAdminsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid
       respond_to do |format|
-        format.html { render :new, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
 
         format.json do
-          render json: @all_casa_admin.errors.full_messages, status: :unprocessable_entity
+          render json: @all_casa_admin.errors.full_messages, status: :unprocessable_content
         end
       end
     end
@@ -53,8 +53,8 @@ class AllCasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @user.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -78,8 +78,8 @@ class AllCasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @user.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @user.errors.full_messages, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -35,7 +35,7 @@ class BannersController < ApplicationController
 
     redirect_to banners_path
   rescue
-    render :new, status: :unprocessable_entity
+    render :new, status: :unprocessable_content
   end
 
   def update
@@ -48,7 +48,7 @@ class BannersController < ApplicationController
 
     redirect_to banners_path
   rescue
-    render :edit, status: :unprocessable_entity
+    render :edit, status: :unprocessable_content
   end
 
   def destroy

--- a/app/controllers/bulk_court_dates_controller.rb
+++ b/app/controllers/bulk_court_dates_controller.rb
@@ -15,7 +15,7 @@ class BulkCourtDatesController < ApplicationController
     case_group_id = params[:court_date][:case_group_id]
     if case_group_id.empty?
       @court_date = build_court_date_with_error_message
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
       return
     end
 
@@ -26,7 +26,7 @@ class BulkCourtDatesController < ApplicationController
 
     if court_date_with_error
       @court_date = court_date_with_error
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     else
       redirect_to new_bulk_court_date_path, notice: "#{court_dates.size} #{"court date".pluralize(court_dates.size)} created!"
     end

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -26,8 +26,8 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -59,8 +59,8 @@ class CasaAdminsController < ApplicationController
       end
     rescue ActiveRecord::RecordInvalid
       respond_to do |format|
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: service.casa_admin.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: service.casa_admin.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -81,8 +81,8 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_content }
       end
     end
   rescue Errno::ECONNREFUSED => error
@@ -100,8 +100,8 @@ class CasaAdminsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_admin.errors.full_messages, status: :unprocessable_content }
       end
     end
   rescue Errno::ECONNREFUSED => error

--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -59,8 +59,8 @@ class CasaCasesController < ApplicationController
       set_contact_types
       @empty_court_date = court_date_unknown?
       respond_to do |format|
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -79,8 +79,8 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -101,8 +101,8 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -123,8 +123,8 @@ class CasaCasesController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_case.errors.full_messages, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/casa_org_controller.rb
+++ b/app/controllers/casa_org_controller.rb
@@ -30,8 +30,8 @@ class CasaOrgController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @casa_org.errors.full_messages, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/case_assignments_controller.rb
+++ b/app/controllers/case_assignments_controller.rb
@@ -53,8 +53,8 @@ class CaseAssignmentsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @case_assignment.errors.full_messages, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @case_assignment.errors.full_messages, status: :unprocessable_content }
       end
     end
   end
@@ -133,6 +133,6 @@ class CaseAssignmentsController < ApplicationController
   def handle_failed_assignment(msg)
     @message = msg
     flash.alert = msg
-    @status = :unprocessable_entity
+    @status = :unprocessable_content
   end
 end

--- a/app/controllers/case_contacts/form_controller.rb
+++ b/app/controllers/case_contacts/form_controller.rb
@@ -35,7 +35,7 @@ class CaseContacts::FormController < ApplicationController
         if @case_contact.update(case_contact_params)
           render json: @case_contact, status: :ok
         else
-          render json: @case_contact.errors.full_messages, status: :unprocessable_entity
+          render json: @case_contact.errors.full_messages, status: :unprocessable_content
         end
       end
     end

--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -49,7 +49,7 @@ class CaseCourtReportsController < ApplicationController
     render json: {status: :not_found, error_messages: error_messages}, status: :not_found
   rescue => e
     error_messages = generate_error(e.to_s)
-    render json: {status: :unprocessable_entity, error_messages: error_messages}, status: :unprocessable_entity
+    render json: {status: :unprocessable_content, error_messages: error_messages}, status: :unprocessable_content
   end
 
   private

--- a/app/controllers/case_groups_controller.rb
+++ b/app/controllers/case_groups_controller.rb
@@ -23,7 +23,7 @@ class CaseGroupsController < ApplicationController
     if @case_group.save
       redirect_to case_groups_path, notice: "Case group created!"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -33,7 +33,7 @@ class CaseGroupsController < ApplicationController
     if @case_group.update(case_group_params)
       redirect_to case_groups_path, notice: "Case group updated!"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/checklist_items_controller.rb
+++ b/app/controllers/checklist_items_controller.rb
@@ -13,7 +13,7 @@ class ChecklistItemsController < ApplicationController
       set_checklist_updated_date(@hearing_type)
       redirect_to edit_hearing_type_path(@hearing_type), notice: "Checklist item was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -25,7 +25,7 @@ class ChecklistItemsController < ApplicationController
       set_checklist_updated_date(@hearing_type)
       redirect_to edit_hearing_type_path(@hearing_type), notice: "Checklist item was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/contact_topic_answers_controller.rb
+++ b/app/controllers/contact_topic_answers_controller.rb
@@ -8,7 +8,7 @@ class ContactTopicAnswersController < ApplicationController
     if @contact_topic_answer.save
       render json: @contact_topic_answer.as_json, status: :created
     else
-      render json: @contact_topic_answer.errors.as_json, status: :unprocessable_entity
+      render json: @contact_topic_answer.errors.as_json, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/contact_topics_controller.rb
+++ b/app/controllers/contact_topics_controller.rb
@@ -21,7 +21,7 @@ class ContactTopicsController < ApplicationController
     if @contact_topic.save
       redirect_to edit_casa_org_path(current_organization), notice: "Contact topic was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -32,7 +32,7 @@ class ContactTopicsController < ApplicationController
     if @contact_topic.update(contact_topic_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact topic was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -43,7 +43,7 @@ class ContactTopicsController < ApplicationController
     if @contact_topic.update(soft_delete: true)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact topic was successfully removed."
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/contact_type_groups_controller.rb
+++ b/app/controllers/contact_type_groups_controller.rb
@@ -14,7 +14,7 @@ class ContactTypeGroupsController < ApplicationController
     if @contact_type_group.save
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type Group was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -27,7 +27,7 @@ class ContactTypeGroupsController < ApplicationController
     if @contact_type_group.update(contact_type_group_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type Group was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/contact_types_controller.rb
+++ b/app/controllers/contact_types_controller.rb
@@ -14,7 +14,7 @@ class ContactTypesController < ApplicationController
     if @contact_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -27,7 +27,7 @@ class ContactTypesController < ApplicationController
     if @contact_type.update(contact_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Contact Type was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -38,7 +38,7 @@ class CourtDatesController < ApplicationController
     if @court_date.save && @casa_case.save
       redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -47,7 +47,7 @@ class CourtDatesController < ApplicationController
     if @court_date.update(court_date_params(@casa_case))
       redirect_to casa_case_court_date_path(@casa_case, @court_date), notice: "Court date was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/custom_org_links_controller.rb
+++ b/app/controllers/custom_org_links_controller.rb
@@ -15,7 +15,7 @@ class CustomOrgLinksController < ApplicationController
     if @custom_org_link.save
       redirect_to edit_casa_org_path(current_organization), notice: "Custom link was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -28,7 +28,7 @@ class CustomOrgLinksController < ApplicationController
     if @custom_org_link.update(custom_org_link_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Custom link was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/fund_requests_controller.rb
+++ b/app/controllers/fund_requests_controller.rb
@@ -15,7 +15,7 @@ class FundRequestsController < ApplicationController
       FundRequestMailer.send_request(nil, @fund_request).deliver
       redirect_to casa_case_path(@casa_case), notice: "Fund Request was sent for case #{@casa_case.case_number}"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/hearing_types_controller.rb
+++ b/app/controllers/hearing_types_controller.rb
@@ -14,7 +14,7 @@ class HearingTypesController < ApplicationController
     if @hearing_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Hearing Type was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -27,7 +27,7 @@ class HearingTypesController < ApplicationController
     if @hearing_type.update(hearing_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Hearing Type was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/judges_controller.rb
+++ b/app/controllers/judges_controller.rb
@@ -14,7 +14,7 @@ class JudgesController < ApplicationController
     if @judge.save
       redirect_to edit_casa_org_path(current_organization), notice: "Judge was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -27,7 +27,7 @@ class JudgesController < ApplicationController
     if @judge.update(judge_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Judge was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -18,7 +18,7 @@ class LanguagesController < ApplicationController
       if @language.save
         format.html { redirect_to edit_casa_org_path(current_organization.id), notice: "Language was successfully created." }
       else
-        format.html { render :new, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
       end
     end
   end
@@ -29,7 +29,7 @@ class LanguagesController < ApplicationController
       if @language.update(language_params)
         format.html { redirect_to edit_casa_org_path(current_organization.id), notice: "Language was successfully updated." }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/learning_hour_topics_controller.rb
+++ b/app/controllers/learning_hour_topics_controller.rb
@@ -18,7 +18,7 @@ class LearningHourTopicsController < ApplicationController
     if @learning_hour_topic.save
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Topic was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -28,7 +28,7 @@ class LearningHourTopicsController < ApplicationController
     if @learning_hour_topic.update(learning_hour_topic_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Topic was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/learning_hour_types_controller.rb
+++ b/app/controllers/learning_hour_types_controller.rb
@@ -18,7 +18,7 @@ class LearningHourTypesController < ApplicationController
     if @learning_hour_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -28,7 +28,7 @@ class LearningHourTypesController < ApplicationController
     if @learning_hour_type.update(learning_hour_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Learning Type was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/learning_hours_controller.rb
+++ b/app/controllers/learning_hours_controller.rb
@@ -24,7 +24,7 @@ class LearningHoursController < ApplicationController
       if @learning_hour.save
         format.html { redirect_to learning_hours_path, notice: "New entry was successfully created." }
       else
-        format.html { render :new, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
       end
     end
   end
@@ -39,7 +39,7 @@ class LearningHoursController < ApplicationController
       if @learning_hour.update(update_learning_hours_params)
         format.html { redirect_to learning_hour_path(@learning_hour), notice: "Entry was successfully updated." }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/mileage_rates_controller.rb
+++ b/app/controllers/mileage_rates_controller.rb
@@ -18,7 +18,7 @@ class MileageRatesController < ApplicationController
     if @mileage_rate.save
       redirect_to mileage_rates_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -32,7 +32,7 @@ class MileageRatesController < ApplicationController
     if @mileage_rate.update(mileage_rate_params)
       redirect_to mileage_rates_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/other_duties_controller.rb
+++ b/app/controllers/other_duties_controller.rb
@@ -26,7 +26,7 @@ class OtherDutiesController < ApplicationController
     if @other_duty.save
       redirect_to other_duties_path, notice: "Duty was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -40,7 +40,7 @@ class OtherDutiesController < ApplicationController
     if @other_duty.update(other_duty_params)
       redirect_to other_duties_path, notice: "Duty was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/placement_types_controller.rb
+++ b/app/controllers/placement_types_controller.rb
@@ -15,7 +15,7 @@ class PlacementTypesController < ApplicationController
     if @placement_type.save
       redirect_to edit_casa_org_path(current_organization), notice: "Placement Type was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -29,7 +29,7 @@ class PlacementTypesController < ApplicationController
     if @placement_type.update(placement_type_params)
       redirect_to edit_casa_org_path(current_organization), notice: "Placement Type was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/placements_controller.rb
+++ b/app/controllers/placements_controller.rb
@@ -27,7 +27,7 @@ class PlacementsController < ApplicationController
     if @placement.save
       redirect_to casa_case_placements_path(@casa_case), notice: "Placement was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -37,7 +37,7 @@ class PlacementsController < ApplicationController
     if @placement.update(placement_params)
       redirect_to casa_case_placements_path(@casa_case), notice: "Placement was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -47,7 +47,7 @@ class PlacementsController < ApplicationController
     if @placement.destroy
       redirect_to casa_case_placements_path(@casa_case), notice: "Placement was successfully deleted."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -35,7 +35,7 @@ class SupervisorsController < ApplicationController
       sms_status = deliver_sms_to @supervisor, body_msg
       redirect_to edit_supervisor_path(@supervisor), notice: sms_acct_creation_notice("supervisor", sms_status)
     else
-      render new_supervisor_path, status: :unprocessable_entity
+      render new_supervisor_path, status: :unprocessable_content
     end
   end
 
@@ -55,7 +55,7 @@ class SupervisorsController < ApplicationController
       @supervisor.filter_old_emails!(@supervisor.email)
       redirect_to edit_supervisor_path(@supervisor), notice: notice
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,19 +16,19 @@ class UsersController < ApplicationController
       flash[:success] = "Profile was successfully updated."
       redirect_to edit_users_path
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
   def add_language
     if @language.nil?
       @user.errors.add(:language_id, "can not be blank. Please select a language before adding.")
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     if current_user.languages.include?(@language)
       @user.errors.add(:language_id, "#{@language.name} is already in your languages list.")
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     current_user.languages << @language
@@ -54,11 +54,11 @@ class UsersController < ApplicationController
   def update_password
     unless valid_user_password
       @user.errors.add(:base, "Current password is incorrect")
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     unless update_user_password
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     bypass_sign_in(@user) if @user == true_user
@@ -72,11 +72,11 @@ class UsersController < ApplicationController
   def update_email
     unless valid_user_password
       @user.errors.add(:base, "Current password is incorrect")
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     unless update_user_email
-      return render "edit", status: :unprocessable_entity
+      return render "edit", status: :unprocessable_content
     end
 
     bypass_sign_in(@user) if @user == true_user

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -50,7 +50,7 @@ class VolunteersController < ApplicationController
       sms_status = deliver_sms_to @volunteer, account_activation_msg("volunteer", hash_of_short_urls)
       redirect_to edit_volunteer_path(@volunteer), notice: sms_acct_creation_notice("volunteer", sms_status)
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -67,7 +67,7 @@ class VolunteersController < ApplicationController
       @volunteer.filter_old_emails!(@volunteer.email)
       redirect_to edit_volunteer_path(@volunteer), notice: notice
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -82,7 +82,7 @@ class VolunteersController < ApplicationController
         redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was activated. They have been sent an email."
       end
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -91,7 +91,7 @@ class VolunteersController < ApplicationController
     if @volunteer.deactivate
       redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was deactivated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/spec/requests/additional_expenses_spec.rb
+++ b/spec/requests/additional_expenses_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "/additional_expenses", type: :request do
 
       it "fails and responds unprocessable_entity" do
         expect { subject }.not_to change(ContactTopicAnswer, :count)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns errors as json" do

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "All-Casa Admin", type: :request do
       it "renders new page" do
         expect { subject }.not_to change(CasaAdmin, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template "casa_admins/new"
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe "All-Casa Admin", type: :request do
 
       it "renders new page" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template "casa_admins/edit"
       end
     end
@@ -132,7 +132,7 @@ RSpec.describe "All-Casa Admin", type: :request do
 
       it "renders edit page" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template "casa_admins/edit"
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe "All-Casa Admin", type: :request do
 
       it "renders edit page" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template "casa_admins/edit"
       end
     end

--- a/spec/requests/all_casa_admins/casa_orgs_spec.rb
+++ b/spec/requests/all_casa_admins/casa_orgs_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "AllCasaAdmin::CasaOrgs", type: :request do
         post all_casa_admins_casa_orgs_path(format: :json), params: params
 
         expect(response.content_type).to eq "application/json; charset=utf-8"
-        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_http_status :unprocessable_content
         expect(response.body).to match "Name can't be blank"
       end
     end

--- a/spec/requests/all_casa_admins/patch_notes_spec.rb
+++ b/spec/requests/all_casa_admins/patch_notes_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
         post all_casa_admins_patch_notes_path, params: invalid_attributes
         expect(response.header["Content-Type"]).to match(/application\/json/)
         expect(response.body).not_to be_nil
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)).to have_key("errors")
       end
 
@@ -123,7 +123,7 @@ RSpec.describe "/all_casa_admins/patch_notes", type: :request do
         patch_note = PatchNote.create! valid_attributes
         patch all_casa_admins_patch_note_path(patch_note), params: invalid_attributes
         expect(response.body).not_to be_nil
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)).to have_key("errors")
       end
     end

--- a/spec/requests/all_casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "/all_casa_admins", type: :request do
             email: ""
           }
         }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template "all_casa_admins/new"
       end
 
@@ -102,7 +102,7 @@ RSpec.describe "/all_casa_admins", type: :request do
           }
         }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.content_type).to eq("application/json; charset=utf-8")
         expect(response.body).to match("Email can't be blank".to_json)
       end
@@ -132,7 +132,7 @@ RSpec.describe "/all_casa_admins", type: :request do
       it "does not update the all_casa_admin" do
         other_admin = create(:all_casa_admin)
         patch all_casa_admins_path, params: {all_casa_admin: {email: other_admin.email}}
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         expect(admin.email).not_to eq "newemail@example.com"
       end
@@ -142,7 +142,7 @@ RSpec.describe "/all_casa_admins", type: :request do
         patch all_casa_admins_path(format: :json),
           params: {all_casa_admin: {email: other_admin.email}}
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.content_type).to eq("application/json; charset=utf-8")
         expect(response.body).to match("Email has already been taken".to_json)
       end
@@ -201,7 +201,7 @@ RSpec.describe "/all_casa_admins", type: :request do
       it "does not update the all_casa_admin password" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(admin.reload.valid_password?("newpassword")).to be false
       end
 
@@ -216,7 +216,7 @@ RSpec.describe "/all_casa_admins", type: :request do
       it "also responds as json", :aggregate_failures do
         patch update_password_all_casa_admins_path(format: :json), params: params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.content_type).to eq("application/json; charset=utf-8")
         expect(response.body).to match("Password confirmation doesn't match Password".to_json)
       end

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "/casa_admins", type: :request do
         }
 
         expect(response.content_type).to eq("application/json; charset=utf-8")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to match("Email can't be blank".to_json)
       end
     end
@@ -259,7 +259,7 @@ RSpec.describe "/casa_admins", type: :request do
         patch activate_casa_admin_path(casa_admin_inactive, format: :json)
 
         expect(response.content_type).to eq("application/json; charset=utf-8")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to match("Error message test".to_json)
       end
     end
@@ -339,7 +339,7 @@ RSpec.describe "/casa_admins", type: :request do
           patch deactivate_casa_admin_path(casa_admin_active, format: :json)
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to match("Error message test".to_json)
         end
       end
@@ -518,7 +518,7 @@ RSpec.describe "/casa_admins", type: :request do
         post casa_admins_path(format: :json), params: {casa_admin: params}
 
         expect(response.content_type).to eq("application/json; charset=utf-8")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to match("Some error message".to_json)
       end
     end

--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -234,14 +234,14 @@ RSpec.describe "/casa_cases", type: :request do
 
           it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
             post casa_cases_url, params: {casa_case: invalid_attributes}
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
 
           it "also respond to json", :aggregate_failures do
             post casa_cases_url(format: :json), params: {casa_case: invalid_attributes}
 
             expect(response.content_type).to eq("application/json; charset=utf-8")
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expected_response_body = [
               "Birth month year youth can't be blank",
               "Case number can't be blank",
@@ -272,7 +272,7 @@ RSpec.describe "/casa_cases", type: :request do
 
           it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
             post casa_cases_url, params: {casa_case: invalid_params}
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end
@@ -330,14 +330,14 @@ RSpec.describe "/casa_cases", type: :request do
       context "with invalid parameters" do
         it "renders an unprocessable entity response displaying the edit template" do
           patch casa_case_url(casa_case), params: {casa_case: invalid_attributes}
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "also responds as json", :aggregate_failures do
           patch casa_case_url(casa_case, format: :json), params: {casa_case: invalid_attributes}
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to match(["Case number can't be blank"].to_json)
         end
       end
@@ -443,7 +443,7 @@ RSpec.describe "/casa_cases", type: :request do
           patch deactivate_casa_case_path(casa_case, format: :json), params: params
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to match([].to_json)
         end
       end
@@ -502,7 +502,7 @@ RSpec.describe "/casa_cases", type: :request do
           patch reactivate_casa_case_path(casa_case, format: :json), params: params
 
           expect(response.content_type).to eq("application/json; charset=utf-8")
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to match([].to_json)
         end
       end

--- a/spec/requests/casa_org_spec.rb
+++ b/spec/requests/casa_org_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "CasaOrg", type: :request do
       end
 
       context "and html format" do
-        it { is_expected.to have_http_status(:unprocessable_entity) }
+        it { is_expected.to have_http_status(:unprocessable_content) }
 
         it "renders the edit template" do
           expect(request.body).to match(/error_explanation/)
@@ -127,7 +127,7 @@ RSpec.describe "CasaOrg", type: :request do
           response
         end
 
-        it { is_expected.to have_http_status(:unprocessable_entity) }
+        it { is_expected.to have_http_status(:unprocessable_content) }
 
         it "returns correct payload" do
           response_data = request.body

--- a/spec/requests/case_contacts/form_spec.rb
+++ b/spec/requests/case_contacts/form_spec.rb
@@ -479,10 +479,10 @@ RSpec.describe "CaseContacts::Forms", type: :request do
           expect { request }.not_to change(case_contact.reload, :attributes)
         end
 
-        it "responds :unprocessable_entity and returns the errors" do
+        it "responds :unprocessable_content and returns the errors" do
           request
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe "/case_court_reports", type: :request do
         expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise StandardError.new("Unexpected Error")
       end
 
-      it { is_expected.to have_http_status(:unprocessable_entity) }
+      it { is_expected.to have_http_status(:unprocessable_content) }
 
       it "shows the correct error message" do
         expect(request.parsed_body["error_messages"]).to include("Unexpected Error")

--- a/spec/requests/case_groups_spec.rb
+++ b/spec/requests/case_groups_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "/case_groups", type: :request do
 
       it "renders new template" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:new)
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe "/case_groups", type: :request do
 
       it "renders new template" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:edit)
       end
     end

--- a/spec/requests/contact_topic_answers_spec.rb
+++ b/spec/requests/contact_topic_answers_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "/contact_topic_answers", type: :request do
 
       it "fails and responds unprocessable_entity" do
         expect { subject }.not_to change(ContactTopicAnswer, :count)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns errors as json" do

--- a/spec/requests/contact_topics_spec.rb
+++ b/spec/requests/contact_topics_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "/contact_topics", type: :request do
 
       it "renders a response with 422 status (i.e. to display the 'new' template)" do
         post contact_topics_url, params: {contact_topic: attributes}
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -133,7 +133,7 @@ RSpec.describe "/contact_topics", type: :request do
 
       it "renders a response with 422 status (i.e. to display the 'edit' template)" do
         patch contact_topic_url(contact_topic), params: {contact_topic: attributes}
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/court_dates_spec.rb
+++ b/spec/requests/court_dates_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
 
         it "renders an unprocessable entity response (i.e. to display the 'new' template)" do
           post casa_case_court_dates_path(casa_case), params: {court_date: invalid_attributes}
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expected_errors = [
             "Date can't be blank"
           ].freeze
@@ -314,7 +314,7 @@ RSpec.describe "/casa_cases/:casa_case_id/court_dates/:id", type: :request do
       it "renders an unprocessable entity response displaying the edit template" do
         patch casa_case_court_date_path(casa_case, court_date), params: {court_date: invalid_attributes}
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expected_errors = [
           "Date can't be blank"
         ].freeze

--- a/spec/requests/fund_requests_spec.rb
+++ b/spec/requests/fund_requests_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe FundRequestsController, type: :request do
               post casa_case_fund_request_path(casa_case), params: params
             }.not_to change(FundRequest, :count)
 
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end

--- a/spec/requests/mileage_rates_spec.rb
+++ b/spec/requests/mileage_rates_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "/mileage_rates", type: :request do
         expect {
           post mileage_rates_path, params: params
         }.not_to change { MileageRate.count }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe "/mileage_rates", type: :request do
         expect {
           post mileage_rates_path, params: params
         }.not_to change { MileageRate.count }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -142,7 +142,7 @@ RSpec.describe "/mileage_rates", type: :request do
       it "does not update a mileage rate" do
         patch mileage_rate_path(mileage_rate), params: params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         mileage_rate.reload
         expect(mileage_rate.amount).to eq(10.11)

--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "/other_duties", type: :request do
           expect {
             post other_duties_path, params: {other_duty: attributes_for(:other_duty, notes: "")}
           }.not_to change(OtherDuty, :count)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe "/other_duties", type: :request do
           patch other_duty_path(other_duty), params: {other_duty: {notes: ""}}
 
           expect(other_duty.reload.notes).to eq "Test 1"
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe "/supervisors", type: :request do
         it "gracefully fails" do
           patch supervisor_path(supervisor), params: {supervisor: {email: other_supervisor.email}}
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe "/users", type: :request do
         patch add_language_users_path(volunteer), params: {
           language_id: ""
         }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("Please select a language before adding.")
       end
     end
@@ -453,7 +453,7 @@ RSpec.describe "/users", type: :request do
       end
 
       it "notifies the user that the language is already in their list" do
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include("#{language.name} is already in your languages list.")
       end
     end

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "/volunteers", type: :request do
           post volunteers_url, params: params
         }.to change(Volunteer, :count).by(0)
           .and change(ActionMailer::Base.deliveries, :count).by(0)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -263,7 +263,7 @@ RSpec.describe "/volunteers", type: :request do
         patch volunteer_path(volunteer), params: {
           volunteer: {email: other_volunteer.email, display_name: "New Name", phone_number: "+15463457898"}
         }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         volunteer.reload
         expect(volunteer.display_name).not_to eq "New Name"


### PR DESCRIPTION
### What github issue is this PR for, if any?
No associated github issue.

### What changed, and _why_?
422 Status codes use `:unprocessable_content` instead of `:unprocessable_entity`.

This was done because `:unprocessable_entity` is deprecated in Rack, and this is the suggested fix.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Changed the tests that expected `:unprocessable_entity`  to expect `:unprocessable_content`

### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 

(These messages don't appear anymore when running rspec)
<img width="2512" height="307" alt="image" src="https://github.com/user-attachments/assets/d138e634-c1af-461f-8c1d-96427726a400" />



### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
