### PR TITLE
Simplifies text for email update

### DIFF
--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -3,4 +3,3 @@
 <% else %>
   <p>Your CASA account's email has been updated to <%= @resource.email %>.</p>
 <% end %>
-

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,1 @@
-<p>Hello <%= @email %>!</p>
-
-<% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
-<% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
-<% end %>
+<p>Your CASA account's email has been updated to <%= @resource.unconfirmed_email.presence || @resource.email %>.</p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,1 +1,6 @@
-<p>Your CASA account's email has been updated to <%= @resource.unconfirmed_email.presence || @resource.email %>.</p>
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>Your CASA account's email has been updated to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>Your CASA account's email has been updated to <%= @resource.email %>.</p>
+<% end %>
+

--- a/spec/system/all_casa_admins/all_casa_admin_spec.rb
+++ b/spec/system/all_casa_admins/all_casa_admin_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "all_casa_admins/casa_orgs/casa_admins/new", type: :system do
     fill_in "all_casa_admin_email", with: "newemail@example.com"
     click_on "Update Profile"
     expect(page).to have_text "successfully updated"
-    expect(ActionMailer::Base.deliveries.last.body.encoded).to match(">We're contacting you to notify you that your email has been changed to newemail@example.com")
+    expect(ActionMailer::Base.deliveries.last.body.encoded).to match(">Your CASA account's email has been updated to newemail@example.com")
 
     # change password
     click_on "Change Password"


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6636

### What changed, and _why_?
It's an email, so the recipient doesn't need to see who it's addressed to - Removed recipient from email body

Updates text to read: Your CASA account's email has been updated to <NEW EMAIL ADDRESS>


### How is this **tested**? (please write rspec and jest tests!) 💖💪
RSPEC + Jest Tests


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
