### PR TITLE
Remove unnecessary 'require faker'

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,6 @@
 # If you specify the string 'random' (e.g. `export DB_SEEDS_RANDOM_SEED=random`), a random seed will be assigned for you.
 # If you don't specify anything, 0 will be used as the seed, ensuring consistent data across hosts and runs.
 
-require "faker"
 require_relative "seeds/casa_org_populator_presets"
 require_relative "seeds/db_populator"
 require_relative "../lib/tasks/data_post_processors/case_contact_populator"

--- a/spec/system/judges/new_spec.rb
+++ b/spec/system/judges/new_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "faker"
 
 RSpec.describe "judges/new", type: :system do
   let(:organization) { create(:casa_org) }


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #6672 

### What changed, and _why_?

The gem is already installed and loaded automatically, so no need to require it again on
these specific files.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

CI is enough. I also ran the seeds locally and the DB got populated correctly after re-running the seeds (logged in as casa_admin1@example.com):

<img width="1870" height="771" alt="Screenshot 2026-01-23 at 4 44 27 PM" src="https://github.com/user-attachments/assets/e1b8741b-3f4a-47dd-8ac5-8c06ac5bab9b" />

### Feelings gif (optional)

https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXM1cHRzZHBycWxka3FvZDdhc2MyY24zcWM0OXg2bHY0NzRsYjdrayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/sTczweWUTxLqg/giphy.gif
