### PR TITLE
Updating email instructions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -81,6 +81,7 @@ class UsersController < ApplicationController
 
     bypass_sign_in(@user) if @user == true_user
 
+    flash[:success] = "Click the link in your new email to finalize the email transfer"
     redirect_to edit_users_path
   end
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,3 +1,3 @@
 <p>Click here to confirm your email.</p>
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
-<p>If you weren't expecting this email, please disregard</p>
+<p>If you weren't expecting this email, please disregard.</p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,3 @@
-<p>Hello! <%= @email %>!</p>
-
-<p>You can confirm your account email through the link below:</p>
-
+<p>Click here to confirm your email.</p>
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p>If you weren't expecting this email, please disregard</p>

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "All-Casa Admin", type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
       end
 
       it { is_expected.to redirect_to edit_all_casa_admins_casa_org_casa_admin_path(casa_org, casa_admin) }

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "/casa_admins", type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
       end
 
       it "also respond as json", :aggregate_failures do

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "/supervisors", type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
       end
 
       it "can set the supervisor to be inactive" do
@@ -206,7 +206,7 @@ RSpec.describe "/supervisors", type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
       end
 
       it "cannot change its own type" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "/users", type: :request do
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
           expect(ActionMailer::Base.deliveries.last.body.encoded)
-            .to match("You can confirm your account email through the link below:")
+            .to match("Click here to confirm your email")
         end
       end
 
@@ -304,7 +304,7 @@ RSpec.describe "/users", type: :request do
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
           expect(ActionMailer::Base.deliveries.last.body.encoded)
-            .to match("You can confirm your account email through the link below:")
+            .to match("Click here to confirm your email")
         end
 
         it "bypasses sign in if the current user is the true user" do
@@ -363,7 +363,7 @@ RSpec.describe "/users", type: :request do
 
           expect(ActionMailer::Base.deliveries.count).to eq(1)
           expect(ActionMailer::Base.deliveries.last.body.encoded)
-            .to match("You can confirm your account email through the link below:")
+            .to match("Click here to confirm your email")
         end
 
         it "bypasses sign in if the current user is the true user" do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "/volunteers", type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
       end
     end
 

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "casa_admins/edit", type: :system do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("You can confirm your account email through the link below:")
+        .to match("Click here to confirm your email")
 
       expect(page).to have_text "Admin was successfully updated. Confirmation Email Sent."
       expect(page).to have_field("Email", with: @old_email)

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "supervisors/edit", type: :system do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
 
         expect(page).to have_text "Supervisor was successfully updated. Confirmation Email Sent."
         expect(page).to have_field("Email", with: @old_email)

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -112,10 +112,12 @@ RSpec.describe "users/edit", type: :system do
       fill_in "New Email", with: "new_volunteer@example.com"
       click_on "Update Email"
 
+      expect(page).to have_content "Click the link in your new email to finalize the email transfer"
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to have_text("You can confirm your account email through the link below:")
+        .to have_text("Click here to confirm your email")
     end
 
     it "displays email errors messages when user is unable to set a email with incorrect current password" do
@@ -264,10 +266,12 @@ RSpec.describe "users/edit", type: :system do
       fill_in "New Email", with: "new_supervisor@example.com"
       click_on "Update Email"
 
+      expect(page).to have_content "Click the link in your new email to finalize the email transfer"
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("You can confirm your account email through the link below:")
+        .to match("Click here to confirm your email")
     end
 
     it "displays email errors messages when user is unable to set a email with incorrect current password" do
@@ -428,7 +432,7 @@ RSpec.describe "users/edit", type: :system do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("You can confirm your account email through the link below:")
+        .to match("Click here to confirm your email")
     end
 
     it "displays email errors messages when user is unable to set a email with incorrect current password" do

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "volunteers/edit", type: :system do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("You can confirm your account email through the link below:")
+          .to match("Click here to confirm your email")
 
         expect(page).to have_text "Volunteer was successfully updated. Confirmation Email Sent."
         expect(page).to have_field("Email", with: old_email)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6638

### What changed, and _why_?
Added update message when updating user email, explaining the process of confirming email changes via email.
Confirmation email template's working was also slightly changed.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Added assertions checking that new message is present.
Updated tests that checked things like confirmation messages


### Screenshots please :)
<img width="712" height="299" alt="image" src="https://github.com/user-attachments/assets/e7954a45-aebd-460a-ae4e-d24257a7d3e3" />
<img width="411" height="156" alt="image" src="https://github.com/user-attachments/assets/bf1bb16e-ed73-4aa5-8bf7-9f4ed9679daa" />


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
