### PR TITLE
CasaCasesEmancipationOption rename to follow naming convention

### DIFF
--- a/app/models/casa_case.rb
+++ b/app/models/casa_case.rb
@@ -32,8 +32,8 @@ class CasaCase < ApplicationRecord
   has_many :case_contacts, dependent: :destroy
   has_many :casa_case_emancipation_categories, dependent: :destroy
   has_many :emancipation_categories, through: :casa_case_emancipation_categories
-  has_many :casa_cases_emancipation_options, dependent: :destroy
-  has_many :emancipation_options, through: :casa_cases_emancipation_options
+  has_many :casa_case_emancipation_options, dependent: :destroy
+  has_many :emancipation_options, through: :casa_case_emancipation_options
   has_many :court_dates, dependent: :destroy
   has_many :placements, dependent: :destroy
   has_many :case_group_memberships

--- a/app/models/casa_case_emancipation_option.rb
+++ b/app/models/casa_case_emancipation_option.rb
@@ -1,4 +1,4 @@
-class CasaCasesEmancipationOption < ApplicationRecord
+class CasaCaseEmancipationOption < ApplicationRecord
   belongs_to :casa_case
   belongs_to :emancipation_option
 
@@ -7,7 +7,7 @@ end
 
 # == Schema Information
 #
-# Table name: casa_cases_emancipation_options
+# Table name: casa_case_emancipation_options
 #
 #  id                     :bigint           not null, primary key
 #  created_at             :datetime         not null
@@ -17,7 +17,7 @@ end
 #
 # Indexes
 #
-#  index_cases_options_on_case_id_and_option_id  (casa_case_id,emancipation_option_id) UNIQUE
+#  index_case_options_on_case_id_and_option_id  (casa_case_id,emancipation_option_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/emancipation_option.rb
+++ b/app/models/emancipation_option.rb
@@ -1,7 +1,7 @@
 class EmancipationOption < ApplicationRecord
   belongs_to :emancipation_category
-  has_many :casa_cases_emancipation_options, dependent: :destroy
-  has_many :casa_cases, through: :casa_cases_emancipation_options
+  has_many :casa_case_emancipation_options, dependent: :destroy
+  has_many :casa_cases, through: :casa_case_emancipation_options
 
   validates :name, presence: true, uniqueness: {scope: :emancipation_category_id}
 
@@ -11,7 +11,7 @@ class EmancipationOption < ApplicationRecord
 
   scope :options_with_category_and_case, ->(emancipation_category_id, casa_case_id) {
     joins(:casa_cases)
-      .where(casa_cases_emancipation_options: {casa_case_id: casa_case_id})
+      .where(casa_case_emancipation_options: {casa_case_id: casa_case_id})
       .where(emancipation_category_id: emancipation_category_id)
   }
 end

--- a/db/migrate/20260210233737_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options.rb
+++ b/db/migrate/20260210233737_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options.rb
@@ -1,20 +1,31 @@
 class RenameCasaCasesEmancipatonOptionsToCasaCaseEmancipatonOptions < ActiveRecord::Migration[7.2]
   def change
-    create_table "casa_case_emancipation_options" do |t|
-      t.bigint "casa_case_id", null: false
-      t.bigint "emancipation_option_id", null: false
-      t.datetime "created_at", null: false
-      t.datetime "updated_at", null: false
-      t.index ["casa_case_id", "emancipation_option_id"], name: "index_case_options_on_case_id_and_option_id", unique: true
-    end
+    reversible do |dir|
+      dir.up do
+        create_table "casa_case_emancipation_options" do |t|
+          t.bigint "casa_case_id", null: false
+          t.bigint "emancipation_option_id", null: false
+          t.datetime "created_at", null: false
+          t.datetime "updated_at", null: false
+          t.index ["casa_case_id", "emancipation_option_id"], name: "index_case_options_on_case_id_and_option_id", unique: true
+        end
 
-    add_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
-    add_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
+        add_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
+        add_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
 
-    safety_assured do
-      execute <<-SQL
-        INSERT INTO casa_case_emancipation_options (casa_case_id, emancipation_option_id, created_at, updated_at) SELECT casa_case_id, emancipation_option_id, created_at, updated_at FROM casa_cases_emancipation_options;
-      SQL
+        safety_assured do
+          execute <<-SQL
+            INSERT INTO casa_case_emancipation_options (casa_case_id, emancipation_option_id, created_at, updated_at) SELECT casa_case_id, emancipation_option_id, created_at, updated_at FROM casa_cases_emancipation_options;
+          SQL
+        end
+      end
+
+      dir.down do
+        remove_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
+        remove_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
+
+        drop_table :casa_case_emancipation_options
+      end
     end
   end
 end

