### PR TITLE
Ensure CustomOrgLink#active tests inclusion in [true, false]

### DIFF
--- a/spec/models/custom_org_link_spec.rb
+++ b/spec/models/custom_org_link_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe CustomOrgLink, type: :model do
   it { is_expected.to validate_presence_of :text }
   it { is_expected.to validate_presence_of :url }
   it { is_expected.to validate_length_of(:text).is_at_most described_class::TEXT_MAX_LENGTH }
-  it { is_expected.to validate_inclusion_of(:active).in_array [true, false] }
 
   describe "#trim_name" do
     let(:casa_org) { create(:casa_org) }
@@ -26,5 +25,15 @@ RSpec.describe CustomOrgLink, type: :model do
     it { is_expected.not_to allow_value("ftp://example.com").for(:url) }
     it { is_expected.not_to allow_value("example.com").for(:url) }
     it { is_expected.not_to allow_value("some arbitrary string").for(:url) }
+  end
+
+  describe "#active" do
+    it "only allows true or false" do
+      casa_org = build(:casa_org)
+
+      expect(build(:custom_org_link, casa_org: casa_org, active: false)).to be_valid
+      expect(build(:custom_org_link, casa_org: casa_org, active: true)).to be_valid
+      expect(build(:custom_org_link, casa_org: casa_org, active: nil)).to be_invalid
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Closes #6670

### What changed, and _why_?

When running the tests, the following shoulda-matchers warning message is printed out:

```
Warning from shoulda-matchers:

You are using `validate_inclusion_of` to assert that a boolean column
allows boolean values and disallows non-boolean ones. Be aware that it
is not possible to fully test this, as boolean columns will
automatically convert non-boolean values to boolean ones. Hence, you
should consider removing this test.
```

`active` needs to be either true or false but not nil. With this explicit test, we ensure the attribute is accurately covered.

### Screenshots please :)

Not a screenshot but this PR's tests result don't show the warn anymore: https://github.com/rubyforgood/casa/actions/runs/21302007793/job/61321712156?pr=6671

### Feelings gif (optional)

https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnVyemZodWVibmd1ejRoY3hqZW9ybHpwN2lvYzZiNHc3eTdiaGNkMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/glvyCVWYJ21fq/giphy.gif
