### PR TITLE
Display the user's email on their profile page

### DIFF
--- a/app/views/users/_edit_profile.erb
+++ b/app/views/users/_edit_profile.erb
@@ -7,6 +7,10 @@
   <%= resource&.decorate(context: {format: :edit_profile})&.formatted_created_at %>
 </div>
 <div class="mb-1">
+  <strong class="text-dark">Email</strong>
+  <%= resource&.email %>
+</div>
+<div class="mb-1">
   <strong class="text-dark">Invitation email sent </strong>
   <%= resource&.decorate(context: {format: :edit_profile})&.formatted_invitation_sent_at || "never" %>
 </div>

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -9,21 +9,25 @@ RSpec.describe "/users", type: :request do
   describe "GET /edit" do
     context "with a volunteer signed in" do
       it "renders a successful response" do
-        sign_in create(:volunteer)
+        volunteer = create(:volunteer)
+        sign_in volunteer
 
         get edit_users_path
 
         expect(response).to be_successful
+        expect(response.body).to include(volunteer.email)
       end
     end
 
     context "with an admin signed in" do
       it "renders a successful response" do
-        sign_in build(:casa_admin)
+        admin = build(:casa_admin)
+        sign_in admin
 
         get edit_users_path
 
         expect(response).to be_successful
+        expect(response.body).to include(admin.email)
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6637

### What changed, and _why_?
Added a line to the page at `/users/edit` for users to view their current email.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Added a couple of assertions to existing requests specs.

### Screenshots please :)
| volunteer | supervisor | admin |
|--------|--------|--------|
| <img width="1605" height="1263" alt="volunteer" src="https://github.com/user-attachments/assets/5c1e1f15-190f-48ab-926d-63aa0169b63d" /> | <img width="1605" height="1263" alt="supervisor" src="https://github.com/user-attachments/assets/c404b58c-19e4-42ff-99e8-a2650e19e22b" /> | <img width="1605" height="1263" alt="admin" src="https://github.com/user-attachments/assets/74a0d41b-9ffa-4ccd-80fd-bd048ff8c7aa" /> | 