--- a/db/migrate/20260210233737_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options.rb
+++ b/db/migrate/20260210233737_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options.rb
@@ -1,0 +1,20 @@
+class RenameCasaCasesEmancipatonOptionsToCasaCaseEmancipatonOptions < ActiveRecord::Migration[7.2]
+  def change
+    create_table "casa_case_emancipation_options" do |t|
+      t.bigint "casa_case_id", null: false
+      t.bigint "emancipation_option_id", null: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["casa_case_id", "emancipation_option_id"], name: "index_case_options_on_case_id_and_option_id", unique: true
+    end
+
+    add_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
+    add_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
+
+    safety_assured do
+      execute <<-SQL
+        INSERT INTO casa_case_emancipation_options (casa_case_id, emancipation_option_id, created_at, updated_at) SELECT casa_case_id, emancipation_option_id, created_at, updated_at FROM casa_cases_emancipation_options;
+      SQL
+    end
+  end
+end

--- a/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
+++ b/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
@@ -1,8 +1,12 @@
 class RenameCasaCasesEmancipatonOptionsToCasaCaseEmancipatonOptionsFollowUp < ActiveRecord::Migration[7.2]
-  def change
+  def up
     validate_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
     validate_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
 
     drop_table :casa_cases_emancipation_options
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
+++ b/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
@@ -1,0 +1,8 @@
+class RenameCasaCasesEmancipatonOptionsToCasaCaseEmancipatonOptionsFollowUp < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
+    validate_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
+
+    drop_table :casa_cases_emancipation_options
+  end
+end

--- a/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
+++ b/db/migrate/20260211001655_rename_casa_cases_emancipaton_options_to_casa_case_emancipaton_options_follow_up.rb
@@ -1,7 +1,7 @@
 class RenameCasaCasesEmancipatonOptionsToCasaCaseEmancipatonOptionsFollowUp < ActiveRecord::Migration[7.2]
   def up
-    validate_foreign_key "casa_case_emancipation_options", "casa_cases", validate: false
-    validate_foreign_key "casa_case_emancipation_options", "emancipation_options", validate: false
+    validate_foreign_key "casa_case_emancipation_options", "casa_cases"
+    validate_foreign_key "casa_case_emancipation_options", "emancipation_options"
 
     drop_table :casa_cases_emancipation_options
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_02_142004) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_11_001655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -127,6 +127,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_142004) do
     t.index ["casa_case_id"], name: "index_casa_case_emancipation_categories_on_casa_case_id"
   end
 
+  create_table "casa_case_emancipation_options", force: :cascade do |t|
+    t.bigint "casa_case_id", null: false
+    t.bigint "emancipation_option_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["casa_case_id", "emancipation_option_id"], name: "index_case_options_on_case_id_and_option_id", unique: true
+  end
+
   create_table "casa_cases", force: :cascade do |t|
     t.string "case_number", null: false
     t.boolean "transition_aged_youth", default: false
@@ -143,14 +151,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_142004) do
     t.index ["casa_org_id"], name: "index_casa_cases_on_casa_org_id"
     t.index ["case_number", "casa_org_id"], name: "index_casa_cases_on_case_number_and_casa_org_id", unique: true
     t.index ["slug"], name: "index_casa_cases_on_slug"
-  end
-
-  create_table "casa_cases_emancipation_options", force: :cascade do |t|
-    t.bigint "casa_case_id", null: false
-    t.bigint "emancipation_option_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["casa_case_id", "emancipation_option_id"], name: "index_cases_options_on_case_id_and_option_id", unique: true
   end
 
   create_table "casa_orgs", force: :cascade do |t|
@@ -678,9 +678,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_142004) do
   add_foreign_key "banners", "users"
   add_foreign_key "casa_case_emancipation_categories", "casa_cases"
   add_foreign_key "casa_case_emancipation_categories", "emancipation_categories"
+  add_foreign_key "casa_case_emancipation_options", "casa_cases"
+  add_foreign_key "casa_case_emancipation_options", "emancipation_options"
   add_foreign_key "casa_cases", "casa_orgs"
-  add_foreign_key "casa_cases_emancipation_options", "casa_cases"
-  add_foreign_key "casa_cases_emancipation_options", "emancipation_options"
   add_foreign_key "case_assignments", "casa_cases"
   add_foreign_key "case_assignments", "users", column: "volunteer_id"
   add_foreign_key "case_contacts", "casa_cases"

