### PR TITLE
#6563 improve case contact workflow for supervisor and admin

### DIFF
--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -6,7 +6,8 @@ class CaseContactsController < ApplicationController
   before_action :set_case_contact, only: %i[edit destroy]
   before_action :set_contact_types, only: %i[new edit create]
   before_action :require_organization!
-  after_action :verify_authorized, except: %i[leave]
+  before_action :set_volunteer, only: %i[impersonate_and_edit]
+  after_action :verify_authorized, except: %i[leave, impersonate_and_edit]
 
   def index
     load_case_contacts
@@ -61,6 +62,12 @@ class CaseContactsController < ApplicationController
     redirect_back_to_referer(fallback_location: case_contacts_path)
   end
 
+
+  def impersonate_and_edit
+    impersonate_user(@volunteer)
+    redirect_to casa_case_path(params[:casa_case_id])
+  end
+
   private
 
   def update_or_create_additional_expense(all_ae_params, cc)
@@ -97,5 +104,9 @@ class CaseContactsController < ApplicationController
     return [casa_cases.first.id] if casa_cases.count == 1
 
     []
+  end
+
+  def set_volunteer
+    @volunteer = Volunteer.find(params[:creator_id])
   end
 end

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -7,7 +7,7 @@ class CaseContactsController < ApplicationController
   before_action :set_contact_types, only: %i[new edit create]
   before_action :require_organization!
   before_action :set_volunteer, only: %i[impersonate_and_edit]
-  after_action :verify_authorized, except: %i[leave, impersonate_and_edit]
+  after_action :verify_authorized, except: %i[leave impersonate_and_edit]
 
   def index
     load_case_contacts
@@ -62,9 +62,9 @@ class CaseContactsController < ApplicationController
     redirect_back_to_referer(fallback_location: case_contacts_path)
   end
 
-
   def impersonate_and_edit
     impersonate_user(@volunteer)
+
     redirect_to casa_case_path(params[:casa_case_id])
   end
 

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -38,7 +38,7 @@
         <% if Pundit.policy(current_user, contact).update? %>
           <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
           <div class="mr-2">
-            <% if current_user.casa_admin? || current_user.supervisor? %>
+            <% if (current_user.casa_admin? || current_user.supervisor?) && contact.creator != current_user %>
               <%= link_to case_contacts_impersonate_and_edit_path(creator_id: contact.creator.id, casa_case_id: @casa_case), class: "text-danger", data: { turbo: false } do %>
                 <i class="lni lni-pencil-alt"></i> View/Edit
               <% end %>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -38,7 +38,7 @@
         <% if Pundit.policy(current_user, contact).update? %>
           <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
           <div class="mr-2">
-            <% if (current_user.casa_admin? || current_user.supervisor?) && contact.creator != current_user %>
+            <% if (current_user.casa_admin? || current_user.supervisor?) && contact.creator&.volunteer? && contact.creator != current_user %>
               <%= link_to case_contacts_impersonate_and_edit_path(creator_id: contact.creator.id, casa_case_id: @casa_case), class: "text-danger", data: { turbo: false } do %>
                 <i class="lni lni-pencil-alt"></i> View/Edit
               <% end %>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -38,8 +38,16 @@
         <% if Pundit.policy(current_user, contact).update? %>
           <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
           <div class="mr-2">
-            <%= link_to edit_case_contact_path(contact), class: "text-danger", data: { turbo: false } do %>
-              <i class="lni lni-pencil-alt"></i> Edit
+            <%# debugger %>
+            <%# this is the place where i have to make UI change - utkarsh %>
+            <% if current_user.casa_admin? || current_user.supervisor? %>
+              <%= link_to case_contacts_impersonate_and_edit_path(creator_id: contact.creator.id, casa_case_id: @casa_case), class: "text-danger", data: { turbo: false } do %>
+                <i class="lni lni-pencil-alt"></i> View/Edit
+              <% end %>
+            <% else %>
+              <%= link_to edit_case_contact_path(contact), class: "text-danger", data: { turbo: false } do %>
+                <i class="lni lni-pencil-alt"></i> Edit
+              <% end %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -38,8 +38,6 @@
         <% if Pundit.policy(current_user, contact).update? %>
           <%= render "case_contacts/followup", contact: contact, followup: contact.requested_followup %>
           <div class="mr-2">
-            <%# debugger %>
-            <%# this is the place where i have to make UI change - utkarsh %>
             <% if current_user.casa_admin? || current_user.supervisor? %>
               <%= link_to case_contacts_impersonate_and_edit_path(creator_id: contact.creator.id, casa_case_id: @casa_case), class: "text-danger", data: { turbo: false } do %>
                 <i class="lni lni-pencil-alt"></i> View/Edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
   # Feature flag for new case contact table design
   get "case_contacts/new_design", to: "case_contacts/case_contacts_new_design#index"
   post "case_contacts/new_design/datatable", to: "case_contacts/case_contacts_new_design#datatable", as: "datatable_case_contacts_new_design"
+  get "case_contacts/impersonate_and_edit", to: "case_contacts#impersonate_and_edit"
   resources :case_contacts, except: %i[create update show], concerns: %i[with_datatable] do
     member do
       post :restore

--- a/spec/views/case_contacts/case_contact.html.erb_spec.rb
+++ b/spec/views/case_contacts/case_contact.html.erb_spec.rb
@@ -73,17 +73,16 @@ RSpec.describe "case_contacts/case_contact", type: :view do
       enable_pundit(view, admin)
       allow(view).to receive(:current_user).and_return(admin)
     end
-
     context "occurred_at is before the last day of the month in the quarter that the case contact was created" do
       let(:case_contact) { build_stubbed(:case_contact, creator: volunteer) }
       let(:case_contact2) { build_stubbed(:case_contact, deleted_at: Time.current, creator: volunteer) }
 
-      it "shows edit button" do
+      it "shows view/edit button" do
         assign :case_contact, case_contact
         assign :casa_cases, [case_contact.casa_case]
 
         render(partial: "case_contacts/case_contact", locals: {contact: case_contact})
-        expect(rendered).to have_link(nil, href: "/case_contacts/#{case_contact.id}/edit")
+        expect(rendered).to have_link(nil, href: "/case_contacts/impersonate_and_edit?creator_id=#{case_contact.creator.id}")
       end
 
       it "shows make reminder button" do


### PR DESCRIPTION
### 6563
Resolves #6563 


### Supervisor and admins can now directly impersonate as volunteer and view the case details 

You can login as supervisor , see a case details and directly click on "View/Edit" button and it will impersonate the said volunteer and take you to the view page page as that volunteer, then you can edit
- Previously you used to click on edit (as supervisor) and it would take you to volunteer page and then you would had to impersonate and then find the case.
- this makes workflow easier for supervisor and admin
- Note - The workflow remains the same for volunteers, no change to them 

### Screenshots please :)
[Note - Video is attached, i suggest we rename the button to "Impersonate and View/edit", but for now as per original ticket , i have kept it simple and went ahead with original requirement of "View/Edit"]

https://github.com/user-attachments/assets/f60c2443-ea11-4c9b-ab19-0f7c3d76c1f9