--- a/spec/factories/casa_case_emancipation_options.rb
+++ b/spec/factories/casa_case_emancipation_options.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :casa_cases_emancipation_option do
+  factory :casa_case_emancipation_option do
     casa_case do
       create(:casa_case)
     end

--- a/spec/helpers/emancipations_helper_spec.rb
+++ b/spec/helpers/emancipations_helper_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe EmancipationsHelper, type: :helper do
     let(:emancipation_option) { create(:emancipation_option) }
 
     it "returns \"checked\" when passed an associated casa case and emancipation option" do
-      create(:casa_cases_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
+      create(:casa_case_emancipation_option, casa_case_id: casa_case.id, emancipation_option_id: emancipation_option.id)
       expect(helper.emancipation_option_checkbox_checked(casa_case, emancipation_option)).to eq("checked")
     end
 

--- a/spec/models/casa_case_emancipation_option_spec.rb
+++ b/spec/models/casa_case_emancipation_option_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CasaCasesEmancipationOption, type: :model do
+RSpec.describe CasaCaseEmancipationOption, type: :model do
   it { is_expected.to belong_to(:casa_case) }
   it { is_expected.to belong_to(:emancipation_option) }
 
@@ -15,7 +15,7 @@ RSpec.describe CasaCasesEmancipationOption, type: :model do
   end
 
   it "has a valid factory" do
-    case_option_association = build(:casa_cases_emancipation_option)
+    case_option_association = build(:casa_case_emancipation_option)
     expect(case_option_association.valid?).to be true
   end
 end

--- a/spec/models/casa_case_spec.rb
+++ b/spec/models/casa_case_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe CasaCase, type: :model do
   it { is_expected.to belong_to(:casa_org) }
   it { is_expected.to have_many(:casa_case_emancipation_categories).dependent(:destroy) }
   it { is_expected.to have_many(:emancipation_categories).through(:casa_case_emancipation_categories) }
-  it { is_expected.to have_many(:casa_cases_emancipation_options).dependent(:destroy) }
-  it { is_expected.to have_many(:emancipation_options).through(:casa_cases_emancipation_options) }
+  it { is_expected.to have_many(:casa_case_emancipation_options).dependent(:destroy) }
+  it { is_expected.to have_many(:emancipation_options).through(:casa_case_emancipation_options) }
   it { is_expected.to have_many(:case_court_orders).dependent(:destroy) }
   it { is_expected.to have_many(:volunteers).through(:case_assignments) }
 

--- a/spec/models/emancipation_option_spec.rb
+++ b/spec/models/emancipation_option_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe EmancipationOption, type: :model do
   it { is_expected.to belong_to(:emancipation_category) }
-  it { is_expected.to have_many(:casa_cases_emancipation_options).dependent(:destroy) }
-  it { is_expected.to have_many(:casa_cases).through(:casa_cases_emancipation_options) }
+  it { is_expected.to have_many(:casa_case_emancipation_options).dependent(:destroy) }
+  it { is_expected.to have_many(:casa_cases).through(:casa_case_emancipation_options) }
   it { is_expected.to validate_presence_of(:name) }
 
   context "When creating a new option" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6707

### What changed, and _why_?
The model class CasaCasesEmancipationOption has casa cases in plural which doesn't follow the naming convention of join tables.
The class name was renamed to CasaCaseEmancipationOption


### How is this **tested**? (please write rspec and jest tests!) 💖💪
Tried the migrations locally. Rest of it should be caught by CI.

```
casa(dev)> CasaCaseEmancipationOption.all
  CasaCaseEmancipationOption Load (0.4ms)  SELECT "casa_case_emancipation_options".* FROM "casa_case_emancipation_options" /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
=> 
[#<CasaCaseEmancipationOption:0x00007fa7f80001c0
  id: 2,
  casa_case_id: 5,
  emancipation_option_id: 13,
  created_at: "2026-02-11 00:51:41.493401000 +0000",
  updated_at: "2026-02-11 00:51:41.493401000 +0000">,
 #<CasaCaseEmancipationOption:0x00007fa7f801d9a0
  id: 3,
  casa_case_id: 5,
  emancipation_option_id: 7,
  created_at: "2026-02-11 00:51:47.890838000 +0000",
  updated_at: "2026-02-11 00:51:47.890838000 +0000">,
 #<CasaCaseEmancipationOption:0x00007fa7f801d860
  id: 4,
  casa_case_id: 5,
  emancipation_option_id: 8,
  created_at: "2026-02-11 00:51:48.419185000 +0000",
  updated_at: "2026-02-11 00:51:48.419185000 +0000">]
```