### PR TITLE
Fix race conditions in system specs Fixes #6693

### DIFF
--- a/spec/callbacks/case_contact_metadata_callback_spec.rb
+++ b/spec/callbacks/case_contact_metadata_callback_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe CaseContactMetadataCallback do
   let(:past) { Date.new(2020, 1, 1).in_time_zone }
@@ -14,127 +14,127 @@ RSpec.describe CaseContactMetadataCallback do
   # with metadata surrounding cases that are not processed in the correct order.
   # A user would not be able to replicate this behavior.
   #
-  describe "after_commit" do
-    it "sets started metadata when case contact is created" do
+  describe 'after_commit' do
+    it 'sets started metadata when case contact is created' do
       cc = create(:case_contact)
 
-      expect(cc.metadata.dig("status", "active")).to eq(parsed_present)
+      expect(cc.metadata.dig('status', 'active')).to eq(parsed_present)
     end
 
-    context "case contact is in started status" do
+    context 'case contact is in started status' do
       let(:case_contact) { create(:case_contact, :started, created_at: past) }
 
-      context "updates to started status" do
-        before { case_contact.update(status: "started") }
+      context 'updates to started status' do
+        before { case_contact.update(status: 'started') }
 
-        it "does not update the metadata" do
-          expect(case_contact.metadata.dig("status", "started")).to eq(parsed_past)
+        it 'does not update the metadata' do
+          expect(case_contact.metadata.dig('status', 'started')).to eq(parsed_past)
         end
       end
 
-      context "updates to details status" do
-        before { case_contact.update(status: "details") }
+      context 'updates to details status' do
+        before { case_contact.update(status: 'details') }
 
-        it { expect(case_contact.metadata.dig("status", "details")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'details')).to eq(parsed_present) }
       end
 
-      context "updates to notes status" do
-        before { case_contact.update(status: "notes") }
+      context 'updates to notes status' do
+        before { case_contact.update(status: 'notes') }
 
-        it { expect(case_contact.metadata.dig("status", "notes")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'notes')).to eq(parsed_present) }
       end
 
-      context "updates to expenses status" do
-        before { case_contact.update(status: "expenses") }
+      context 'updates to expenses status' do
+        before { case_contact.update(status: 'expenses') }
 
-        it { expect(case_contact.metadata.dig("status", "expenses")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'expenses')).to eq(parsed_present) }
       end
 
-      context "updates to active status" do
-        before { case_contact.update(status: "active") }
+      context 'updates to active status' do
+        before { case_contact.update(status: 'active') }
 
-        it { expect(case_contact.metadata.dig("status", "active")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'active')).to eq(parsed_present) }
       end
     end
 
-    context "case contact is in details status" do
+    context 'case contact is in details status' do
       let(:case_contact) { create(:case_contact, :details, created_at: past) }
 
-      context "updates to details status" do
-        before { case_contact.update(status: "details") }
+      context 'updates to details status' do
+        before { case_contact.update(status: 'details') }
 
-        it "does not update the metadata" do
-          expect(case_contact.metadata.dig("status", "details")).to eq(parsed_past)
+        it 'does not update the metadata' do
+          expect(case_contact.metadata.dig('status', 'details')).to eq(parsed_past)
         end
       end
 
-      context "updates to notes status" do
-        before { case_contact.update(status: "notes") }
+      context 'updates to notes status' do
+        before { case_contact.update(status: 'notes') }
 
-        it { expect(case_contact.metadata.dig("status", "notes")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'notes')).to eq(parsed_present) }
       end
 
-      context "updates to expenses status" do
-        before { case_contact.update(status: "expenses") }
+      context 'updates to expenses status' do
+        before { case_contact.update(status: 'expenses') }
 
-        it { expect(case_contact.metadata.dig("status", "expenses")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'expenses')).to eq(parsed_present) }
       end
 
-      context "updates to active status" do
-        before { case_contact.update(status: "active") }
+      context 'updates to active status' do
+        before { case_contact.update(status: 'active') }
 
-        it { expect(case_contact.metadata.dig("status", "active")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'active')).to eq(parsed_present) }
       end
     end
 
-    context "case contact is in notes status" do
+    context 'case contact is in notes status' do
       let(:case_contact) { create(:case_contact, :notes, created_at: past) }
 
-      context "updates to notes status" do
-        before { case_contact.update(status: "notes") }
+      context 'updates to notes status' do
+        before { case_contact.update(status: 'notes') }
 
-        it { expect(case_contact.metadata.dig("status", "notes")).to eq(parsed_past) }
+        it { expect(case_contact.metadata.dig('status', 'notes')).to eq(parsed_past) }
       end
 
-      context "updates to expenses status" do
-        before { case_contact.update(status: "expenses") }
+      context 'updates to expenses status' do
+        before { case_contact.update(status: 'expenses') }
 
-        it { expect(case_contact.metadata.dig("status", "expenses")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'expenses')).to eq(parsed_present) }
       end
 
-      context "updates to active status" do
-        before { case_contact.update(status: "active") }
+      context 'updates to active status' do
+        before { case_contact.update(status: 'active') }
 
-        it { expect(case_contact.metadata.dig("status", "active")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'active')).to eq(parsed_present) }
       end
     end
 
-    context "case contact is in expenses status" do
+    context 'case contact is in expenses status' do
       let!(:case_contact) { create(:case_contact, :expenses, created_at: past) }
 
-      context "updates to expenses status" do
-        before { case_contact.update(status: "expenses") }
+      context 'updates to expenses status' do
+        before { case_contact.update(status: 'expenses') }
 
-        it "does not update the metadata" do
-          expect(case_contact.metadata.dig("status", "expenses")).to eq(parsed_past)
+        it 'does not update the metadata' do
+          expect(case_contact.metadata.dig('status', 'expenses')).to eq(parsed_past)
         end
       end
 
-      context "updates to active status" do
-        before { case_contact.update(status: "active") }
+      context 'updates to active status' do
+        before { case_contact.update(status: 'active') }
 
-        it { expect(case_contact.metadata.dig("status", "active")).to eq(parsed_present) }
+        it { expect(case_contact.metadata.dig('status', 'active')).to eq(parsed_present) }
       end
     end
 
-    context "case contact is in active status" do
+    context 'case contact is in active status' do
       let(:case_contact) { create(:case_contact, created_at: past) }
 
-      context "updates to active status" do
-        before { case_contact.update(status: "active") }
+      context 'updates to active status' do
+        before { case_contact.update(status: 'active') }
 
-        it "does not update the metadata" do
-          expect(case_contact.metadata.dig("status", "active")).to eq(parsed_past)
+        it 'does not update the metadata' do
+          expect(case_contact.metadata.dig('status', 'active')).to eq(parsed_past)
         end
       end
     end

--- a/spec/datatables/volunteer_datatable_spec.rb
+++ b/spec/datatables/volunteer_datatable_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe VolunteerDatatable do
   let(:org) { CasaOrg.first }
@@ -12,8 +12,8 @@ RSpec.describe VolunteerDatatable do
       transition_aged_youth: %w[false true]
     }
   end
-  let(:order_by) { "display_name" }
-  let(:order_direction) { "asc" }
+  let(:order_by) { 'display_name' }
+  let(:order_direction) { 'asc' }
   let(:page) { 1 }
   let(:per_page) { 10 }
   let(:search_term) { nil }
@@ -28,14 +28,14 @@ RSpec.describe VolunteerDatatable do
     )
   end
 
-  describe ":has_transition_aged_youth_cases" do
+  describe ':has_transition_aged_youth_cases' do
     let(:volunteer_has_transition_aged_youth) { subject[:data].first[:has_transition_aged_youth_cases] }
     let(:non_transitional_birth) { 10.years.ago }
     let(:transitional_birth) { 16.years.ago }
     let(:org) { build :casa_org }
     let(:active_assignment) { true }
 
-    context "with a volunteer with a case assignment" do
+    context 'with a volunteer with a case assignment' do
       let(:casa_case) { build :casa_case, casa_org: org, birth_month_year_youth: youth_month_year }
       let(:supervisor) { create :supervisor, casa_org: org }
       let(:volunteer) { create :volunteer, casa_org: org, supervisor: supervisor }
@@ -44,38 +44,35 @@ RSpec.describe VolunteerDatatable do
         create :case_assignment, volunteer: volunteer, casa_case: casa_case, active: active_assignment
       end
 
-      context "which has a non-transition aged case" do
+      context 'which has a non-transition aged case' do
         let(:youth_month_year) { non_transitional_birth }
 
         it "is 'false'" do
-          expect(volunteer_has_transition_aged_youth).to eq "false"
+          expect(volunteer_has_transition_aged_youth).to eq 'false'
         end
       end
 
-      context "which had (but no longer has) a transition aged case" do
+      context 'which had (but no longer has) a transition aged case' do
         let(:youth_month_year) { transitional_birth }
         let(:active_assignment) { false }
 
         it "is 'false'" do
-          expect(volunteer_has_transition_aged_youth).to eq "false"
+          expect(volunteer_has_transition_aged_youth).to eq 'false'
         end
       end
 
-      context "which has a transition aged case" do
+      context 'which has a transition aged case' do
         let(:youth_month_year) { transitional_birth }
 
         it "is 'true'" do
-          expect(volunteer_has_transition_aged_youth).to eq "true"
+          expect(volunteer_has_transition_aged_youth).to eq 'true'
         end
       end
     end
   end
 
-  context "with supervisors who have volunteers who have cases" do
-    before :all do
-      DatabaseCleaner.strategy = :transaction
-      DatabaseCleaner.start
-
+  context 'with supervisors who have volunteers who have cases' do
+    before do
       org = build(:casa_org)
       supervisors = create_list :supervisor, 3, casa_org: org
 
@@ -83,18 +80,15 @@ RSpec.describe VolunteerDatatable do
         volunteers = create_list :volunteer, 2, casa_org: org, supervisor: supervisor
 
         volunteers.each_with_index do |volunteer, idx|
-          volunteer.casa_cases << build(:casa_case, casa_org: org, birth_month_year_youth: (idx == 1) ? 10.years.ago : 16.years.ago)
+          volunteer.casa_cases << build(:casa_case, casa_org: org,
+                                                    birth_month_year_youth: idx == 1 ? 10.years.ago : 16.years.ago)
         end
       end
 
       create_list :volunteer, 2, casa_org: org
     end
 
-    after :all do
-      DatabaseCleaner.clean
-    end
-
-    describe "order by" do
+    describe 'order by' do
       let(:values) { subject[:data] }
 
       let(:check_attr_equality) do
@@ -115,61 +109,61 @@ RSpec.describe VolunteerDatatable do
         }
       end
 
-      describe "display_name" do
-        let(:order_by) { "display_name" }
+      describe 'display_name' do
+        let(:order_by) { 'display_name' }
         let(:sorted_models) { assigned_volunteers.order :display_name }
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             check_asc_order.call
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
 
-          it "is succesful" do
+          it 'is succesful' do
             check_desc_order.call
           end
         end
       end
 
-      describe "email" do
-        let(:order_by) { "email" }
+      describe 'email' do
+        let(:order_by) { 'email' }
         let(:sorted_models) { assigned_volunteers.order :email }
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             check_asc_order.call
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
 
-          it "is successful" do
+          it 'is successful' do
             check_desc_order.call
           end
         end
       end
 
-      describe "supervisor_name" do
-        let(:order_by) { "supervisor_name" }
+      describe 'supervisor_name' do
+        let(:order_by) { 'supervisor_name' }
         let(:sorted_models) { assigned_volunteers.sort_by { |v| v.supervisor.display_name } }
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             sorted_models.each_with_index do |model, idx|
               expect(CGI.unescapeHTML(values[idx][:supervisor][:name])).to eq model.supervisor.display_name
             end
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
           let(:sorted_models) { assigned_volunteers.sort_by { |v| v.supervisor.display_name } }
 
-          it "is successful" do
+          it 'is successful' do
             sorted_models.reverse.each_with_index do |model, idx|
               expect(CGI.unescapeHTML(values[idx][:supervisor][:name])).to eq model.supervisor.display_name
             end
@@ -177,32 +171,32 @@ RSpec.describe VolunteerDatatable do
         end
       end
 
-      describe "active" do
-        let(:order_by) { "active" }
+      describe 'active' do
+        let(:order_by) { 'active' }
         let(:sorted_models) { assigned_volunteers.order :active, :id }
 
         before do
           supervisors.each { |s| s.volunteers.first.update active: false }
         end
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             check_asc_order.call
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
           let(:sorted_models) { assigned_volunteers.order :active, id: :desc }
 
-          it "is successful" do
+          it 'is successful' do
             check_desc_order.call
           end
         end
       end
 
-      describe "has_transition_aged_youth_cases" do
-        let(:order_by) { "has_transition_aged_youth_cases" }
+      describe 'has_transition_aged_youth_cases' do
+        let(:order_by) { 'has_transition_aged_youth_cases' }
         let(:transition_aged_youth_bool_to_int) do
           lambda { |volunteer|
             volunteer.casa_cases.exists?(birth_month_year_youth: ..CasaCase::TRANSITION_AGE.years.ago) ? 1 : 0
@@ -210,19 +204,19 @@ RSpec.describe VolunteerDatatable do
         end
         let(:sorted_models) { assigned_volunteers.sort_by(&transition_aged_youth_bool_to_int) }
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             sorted_models.each_with_index do |model, idx|
               expect(values[idx][:has_transition_aged_youth_cases]).to eq model.casa_cases.exists?(birth_month_year_youth: ..CasaCase::TRANSITION_AGE.years.ago).to_s
             end
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
           let(:sorted_models) { assigned_volunteers.sort_by(&transition_aged_youth_bool_to_int) }
 
-          it "is successful" do
+          it 'is successful' do
             sorted_models.reverse.each_with_index do |model, idx|
               expect(values[idx][:has_transition_aged_youth_cases]).to eq model.casa_cases.exists?(birth_month_year_youth: ..CasaCase::TRANSITION_AGE.years.ago).to_s
             end
@@ -230,33 +224,36 @@ RSpec.describe VolunteerDatatable do
         end
       end
 
-      describe "most_recent_attempt_occurred_at" do
-        let(:order_by) { "most_recent_attempt_occurred_at" }
+      describe 'most_recent_attempt_occurred_at' do
+        let(:order_by) { 'most_recent_attempt_occurred_at' }
         let(:sorted_models) do
           assigned_volunteers.order(:id).sort_by { |v| v.case_contacts.maximum :occurred_at }
         end
 
         before do
-          CasaCase.all.each_with_index { |cc, idx| cc.case_contacts << build(:case_contact, contact_made: true, creator: cc.volunteers.first, occurred_at: idx.days.ago) }
+          CasaCase.all.each_with_index do |cc, idx|
+            cc.case_contacts << build(:case_contact, contact_made: true, creator: cc.volunteers.first,
+                                                     occurred_at: idx.days.ago)
+          end
         end
 
-        context "when ascending" do
-          it "is successful" do
+        context 'when ascending' do
+          it 'is successful' do
             check_asc_order.call
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
 
-          it "is successful" do
+          it 'is successful' do
             check_desc_order.call
           end
         end
       end
 
-      describe "contacts_made_in_past_days" do
-        let(:order_by) { "contacts_made_in_past_days" }
+      describe 'contacts_made_in_past_days' do
+        let(:order_by) { 'contacts_made_in_past_days' }
         let(:volunteer1) { assigned_volunteers.first }
         let(:casa_case1) { volunteer1.casa_cases.first }
         let(:volunteer2) { assigned_volunteers.second }
@@ -270,99 +267,107 @@ RSpec.describe VolunteerDatatable do
 
         before do
           4.times do |i|
-            create(:case_contact, contact_made: true, casa_case: casa_case1, creator: volunteer1, occurred_at: (19 * (i + 1)).days.ago)
+            create(:case_contact, contact_made: true, casa_case: casa_case1, creator: volunteer1,
+                                  occurred_at: (19 * (i + 1)).days.ago)
           end
 
           3.times do |i|
-            create(:case_contact, contact_made: true, casa_case: casa_case2, creator: volunteer2, occurred_at: (29 * (i + 1)).days.ago)
+            create(:case_contact, contact_made: true, casa_case: casa_case2, creator: volunteer2,
+                                  occurred_at: (29 * (i + 1)).days.ago)
           end
         end
 
-        context "when ascending" do
-          it "is successful" do
-            expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["2", "3", "", "", "", ""]
+        context 'when ascending' do
+          it 'is successful' do
+            expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ['2', '3', '', '', '', '']
           end
         end
 
-        context "when descending" do
-          let(:order_direction) { "desc" }
+        context 'when descending' do
+          let(:order_direction) { 'desc' }
           let(:sorted_models) do
             assigned_volunteers
               .order(id: :desc)
               .sort_by { |v| v.case_contacts.where(occurred_at: 60.days.ago.to_date..).count }
           end
 
-          it "is successful" do
-            expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ["3", "2", "", "", "", ""]
+          it 'is successful' do
+            expect(values.map { |h| h[:contacts_made_in_past_days] }).to eq ['3', '2', '', '', '', '']
           end
 
-          it "moves blanks to the end" do
+          it 'moves blanks to the end' do
             expect(values[0][:contacts_made_in_past_days]).not_to be_blank
           end
         end
       end
     end
 
-    describe "search" do
+    describe 'search' do
       let(:volunteer) { assigned_volunteers.first }
       let(:search_term) { volunteer.display_name }
 
-      describe "recordsTotal" do
-        it "includes all volunteers" do
+      describe 'recordsTotal' do
+        it 'includes all volunteers' do
           expect(subject[:recordsTotal]).to eq org.volunteers.count
         end
       end
 
-      describe "recordsFiltered" do
-        it "includes filtered volunteers" do
+      describe 'recordsFiltered' do
+        it 'includes filtered volunteers' do
           expect(subject[:recordsFiltered]).to eq 1
         end
       end
 
-      describe "display_name" do
-        it "is successful" do
+      describe 'display_name' do
+        it 'is successful' do
           expect(subject[:data].length).to eq 1
           expect(subject[:data].first[:id]).to eq volunteer.id.to_s
         end
       end
 
-      describe "email" do
+      describe 'email' do
         let(:search_term) { volunteer.email }
 
-        it "is successful" do
+        it 'is successful' do
           expect(subject[:data].length).to eq 1
           expect(subject[:data].first[:id]).to eq volunteer.id.to_s
         end
       end
 
-      describe "supervisor_name" do
+      describe 'supervisor_name' do
         let(:supervisor) { volunteer.supervisor }
         let(:search_term) { supervisor.display_name }
         let(:volunteers) { supervisor.volunteers }
 
-        it "is successful" do
+        it 'is successful' do
           expect(subject[:data].length).to eq volunteers.count
           expect(subject[:data].map { |d| d[:id] }.sort).to eq volunteers.map { |v| v.id.to_s }.sort
         end
       end
 
-      describe "case_numbers" do
+      describe 'case_numbers' do
         let(:casa_case) { volunteer.casa_cases.first }
         let(:search_term) { casa_case.case_number }
 
         # Sometimes the default case number is a substring of other case numbers
         before { casa_case.update case_number: Random.hex }
 
-        it "is successful" do
+        it 'is successful' do
           expect(subject[:data].length).to eq 1
           expect(subject[:data].first[:id]).to eq volunteer.id.to_s
         end
 
-        context "when search term case number matches unassigned case" do
+        context 'when search term case number matches unassigned case' do
           let(:new_supervisor) { create(:supervisor, casa_org: casa_case.casa_org) }
-          let(:new_casa_case) { create(:casa_case, :pre_transition, casa_org: casa_case.casa_org, case_number: "ABC-123") }
-          let(:volunteer_1) { create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org, supervisor: new_supervisor) }
-          let(:volunteer_2) { create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org, supervisor: new_supervisor) }
+          let(:new_casa_case) do
+            create(:casa_case, :pre_transition, casa_org: casa_case.casa_org, case_number: 'ABC-123')
+          end
+          let(:volunteer_1) do
+            create(:volunteer, display_name: 'Volunteer 1', casa_org: casa_case.casa_org, supervisor: new_supervisor)
+          end
+          let(:volunteer_2) do
+            create(:volunteer, display_name: 'Volunteer 2', casa_org: casa_case.casa_org, supervisor: new_supervisor)
+          end
           let(:search_term) { new_casa_case.case_number }
 
           before do
@@ -370,7 +375,7 @@ RSpec.describe VolunteerDatatable do
             create(:case_assignment, casa_case: new_casa_case, volunteer: volunteer_2, active: false)
           end
 
-          it "does not include unassigned case matches in search results" do
+          it 'does not include unassigned case matches in search results' do
             expect(subject[:data].length).to eq 1
             expect(subject[:data].first[:id]).to eq volunteer_1.id.to_s
           end
@@ -378,106 +383,106 @@ RSpec.describe VolunteerDatatable do
       end
     end
 
-    describe "filter" do
-      describe "supervisor" do
-        context "when unassigned excluded" do
-          it "is successful" do
+    describe 'filter' do
+      describe 'supervisor' do
+        context 'when unassigned excluded' do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to eq assigned_volunteers.count
           end
         end
 
-        context "when unassigned included" do
+        context 'when unassigned included' do
           before { additional_filters[:supervisor] << nil }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to eq Volunteer.count
           end
         end
 
-        context "when no selection" do
+        context 'when no selection' do
           before { additional_filters[:supervisor] = [] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to be_zero
           end
         end
       end
 
-      describe "active" do
-        before { assigned_volunteers.limit(3).update_all active: "false" }
+      describe 'active' do
+        before { assigned_volunteers.limit(3).update_all active: 'false' }
 
-        context "when active" do
+        context 'when active' do
           before { additional_filters[:active] = %w[true] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to eq assigned_volunteers.where(active: true).count
           end
         end
 
-        context "when inactive" do
+        context 'when inactive' do
           before { additional_filters[:active] = %w[false] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to eq assigned_volunteers.where(active: false).count
           end
         end
 
-        context "when both" do
+        context 'when both' do
           before { additional_filters[:active] = %w[false true] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to eq assigned_volunteers.count
           end
         end
 
-        context "when no selection" do
+        context 'when no selection' do
           before { additional_filters[:active] = [] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq Volunteer.count
             expect(subject[:recordsFiltered]).to be_zero
           end
         end
       end
 
-      describe "transition_aged_youth" do
-        context "when yes" do
+      describe 'transition_aged_youth' do
+        context 'when yes' do
           before { additional_filters[:transition_aged_youth] = %w[true] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq 8
             expect(subject[:recordsFiltered]).to eq 3
           end
         end
 
-        context "when no" do
+        context 'when no' do
           before { additional_filters[:transition_aged_youth] = %w[false] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq 8
             expect(subject[:recordsFiltered]).to eq 3
           end
         end
 
-        context "when both" do
+        context 'when both' do
           before { additional_filters[:transition_aged_youth] = %w[false true] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq 8
             expect(subject[:recordsFiltered]).to eq 6
           end
         end
 
-        context "when no selection" do
+        context 'when no selection' do
           before { additional_filters[:transition_aged_youth] = [] }
 
-          it "is successful" do
+          it 'is successful' do
             expect(subject[:recordsTotal]).to eq 8
             expect(subject[:recordsFiltered]).to be_zero
           end
@@ -485,22 +490,22 @@ RSpec.describe VolunteerDatatable do
       end
     end
 
-    describe "pagination" do
+    describe 'pagination' do
       let(:page) { 2 }
       let(:per_page) { 5 }
 
-      it "is successful" do
+      it 'is successful' do
         expect(subject[:data].length).to eq assigned_volunteers.count - 5
       end
 
-      describe "recordsTotal" do
-        it "includes all volunteers" do
+      describe 'recordsTotal' do
+        it 'includes all volunteers' do
           expect(subject[:recordsTotal]).to eq org.volunteers.count
         end
       end
 
-      describe "recordsFiltered" do
-        it "includes all filtered volunteers" do
+      describe 'recordsFiltered' do
+        it 'includes all filtered volunteers' do
           expect(subject[:recordsFiltered]).to eq assigned_volunteers.count
         end
       end

--- a/spec/lib/importers/case_importer_spec.rb
+++ b/spec/lib/importers/case_importer_spec.rb
@@ -1,71 +1,71 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe CaseImporter do
   subject(:case_importer) { CaseImporter.new(import_file_path, casa_org_id) }
 
   let(:casa_org) { create :casa_org }
   let(:casa_org_id) { casa_org.id }
-  let(:import_file_path) { file_fixture "casa_cases.csv" }
+  let(:import_file_path) { file_fixture 'casa_cases.csv' }
 
   before do
     allow(case_importer).to receive(:email_addresses_to_users) do |_clazz, comma_separated_emails|
-      create_list(:volunteer, comma_separated_emails.split(",").size, casa_org_id: casa_org_id)
+      create_list(:volunteer, comma_separated_emails.split(',').size, casa_org_id: casa_org_id)
     end
 
     # next_court_date in casa_cases.csv needs to be a future date
-    travel_to Date.parse("Sept 15 2022")
+    travel_to Date.parse('Sept 15 2022')
   end
 
-  describe "#import_cases" do
-    it "imports cases and associates volunteers with them" do
+  describe '#import_cases' do
+    it 'imports cases and associates volunteers with them' do
       expect { case_importer.import_cases }.to change(CasaCase, :count).by(3)
 
       # correctly imports birth_month_year_youth
-      expect(CasaCase.find_by(case_number: "CINA-01-4347").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2011-03-01"
-      expect(CasaCase.find_by(case_number: "CINA-01-4348").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2000-02-01"
-      expect(CasaCase.find_by(case_number: "CINA-01-4349").birth_month_year_youth&.strftime("%Y-%m-%d")).to eql "2016-12-01"
+      expect(CasaCase.find_by(case_number: 'CINA-01-4347').birth_month_year_youth&.strftime('%Y-%m-%d')).to eql '2011-03-01'
+      expect(CasaCase.find_by(case_number: 'CINA-01-4348').birth_month_year_youth&.strftime('%Y-%m-%d')).to eql '2000-02-01'
+      expect(CasaCase.find_by(case_number: 'CINA-01-4349').birth_month_year_youth&.strftime('%Y-%m-%d')).to eql '2016-12-01'
 
       # correctly adds volunteers
-      expect(CasaCase.find_by(case_number: "CINA-01-4347").volunteers.size).to eq(1)
-      expect(CasaCase.find_by(case_number: "CINA-01-4348").volunteers.size).to eq(2)
-      expect(CasaCase.find_by(case_number: "CINA-01-4349").volunteers.size).to eq(0)
+      expect(CasaCase.find_by(case_number: 'CINA-01-4347').volunteers.size).to eq(1)
+      expect(CasaCase.find_by(case_number: 'CINA-01-4348').volunteers.size).to eq(2)
+      expect(CasaCase.find_by(case_number: 'CINA-01-4349').volunteers.size).to eq(0)
 
       # correctly adds next court date
-      expect(CasaCase.find_by(case_number: "CINA-01-4348").next_court_date.date.strftime("%Y-%m-%d")).to eql "2023-01-01"
-      expect(CasaCase.find_by(case_number: "CINA-01-4347").next_court_date.date.strftime("%Y-%m-%d")).to eql "2022-09-16"
-      expect(CasaCase.find_by(case_number: "CINA-01-4349").next_court_date).to be_nil
+      expect(CasaCase.find_by(case_number: 'CINA-01-4348').next_court_date.date.strftime('%Y-%m-%d')).to eql '2023-01-01'
+      expect(CasaCase.find_by(case_number: 'CINA-01-4347').next_court_date.date.strftime('%Y-%m-%d')).to eql '2022-09-16'
+      expect(CasaCase.find_by(case_number: 'CINA-01-4349').next_court_date).to be_nil
     end
 
-    context "when updating records" do
-      let!(:existing_case) { create(:casa_case, case_number: "CINA-01-4348") }
+    context 'when updating records' do
+      let!(:existing_case) { create(:casa_case, case_number: 'CINA-01-4348') }
 
-      it "assigns new volunteers to the case" do
+      it 'assigns new volunteers to the case' do
         expect { case_importer.import_cases }.to change(existing_case.volunteers, :count).by(2)
       end
 
-      it "updates outdated case fields" do
-        expect {
+      it 'updates outdated case fields' do
+        expect do
           case_importer.import_cases
           existing_case.reload
-        }.to change(existing_case, :birth_month_year_youth).to(Date.new(2000, 2, 1))
+        end.to change(existing_case, :birth_month_year_youth).to(Date.new(2000, 2, 1))
       end
 
-      it "adds a next court date" do
-        expect {
+      it 'adds a next court date' do
+        expect do
           case_importer.import_cases
           existing_case.reload
-        }.to change(existing_case, :court_dates).from([])
+        end.to change(existing_case, :court_dates).from([])
       end
     end
 
-    it "returns a success message with the number of cases imported" do
+    it 'returns a success message with the number of cases imported' do
       alert = case_importer.import_cases
 
       expect(alert[:type]).to eq(:success)
-      expect(alert[:message]).to eq("You successfully imported 3 casa_cases.")
+      expect(alert[:message]).to eq('You successfully imported 3 casa_cases.')
     end
 
-    specify "static and instance methods have identical results" do
+    specify 'static and instance methods have identical results' do
       CaseImporter.new(import_file_path, casa_org_id).import_cases
       data_using_instance = CasaCase.pluck(:case_number).sort
 
@@ -78,23 +78,23 @@ RSpec.describe CaseImporter do
       expect(data_using_static).not_to be_empty
     end
 
-    context "when the importer has already run once" do
+    context 'when the importer has already run once' do
       before { case_importer.import_cases }
 
-      it "does not duplicate casa case files from csv files" do
+      it 'does not duplicate casa case files from csv files' do
         expect { case_importer.import_cases }.not_to change(CasaCase, :count)
       end
     end
 
     context "when there's no case number" do
-      let(:import_file_path) { file_fixture "casa_cases_without_case_number.csv" }
+      let(:import_file_path) { file_fixture 'casa_cases_without_case_number.csv' }
 
-      it "returns an error message if row does not contain a case number" do
+      it 'returns an error message if row does not contain a case number' do
         alert = case_importer.import_cases
 
         expect(alert[:type]).to eq(:error)
-        expect(alert[:message]).to eq("You successfully imported 1 casa_cases. Not all rows were imported.")
-        expect(alert[:exported_rows]).to include("Row does not contain a case number.")
+        expect(alert[:message]).to eq('You successfully imported 1 casa_cases. Not all rows were imported.')
+        expect(alert[:exported_rows]).to include('Row does not contain a case number.')
       end
     end
   end

--- a/spec/lib/tasks/supervisor_weekly_digest_spec.rb
+++ b/spec/lib/tasks/supervisor_weekly_digest_spec.rb
@@ -1,33 +1,33 @@
-require "rails_helper"
-require_relative "../../../lib/tasks/supervisor_weekly_digest"
+require 'rails_helper'
+require_relative '../../../lib/tasks/supervisor_weekly_digest'
 
 RSpec.describe SupervisorWeeklyDigest do
-  describe "#send!" do
+  describe '#send!' do
     subject { described_class.new.send! }
 
-    context "on monday" do
-      context "with active and deactivated supervisor" do
+    context 'on monday' do
+      context 'with active and deactivated supervisor' do
         before do
           travel_to Time.zone.local(2021, 9, 27, 12, 0, 0) # monday noon
           create(:supervisor, active: true)
           create(:supervisor, active: false)
         end
 
-        it "only sends to active supervisor" do
+        it 'only sends to active supervisor' do
           expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
           expect(ActionMailer::Base.deliveries.last.subject).to eq("Weekly summary of volunteers' activities for the week of 2021-09-20")
         end
       end
     end
 
-    context "not on monday" do
+    context 'not on monday' do
       before do
         travel_to Time.zone.local(2021, 9, 29, 12, 0, 0) # not monday
         create(:supervisor, active: true)
       end
 
-      it "does not send email" do
-        expect { subject }.not_to change { ActionMailer::Base.deliveries.count }
+      it 'does not send email' do
+        expect { subject }.not_to(change { ActionMailer::Base.deliveries.count })
       end
     end
   end

--- a/spec/models/case_court_report_context_spec.rb
+++ b/spec/models/case_court_report_context_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-require "sablon"
+require 'rails_helper'
+require 'sablon'
 
-A_TIMEZONE = "America/New_York"
+A_TIMEZONE = 'America/New_York'
 
 RSpec.describe CaseCourtReportContext, type: :model do
   let(:volunteer) { create(:volunteer, :with_casa_cases) }
-  let(:path_to_template) { Rails.root.join("app/documents/templates/default_report_template.docx").to_s }
-  let(:path_to_report) { Rails.root.join("tmp/test_report.docx").to_s }
+  let(:path_to_template) { Rails.root.join('app/documents/templates/default_report_template.docx').to_s }
+  let(:path_to_report) { Rails.root.join('tmp/test_report.docx').to_s }
 
   before do
     travel_to Date.new(2021, 1, 1)
   end
 
-  describe "#context" do
-    it "has the right shape" do
+  describe '#context' do
+    it 'has the right shape' do
       date = 1.day.ago
       court_date = build(:court_date, :with_hearing_type, date: date)
       context = create(:case_court_report_context, court_date: court_date)
@@ -25,16 +25,16 @@ RSpec.describe CaseCourtReportContext, type: :model do
       allow(context).to receive(:case_orders).and_return([])
       allow(context).to receive(:org_address).and_return(nil)
       allow(context).to receive(:volunteer_info).and_return({})
-      allow(context).to receive(:latest_hearing_date).and_return("")
+      allow(context).to receive(:latest_hearing_date).and_return('')
       allow(context).to receive(:court_topics).and_return({})
 
       expected_shape = {
-        created_date: "January 1, 2021",
+        created_date: 'January 1, 2021',
         casa_case: {},
         case_contacts: [],
         case_court_orders: [],
         case_mandates: [],
-        latest_hearing_date: "",
+        latest_hearing_date: '',
         org_address: nil,
         volunteer: {},
         hearing_type_name: court_date.hearing_type.name,
@@ -45,15 +45,15 @@ RSpec.describe CaseCourtReportContext, type: :model do
     end
   end
 
-  describe "case_orders" do
-    it "returns the correct shape" do
+  describe 'case_orders' do
+    it 'returns the correct shape' do
       court_orders = [
-        build(:case_court_order, text: "Court order 1", implementation_status: :unimplemented),
-        build(:case_court_order, text: "Court order 2", implementation_status: :implemented)
+        build(:case_court_order, text: 'Court order 1', implementation_status: :unimplemented),
+        build(:case_court_order, text: 'Court order 2', implementation_status: :implemented)
       ]
       expected = [
-        {order: "Court order 1", status: "Unimplemented"},
-        {order: "Court order 2", status: "Implemented"}
+        { order: 'Court order 1', status: 'Unimplemented' },
+        { order: 'Court order 2', status: 'Implemented' }
       ]
       context = build_stubbed(:case_court_report_context)
 
@@ -61,58 +61,58 @@ RSpec.describe CaseCourtReportContext, type: :model do
     end
   end
 
-  describe "org_address" do
+  describe 'org_address' do
     let(:volunteer) { create(:volunteer) }
     let(:context) { build(:case_court_report_context, volunteer: volunteer) }
 
-    context "when volunteer and default template are provided" do
-      it "returns the CASA org address" do
-        path_to_template = "default_report_template.docx"
+    context 'when volunteer and default template are provided' do
+      it 'returns the CASA org address' do
+        path_to_template = 'default_report_template.docx'
         expected_address = volunteer.casa_org.address
 
         expect(context.org_address(path_to_template)).to eq(expected_address)
       end
     end
 
-    context "when volunteer is provided but not default template" do
-      it "returns nil" do
-        path_to_template = "some_other_template.docx"
+    context 'when volunteer is provided but not default template' do
+      it 'returns nil' do
+        path_to_template = 'some_other_template.docx'
 
         expect(context.org_address(path_to_template)).to be_nil
       end
     end
 
-    context "when volunteer is not provided" do
+    context 'when volunteer is not provided' do
       let(:context) { build(:case_court_report_context, volunteer: false) }
 
-      it "returns nil" do
-        path_to_template = "default_report_template.docx"
+      it 'returns nil' do
+        path_to_template = 'default_report_template.docx'
         expect(context.org_address(path_to_template)).to be_nil
       end
     end
   end
 
-  describe "#latest_hearing_date" do
-    context "when casa_case has court_dates" do
+  describe '#latest_hearing_date' do
+    context 'when casa_case has court_dates' do
       let(:court_date) { build(:court_date, date: 2.day.ago) }
       let(:casa_case) { create(:casa_case, court_dates: [court_date]) }
       let(:instance) { build(:case_court_report_context, casa_case: casa_case) }
 
-      it "returns the formatted date" do
-        expect(instance.latest_hearing_date).to eq("December 30, 2020") # 2 days before spec default date
+      it 'returns the formatted date' do
+        expect(instance.latest_hearing_date).to eq('December 30, 2020') # 2 days before spec default date
       end
     end
 
-    context "when most recent past court date is nil" do
+    context 'when most recent past court date is nil' do
       let(:instance) { build(:case_court_report_context) }
 
-      it "returns the placeholder string" do
-        expect(instance.latest_hearing_date).to eq("___<LATEST HEARING DATE>____")
+      it 'returns the placeholder string' do
+        expect(instance.latest_hearing_date).to eq('___<LATEST HEARING DATE>____')
       end
     end
 
-    context "when there are multiple hearing dates" do
-      let(:casa_case_with_court_dates) {
+    context 'when there are multiple hearing dates' do
+      let(:casa_case_with_court_dates) do
         casa_case = create(:casa_case)
 
         casa_case.court_dates << build(:court_date, date: 9.months.ago)
@@ -120,57 +120,59 @@ RSpec.describe CaseCourtReportContext, type: :model do
         casa_case.court_dates << build(:court_date, date: 15.months.ago)
 
         casa_case
-      }
+      end
 
-      let(:court_report_context_with_latest_hearing_date) { build(:case_court_report_context, casa_case: casa_case_with_court_dates) }
+      let(:court_report_context_with_latest_hearing_date) do
+        build(:case_court_report_context, casa_case: casa_case_with_court_dates)
+      end
 
-      it "sets latest_hearing_date as the latest past court date" do
-        expect(court_report_context_with_latest_hearing_date.latest_hearing_date).to eq("October 1, 2020")
+      it 'sets latest_hearing_date as the latest past court date' do
+        expect(court_report_context_with_latest_hearing_date.latest_hearing_date).to eq('October 1, 2020')
       end
     end
   end
 
-  describe "#calculate_date_range" do
-    context "when @time_zone is set" do
-      it "converts to provided timezone" do
+  describe '#calculate_date_range' do
+    context 'when @time_zone is set' do
+      it 'converts to provided timezone' do
         context = build_context(start_date: 10.day.ago, end_date: 2.day.ago, court_date: nil, time_zone: A_TIMEZONE)
         expect(context.date_range).to eq(zone_days_ago(10)..zone_days_ago(2))
       end
 
-      it "uses current time if end_date not provided" do
+      it 'uses current time if end_date not provided' do
         context = build_context(start_date: 10.day.ago, end_date: nil, court_date: nil, time_zone: A_TIMEZONE)
         expect(context.date_range).to eq(zone_days_ago(10)..nil)
       end
 
-      it "uses court date if available if no start_date" do
+      it 'uses court date if available if no start_date' do
         context = build_context(start_date: nil, end_date: 2.day.ago, court_date: 6.day.ago, time_zone: A_TIMEZONE)
         expect(context.date_range).to eq(zone_days_ago(6)..zone_days_ago(2))
       end
 
-      it "uses nil(includes everything) if no court date or start_date" do
+      it 'uses nil(includes everything) if no court date or start_date' do
         context = build_context(start_date: nil, end_date: 2.day.ago, court_date: nil, time_zone: A_TIMEZONE)
 
         expect(context.date_range).to eq(nil..zone_days_ago(2))
       end
     end
 
-    context "when @time_zone is not set" do
-      it "uses server time zone" do
+    context 'when @time_zone is not set' do
+      it 'uses server time zone' do
         context = build_context(start_date: 10.day.ago, end_date: 2.day.ago, court_date: nil, time_zone: nil)
         expect(context.date_range).to eq(days_ago(10)..days_ago(2))
       end
 
-      it "uses nil if end_date not provided" do
+      it 'uses nil if end_date not provided' do
         context = build_context(start_date: 10.day.ago, end_date: nil, court_date: nil, time_zone: nil)
         expect(context.date_range).to eq(days_ago(10)..nil)
       end
 
-      it "uses court date if available if no start_date" do
+      it 'uses court date if available if no start_date' do
         context = build_context(start_date: nil, end_date: 2.day.ago, court_date: 6.day.ago, time_zone: nil)
         expect(context.date_range).to eq(days_ago(6)..days_ago(2))
       end
 
-      it "uses nil if no court date or start_date" do
+      it 'uses nil if no court date or start_date' do
         context = build_context(start_date: nil, end_date: 2.day.ago, court_date: nil, time_zone: nil)
 
         expect(context.date_range).to eq(nil..days_ago(2))
@@ -178,49 +180,59 @@ RSpec.describe CaseCourtReportContext, type: :model do
     end
   end
 
-  describe "#court_topics" do
+  describe '#court_topics' do
     let(:org) { create(:casa_org) }
     let(:casa_case) { create(:casa_case, casa_org: org) }
-    let(:topics) { [1, 2, 3].map { |i| create(:contact_topic, casa_org: org, question: "Question #{i}", details: "Details #{i}") } }
+    let(:topics) do
+      [1, 2, 3].map do |i|
+        create(:contact_topic, casa_org: org, question: "Question #{i}", details: "Details #{i}")
+      end
+    end
     let(:contacts) do
       [1, 2, 3, 4].map do |i|
         create(:case_contact,
-          casa_case: casa_case,
-          occurred_at: 1.month.ago + i.days,
-          contact_types: [
-            create(:contact_type, name: "Type A#{i}"),
-            create(:contact_type, name: "Type B#{i}")
-          ])
+               casa_case: casa_case,
+               occurred_at: 1.month.ago + i.days,
+               contact_types: [
+                 create(:contact_type, name: "Type A#{i}"),
+                 create(:contact_type, name: "Type B#{i}")
+               ])
       end
     end
 
-    context "when given data" do
+    context 'when given data' do
       before do
         # Contact 1 Answers
-        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[0], value: "Answer 1")
-        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[1], value: "Answer 2")
+        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[0], value: 'Answer 1')
+        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[1], value: 'Answer 2')
 
         # Contact 2 Answers
-        create(:contact_topic_answer, case_contact: contacts[1], contact_topic: topics[0], value: "Answer 3")
+        create(:contact_topic_answer, case_contact: contacts[1], contact_topic: topics[0], value: 'Answer 3')
         create(:contact_topic_answer, case_contact: contacts[1], contact_topic: topics[2], value: nil)
 
         # Contact 3 Answers
-        create(:contact_topic_answer, case_contact: contacts[2], contact_topic: topics[1], value: "Answer 5")
-        create(:contact_topic_answer, case_contact: contacts[2], contact_topic: topics[2], value: "")
+        create(:contact_topic_answer, case_contact: contacts[2], contact_topic: topics[1], value: 'Answer 5')
+        create(:contact_topic_answer, case_contact: contacts[2], contact_topic: topics[2], value: '')
 
         # Contacts that will be filtered
-        one_day_ago_contact = create(:case_contact, casa_case: casa_case, medium_type: "in-person", occurred_at: 1.day.ago)
-        create_list(:contact_topic_answer, 2, case_contact: one_day_ago_contact, contact_topic: topics[0], value: "Answer From One Day Ago")
+        one_day_ago_contact = create(:case_contact, casa_case: casa_case, medium_type: 'in-person',
+                                                    occurred_at: 1.day.ago)
+        create_list(:contact_topic_answer, 2, case_contact: one_day_ago_contact, contact_topic: topics[0],
+                                              value: 'Answer From One Day Ago')
 
-        one_year_ago_contact = create(:case_contact, casa_case: casa_case, medium_type: "in-person", occurred_at: 1.year.ago)
-        create_list(:contact_topic_answer, 2, case_contact: one_year_ago_contact, contact_topic: topics[0], value: "Answer From One Year Ago")
+        one_year_ago_contact = create(:case_contact, casa_case: casa_case, medium_type: 'in-person',
+                                                     occurred_at: 1.year.ago)
+        create_list(:contact_topic_answer, 2, case_contact: one_year_ago_contact, contact_topic: topics[0],
+                                              value: 'Answer From One Year Ago')
 
         other_case = create(:casa_case, casa_org: org)
-        other_case_contact = create(:case_contact, casa_case: other_case, medium_type: "in-person", occurred_at: 1.month.ago)
-        create_list(:contact_topic_answer, 2, case_contact: other_case_contact, contact_topic: topics[0], value: "Answer From Another Case")
+        other_case_contact = create(:case_contact, casa_case: other_case, medium_type: 'in-person',
+                                                   occurred_at: 1.month.ago)
+        create_list(:contact_topic_answer, 2, case_contact: other_case_contact, contact_topic: topics[0],
+                                              value: 'Answer From Another Case')
       end
 
-      it "returns a hash of topics with the correct shape" do
+      it 'returns a hash of topics with the correct shape' do
         court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
 
         expect(court_topics).to be_a(Hash)
@@ -232,7 +244,7 @@ RSpec.describe CaseCourtReportContext, type: :model do
             details: a_kind_of(String),
             answers: all(
               a_hash_including(
-                date: a_string_matching(/\d{2}\/\d{2}\/\d{2}/),
+                date: a_string_matching(%r{\d{2}/\d{2}/\d{2}}),
                 medium: a_kind_of(String),
                 value: a_kind_of(String)
               )
@@ -241,46 +253,51 @@ RSpec.describe CaseCourtReportContext, type: :model do
         )
       end
 
-      it "returns topics related to the case" do
+      it 'returns topics related to the case' do
         court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
 
-        expect(court_topics.keys).to match_array(["Question 1", "Question 2", "Question 3"])
-        expect(court_topics["Question 1"][:answers].map { |a| a[:value] }).to match_array(
-          ["Answer From One Year Ago", "Answer 1", "Answer 3", "Answer From One Day Ago"]
-        )
-        expect(court_topics["Question 2"][:answers].map { |a| a[:value] }).to match_array(["Answer 2", "Answer 5"])
-        expect(court_topics["Question 3"][:answers].map { |a| a[:value] }).to match_array(["No Answer Provided", "No Answer Provided"])
+        expect(court_topics.keys).to contain_exactly('Question 1', 'Question 2', 'Question 3')
+        expect(court_topics['Question 1'][:answers].map do |a|
+          a[:value]
+        end).to contain_exactly('Answer From One Year Ago', 'Answer 1', 'Answer 3', 'Answer From One Day Ago')
+        expect(court_topics['Question 2'][:answers].map { |a| a[:value] }).to contain_exactly('Answer 2', 'Answer 5')
+        expect(court_topics['Question 3'][:answers].map do |a|
+          a[:value]
+        end).to contain_exactly('No Answer Provided', 'No Answer Provided')
       end
 
-      it "filters by date range" do
-        court_topics = build(:case_court_report_context, start_date: 45.day.ago.to_s, end_date: 5.day.ago.to_s, casa_case: casa_case).court_topics
+      it 'filters by date range' do
+        court_topics = build(:case_court_report_context, start_date: 45.day.ago.to_s, end_date: 5.day.ago.to_s,
+                                                         casa_case: casa_case).court_topics
 
-        expect(court_topics.keys).to match_array(["Question 1", "Question 2", "Question 3"])
-        expect(court_topics["Question 1"][:answers].map { |a| a[:value] }).to match_array(["Answer 1", "Answer 3"])
+        expect(court_topics.keys).to contain_exactly('Question 1', 'Question 2', 'Question 3')
+        expect(court_topics['Question 1'][:answers].map { |a| a[:value] }).to contain_exactly('Answer 1', 'Answer 3')
       end
 
-      it "filters answers from topics set be excluded from court report" do
+      it 'filters answers from topics set be excluded from court report' do
         topics[0].update(exclude_from_court_report: true)
 
         court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
 
-        expect(court_topics.keys).not_to include("Question 1")
-        expect(court_topics.keys).to include("Question 2", "Question 3")
+        expect(court_topics.keys).not_to include('Question 1')
+        expect(court_topics.keys).to include('Question 2', 'Question 3')
       end
     end
 
-    context "when there are no contact topics" do
-      it "returns an empty hash" do
-        court_report_context = build(:case_court_report_context, start_date: 45.day.ago.to_s, end_date: 5.day.ago.to_s, casa_case: casa_case)
+    context 'when there are no contact topics' do
+      it 'returns an empty hash' do
+        court_report_context = build(:case_court_report_context, start_date: 45.day.ago.to_s, end_date: 5.day.ago.to_s,
+                                                                 casa_case: casa_case)
         expect(court_report_context.court_topics).to eq({})
       end
     end
   end
 
-  describe "#filtered_interviewees" do
-    it "filters based on date range" do
+  describe '#filtered_interviewees' do
+    it 'filters based on date range' do
       casa_case = create(:casa_case)
-      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: 5.day.ago.to_s, casa_case: casa_case)
+      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: 5.day.ago.to_s,
+                                                               casa_case: casa_case)
 
       create_list(:case_contact, 3, occurred_at: 10.day.ago, casa_case: casa_case)
       create_list(:case_contact, 3, occurred_at: 1.day.ago, casa_case: casa_case)
@@ -291,9 +308,10 @@ RSpec.describe CaseCourtReportContext, type: :model do
       expect(result).to contain_exactly(included_interviewee)
     end
 
-    it "filters if start of date range is nil" do
+    it 'filters if start of date range is nil' do
       casa_case = create(:casa_case)
-      court_report_context = build(:case_court_report_context, start_date: nil, end_date: 5.day.ago.to_s, casa_case: casa_case)
+      court_report_context = build(:case_court_report_context, start_date: nil, end_date: 5.day.ago.to_s,
+                                                               casa_case: casa_case)
 
       create_list(:case_contact, 3, occurred_at: 1.day.ago, casa_case: casa_case)
       interviewees = create_list(:case_contact, 3, occurred_at: 10.day.ago, casa_case: casa_case)
@@ -304,9 +322,10 @@ RSpec.describe CaseCourtReportContext, type: :model do
       expect(result).to match_array(interviewees)
     end
 
-    it "filters if end of date range is nil" do
+    it 'filters if end of date range is nil' do
       casa_case = create(:casa_case)
-      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: nil, casa_case: casa_case)
+      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: nil,
+                                                               casa_case: casa_case)
 
       create_list(:case_contact, 3, occurred_at: 10.day.ago, casa_case: casa_case)
       interviewees = create_list(:case_contact, 3, occurred_at: 1.day.ago, casa_case: casa_case)
@@ -317,7 +336,7 @@ RSpec.describe CaseCourtReportContext, type: :model do
       expect(result).to match_array(interviewees)
     end
 
-    it "does not filter if both start and end of date range are nil" do
+    it 'does not filter if both start and end of date range are nil' do
       casa_case = create(:casa_case)
       court_report_context = build(:case_court_report_context, start_date: nil, end_date: nil, casa_case: casa_case)
 
@@ -330,9 +349,10 @@ RSpec.describe CaseCourtReportContext, type: :model do
       expect(result).to match_array(CaseContact.all)
     end
 
-    it "returns an empty array if there are no interviewees" do
+    it 'returns an empty array if there are no interviewees' do
       casa_case = create(:casa_case)
-      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: nil, casa_case: casa_case)
+      court_report_context = build(:case_court_report_context, start_date: 5.day.ago.to_s, end_date: nil,
+                                                               casa_case: casa_case)
 
       result = court_report_context.filtered_interviewees.map(&:case_contact)
 
@@ -340,25 +360,28 @@ RSpec.describe CaseCourtReportContext, type: :model do
     end
   end
 
-  describe "#context" do
+  describe '#context' do
     let(:court_report_context) { build(:case_court_report_context) }
 
-    describe ":created_date" do
-      it "has a created date equal to the current date" do
-        expect(court_report_context.context[:created_date]).to eq("January 1, 2021")
+    describe ':created_date' do
+      it 'has a created date equal to the current date' do
+        expect(court_report_context.context[:created_date]).to eq('January 1, 2021')
       end
     end
   end
 
-  describe "#volunteer_info" do
-    let(:volunteer) { create(:volunteer, display_name: "Y>cy%F7v;\\].-g$", supervisor: build(:supervisor, display_name: "Mm^ED;`zg(g<Z]q")) }
+  describe '#volunteer_info' do
+    let(:volunteer) do
+      create(:volunteer, display_name: 'Y>cy%F7v;\\].-g$',
+                         supervisor: build(:supervisor, display_name: 'Mm^ED;`zg(g<Z]q'))
+    end
     let(:context) { build(:case_court_report_context, volunteer: volunteer) }
 
-    it "correctly transforms the info" do
+    it 'correctly transforms the info' do
       expected = {
-        name: "Y>cy%F7v;\\].-g$",
-        supervisor_name: "Mm^ED;`zg(g<Z]q",
-        assignment_date: "January 1, 2021" # This is the default set in the spec
+        name: 'Y>cy%F7v;\\].-g$',
+        supervisor_name: 'Mm^ED;`zg(g<Z]q',
+        assignment_date: 'January 1, 2021' # This is the default set in the spec
       }
 
       expect(context.volunteer_info).to eq(expected)
@@ -367,7 +390,7 @@ RSpec.describe CaseCourtReportContext, type: :model do
 end
 
 def build_context(start_date:, end_date:, court_date:, time_zone:)
-  args = {time_zone: time_zone, start_date: start_date.to_s, end_date: end_date.to_s}
+  args = { time_zone: time_zone, start_date: start_date.to_s, end_date: end_date.to_s }
 
   if court_date
     court_date_object = build(:court_date, date: court_date)

--- a/spec/requests/banners_spec.rb
+++ b/spec/requests/banners_spec.rb
@@ -1,33 +1,33 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Banners", type: :request do
+RSpec.describe 'Banners', type: :request do
   let!(:casa_org) { create(:casa_org) }
   let!(:active_banner) { create(:banner, casa_org: casa_org) }
   let(:volunteer) { create(:volunteer, casa_org: casa_org) }
 
-  context "when user dismisses a banner" do
+  context 'when user dismisses a banner' do
     subject do
       get dismiss_banner_path(active_banner)
     end
 
-    it "sets session variable" do
+    it 'sets session variable' do
       sign_in volunteer
       subject
       expect(session[:dismissed_banner]).to eq active_banner.id
     end
 
-    it "does not display banner on page reloads" do
+    it 'does not display banner on page reloads' do
       sign_in volunteer
       get casa_cases_path
-      expect(response.body).to include "Please fill out this survey"
+      expect(response.body).to include 'Please fill out this survey'
 
       subject
       get casa_cases_path
-      expect(response.body).not_to include "Please fill out this survey"
+      expect(response.body).not_to include 'Please fill out this survey'
     end
 
-    context "when user logs out and back in" do
-      it "nils out session variable" do
+    context 'when user logs out and back in' do
+      it 'nils out session variable' do
         sign_in volunteer
         subject
         get destroy_user_session_path
@@ -36,101 +36,101 @@ RSpec.describe "Banners", type: :request do
         expect(session[:dismissed_banner]).to be_nil
       end
 
-      it "displays banner" do
+      it 'displays banner' do
         sign_in volunteer
         subject
         get destroy_user_session_path
         sign_in volunteer
 
         get casa_cases_path
-        expect(response.body).to include "Please fill out this survey"
+        expect(response.body).to include 'Please fill out this survey'
       end
     end
   end
 
-  context "when a banner has expires_at" do
-    context "when expires_at is after today" do
+  context 'when a banner has expires_at' do
+    context 'when expires_at is after today' do
       let!(:active_banner) { create(:banner, casa_org: casa_org, expires_at: 7.days.from_now) }
 
-      it "displays the banner" do
+      it 'displays the banner' do
         sign_in volunteer
         get casa_cases_path
-        expect(response.body).to include "Please fill out this survey"
+        expect(response.body).to include 'Please fill out this survey'
       end
     end
 
-    context "when expires_at is before today" do
+    context 'when expires_at is before today' do
       let!(:active_banner) do
         banner = create(:banner, casa_org: casa_org, expires_at: nil)
         banner.update_columns(expires_at: 1.day.ago)
       end
 
-      it "does not display the banner" do
+      it 'does not display the banner' do
         sign_in volunteer
         get casa_cases_path
-        expect(response.body).not_to include "Please fill out this survey"
+        expect(response.body).not_to include 'Please fill out this survey'
       end
     end
   end
 
-  context "when creating a banner" do
+  context 'when creating a banner' do
     let(:admin) { create(:casa_admin, casa_org: casa_org) }
     let(:banner_params) do
       {
         user: admin,
         active: false,
-        content: "Test",
-        name: "Test Announcement",
+        content: 'Test',
+        name: 'Test Announcement',
         expires_at: expires_at
       }
     end
 
-    context "when client timezone is ahead of UTC" do
-      before { travel_to Time.new(2024, 6, 1, 11, 0, 0, "+03:00") } # 08:00 UTC
+    context 'when client timezone is ahead of UTC' do
+      before { travel_to Time.new(2024, 6, 1, 11, 0, 0, '+03:00') } # 08:00 UTC
 
-      context "when submitted time is behind client but ahead of UTC" do
-        let(:expires_at) { Time.new(2024, 6, 1, 9, 0, 0, "UTC") } # 12:00 +03:00
+      context 'when submitted time is behind client but ahead of UTC' do
+        let(:expires_at) { Time.new(2024, 6, 1, 9, 0, 0, 'UTC') } # 12:00 +03:00
 
-        it "succeeds" do
+        it 'succeeds' do
           sign_in admin
-          post banners_path, params: {banner: banner_params}
+          post banners_path, params: { banner: banner_params }
           expect(response).to redirect_to banners_path
         end
       end
 
-      context "when submitted time is behind client and behind UTC" do
-        let(:expires_at) { Time.new(2024, 6, 1, 7, 0, 0, "UTC") } # 10:00 +03:00
+      context 'when submitted time is behind client and behind UTC' do
+        let(:expires_at) { Time.new(2024, 6, 1, 7, 0, 0, 'UTC') } # 10:00 +03:00
 
-        it "fails" do
+        it 'fails' do
           sign_in admin
-          post banners_path, params: {banner: banner_params}
-          expect(response).to render_template "banners/new"
-          expect(response.body).to include "Expires at must take place in the future (after 2024-06-01 08:00:00 UTC)"
+          post banners_path, params: { banner: banner_params }
+          expect(response).to render_template 'banners/new'
+          expect(response.body).to include 'Expires at must take place in the future (after 2024-06-01 08:00:00 UTC)'
         end
       end
     end
 
-    context "when client timezone is behind UTC" do
-      before { travel_to Time.new(2024, 6, 1, 11, 0, 0, "-04:00") } # 15:00 UTC
+    context 'when client timezone is behind UTC' do
+      before { travel_to Time.new(2024, 6, 1, 11, 0, 0, '-04:00') } # 15:00 UTC
 
-      context "when submitted time is ahead of client and ahead of UTC" do
-        let(:expires_at) { Time.new(2024, 6, 1, 16, 0, 0, "UTC") } # 12:00 -04:00
+      context 'when submitted time is ahead of client and ahead of UTC' do
+        let(:expires_at) { Time.new(2024, 6, 1, 16, 0, 0, 'UTC') } # 12:00 -04:00
 
-        it "succeeds" do
+        it 'succeeds' do
           sign_in admin
-          post banners_path, params: {banner: banner_params}
+          post banners_path, params: { banner: banner_params }
           expect(response).to redirect_to banners_path
         end
       end
 
-      context "when submitted time is ahead of client but behind UTC" do
-        let(:expires_at) { Time.new(2024, 6, 1, 14, 0, 0, "UTC") } # 10:00 -04:00
+      context 'when submitted time is ahead of client but behind UTC' do
+        let(:expires_at) { Time.new(2024, 6, 1, 14, 0, 0, 'UTC') } # 10:00 -04:00
 
-        it "fails" do
+        it 'fails' do
           sign_in admin
-          post banners_path, params: {banner: banner_params}
-          expect(response).to render_template "banners/new"
-          expect(response.body).to include "Expires at must take place in the future (after 2024-06-01 15:00:00 UTC)"
+          post banners_path, params: { banner: banner_params }
+          expect(response).to render_template 'banners/new'
+          expect(response.body).to include 'Expires at must take place in the future (after 2024-06-01 15:00:00 UTC)'
         end
       end
     end

--- a/spec/requests/case_contact_reports_spec.rb
+++ b/spec/requests/case_contact_reports_spec.rb
@@ -1,6 +1,6 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "/case_contact_reports", type: :request do
+RSpec.describe '/case_contact_reports', type: :request do
   let!(:case_contact) { build(:case_contact) }
 
   before do
@@ -8,18 +8,18 @@ RSpec.describe "/case_contact_reports", type: :request do
     sign_in user
   end
 
-  describe "GET /case_contact_reports" do
-    context "as volunteer" do
+  describe 'GET /case_contact_reports' do
+    context 'as volunteer' do
       let(:user) { build(:volunteer) }
 
-      it "cannot view reports" do
-        get case_contact_reports_url(format: :csv), params: {report: {}}
+      it 'cannot view reports' do
+        get case_contact_reports_url(format: :csv), params: { report: {} }
         expect(response).to redirect_to root_path
       end
     end
 
-    shared_examples "can view reports" do
-      context "with start_date and end_date" do
+    shared_examples 'can view reports' do
+      context 'with start_date and end_date' do
         let(:case_contact_report_params) do
           {
             start_date: 1.month.ago,
@@ -27,65 +27,66 @@ RSpec.describe "/case_contact_reports", type: :request do
           }
         end
 
-        it "renders a csv file to download" do
-          get case_contact_reports_url(format: :csv), params: {report: {start_date: 1.month.ago, end_date: Date.today}}
+        it 'renders a csv file to download' do
+          get case_contact_reports_url(format: :csv),
+              params: { report: { start_date: 1.month.ago, end_date: Date.today } }
 
           expect(response).to be_successful
           expect(
-            response.headers["Content-Disposition"]
+            response.headers['Content-Disposition']
           ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
         end
       end
 
-      context "without start_date and end_date" do
-        it "renders a csv file to download" do
-          get case_contact_reports_url(format: :csv), params: {report: {start_date: "", end_date: ""}}
+      context 'without start_date and end_date' do
+        it 'renders a csv file to download' do
+          get case_contact_reports_url(format: :csv), params: { report: { start_date: '', end_date: '' } }
 
           expect(response).to be_successful
           expect(
-            response.headers["Content-Disposition"]
+            response.headers['Content-Disposition']
           ).to include 'attachment; filename="case-contacts-report-1577836800.csv'
         end
       end
 
-      context "with supervisor_ids filter" do
-        it "renders csv with only the volunteer" do
+      context 'with supervisor_ids filter' do
+        it 'renders csv with only the volunteer' do
           volunteer = create(:volunteer)
           casa_case = create(:casa_case, casa_org: volunteer.casa_org)
           contact = create(:case_contact, creator_id: volunteer.id, casa_case: casa_case)
           build_stubbed(:case_contact, creator_id: user.id, casa_case: casa_case)
 
-          get case_contact_reports_url(format: :csv), params: {report: {creator_ids: [volunteer.id]}}
+          get case_contact_reports_url(format: :csv), params: { report: { creator_ids: [volunteer.id] } }
 
           expect(response).to be_successful
           expect(
-            response.headers["Content-Disposition"]
+            response.headers['Content-Disposition']
           ).to include 'attachment; filename="case-contacts-report-'
           expect(response.body).to match(/^#{contact.id},/)
           expect(response.body.lines.length).to eq(2)
         end
       end
 
-      context "casa_case_ids filter" do
+      context 'casa_case_ids filter' do
         let!(:casa_case) { create(:casa_case) }
         let!(:case_contacts) { create_list(:case_contact, 3, casa_case: casa_case) }
 
         before { create_list(:case_contact, 5) }
 
-        it "returns success with proper headers" do
+        it 'returns success with proper headers' do
           get case_contact_reports_url(format: :csv),
-            params: {report: {casa_case_ids: [casa_case.id]}}
+              params: { report: { casa_case_ids: [casa_case.id] } }
 
           expect(response).to be_successful
           expect(
-            response.headers["Content-Disposition"]
+            response.headers['Content-Disposition']
           ).to include 'attachment; filename="case-contacts-report-'
         end
 
-        context "when filter is provided" do
-          it "renders csv with contacts from the casa cases" do
+        context 'when filter is provided' do
+          it 'renders csv with contacts from the casa cases' do
             get case_contact_reports_url(format: :csv),
-              params: {report: {casa_case_ids: [casa_case.id]}}
+                params: { report: { casa_case_ids: [casa_case.id] } }
 
             expect(response.body.lines.length).to eq(4)
 
@@ -95,10 +96,10 @@ RSpec.describe "/case_contact_reports", type: :request do
           end
         end
 
-        context "when filter not provided" do
-          it "renders a csv with all case contacts" do
+        context 'when filter not provided' do
+          it 'renders a csv with all case contacts' do
             get case_contact_reports_url(format: :csv),
-              params: {report: {casa_case_ids: nil}}
+                params: { report: { casa_case_ids: nil } }
 
             expect(response.body.lines.length).to eq(9)
 
@@ -110,23 +111,23 @@ RSpec.describe "/case_contact_reports", type: :request do
       end
     end
 
-    context "as supervisor" do
-      it_behaves_like "can view reports" do
+    context 'as supervisor' do
+      it_behaves_like 'can view reports' do
         let(:user) { build(:supervisor) }
       end
     end
 
-    context "as casa_admin" do
-      it_behaves_like "can view reports" do
+    context 'as casa_admin' do
+      it_behaves_like 'can view reports' do
         let(:user) { build(:casa_admin) }
       end
 
       let(:user) { build(:casa_admin) }
 
-      it "passes in casa_org_id to CaseContractReport" do
+      it 'passes in casa_org_id to CaseContractReport' do
         allow(CaseContactReport).to receive(:new).and_return([])
 
-        get case_contact_reports_url(format: :csv), params: {report: {creator_ids: [user.id]}}
+        get case_contact_reports_url(format: :csv), params: { report: { creator_ids: [user.id] } }
 
         expect(CaseContactReport).to have_received(:new)
           .with(hash_including(casa_org_id: user.casa_org_id))

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -1,6 +1,6 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "/case_court_reports", type: :request do
+RSpec.describe '/case_court_reports', type: :request do
   include DownloadHelpers
   let(:volunteer) { create(:volunteer, :with_cases_and_contacts, :with_assigned_supervisor) }
 
@@ -9,8 +9,8 @@ RSpec.describe "/case_court_reports", type: :request do
   end
 
   # case_court_reports#index
-  describe "GET /case_court_reports" do
-    context "as volunteer" do
+  describe 'GET /case_court_reports' do
+    context 'as volunteer' do
       it "can view 'Generate Court Report' page", :aggregate_failures do
         get case_court_reports_path
         expect(response).to be_successful
@@ -18,7 +18,7 @@ RSpec.describe "/case_court_reports", type: :request do
       end
     end
 
-    context "as a supervisor" do
+    context 'as a supervisor' do
       let(:supervisor) { volunteer.supervisor }
 
       before do
@@ -31,7 +31,7 @@ RSpec.describe "/case_court_reports", type: :request do
         expect(assigns(:assigned_cases)).not_to be_empty
       end
 
-      context "with no cases in the organization" do
+      context 'with no cases in the organization' do
         let(:supervisor) { create(:supervisor, casa_org: create(:casa_org)) }
 
         it "can view 'Generate Court Report page", :aggregate_failures do
@@ -44,10 +44,10 @@ RSpec.describe "/case_court_reports", type: :request do
   end
 
   # case_court_reports#show
-  describe "GET /case_court_reports/:id" do
-    context "when a valid / existing case is sent" do
+  describe 'GET /case_court_reports/:id' do
+    context 'when a valid / existing case is sent' do
       subject(:request) do
-        get case_court_report_path(casa_case.case_number, format: "docx")
+        get case_court_report_path(casa_case.case_number, format: 'docx')
 
         response
       end
@@ -62,34 +62,34 @@ RSpec.describe "/case_court_reports", type: :request do
         end
       end
 
-      it "authorizes action" do
+      it 'authorizes action' do
         expect_any_instance_of(CaseCourtReportsController).to receive(:authorize).with(CaseCourtReport).and_call_original
         request
       end
 
-      it "send response as a .DOCX file" do
+      it 'send response as a .DOCX file' do
         expect(request.content_type).to eq Mime::Type.lookup_by_extension(:docx)
       end
 
-      it "send response with a status :ok" do
+      it 'send response with a status :ok' do
         expect(request).to have_http_status(:ok)
       end
     end
 
-    context "when an INVALID / non-existing case is sent" do
+    context 'when an INVALID / non-existing case is sent' do
       let(:invalid_casa_case) { build_stubbed(:casa_case) }
 
       before do
         Capybara.current_driver = :selenium_chrome
-        get case_court_report_path(invalid_casa_case.case_number, format: "docx")
+        get case_court_report_path(invalid_casa_case.case_number, format: 'docx')
       end
 
       it "redirects back to 'Generate Court Report' page", :aggregate_failures, :js do
         expect(response).to redirect_to(case_court_reports_path)
-        expect(response.content_type).to eq "text/html; charset=utf-8"
+        expect(response.content_type).to eq 'text/html; charset=utf-8'
       end
 
-      it "shows correct flash message" do
+      it 'shows correct flash message' do
         request
         expect(flash[:alert]).to eq "Report #{invalid_casa_case.case_number} is not found."
       end
@@ -97,76 +97,78 @@ RSpec.describe "/case_court_reports", type: :request do
   end
 
   # case_court_reports#generate
-  describe "POST /case_court_reports" do
+  describe 'POST /case_court_reports' do
     subject(:request) do
-      post generate_case_court_reports_path, params: params, headers: {ACCEPT: "application/json"}
+      post generate_case_court_reports_path, params: params, headers: { ACCEPT: 'application/json' }
 
       response
     end
 
     let(:casa_case) { volunteer.casa_cases.first }
-    let(:params) {
+    let(:params) do
       {
         case_court_report: {
           case_number: casa_case.case_number.to_s,
-          start_date: "January 1, 2020",
-          end_date: "January 1, 2021"
+          start_date: 'January 1, 2020',
+          end_date: 'January 1, 2021'
         }
       }
-    }
+    end
 
-    it "authorizes action" do
+    it 'authorizes action' do
       expect_any_instance_of(CaseCourtReportsController).to receive(:authorize).with(CaseCourtReport).and_call_original
       request
     end
 
-    context "when no custom template is set" do
-      it "sends response as a JSON string", :aggregate_failures do
-        expect(request.content_type).to eq("application/json; charset=utf-8")
+    context 'when no custom template is set' do
+      it 'sends response as a JSON string', :aggregate_failures do
+        expect(request.content_type).to eq('application/json; charset=utf-8')
         expect(request.parsed_body).to be_a(ActiveSupport::HashWithIndifferentAccess)
       end
 
       it "has keys ['link', 'status'] in JSON string", :aggregate_failures do
         body_hash = request.parsed_body
 
-        expect(body_hash).to have_key "link"
-        expect(body_hash).to have_key "status"
+        expect(body_hash).to have_key 'link'
+        expect(body_hash).to have_key 'status'
       end
 
-      it "sends response with status :ok" do
+      it 'sends response with status :ok' do
         expect(request).to have_http_status(:ok)
       end
 
-      it "contains a link ending with .DOCX extension" do
-        expect(request.parsed_body["link"]).to end_with(".docx")
+      it 'contains a link ending with .DOCX extension' do
+        expect(request.parsed_body['link']).to end_with('.docx')
       end
 
-      it "uses the default template" do
-        get request.parsed_body["link"]
+      it 'uses the default template' do
+        get request.parsed_body['link']
 
         docx_response = Docx::Document.open(StringIO.new(response.body))
 
-        expect(header_text(docx_response)).to include("YOUR CASA ORG’S NUMBER")
+        expect(header_text(docx_response)).to include('YOUR CASA ORG’S NUMBER')
       end
     end
 
-    context "when a custom template is set" do
+    context 'when a custom template is set' do
       before do
         stub_twilio
-        volunteer.casa_org.court_report_template.attach(io: File.new(Rails.root.join("app/documents/templates/montgomery_report_template.docx")), filename: "montgomery_report_template.docx")
+        volunteer.casa_org.court_report_template.attach(
+          io: File.new(Rails.root.join('app/documents/templates/montgomery_report_template.docx')), filename: 'montgomery_report_template.docx'
+        )
       end
 
-      it "uses the custom template" do
-        get request.parsed_body["link"]
+      it 'uses the custom template' do
+        get request.parsed_body['link']
         followed_link_response = response
 
         docx_response = Docx::Document.open(StringIO.new(followed_link_response.body))
 
-        expect(docx_response.paragraphs.map(&:to_s)).to include("Did you forget to enter your court orders?")
+        expect(docx_response.paragraphs.map(&:to_s)).to include('Did you forget to enter your court orders?')
       end
     end
 
-    context "with date filtering" do
+    context 'with date filtering' do
       let(:casa_case) { volunteer.casa_cases.first }
       let!(:contact_in_range) do
         create(:case_contact, casa_case: casa_case, occurred_at: Date.new(2025, 10, 10))
@@ -174,49 +176,49 @@ RSpec.describe "/case_court_reports", type: :request do
       let!(:contact_out_of_range) do
         create(:case_contact, casa_case: casa_case, occurred_at: Date.new(2024, 10, 30))
       end
-      let(:params) {
+      let(:params) do
         {
           case_court_report: {
             case_number: casa_case.case_number.to_s,
-            start_date: "2025-10-01",
-            end_date: "2025-10-23"
+            start_date: '2025-10-01',
+            end_date: '2025-10-23'
           }
         }
-      }
+      end
 
-      it "includes contacts within the date range in the generated report" do
-        post generate_case_court_reports_path, params: params, headers: {ACCEPT: "application/json"}
-        get response.parsed_body["link"]
+      it 'includes contacts within the date range in the generated report' do
+        post generate_case_court_reports_path, params: params, headers: { ACCEPT: 'application/json' }
+        get response.parsed_body['link']
         docx_response = Docx::Document.open(StringIO.new(response.body))
         # The contact dates are in table cells, so we need to extract them specifically.
         table_texts = docx_response.tables.flat_map { |table| table.rows.flat_map { |row| row.cells.map(&:text) } }
 
-        expect(table_texts.join(" ")).to include(contact_in_range.occurred_at.strftime("%-m/%-d"))
+        expect(table_texts.join(' ')).to include(contact_in_range.occurred_at.strftime('%-m/%-d'))
       end
 
-      it "does not include contacts outside the date range in the generated report" do
-        post generate_case_court_reports_path, params: params, headers: {ACCEPT: "application/json"}
-        get response.parsed_body["link"]
+      it 'does not include contacts outside the date range in the generated report' do
+        post generate_case_court_reports_path, params: params, headers: { ACCEPT: 'application/json' }
+        get response.parsed_body['link']
         docx_response = Docx::Document.open(StringIO.new(response.body))
         table_texts = docx_response.tables.flat_map { |table| table.rows.flat_map { |row| row.cells.map(&:text) } }
 
-        expect(table_texts.join(" ")).not_to include(contact_out_of_range.occurred_at.strftime("%-m/%-d"))
+        expect(table_texts.join(' ')).not_to include(contact_out_of_range.occurred_at.strftime('%-m/%-d'))
       end
     end
 
-    context "when user timezone" do
-      let(:server_time) { Time.zone.parse("2020-12-31 23:00:00") }
+    context 'when user timezone' do
+      let(:server_time) { Time.zone.parse('2020-12-31 23:00:00') }
       let(:user_different_timezone) do
-        ActiveSupport::TimeZone["Tokyo"]
+        ActiveSupport::TimeZone['Tokyo']
       end
-      let(:params) { {case_court_report: {case_number: casa_case.case_number.to_s}, time_zone: "Tokyo"} }
+      let(:params) { { case_court_report: { case_number: casa_case.case_number.to_s }, time_zone: 'Tokyo' } }
 
       before do
         travel_to server_time
       end
 
-      it "is different than server" do
-        get request.parsed_body["link"]
+      it 'is different than server' do
+        get request.parsed_body['link']
         followed_link_response = response
 
         docx_response = Docx::Document.open(StringIO.new(followed_link_response.body))
@@ -227,57 +229,57 @@ RSpec.describe "/case_court_reports", type: :request do
       end
     end
 
-    context "when an INVALID / non-existing case is sent" do
+    context 'when an INVALID / non-existing case is sent' do
       let(:casa_case) { build_stubbed(:casa_case) }
 
-      it "sends response as a JSON string", :aggregate_failures do
-        expect(request.content_type).to eq("application/json; charset=utf-8")
+      it 'sends response as a JSON string', :aggregate_failures do
+        expect(request.content_type).to eq('application/json; charset=utf-8')
         expect(request.parsed_body).to be_a(ActiveSupport::HashWithIndifferentAccess)
       end
 
       it "has keys ['link','status','error_messages'] in JSON string", :aggregate_failures do
         body_hash = request.parsed_body
 
-        expect(body_hash).to have_key "link"
-        expect(body_hash).to have_key "status"
-        expect(body_hash).to have_key "error_messages"
+        expect(body_hash).to have_key 'link'
+        expect(body_hash).to have_key 'status'
+        expect(body_hash).to have_key 'error_messages'
       end
 
-      it "sends response with status :not_found" do
+      it 'sends response with status :not_found' do
         expect(request).to have_http_status(:not_found)
       end
 
-      it "contains a empty link" do
-        expect(request.parsed_body["link"].length).to be 0
+      it 'contains a empty link' do
+        expect(request.parsed_body['link'].length).to be 0
       end
 
       # TODO: Fix controller to have the error message actually get the param with `case_params[:case_number]`
-      it "shows correct error messages" do
-        expect(request.parsed_body["error_messages"]).to include("Report  is not found")
+      it 'shows correct error messages' do
+        expect(request.parsed_body['error_messages']).to include('Report  is not found')
       end
     end
 
-    context "when zip report fails" do
+    context 'when zip report fails' do
       before do
         expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise Zip::Error.new
       end
 
       it { is_expected.to have_http_status(:not_found) }
 
-      it "shows the correct error message" do
-        expect(request.parsed_body["error_messages"]).to include("Template is not found")
+      it 'shows the correct error message' do
+        expect(request.parsed_body['error_messages']).to include('Template is not found')
       end
     end
 
-    context "when an unpredictable error occurs" do
+    context 'when an unpredictable error occurs' do
       before do
-        expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise StandardError.new("Unexpected Error")
+        expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise StandardError.new('Unexpected Error')
       end
 
       it { is_expected.to have_http_status(:unprocessable_content) }
 
-      it "shows the correct error message" do
-        expect(request.parsed_body["error_messages"]).to include("Unexpected Error")
+      it 'shows the correct error message' do
+        expect(request.parsed_body['error_messages']).to include('Unexpected Error')
       end
     end
   end

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,56 +1,56 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "Health", type: :request do
+RSpec.describe 'Health', type: :request do
   before do
     Casa::Application.load_tasks
-    Rake::Task["after_party:store_deploy_time"].invoke
+    Rake::Task['after_party:store_deploy_time'].invoke
   end
 
-  describe "GET /health" do
+  describe 'GET /health' do
     before do
-      get "/health"
+      get '/health'
     end
 
-    it "renders an html file" do
+    it 'renders an html file' do
       # delete this test when there are more specific tests about the page
-      expect(response.header["Content-Type"]).to include("text/html")
+      expect(response.header['Content-Type']).to include('text/html')
     end
   end
 
-  describe "GET /health.json" do
+  describe 'GET /health.json' do
     before do
-      get "/health.json"
+      get '/health.json'
     end
 
-    it "renders a json file" do
-      expect(response.header["Content-Type"]).to include("application/json")
+    it 'renders a json file' do
+      expect(response.header['Content-Type']).to include('application/json')
     end
 
-    it "has key latest_deploy_time" do
+    it 'has key latest_deploy_time' do
       hash_body = nil # This is here for the linter
       expect { hash_body = JSON.parse(response.body).with_indifferent_access }.not_to raise_exception
-      expect(hash_body.keys).to contain_exactly("latest_deploy_time")
+      expect(hash_body.keys).to contain_exactly('latest_deploy_time')
     end
   end
 
-  describe "GET #case_contacts_creation_times_in_last_week" do
-    it "returns timestamps of case contacts created in the last week" do
+  describe 'GET #case_contacts_creation_times_in_last_week' do
+    it 'returns timestamps of case contacts created in the last week' do
       case_contact1 = create(:case_contact, created_at: 6.days.ago)
       case_contact2 = create(:case_contact, created_at: 2.weeks.ago)
       get case_contacts_creation_times_in_last_week_health_index_path
       expect(response).to have_http_status(:ok)
-      expect(response.content_type).to include("application/json")
-      timestamps = JSON.parse(response.body)["timestamps"]
+      expect(response.content_type).to include('application/json')
+      timestamps = JSON.parse(response.body)['timestamps']
       expect(timestamps).to include(case_contact1.created_at.to_i)
       expect(timestamps).not_to include(case_contact2.created_at.to_i)
     end
   end
 
-  describe "GET #monthly_line_graph_data" do
+  describe 'GET #monthly_line_graph_data' do
     def setup
       # Create case contacts for testing
-      create(:case_contact, notes: "Test Notes", created_at: 11.months.ago)
-      create(:case_contact, notes: "", created_at: 11.months.ago)
+      create(:case_contact, notes: 'Test Notes', created_at: 11.months.ago)
+      create(:case_contact, notes: '', created_at: 11.months.ago)
       create(:case_contact, created_at: 10.months.ago)
       create(:case_contact, created_at: 9.months.ago)
 
@@ -59,51 +59,53 @@ RSpec.describe "Health", type: :request do
       create(:contact_topic_answer, case_contact: CaseContact.last)
     end
 
-    it "returns case contacts creation times in the last year" do
-      travel_to Time.zone.local(2024, 5, 2)
-      setup
+    it 'returns case contacts creation times in the last year' do
+      travel_to Time.zone.local(2024, 5, 2) do
+        setup
 
-      get monthly_line_graph_data_health_index_path
+        get monthly_line_graph_data_health_index_path
 
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to include("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('application/json')
 
-      chart_data = JSON.parse(response.body)
-      expect(chart_data).to be_an(Array)
-      expect(chart_data.length).to eq(12)
+        chart_data = JSON.parse(response.body)
+        expect(chart_data).to be_an(Array)
+        expect(chart_data.length).to eq(12)
 
-      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 2])
-      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 1])
-      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
-      expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
+        expect(chart_data[0]).to eq([11.months.ago.strftime('%b %Y'), 2, 1, 2])
+        expect(chart_data[1]).to eq([10.months.ago.strftime('%b %Y'), 1, 0, 1])
+        expect(chart_data[2]).to eq([9.months.ago.strftime('%b %Y'), 1, 1, 1])
+        expect(chart_data[3]).to eq([8.months.ago.strftime('%b %Y'), 0, 0, 0])
+      end
     end
 
-    it "returns case contacts creation times in the last year (on the first of the month)" do
-      travel_to Time.zone.local(2024, 5, 1)
-      setup
+    it 'returns case contacts creation times in the last year (on the first of the month)' do
+      travel_to Time.zone.local(2024, 5, 1) do
+        setup
 
-      get monthly_line_graph_data_health_index_path
+        get monthly_line_graph_data_health_index_path
 
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to include("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('application/json')
 
-      chart_data = JSON.parse(response.body)
-      expect(chart_data).to be_an(Array)
-      expect(chart_data.length).to eq(12)
+        chart_data = JSON.parse(response.body)
+        expect(chart_data).to be_an(Array)
+        expect(chart_data.length).to eq(12)
 
-      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 2])
-      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 1])
-      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1])
-      expect(chart_data[3]).to eq([8.months.ago.strftime("%b %Y"), 0, 0, 0])
+        expect(chart_data[0]).to eq([11.months.ago.strftime('%b %Y'), 2, 1, 2])
+        expect(chart_data[1]).to eq([10.months.ago.strftime('%b %Y'), 1, 0, 1])
+        expect(chart_data[2]).to eq([9.months.ago.strftime('%b %Y'), 1, 1, 1])
+        expect(chart_data[3]).to eq([8.months.ago.strftime('%b %Y'), 0, 0, 0])
+      end
     end
   end
 
-  describe "GET #monthly_unique_users_graph_data" do
+  describe 'GET #monthly_unique_users_graph_data' do
     def setup
-      volunteer1 = create(:user, type: "Volunteer")
-      volunteer2 = create(:user, type: "Volunteer")
-      supervisor = create(:user, type: "Supervisor")
-      casa_admin = create(:user, type: "CasaAdmin")
+      volunteer1 = create(:user, type: 'Volunteer')
+      volunteer2 = create(:user, type: 'Volunteer')
+      supervisor = create(:user, type: 'Supervisor')
+      casa_admin = create(:user, type: 'CasaAdmin')
       supervisor_volunteer1 = create(:supervisor_volunteer, is_active: true)
       supervisor_volunteer2 = create(:supervisor_volunteer, is_active: true)
 
@@ -121,40 +123,42 @@ RSpec.describe "Health", type: :request do
       create(:case_contact, creator_id: supervisor_volunteer1.volunteer_id, created_at: 10.months.ago)
     end
 
-    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year" do
-      travel_to Time.zone.local(2024, 5, 2)
-      setup
+    it 'returns monthly unique users data for volunteers, supervisors, and admins in the last year' do
+      travel_to Time.zone.local(2024, 5, 2) do
+        setup
 
-      get monthly_unique_users_graph_data_health_index_path
+        get monthly_unique_users_graph_data_health_index_path
 
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to include("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('application/json')
 
-      chart_data = JSON.parse(response.body)
-      expect(chart_data).to be_an(Array)
-      expect(chart_data.length).to eq(12)
+        chart_data = JSON.parse(response.body)
+        expect(chart_data).to be_an(Array)
+        expect(chart_data.length).to eq(12)
 
-      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 1, 2])
-      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 0, 1])
-      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1, 0])
+        expect(chart_data[0]).to eq([11.months.ago.strftime('%b %Y'), 2, 1, 1, 2])
+        expect(chart_data[1]).to eq([10.months.ago.strftime('%b %Y'), 1, 0, 0, 1])
+        expect(chart_data[2]).to eq([9.months.ago.strftime('%b %Y'), 1, 1, 1, 0])
+      end
     end
 
-    it "returns monthly unique users data for volunteers, supervisors, and admins in the last year (on the first of the month)" do
-      travel_to Time.zone.local(2024, 5, 1)
-      setup
+    it 'returns monthly unique users data for volunteers, supervisors, and admins in the last year (on the first of the month)' do
+      travel_to Time.zone.local(2024, 5, 1) do
+        setup
 
-      get monthly_unique_users_graph_data_health_index_path
+        get monthly_unique_users_graph_data_health_index_path
 
-      expect(response).to have_http_status(:ok)
-      expect(response.content_type).to include("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include('application/json')
 
-      chart_data = JSON.parse(response.body)
-      expect(chart_data).to be_an(Array)
-      expect(chart_data.length).to eq(12)
+        chart_data = JSON.parse(response.body)
+        expect(chart_data).to be_an(Array)
+        expect(chart_data.length).to eq(12)
 
-      expect(chart_data[0]).to eq([11.months.ago.strftime("%b %Y"), 2, 1, 1, 2])
-      expect(chart_data[1]).to eq([10.months.ago.strftime("%b %Y"), 1, 0, 0, 1])
-      expect(chart_data[2]).to eq([9.months.ago.strftime("%b %Y"), 1, 1, 1, 0])
+        expect(chart_data[0]).to eq([11.months.ago.strftime('%b %Y'), 2, 1, 1, 2])
+        expect(chart_data[1]).to eq([10.months.ago.strftime('%b %Y'), 1, 0, 0, 1])
+        expect(chart_data[2]).to eq([9.months.ago.strftime('%b %Y'), 1, 1, 1, 0])
+      end
     end
   end
 end

--- a/spec/services/case_contacts_contact_dates_spec.rb
+++ b/spec/services/case_contacts_contact_dates_spec.rb
@@ -1,29 +1,32 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe CaseContactsContactDates do
   before do
     travel_to Date.new(2021, 6, 1)
   end
 
-  describe "#contact_dates_details" do
+  describe '#contact_dates_details' do
     subject { described_class.new(interviewees).contact_dates_details }
 
-    context "without interviewees" do
+    context 'without interviewees' do
       let(:interviewees) { [] }
 
-      it "returns an empty array" do
+      it 'returns an empty array' do
         expect(subject).to eq([])
       end
     end
 
-    context "with interviewees" do
-      let(:contact_type_1) { create(:contact_type, name: "Mental therapist") }
-      let(:contact_type_2) { create(:contact_type, name: "Physical therapist") }
-      let(:contact_type_3) { create(:contact_type, name: "Aunt") }
+    context 'with interviewees' do
+      let(:contact_type_1) { create(:contact_type, name: 'Mental therapist') }
+      let(:contact_type_2) { create(:contact_type, name: 'Physical therapist') }
+      let(:contact_type_3) { create(:contact_type, name: 'Aunt') }
 
       let(:ccct_1) { create(:case_contact_contact_type, contact_type: contact_type_1) }
       let(:ccct_2) { create(:case_contact_contact_type, contact_type: contact_type_2) }
-      let(:ccct_3) { create(:case_contact_contact_type, contact_type: contact_type_2, case_contact: create(:case_contact, occurred_at: 1.month.ago)) }
+      let(:ccct_3) do
+        create(:case_contact_contact_type, contact_type: contact_type_2,
+                                           case_contact: create(:case_contact, occurred_at: 1.month.ago))
+      end
       let(:ccct_4) do
         create(
           :case_contact_contact_type,
@@ -35,25 +38,28 @@ RSpec.describe CaseContactsContactDates do
           )
         )
       end
-      let(:ccct_5) { create(:case_contact_contact_type, contact_type: contact_type_3, case_contact: create(:case_contact, occurred_at: 2.months.ago)) }
+      let(:ccct_5) do
+        create(:case_contact_contact_type, contact_type: contact_type_3,
+                                           case_contact: create(:case_contact, occurred_at: 2.months.ago))
+      end
 
       let(:interviewees) { [ccct_1, ccct_2, ccct_3, ccct_4, ccct_5] }
 
-      it "returns formatted data" do
+      it 'returns formatted data' do
         expect(subject).to eq([
-          {dates: "6/01*",
-           dates_by_medium_type: {"in-person" => "6/01*"},
-           name: "Names of persons involved, starting with the child's name",
-           type: "Mental therapist"},
-          {dates: "4/01*, 5/01*, 6/01*",
-           dates_by_medium_type: {"in-person" => "5/01*, 6/01*", "text/email" => "4/01*"},
-           name: "Names of persons involved, starting with the child's name",
-           type: "Physical therapist"},
-          {dates: "4/01*",
-           dates_by_medium_type: {"in-person" => "4/01*"},
-           name: "Names of persons involved, starting with the child's name",
-           type: "Aunt"}
-        ])
+                                { dates: '6/01*',
+                                  dates_by_medium_type: { 'in-person' => '6/01*' },
+                                  name: "Names of persons involved, starting with the child's name",
+                                  type: 'Mental therapist' },
+                                { dates: '4/01*, 5/01*, 6/01*',
+                                  dates_by_medium_type: { 'in-person' => '5/01*, 6/01*', 'text/email' => '4/01*' },
+                                  name: "Names of persons involved, starting with the child's name",
+                                  type: 'Physical therapist' },
+                                { dates: '4/01*',
+                                  dates_by_medium_type: { 'in-person' => '4/01*' },
+                                  name: "Names of persons involved, starting with the child's name",
+                                  type: 'Aunt' }
+                              ])
       end
     end
   end

--- a/spec/services/deployment/backfill_case_contact_started_metadata_service_spec.rb
+++ b/spec/services/deployment/backfill_case_contact_started_metadata_service_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Deployment::BackfillCaseContactStartedMetadataService do
   let(:past) { Date.new(2020, 1, 1).in_time_zone }
@@ -9,46 +9,46 @@ RSpec.describe Deployment::BackfillCaseContactStartedMetadataService do
 
   before { travel_to present }
 
-  context "when a case contact has status metadata" do
+  context 'when a case contact has status metadata' do
     let(:case_contact) { create(:case_contact) }
 
-    context "when a case contact has status started metadata" do
+    context 'when a case contact has status started metadata' do
       let!(:case_contact) { create(:case_contact, :started, created_at: past) }
 
-      it "does not change metadata" do
+      it 'does not change metadata' do
         described_class.new.backfill_metadata
 
-        expect(case_contact.reload.metadata.dig("status", "started")).to eq(parsed_past)
+        expect(case_contact.reload.metadata.dig('status', 'started')).to eq(parsed_past)
       end
     end
 
-    context "when a case contact has other status metadata" do
-      let!(:case_contact) {
+    context 'when a case contact has other status metadata' do
+      let!(:case_contact) do
         create(:case_contact, created_at: past, metadata:
-        {"status" => {"details" => parsed_past}})
-      }
-
-      it "does not change status details" do
-        described_class.new.backfill_metadata
-
-        expect(case_contact.reload.metadata.dig("status", "started")).to eq(parsed_past)
+        { 'status' => { 'details' => parsed_past } })
       end
 
-      it "sets status started" do
+      it 'does not change status details' do
         described_class.new.backfill_metadata
 
-        expect(case_contact.reload.metadata.dig("status", "started")).to eq(parsed_past)
+        expect(case_contact.reload.metadata.dig('status', 'started')).to eq(parsed_past)
+      end
+
+      it 'sets status started' do
+        described_class.new.backfill_metadata
+
+        expect(case_contact.reload.metadata.dig('status', 'started')).to eq(parsed_past)
       end
     end
   end
 
-  context "when a case contact has no metadata" do
+  context 'when a case contact has no metadata' do
     let!(:case_contact) { create(:case_contact, created_at: past, metadata: {}) }
 
-    it "does not change metadata" do
+    it 'does not change metadata' do
       described_class.new.backfill_metadata
 
-      expect(case_contact.reload.metadata.dig("status", "started")).to be_nil
+      expect(case_contact.reload.metadata.dig('status', 'started')).to be_nil
     end
   end
 end

--- a/spec/services/emancipation_checklist_reminder_service_spec.rb
+++ b/spec/services/emancipation_checklist_reminder_service_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe EmancipationChecklistReminderService do
   include ActiveJob::TestHelper
@@ -13,7 +13,7 @@ RSpec.describe EmancipationChecklistReminderService do
     clear_enqueued_jobs
   end
 
-  context "with only two eligible cases" do
+  context 'with only two eligible cases' do
     subject(:task) { described_class.new }
 
     let!(:eligible_case1) { create(:case_assignment) }
@@ -21,47 +21,47 @@ RSpec.describe EmancipationChecklistReminderService do
     let!(:ineligible_case1) { create(:case_assignment, pre_transition: true) }
     let!(:inactive_case) { create(:case_assignment, :inactive) }
 
-    it "#initialize correctly captures the eligible cases" do
+    it '#initialize correctly captures the eligible cases' do
       expect(CasaCase.count).to eq(4)
       expect(task.cases).not_to be_empty
       expect(task.cases.length).to eq(2)
     end
   end
 
-  context "volunteer with transition age youth case" do
+  context 'volunteer with transition age youth case' do
     let!(:casa_case) { create(:casa_case, :with_one_case_assignment) }
 
-    it "sends notification" do
+    it 'sends notification' do
       expect { send_reminders }.to change { casa_case.case_assignments.first.volunteer.notifications.count }.by(1)
     end
   end
 
-  context "volunteer with multiple transition age youth cases" do
+  context 'volunteer with multiple transition age youth cases' do
     let!(:volunteer) { create(:volunteer, :with_casa_cases) }
 
-    it "sends notification for each case" do
+    it 'sends notification for each case' do
       expect { send_reminders }.to change { volunteer.notifications.count }.by(2)
     end
   end
 
-  context "volunteer without transition age youth case" do
+  context 'volunteer without transition age youth case' do
     let!(:casa_case) { create(:casa_case, :with_one_case_assignment, birth_month_year_youth: 13.years.ago) }
 
-    it "does not send notification" do
-      expect { send_reminders }.not_to change { casa_case.case_assignments.first.volunteer.notifications.count }
+    it 'does not send notification' do
+      expect { send_reminders }.not_to(change { casa_case.case_assignments.first.volunteer.notifications.count })
     end
   end
 
-  context "when the case assignment is inactive" do
+  context 'when the case assignment is inactive' do
     let!(:case_assignment) { create(:case_assignment, :inactive) }
 
-    it "does not send notification" do
-      expect { send_reminders }.not_to change { case_assignment.volunteer.notifications.count }
+    it 'does not send notification' do
+      expect { send_reminders }.not_to(change { case_assignment.volunteer.notifications.count })
     end
   end
 
-  context "when there are no case assignments" do
-    it "does not raise error" do
+  context 'when there are no case assignments' do
+    it 'does not raise error' do
       expect { send_reminders }.not_to raise_error
     end
   end

--- a/spec/services/volunteer_birthday_reminder_service_spec.rb
+++ b/spec/services/volunteer_birthday_reminder_service_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe VolunteerBirthdayReminderService do
   include ActiveJob::TestHelper
@@ -18,74 +18,74 @@ RSpec.describe VolunteerBirthdayReminderService do
     clear_enqueued_jobs
   end
 
-  context "there is a volunteer with a birthday next month" do
+  context 'there is a volunteer with a birthday next month' do
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: next_month)
     end
 
-    it "creates a notification" do
+    it 'creates a notification' do
       expect { send_reminders }.to change { volunteer.supervisor.notifications.count }.by(1)
     end
   end
 
-  context "there are multiple volunteers with birthdays next month" do
+  context 'there are multiple volunteers with birthdays next month' do
     let(:supervisor) { create(:supervisor) }
     let!(:volunteer) do
       create_list(:volunteer, 4, :with_assigned_supervisor, date_of_birth: next_month, supervisor: supervisor)
     end
 
-    it "creates multiple notifications" do
+    it 'creates multiple notifications' do
       expect { send_reminders }.to change { Noticed::Notification.count }.by(4)
     end
   end
 
-  context "there is an unsupervised volunteer with a birthday next month" do
+  context 'there is an unsupervised volunteer with a birthday next month' do
     let!(:volunteer) do
       create(:volunteer, date_of_birth: next_month)
     end
 
-    it "does not create a notification" do
-      expect { send_reminders }.not_to change { Noticed::Notification.count }
+    it 'does not create a notification' do
+      expect { send_reminders }.not_to(change { Noticed::Notification.count })
     end
   end
 
-  context "there is a volunteer with no date_of_birth" do
+  context 'there is a volunteer with no date_of_birth' do
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: nil)
     end
 
-    it "does not create a notification" do
-      expect { send_reminders }.not_to change { volunteer.supervisor.notifications.count }
+    it 'does not create a notification' do
+      expect { send_reminders }.not_to(change { volunteer.supervisor.notifications.count })
     end
   end
 
-  context "there is a volunteer with a birthday that is not next month" do
+  context 'there is a volunteer with a birthday that is not next month' do
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: not_next_month)
     end
 
-    it "does not create a notification" do
-      expect { send_reminders }.not_to change { volunteer.supervisor.notifications.count }
+    it 'does not create a notification' do
+      expect { send_reminders }.not_to(change { volunteer.supervisor.notifications.count })
     end
   end
 
-  context "when today is the 15th" do
+  context 'when today is the 15th' do
     before { travel_to(this_month_15th) }
 
     let!(:volunteer) do
       create(:volunteer, :with_assigned_supervisor, date_of_birth: next_month)
     end
 
-    it "runs the rake task" do
+    it 'runs the rake task' do
       expect { send_reminders }.to change { volunteer.supervisor.notifications.count }.by(1)
     end
   end
 
-  context "when today is not the 15th" do
+  context 'when today is not the 15th' do
     before { travel_to(this_month_15th + 2.days) }
 
-    it "skips the rake task" do
-      expect { send_reminders }.not_to change { Noticed::Notification.count }
+    it 'skips the rake task' do
+      expect { send_reminders }.not_to(change { Noticed::Notification.count })
     end
   end
 end

--- a/spec/support/shared_examples/shows_court_dates_links.rb
+++ b/spec/support/shared_examples/shows_court_dates_links.rb
@@ -1,22 +1,23 @@
-RSpec.shared_examples_for "shows court dates links" do
+RSpec.shared_examples_for 'shows court dates links' do
   before do
     travel_to Date.new(2020, 1, 2)
     _newest_pcd = create(:court_date, date: DateTime.current - 5.days, casa_case: casa_case)
     _oldest_pcd = create(:court_date, date: DateTime.current - 10.days, casa_case: casa_case)
-    hearing_type = create(:hearing_type, name: "Some Hearing Name")
-    _court_date_with_details = create(:court_date, :with_court_details, casa_case: casa_case, hearing_type: hearing_type)
+    hearing_type = create(:hearing_type, name: 'Some Hearing Name')
+    _court_date_with_details = create(:court_date, :with_court_details, casa_case: casa_case,
+                                                                        hearing_type: hearing_type)
   end
 
-  it "shows court orders" do
+  it 'shows court orders' do
     visit edit_casa_case_path(casa_case)
-    expect(page).to have_link("December 23, 2019")
-    expect(page).to have_link("December 26, 2019")
-    expect(page).to have_link("December 26, 2019 - Some Hearing Name")
+    expect(page).to have_link('December 23, 2019')
+    expect(page).to have_link('December 26, 2019')
+    expect(page).to have_link('December 26, 2019 - Some Hearing Name')
   end
 
-  it "past court dates are ordered" do
+  it 'past court dates are ordered' do
     visit casa_case_path(casa_case)
-    expect(page).to have_text("December 23, 2019")
+    expect(page).to have_text('December 23, 2019')
     expect(page).to have_text(/December 23, 2019.*December 28, 2019/m)
   end
 end

--- a/spec/system/bulk_court_dates/new_spec.rb
+++ b/spec/system/bulk_court_dates/new_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "bulk_court_dates/new", type: :system do
+RSpec.describe 'bulk_court_dates/new', type: :system do
   let(:now) { Date.new(2021, 1, 1) }
   let(:casa_org) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: casa_org) }
@@ -12,34 +12,35 @@ RSpec.describe "bulk_court_dates/new", type: :system do
   let!(:hearing_type) { create(:hearing_type) }
   let(:court_order_text) { Faker::Lorem.paragraph(sentence_count: 2) }
 
-  it "is successful", :js do
+  it 'is successful', :js do
     case_group = build(:case_group, casa_org: casa_org)
     case_group.case_group_memberships.first.casa_case = casa_case
     case_group.save!
 
-    travel_to now
-    sign_in admin
-    visit casa_cases_path
-    click_on "New Bulk Court Date"
+    travel_to now do
+      sign_in admin
+      visit casa_cases_path
+      click_on 'New Bulk Court Date'
 
-    select case_group.name, from: "Case Group"
-    fill_in "court_date_date", with: :now
-    fill_in "court_date_court_report_due_date", with: :now
-    select judge.name, from: "Judge"
-    select hearing_type.name, from: "Hearing type"
+      select case_group.name, from: 'Case Group'
+      fill_in 'court_date_date', with: now
+      fill_in 'court_date_court_report_due_date', with: now
+      select judge.name, from: 'Judge'
+      select hearing_type.name, from: 'Hearing type'
 
-    click_on "Add a court order"
-    text_area = first(:css, "textarea").native
-    text_area.send_keys(court_order_text)
-    page.find("select.implementation-status").find(:option, text: "Partially implemented").select_option
+      click_on 'Add a court order'
+      find('.court-order-text-entry').set(court_order_text)
+      page.find('select.implementation-status').find(:option, text: 'Partially implemented').select_option
 
-    within ".top-page-actions" do
-      click_on "Create"
+      within '.top-page-actions' do
+        click_on 'Create'
+      end
+
+      expect(page).to have_content('1 court date created!')
+      visit casa_case_path(casa_case)
+      expect(page).to have_text('CASA Case Details')
+      expect(page).to have_content(hearing_type.name)
+      expect(page).to have_content(court_order_text)
     end
-
-    visit casa_case_path(casa_case)
-    expect(page).to have_content(hearing_type.name)
-    expect(page).to have_content(court_order_text)
-    travel_back
   end
 end

--- a/spec/system/casa_cases/edit_spec.rb
+++ b/spec/system/casa_cases/edit_spec.rb
@@ -1,8 +1,8 @@
-require "rails_helper"
-require "stringio"
+require 'rails_helper'
+require 'stringio'
 
-RSpec.describe "Edit CASA Case", type: :system do
-  context "logged in as admin" do
+RSpec.describe 'Edit CASA Case', type: :system do
+  context 'logged in as admin' do
     let(:organization) { build(:casa_org) }
     let(:other_organization) { build(:casa_org) }
     let(:admin) { create(:casa_admin, casa_org: organization) }
@@ -26,9 +26,9 @@ RSpec.describe "Edit CASA Case", type: :system do
 
     before { sign_in admin }
 
-    it_behaves_like "shows court dates links"
+    it_behaves_like 'shows court dates links'
 
-    it "shows court orders" do
+    it 'shows court orders' do
       visit edit_casa_case_path(casa_case)
 
       court_order = casa_case.case_court_orders.first
@@ -37,138 +37,139 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text(court_order.implementation_status.humanize)
     end
 
-    it "edits case", :js do
+    it 'edits case', :js do
       visit casa_case_path(casa_case.id)
-      click_on "Edit Case Details"
-      select "Submitted", from: "casa_case_court_report_status"
+      click_on 'Edit Case Details'
+      select 'Submitted', from: 'casa_case_court_report_status'
 
-      find(".ts-control").click
+      find('.ts-control').click
 
-      page.all(".ts-dropdown-content input")
+      page.all('.ts-dropdown-content input')
 
-      select_all_el = page.find("span[data-test=select-all-input]")
+      select_all_el = page.find('span[data-test=select-all-input]')
       # uncheck all contact type options
       select_all_el.click
-      within ".ts-dropdown-content" do
-        expect(page).not_to have_css(".form-check-input--checked")
-        expect(page).to have_css(".form-check-input--unchecked", count: 3)
+      within '.ts-dropdown-content' do
+        expect(page).not_to have_css('.form-check-input--checked')
+        expect(page).to have_css('.form-check-input--unchecked', count: 3)
       end
       # check all contact type options
       select_all_el.click
-      within ".ts-dropdown-content" do
-        expect(page).not_to have_css("input.form-check-input--unchecked")
-        expect(page).to have_css("input.form-check-input--checked", count: 3)
+      within '.ts-dropdown-content' do
+        expect(page).not_to have_css('input.form-check-input--unchecked')
+        expect(page).to have_css('input.form-check-input--checked', count: 3)
       end
 
       # unselect contact_type from dropdown
-      find("span", text: contact_type.name).click
+      find('span', text: contact_type.name).click
 
       page.find('button[data-action="court-order-form#add"]').click
-      find("#court-orders-list-container").first("textarea").send_keys("Court Order Text One")
+      find('#court-orders-list-container').first('textarea').send_keys('Court Order Text One')
 
-      within ".top-page-actions" do
-        click_on "Update CASA Case"
+      within '.top-page-actions' do
+        click_on 'Update CASA Case'
       end
-      expect(page).to have_text("Submitted")
-      expect(page).to have_text("Court Date")
-      expect(page).not_to have_text("Court Report Due Date")
-      expect(page).not_to have_field("Court Report Due Date")
+      expect(page).to have_text('Submitted')
+      expect(page).to have_text('Court Date')
+      expect(page).not_to have_text('Court Report Due Date')
+      expect(page).not_to have_field('Court Report Due Date')
       expect(page).to have_text("Youth's Date in Care")
-      expect(page).to have_text("Court Order Text One")
-      expect(page).not_to have_text("Deactivate Case")
+      expect(page).to have_text('Court Order Text One')
+      expect(page).not_to have_text('Deactivate Case')
 
       expect(casa_case.contact_types).to eq [another_contact_type]
       has_checked_field? contact_type.name
     end
 
-    it "does not display anything when not part of the organization", :js do
+    it 'does not display anything when not part of the organization', :js do
       visit casa_case_path(other_org_casa_case.id)
-      expect(page).to have_text("Sorry, you are not authorized to perform this action.")
+      expect(page).to have_text('Sorry, you are not authorized to perform this action.')
     end
 
-    it "deactivates a case when part of the same organization", :js do
+    it 'deactivates a case when part of the same organization', :js do
       visit edit_casa_case_path(casa_case)
 
-      click_on "Deactivate CASA Case"
-      click_on "Yes, deactivate"
+      click_on 'Deactivate CASA Case'
+      click_on 'Yes, deactivate'
       expect(page).to have_text("Case #{casa_case.case_number} has been deactivated")
-      expect(page).to have_text("Case was deactivated on: #{I18n.l(casa_case.updated_at, format: :standard, default: nil)}")
-      expect(page).to have_text("Reactivate CASA Case")
-      expect(page).not_to have_text("Court Date")
-      expect(page).not_to have_text("Court Report Due Date")
-      expect(page).not_to have_field("Court Report Due Date")
+      expect(page).to have_text("Case was deactivated on: #{I18n.l(casa_case.updated_at, format: :standard,
+                                                                                         default: nil)}")
+      expect(page).to have_text('Reactivate CASA Case')
+      expect(page).not_to have_text('Court Date')
+      expect(page).not_to have_text('Court Report Due Date')
+      expect(page).not_to have_field('Court Report Due Date')
     end
 
-    it "does not allow an admin to deactivate a case if not in an organization" do
+    it 'does not allow an admin to deactivate a case if not in an organization' do
       visit edit_casa_case_path(other_org_casa_case)
-      expect(page).to have_text("Sorry, you are not authorized to perform this action.")
+      expect(page).to have_text('Sorry, you are not authorized to perform this action.')
     end
 
-    it "reactivates a case", :js do
+    it 'reactivates a case', :js do
       visit edit_casa_case_path(casa_case)
-      click_on "Deactivate CASA Case"
-      click_on "Yes, deactivate"
-      click_link("Reactivate CASA Case")
+      click_on 'Deactivate CASA Case'
+      click_on 'Yes, deactivate'
+      click_link('Reactivate CASA Case')
 
       expect(page).to have_text("Case #{casa_case.case_number} has been reactivated.")
-      expect(page).to have_text("Deactivate CASA Case")
-      expect(page).to have_text("Court Date")
-      expect(page).not_to have_text("Court Report Due Date")
-      expect(page).not_to have_field("Court Report Due Date")
+      expect(page).to have_text('Deactivate CASA Case')
+      expect(page).to have_text('Court Date')
+      expect(page).not_to have_text('Court Report Due Date')
+      expect(page).not_to have_field('Court Report Due Date')
     end
 
-    context "when trying to assign a volunteer to a case" do
-      it "is able to assign volunteers if in the same organization", :js do
+    context 'when trying to assign a volunteer to a case' do
+      it 'is able to assign volunteers if in the same organization', :js do
         visit edit_casa_case_path(casa_case)
 
-        expect(page).to have_content("Manage Volunteers")
-        expect(page).to have_css("#volunteer-assignment")
+        expect(page).to have_content('Manage Volunteers')
+        expect(page).to have_css('#volunteer-assignment')
       end
 
-      it "errors if trying to assign volunteers for another organization" do
+      it 'errors if trying to assign volunteers for another organization' do
         visit edit_casa_case_path(other_org_casa_case)
-        expect(page).to have_text("Sorry, you are not authorized to perform this action.")
+        expect(page).to have_text('Sorry, you are not authorized to perform this action.')
       end
     end
 
-    context "Copy all court orders from a case" do
-      it "does not allow access to cases not within the organization" do
+    context 'Copy all court orders from a case' do
+      it 'does not allow access to cases not within the organization' do
         visit edit_casa_case_path(other_org_casa_case)
-        expect(page).to have_text("Sorry, you are not authorized to perform this action.")
+        expect(page).to have_text('Sorry, you are not authorized to perform this action.')
       end
 
-      it "copy button should be disabled when no case is selected", :js do
+      it 'copy button should be disabled when no case is selected', :js do
         visit edit_casa_case_path(casa_case)
-        expect(page).to have_button("copy-court-button", disabled: true)
+        expect(page).to have_button('copy-court-button', disabled: true)
       end
 
-      it "copy button should be enabled when a case is selected", :js do
+      it 'copy button should be enabled when a case is selected', :js do
         visit edit_casa_case_path(casa_case)
-        select siblings_casa_cases.first.case_number, from: "casa_case_siblings_casa_cases"
-        expect(page).to have_button("copy-court-button", disabled: false)
+        select siblings_casa_cases.first.case_number, from: 'casa_case_siblings_casa_cases'
+        expect(page).to have_button('copy-court-button', disabled: false)
       end
 
-      it "containses all case from organization except current case", :js do
+      it 'containses all case from organization except current case', :js do
         visit edit_casa_case_path(casa_case)
-        within "#casa_case_siblings_casa_cases" do
+        within '#casa_case_siblings_casa_cases' do
           siblings_casa_cases.each do |scc|
-            expect(page).to have_selector("option", text: scc.case_number)
+            expect(page).to have_selector('option', text: scc.case_number)
           end
-          expect(page).not_to have_selector("option", text: casa_case.case_number)
+          expect(page).not_to have_selector('option', text: casa_case.case_number)
         end
       end
 
-      it "copies all court orders from selected case", :js do
+      it 'copies all court orders from selected case', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         court_orders_text = casa_case.case_court_orders.map(&:text)
         court_orders_status = casa_case.case_court_orders.map(&:implementation_status)
@@ -178,18 +179,18 @@ RSpec.describe "Edit CASA Case", type: :system do
         end
       end
 
-      it "does not overwrite existing court orders", :js do
+      it 'does not overwrite existing court orders', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
         current_orders = casa_case.case_court_orders.each(&:dup)
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         current_orders.each do |orders|
           expect(casa_case.case_court_orders.map(&:text)).to include orders.text
@@ -197,102 +198,103 @@ RSpec.describe "Edit CASA Case", type: :system do
         expect(casa_case.case_court_orders.count).to be >= current_orders.count
       end
 
-      it "does not move court orders from one case to another", :js do
+      it 'does not move court orders from one case to another', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         expect(selected_case.case_court_orders.count).to be > 0
       end
     end
   end
 
-  context "logged in as supervisor" do
+  context 'logged in as supervisor' do
     let(:casa_org) { build(:casa_org) }
     let(:supervisor) { create(:supervisor, casa_org: casa_org) }
     let(:casa_case) { create(:casa_case, :with_one_court_order, casa_org: casa_org) }
     let!(:contact_type_group) { build(:contact_type_group, casa_org: casa_org) }
-    let!(:contact_type_1) { create(:contact_type, name: "Youth", contact_type_group: contact_type_group) }
-    let!(:contact_type_2) { build(:contact_type, name: "Supervisor", contact_type_group: contact_type_group) }
+    let!(:contact_type_1) { create(:contact_type, name: 'Youth', contact_type_group: contact_type_group) }
+    let!(:contact_type_2) { build(:contact_type, name: 'Supervisor', contact_type_group: contact_type_group) }
     let!(:next_year) { (Date.today.year + 1).to_s }
 
     before { sign_in supervisor }
 
-    it_behaves_like "shows court dates links"
+    it_behaves_like 'shows court dates links'
 
-    it "edits case", :js do
+    it 'edits case', :js do
       stub_twilio
       visit casa_case_path(casa_case)
-      expect(page).to have_text("Court Report Status: Not submitted")
+      expect(page).to have_text('Court Report Status: Not submitted')
       visit edit_casa_case_path(casa_case)
-      select "Submitted", from: "casa_case_court_report_status"
+      select 'Submitted', from: 'casa_case_court_report_status'
 
       scroll_to('button[data-action="court-order-form#add"]').click
-      find("#court-orders-list-container").first("textarea").send_keys("Court Order Text One")
+      find('#court-orders-list-container').first('textarea').send_keys('Court Order Text One')
 
-      select "Partially implemented", from: "casa_case[case_court_orders_attributes][0][implementation_status]"
+      select 'Partially implemented', from: 'casa_case[case_court_orders_attributes][0][implementation_status]'
 
-      expect(page).to have_text("Set Implementation Status")
+      expect(page).to have_text('Set Implementation Status')
 
-      find(".ts-control").click
+      find('.ts-control').click
 
-      select_all_el = page.find("span[data-test=select-all-input]")
+      select_all_el = page.find('span[data-test=select-all-input]')
       # uncheck all contact type options
       select_all_el.click
-      within ".ts-dropdown-content" do
-        expect(page).not_to have_css(".form-check-input--checked")
-        expect(page).to have_css(".form-check-input--unchecked", count: 2)
+      within '.ts-dropdown-content' do
+        expect(page).not_to have_css('.form-check-input--checked')
+        expect(page).to have_css('.form-check-input--unchecked', count: 2)
       end
       # check all contact type options
       select_all_el.click
-      within ".ts-dropdown-content" do
-        expect(page).not_to have_css("input.form-check-input--unchecked")
-        expect(page).to have_css("input.form-check-input--checked", count: 2)
+      within '.ts-dropdown-content' do
+        expect(page).not_to have_css('input.form-check-input--unchecked')
+        expect(page).to have_css('input.form-check-input--checked', count: 2)
       end
       # since all contact type options checked, don't need to select one
-      within ".top-page-actions" do
-        click_on "Update CASA Case"
+      within '.top-page-actions' do
+        click_on 'Update CASA Case'
       end
-      has_checked_field? "Youth"
-      has_no_checked_field? "Supervisor"
+      has_checked_field? 'Youth'
+      has_no_checked_field? 'Supervisor'
 
-      expect(page).to have_text("Court Date")
-      expect(page).not_to have_text("Court Report Due Date")
-      expect(page).not_to have_field("Court Report Due Date")
-      expect(page).not_to have_field("Court Report Due Date", with: "#{next_year}-09-08")
+      expect(page).to have_text('Court Date')
+      expect(page).not_to have_text('Court Report Due Date')
+      expect(page).not_to have_field('Court Report Due Date')
+      expect(page).not_to have_field('Court Report Due Date', with: "#{next_year}-09-08")
       expect(page).to have_text("Youth's Date in Care")
-      expect(page).to have_text("Court Order Text One")
-      expect(page).to have_text("Partially implemented")
+      expect(page).to have_text('Court Order Text One')
+      expect(page).to have_text('Partially implemented')
 
       visit casa_case_path(casa_case)
 
-      expect(page).to have_text("Court Report Status: Submitted")
+      expect(page).to have_text('Court Report Status: Submitted')
       expect(page).not_to have_text("8-SEP-#{next_year}")
     end
 
-    it "views deactivated case" do
+    it 'views deactivated case' do
       casa_case.deactivate
       visit edit_casa_case_path(casa_case)
 
-      expect(page).to have_text("Case was deactivated on: #{I18n.l(casa_case.updated_at, format: :standard, default: nil)}")
-      expect(page).not_to have_text("Court Date")
-      expect(page).not_to have_text("Court Report Due Date")
+      expect(page).to have_text("Case was deactivated on: #{I18n.l(casa_case.updated_at, format: :standard,
+                                                                                         default: nil)}")
+      expect(page).not_to have_text('Court Date')
+      expect(page).not_to have_text('Court Report Due Date')
       expect(page).not_to have_text("Youth's Date in Care")
-      expect(page).not_to have_text("Day")
-      expect(page).not_to have_text("Month")
-      expect(page).not_to have_text("Year")
-      expect(page).not_to have_text("Reactivate Case")
-      expect(page).not_to have_text("Update Casa Case")
+      expect(page).not_to have_text('Day')
+      expect(page).not_to have_text('Month')
+      expect(page).not_to have_text('Year')
+      expect(page).not_to have_text('Reactivate Case')
+      expect(page).not_to have_text('Update Casa Case')
     end
 
-    it "shows court orders" do
+    it 'shows court orders' do
       visit edit_casa_case_path(casa_case)
 
       court_order = casa_case.case_court_orders.first
@@ -301,7 +303,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text(court_order.implementation_status.humanize)
     end
 
-    describe "assign and unassign a volunteer to a case" do
+    describe 'assign and unassign a volunteer to a case' do
       let(:organization) { build(:casa_org) }
       let(:casa_case) { create(:casa_case, casa_org: organization) }
       let(:supervisor1) { build(:supervisor, casa_org: organization) }
@@ -310,56 +312,56 @@ RSpec.describe "Edit CASA Case", type: :system do
       def sign_in_and_assign_volunteer
         sign_in supervisor1
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
 
-        select volunteer.display_name, from: "case_assignment[volunteer_id]"
+        select volunteer.display_name, from: 'case_assignment[volunteer_id]'
 
-        click_on "Assign Volunteer"
+        click_on 'Assign Volunteer'
       end
 
       before do
         travel_to Time.zone.local(2020, 8, 29, 4, 5, 6)
       end
 
-      context "when a volunteer is assigned to a case" do
-        it "marks the volunteer as assigned and shows the start date of the assignment", :js do
+      context 'when a volunteer is assigned to a case' do
+        it 'marks the volunteer as assigned and shows the start date of the assignment', :js do
           sign_in_and_assign_volunteer
-          expect(page).to have_content("Volunteer assigned to case")
+          expect(page).to have_content('Volunteer assigned to case')
 
           expect(casa_case.case_assignments.count).to eq 1
 
-          unassign_button = page.find("button.btn-outline-danger")
-          expect(unassign_button.text).to eq "Unassign Volunteer"
+          unassign_button = page.find('button.btn-outline-danger')
+          expect(unassign_button.text).to eq 'Unassign Volunteer'
 
-          assign_badge = page.find("span.bg-success")
-          expect(assign_badge.text).to eq "ASSIGNED"
+          assign_badge = page.find('span.bg-success')
+          expect(assign_badge.text).to eq 'ASSIGNED'
         end
 
-        it "shows an assignment start date and no assignment end date" do
+        it 'shows an assignment start date and no assignment end date' do
           sign_in_and_assign_volunteer
-          assignment_start = page.find("td[data-test=assignment-start]").text
-          assignment_end = page.find("td[data-test=assignment-end]").text
+          assignment_start = page.find('td[data-test=assignment-start]').text
+          assignment_end = page.find('td[data-test=assignment-end]').text
 
-          expect(assignment_start).to eq("August 29, 2020")
+          expect(assignment_start).to eq('August 29, 2020')
           expect(assignment_end).to be_empty
         end
       end
 
-      context "when a volunteer is unassigned from a case" do
-        it "marks the volunteer as unassigned and shows assignment start/end dates", :js do
+      context 'when a volunteer is unassigned from a case' do
+        it 'marks the volunteer as unassigned and shows assignment start/end dates', :js do
           sign_in_and_assign_volunteer
-          unassign_button = page.find("button.btn-outline-danger")
-          expect(unassign_button.text).to eq "Unassign Volunteer"
+          unassign_button = page.find('button.btn-outline-danger')
+          expect(unassign_button.text).to eq 'Unassign Volunteer'
 
-          click_on "Unassign Volunteer"
+          click_on 'Unassign Volunteer'
 
-          assign_badge = page.find("span.bg-danger")
-          expect(assign_badge.text).to eq "UNASSIGNED"
+          assign_badge = page.find('span.bg-danger')
+          expect(assign_badge.text).to eq 'UNASSIGNED'
 
-          expected_start_and_end_date = "August 29, 2020"
+          expected_start_and_end_date = 'August 29, 2020'
 
-          assignment_start = page.find("td[data-test=assignment-start]").text
-          assignment_end = page.find("td[data-test=assignment-end]").text
+          assignment_start = page.find('td[data-test=assignment-start]').text
+          assignment_end = page.find('td[data-test=assignment-end]').text
 
           expect(assignment_start).to eq(expected_start_and_end_date)
           expect(assignment_end).to eq(expected_start_and_end_date)
@@ -369,98 +371,100 @@ RSpec.describe "Edit CASA Case", type: :system do
       context "when supervisor other than volunteer's supervisor" do
         before { volunteer.update(supervisor: build(:supervisor)) }
 
-        it "unassigns volunteer", :js do
+        it 'unassigns volunteer', :js do
           sign_in_and_assign_volunteer
-          unassign_button = page.find("button.btn-outline-danger")
-          expect(unassign_button.text).to eq "Unassign Volunteer"
+          unassign_button = page.find('button.btn-outline-danger')
+          expect(unassign_button.text).to eq 'Unassign Volunteer'
 
-          click_on "Unassign Volunteer"
+          click_on 'Unassign Volunteer'
 
-          assign_badge = page.find("span.bg-danger")
-          expect(assign_badge.text).to eq "UNASSIGNED"
+          assign_badge = page.find('span.bg-danger')
+          expect(assign_badge.text).to eq 'UNASSIGNED'
         end
       end
 
-      it "when can assign only active volunteer to a case" do
+      it 'when can assign only active volunteer to a case' do
         create(:volunteer, casa_org: organization)
         build_stubbed(:volunteer, :inactive, casa_org: organization)
 
         sign_in_and_assign_volunteer
 
-        expect(find("select[name='case_assignment[volunteer_id]']").all("option").count { |option| option[:value].present? }).to eq 1
+        expect(find("select[name='case_assignment[volunteer_id]']").all('option').count do |option|
+          option[:value].present?
+        end).to eq 1
       end
     end
 
-    describe "case assigned to multiple volunteers" do
+    describe 'case assigned to multiple volunteers' do
       let(:organization) { build(:casa_org) }
       let(:supervisor) { create(:casa_admin, casa_org: organization) }
       let(:casa_case) { create(:casa_case, casa_org: organization) }
 
-      let!(:volunteer_1) { create(:volunteer, display_name: "AAA", casa_org: organization) }
-      let!(:volunteer_2) { create(:volunteer, display_name: "BBB", casa_org: organization) }
+      let!(:volunteer_1) { create(:volunteer, display_name: 'AAA', casa_org: organization) }
+      let!(:volunteer_2) { create(:volunteer, display_name: 'BBB', casa_org: organization) }
 
-      it "supervisor assigns multiple volunteers to the same case" do
+      it 'supervisor assigns multiple volunteers to the same case' do
         sign_in supervisor
         visit edit_casa_case_path(casa_case.id)
 
-        select volunteer_1.display_name, from: "Select a Volunteer"
-        click_on "Assign Volunteer"
-        expect(page).to have_text("Volunteer assigned to case")
+        select volunteer_1.display_name, from: 'Select a Volunteer'
+        click_on 'Assign Volunteer'
+        expect(page).to have_text('Volunteer assigned to case')
         expect(page).to have_text(volunteer_1.display_name)
 
         # Attempt to assign a second volunteer without selecting one
-        click_on "Assign Volunteer"
+        click_on 'Assign Volunteer'
         expect(page).to have_text("Unable to assign volunteer to case: Volunteer must exist. Volunteer can't be blank.")
 
-        select volunteer_2.display_name, from: "Select a Volunteer"
-        click_on "Assign Volunteer"
-        expect(page).to have_text("Volunteer assigned to case")
+        select volunteer_2.display_name, from: 'Select a Volunteer'
+        click_on 'Assign Volunteer'
+        expect(page).to have_text('Volunteer assigned to case')
         expect(page).to have_text(volunteer_2.display_name)
       end
     end
 
-    describe "form behavior" do
+    describe 'form behavior' do
       it "displays 'Please select volunteer' in the dropdown" do
         sign_in supervisor
         visit edit_casa_case_path(casa_case.id)
 
-        select_element = find("#case_assignment_casa_case_id")
+        select_element = find('#case_assignment_casa_case_id')
 
         # Check if the default option exists and has the expected text
-        expect(select_element).to have_selector("option[value='']", text: "Please Select Volunteer")
+        expect(select_element).to have_selector("option[value='']", text: 'Please Select Volunteer')
       end
     end
 
-    context "deleting court orders", :js do
+    context 'deleting court orders', :js do
       let(:casa_case) { create(:casa_case, :with_one_court_order, :with_casa_case_contact_types) }
       let(:text) { casa_case.case_court_orders.first.text }
 
-      it "can delete a court order" do
+      it 'can delete a court order' do
         visit edit_casa_case_path(casa_case.case_number.parameterize)
 
         expect(page).to have_text(text)
 
         find('button[data-action="click->court-order-form#remove"]').click
-        expect(page).to have_text("Are you sure you want to remove this court order? Doing so will delete all records of it unless it was included in a previous court report.")
+        expect(page).to have_text('Are you sure you want to remove this court order? Doing so will delete all records of it unless it was included in a previous court report.')
 
-        find("button.swal2-confirm").click
+        find('button.swal2-confirm').click
         expect(page).not_to have_text(text)
 
-        within ".actions-cc" do
-          click_on "Update CASA Case"
+        within '.actions-cc' do
+          click_on 'Update CASA Case'
         end
         expect(page).not_to have_text(text)
       end
     end
 
-    context "a casa case with contact type" do
+    context 'a casa case with contact type' do
       let(:organization) { build(:casa_org) }
       let(:casa_case_with_contact_type) { create(:casa_case, :with_casa_case_contact_types, casa_org: organization) }
 
-      it "has contact type checked" do
+      it 'has contact type checked' do
         contact_types = casa_case_with_contact_type.contact_types.map(&:id)
         visit edit_casa_case_path(casa_case_with_contact_type)
-        all("input[type=checkbox][class~=case-contact-contact-type]").each do |checkbox|
+        all('input[type=checkbox][class~=case-contact-contact-type]').each do |checkbox|
           if contact_types.include? checkbox.value
             expect(checkbox).to be_checked
           else
@@ -470,17 +474,17 @@ RSpec.describe "Edit CASA Case", type: :system do
       end
     end
 
-    context "when trying to assign a volunteer to a case" do
-      it "is able to assign volunteers", :js do
+    context 'when trying to assign a volunteer to a case' do
+      it 'is able to assign volunteers', :js do
         visit edit_casa_case_path(casa_case)
 
-        expect(page).to have_content("Manage Volunteers")
-        expect(page).to have_css("#volunteer-assignment")
+        expect(page).to have_content('Manage Volunteers')
+        expect(page).to have_css('#volunteer-assignment')
       end
     end
   end
 
-  context "logged in as volunteer" do
+  context 'logged in as volunteer' do
     let(:volunteer) { build(:volunteer) }
     let(:casa_case) { create(:casa_case, :with_one_court_order, casa_org: volunteer.casa_org) }
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
@@ -491,7 +495,7 @@ RSpec.describe "Edit CASA Case", type: :system do
 
     let!(:reports) do
       [5, 11, 23, 44, 91].map do |n|
-        path_to_template = "app/documents/templates/default_report_template.docx"
+        path_to_template = 'app/documents/templates/default_report_template.docx'
         args = {
           volunteer_id: volunteer.id,
           case_id: casa_case.id,
@@ -516,14 +520,14 @@ RSpec.describe "Edit CASA Case", type: :system do
 
     before { sign_in volunteer }
 
-    it_behaves_like "shows court dates links"
+    it_behaves_like 'shows court dates links'
 
-    it "views attached court reports" do
+    it 'views attached court reports' do
       visit edit_casa_case_path(casa_case)
 
       # test court dates with reports get the correct ones
       [[0, 1], [2, 3], [3, 4]].each do |di, ri|
-        expect(page).to have_link("(Attached Report)", href: rails_blob_path(reports[ri], disposition: "attachment"))
+        expect(page).to have_link('(Attached Report)', href: rails_blob_path(reports[ri], disposition: 'attachment'))
         expect(page).to have_link(I18n.l(court_dates[di].date, format: :full, default: nil))
       end
 
@@ -532,7 +536,7 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text(I18n.l(court_dates[1].date, format: :full, default: nil))
     end
 
-    it "shows court orders" do
+    it 'shows court orders' do
       visit edit_casa_case_path(casa_case)
 
       court_order = casa_case.case_court_orders.first
@@ -541,52 +545,52 @@ RSpec.describe "Edit CASA Case", type: :system do
       expect(page).to have_text(court_order.implementation_status.humanize)
     end
 
-    it "edits case" do
+    it 'edits case' do
       visit casa_case_path(casa_case)
-      expect(page).to have_text("Court Report Status: Not submitted")
+      expect(page).to have_text('Court Report Status: Not submitted')
       visit edit_casa_case_path(casa_case)
-      select "Submitted", from: "casa_case_court_report_status"
-      within ".actions-cc" do
-        click_on "Update CASA Case"
+      select 'Submitted', from: 'casa_case_court_report_status'
+      within '.actions-cc' do
+        click_on 'Update CASA Case'
       end
 
-      expect(page).not_to have_field("Court Report Due Date")
+      expect(page).not_to have_field('Court Report Due Date')
       expect(page).not_to have_text("Youth's Date in Care")
-      expect(page).not_to have_text("Deactivate Case")
+      expect(page).not_to have_text('Deactivate Case')
 
       expect(page).to have_css('button[data-action="court-order-form#add"]')
 
       visit casa_case_path(casa_case)
-      expect(page).to have_text("Court Report Status: Submitted")
+      expect(page).to have_text('Court Report Status: Submitted')
     end
 
-    it "adds a standard court order", :js do
+    it 'adds a standard court order', :js do
       visit edit_casa_case_path(casa_case)
-      select("Family therapy", from: "Court Order Type")
-      click_button("Add a court order")
+      select('Family therapy', from: 'Court Order Type')
+      click_button('Add a court order')
 
-      textarea = all("textarea.court-order-text-entry").last
-      expect(textarea.value).to eq("Family therapy")
+      textarea = all('textarea.court-order-text-entry').last
+      expect(textarea.value).to eq('Family therapy')
     end
 
-    it "adds a custom court order", :js do
+    it 'adds a custom court order', :js do
       visit edit_casa_case_path(casa_case)
-      click_button("Add a court order")
+      click_button('Add a court order')
 
-      textarea = all("textarea.court-order-text-entry").last
-      expect(textarea.value).to eq("")
+      textarea = all('textarea.court-order-text-entry').last
+      expect(textarea.value).to eq('')
     end
 
-    context "Copy all court orders from a case" do
-      it "copy button should be disabled when no case is selected", :js do
+    context 'Copy all court orders from a case' do
+      it 'copy button should be disabled when no case is selected', :js do
         visit edit_casa_case_path(casa_case)
-        expect(page).to have_button("copy-court-button", disabled: true)
+        expect(page).to have_button('copy-court-button', disabled: true)
       end
 
-      it "copy button should be enabled when a case is selected", :js do
+      it 'copy button should be enabled when a case is selected', :js do
         visit edit_casa_case_path(casa_case)
-        select siblings_casa_cases.first.case_number, from: "casa_case_siblings_casa_cases"
-        expect(page).to have_button("copy-court-button", disabled: false)
+        select siblings_casa_cases.first.case_number, from: 'casa_case_siblings_casa_cases'
+        expect(page).to have_button('copy-court-button', disabled: false)
       end
 
       it "copy button and select shouldn't be visible when a volunteer only has one case", :js do
@@ -594,31 +598,31 @@ RSpec.describe "Edit CASA Case", type: :system do
         casa_case = create(:casa_case, :with_one_court_order, casa_org: volunteer.casa_org)
         create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
         visit edit_casa_case_path(casa_case)
-        expect(page).not_to have_button("copy-court-button")
-        expect(page).not_to have_selector("casa_case_siblings_casa_cases")
+        expect(page).not_to have_button('copy-court-button')
+        expect(page).not_to have_selector('casa_case_siblings_casa_cases')
       end
 
-      it "containses all cases associated to current volunteer except current case", :js do
+      it 'containses all cases associated to current volunteer except current case', :js do
         visit edit_casa_case_path(casa_case)
-        within "#casa_case_siblings_casa_cases" do
+        within '#casa_case_siblings_casa_cases' do
           siblings_casa_cases.each do |scc|
-            expect(page).to have_selector("option", text: scc.case_number)
+            expect(page).to have_selector('option', text: scc.case_number)
           end
-          expect(page).not_to have_selector("option", text: casa_case.case_number)
+          expect(page).not_to have_selector('option', text: casa_case.case_number)
         end
       end
 
-      it "copies all court orders from selected case", :js do
+      it 'copies all court orders from selected case', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         court_orders_text = casa_case.case_court_orders.map(&:text)
         court_orders_status = casa_case.case_court_orders.map(&:implementation_status)
@@ -628,18 +632,18 @@ RSpec.describe "Edit CASA Case", type: :system do
         end
       end
 
-      it "does not overwrite existing court orders", :js do
+      it 'does not overwrite existing court orders', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
         current_orders = casa_case.case_court_orders.each(&:dup)
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         current_orders.each do |orders|
           expect(casa_case.case_court_orders.map(&:text)).to include orders.text
@@ -647,17 +651,17 @@ RSpec.describe "Edit CASA Case", type: :system do
         expect(casa_case.case_court_orders.count).to be >= current_orders.count
       end
 
-      it "does not move court orders from one case to another", :js do
+      it 'does not move court orders from one case to another', :js do
         visit casa_case_path(casa_case.id)
-        click_on "Edit Case Details"
+        click_on 'Edit Case Details'
         selected_case = siblings_casa_cases.first
-        select selected_case.case_number, from: "casa_case_siblings_casa_cases"
-        click_on "Copy"
-        within ".swal2-popup" do
+        select selected_case.case_number, from: 'casa_case_siblings_casa_cases'
+        click_on 'Copy'
+        within '.swal2-popup' do
           expect(page).to have_text("Copy all orders from case ##{selected_case.case_number}?")
-          click_on "Copy"
+          click_on 'Copy'
         end
-        expect(page).to have_text("Court orders have been copied")
+        expect(page).to have_text('Court orders have been copied')
         casa_case.reload
         expect(selected_case.case_court_orders.count).to be > 0
       end

--- a/spec/system/casa_cases/show_spec.rb
+++ b/spec/system/casa_cases/show_spec.rb
@@ -1,15 +1,15 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "casa_cases/show", type: :system do
+RSpec.describe 'casa_cases/show', type: :system do
   include ActionView::Helpers::DateHelper
 
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
-  let(:volunteer) { build(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
-  let(:casa_case) {
+  let(:volunteer) { build(:volunteer, display_name: 'Bob Loblaw', casa_org: organization) }
+  let(:casa_case) do
     create(:casa_case, :with_one_court_order, casa_org: organization,
-      case_number: "CINA-1", date_in_care: date_in_care)
-  }
+                                              case_number: 'CINA-1', date_in_care: date_in_care)
+  end
   let!(:court_date) { create(:court_date, court_report_due_date: 1.month.from_now) }
   let(:date_in_care) { 6.years.ago }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
@@ -22,26 +22,26 @@ RSpec.describe "casa_cases/show", type: :system do
     visit casa_case_path(casa_case.id)
   end
 
-  shared_examples "shows emancipation checklist link" do
-    context "when youth is in transition age" do
-      it "sees link to emancipation" do
+  shared_examples 'shows emancipation checklist link' do
+    context 'when youth is in transition age' do
+      it 'sees link to emancipation' do
         expect(page).to have_link("Emancipation 0 / #{emancipation_categories.size}")
       end
     end
 
-    context "when youth is not in transition age" do
+    context 'when youth is not in transition age' do
       before do
         casa_case.update!(birth_month_year_youth: DateTime.current)
         visit casa_case_path(casa_case)
       end
 
-      it "does not see a link to emancipation checklist" do
+      it 'does not see a link to emancipation checklist' do
         expect(page).not_to have_link("Emancipation 0 / #{emancipation_categories.size}")
       end
     end
   end
 
-  describe "Report Generation", :js do
+  describe 'Report Generation', :js do
     let(:modal_selector) { '[data-bs-target="#generate-docx-report-modal"]' }
     let(:user) { volunteer }
 
@@ -52,9 +52,9 @@ RSpec.describe "casa_cases/show", type: :system do
     end
 
     context "when first arriving to 'Generate Court Report' page" do
-      it "generation modal hidden" do
-        expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: false
-        expect(page).not_to have_selector ".select2"
+      it 'generation modal hidden' do
+        expect(page).to have_selector '#btnGenerateReport', text: 'Generate Report', visible: false
+        expect(page).not_to have_selector '.select2'
       end
     end
 
@@ -64,26 +64,26 @@ RSpec.describe "casa_cases/show", type: :system do
       end
 
       # putting all this in the same system test shaves 3 seconds off the test suite
-      it "modal has correct contents" do
-        start_date = page.find("#start_date").value
-        expect(start_date).to eq("January 01, 2021") # default date
+      it 'modal has correct contents' do
+        start_date = page.find('#start_date').value
+        expect(start_date).to eq('January 01, 2021') # default date
 
-        end_date = page.find("#end_date").value
-        expect(end_date).to eq("January 01, 2021") # default date
+        end_date = page.find('#end_date').value
+        expect(end_date).to eq('January 01, 2021') # default date
 
-        expect(page).to have_selector "#btnGenerateReport", text: "Generate Report", visible: true
-        expect(page).not_to have_selector ".select2"
+        expect(page).to have_selector '#btnGenerateReport', text: 'Generate Report', visible: true
+        expect(page).not_to have_selector '.select2'
 
-        expect(page).to have_selector("#btnGenerateReport .lni-download", visible: true)
-        expect(page).not_to have_selector("#btnGenerateReport[disabled]")
-        expect(page).to have_selector("#spinner", visible: :hidden)
+        expect(page).to have_selector('#btnGenerateReport .lni-download', visible: true)
+        expect(page).not_to have_selector('#btnGenerateReport[disabled]')
+        expect(page).to have_selector('#spinner', visible: :hidden)
 
-        within("#generate-docx-report-modal") do
+        within('#generate-docx-report-modal') do
           expect(page).to have_content(casa_case.case_number)
 
           # when choosing the prompt option (value is empty) and click on 'Generate Report' button, nothing should happen"
           # should have disabled generate button, download icon and no spinner
-          click_button "Generate Report"
+          click_button 'Generate Report'
         end
 
         wait_for_download
@@ -92,31 +92,31 @@ RSpec.describe "casa_cases/show", type: :system do
     end
   end
 
-  context "admin user" do
+  context 'admin user' do
     let(:user) { admin }
 
-    it_behaves_like "shows court dates links"
-    it_behaves_like "shows emancipation checklist link"
+    it_behaves_like 'shows court dates links'
+    it_behaves_like 'shows emancipation checklist link'
 
-    it "can see case creator in table" do
-      expect(page).to have_text("Bob Loblaw")
+    it 'can see case creator in table' do
+      expect(page).to have_text('Bob Loblaw')
     end
 
-    it "can navigate to edit volunteer page" do
-      expect(page).to have_link("Bob Loblaw", href: "/volunteers/#{volunteer.id}/edit")
+    it 'can navigate to edit volunteer page' do
+      expect(page).to have_link('Bob Loblaw', href: "/volunteers/#{volunteer.id}/edit")
     end
 
-    it "sees link to profile page" do
-      expect(page).to have_link(href: "/users/edit")
+    it 'sees link to profile page' do
+      expect(page).to have_link(href: '/users/edit')
     end
 
-    it "can see court orders" do
-      expect(page).to have_content("Court Orders")
+    it 'can see court orders' do
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
     end
 
-    it "can see next court date", :js do
+    it 'can see next court date', :js do
       expect(page).to have_content(
         "Next Court Date: #{I18n.l(future_court_date.date, format: :day_and_date)}"
       )
@@ -132,215 +132,221 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content("#{time_ago_in_words(date_in_care)} ago")
     end
 
-    it "can see Add to Calendar buttons", :js do
-      expect(page).to have_content("Add to Calendar")
+    it 'can see Add to Calendar buttons', :js do
+      expect(page).to have_content('Add to Calendar')
     end
 
-    context "court report download link visibility" do
-      it "does not show download link to admin when report status is not submitted" do
-        fixture = Rails.root.join("spec/fixtures/files/sample_report.docx")
+    context 'court report download link visibility' do
+      it 'does not show download link to admin when report status is not submitted' do
+        fixture = Rails.root.join('spec/fixtures/files/sample_report.docx')
         casa_case.court_reports.attach(
           io: File.open(fixture),
-          filename: "sample_report.docx",
-          content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          filename: 'sample_report.docx',
+          content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
         casa_case.update!(court_report_status: :in_review)
 
         visit casa_case_path(casa_case.id)
-        expect(page).not_to have_link("Click to download")
+        expect(page).not_to have_link('Click to download')
       end
 
-      it "shows download link to admin when report status is submitted" do
-        fixture = Rails.root.join("spec/fixtures/files/sample_report.docx")
+      it 'shows download link to admin when report status is submitted' do
+        fixture = Rails.root.join('spec/fixtures/files/sample_report.docx')
         casa_case.court_reports.attach(
           io: File.open(fixture),
-          filename: "sample_report.docx",
-          content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          filename: 'sample_report.docx',
+          content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
         casa_case.update!(court_report_status: :submitted)
 
         visit casa_case_path(casa_case.id)
-        expect(page).to have_link("Click to download")
+        expect(page).to have_link('Click to download')
       end
     end
 
-    context "when there is no future court date or court report due date" do
+    context 'when there is no future court date or court report due date' do
       before do
         casa_case = create(:casa_case, casa_org: organization)
         visit casa_case_path(casa_case.id)
       end
 
-      it "can not see Add to Calendar buttons", :js do
-        expect(page).not_to have_content("Add to Calendar")
+      it 'can not see Add to Calendar buttons', :js do
+        expect(page).not_to have_content('Add to Calendar')
       end
     end
 
-    context "when old case contacts are hidden" do
-      it "displays all case contacts to admin", :js do
+    context 'when old case contacts are hidden' do
+      it 'displays all case contacts to admin', :js do
         casa_case = create(:casa_case, casa_org: organization)
-        volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
-        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        volunteer_1 = create(:volunteer, display_name: 'Volunteer 1', casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: 'Volunteer 2', casa_org: casa_case.casa_org)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1,
+                              occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2,
+                              occurred_at: DateTime.now - 1)
 
         visit casa_case_path(casa_case.id)
 
-        expect(page).to have_css("#case_contacts_list .card-content", count: 2)
+        expect(page).to have_css('#case_contacts_list .card-content', count: 2)
       end
     end
   end
 
-  context "supervisor user" do
+  context 'supervisor user' do
     let(:user) { create(:supervisor, casa_org: organization) }
     let!(:case_contact) { create(:case_contact, creator: user, casa_case: casa_case) }
 
-    it_behaves_like "shows emancipation checklist link"
+    it_behaves_like 'shows emancipation checklist link'
 
-    it "sees link to own edit page" do
+    it 'sees link to own edit page' do
       expect(page).to have_link(href: "/supervisors/#{user.id}/edit")
     end
 
-    context "case contact by another supervisor" do
+    context 'case contact by another supervisor' do
       let(:other_supervisor) { create(:supervisor, casa_org: organization) }
       let!(:case_contact) { create(:case_contact, creator: other_supervisor, casa_case: casa_case) }
 
-      it "sees link to other supervisor" do
+      it 'sees link to other supervisor' do
         expect(page).to have_link(href: "/supervisors/#{other_supervisor.id}/edit")
       end
     end
 
-    it "can see court orders" do
-      expect(page).to have_content("Court Orders")
+    it 'can see court orders' do
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
     end
 
-    context "court report download link visibility" do
-      it "does not show download link to supervisor when report status is not submitted" do
-        fixture = Rails.root.join("spec/fixtures/files/sample_report.docx")
+    context 'court report download link visibility' do
+      it 'does not show download link to supervisor when report status is not submitted' do
+        fixture = Rails.root.join('spec/fixtures/files/sample_report.docx')
         casa_case.court_reports.attach(
           io: File.open(fixture),
-          filename: "sample_report.docx",
-          content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          filename: 'sample_report.docx',
+          content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
         casa_case.update!(court_report_status: :in_review)
 
         visit casa_case_path(casa_case.id)
-        expect(page).not_to have_link("Click to download")
+        expect(page).not_to have_link('Click to download')
       end
 
-      it "shows download link to supervisor when report status is submitted" do
-        fixture = Rails.root.join("spec/fixtures/files/sample_report.docx")
+      it 'shows download link to supervisor when report status is submitted' do
+        fixture = Rails.root.join('spec/fixtures/files/sample_report.docx')
         casa_case.court_reports.attach(
           io: File.open(fixture),
-          filename: "sample_report.docx",
-          content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          filename: 'sample_report.docx',
+          content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
         )
         casa_case.update!(court_report_status: :submitted)
 
         visit casa_case_path(casa_case.id)
-        expect(page).to have_link("Click to download")
+        expect(page).to have_link('Click to download')
       end
     end
 
-    context "when old case contacts are hidden" do
-      it "displays all case contacts to supervisor", :js do
+    context 'when old case contacts are hidden' do
+      it 'displays all case contacts to supervisor', :js do
         casa_case = create(:casa_case, casa_org: organization)
-        volunteer_1 = create(:volunteer, display_name: "Volunteer 1", casa_org: casa_case.casa_org)
-        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        volunteer_1 = create(:volunteer, display_name: 'Volunteer 1', casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: 'Volunteer 2', casa_org: casa_case.casa_org)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_1)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1, occurred_at: DateTime.now - 1)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_1,
+                              occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2,
+                              occurred_at: DateTime.now - 1)
 
         visit casa_case_path(casa_case.id)
 
-        expect(page).to have_css("#case_contacts_list .card-content", count: 2)
+        expect(page).to have_css('#case_contacts_list .card-content', count: 2)
       end
     end
   end
 
-  context "volunteer user" do
+  context 'volunteer user' do
     let(:user) { volunteer }
 
-    it_behaves_like "shows emancipation checklist link"
+    it_behaves_like 'shows emancipation checklist link'
 
-    it "can see court orders" do
-      expect(page).to have_content("Court Orders")
+    it 'can see court orders' do
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
       expect(page).to have_content(casa_case.case_court_orders[0].implementation_status_symbol)
     end
 
-    context "when old case contacts are hidden" do
+    context 'when old case contacts are hidden' do
       before do
-        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: 'Volunteer 2', casa_org: casa_case.casa_org)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: true)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2,
+                              occurred_at: DateTime.now - 1)
       end
 
-      it "displays only visible cases to volunteer", :js do
+      it 'displays only visible cases to volunteer', :js do
         visit casa_case_path(casa_case.id)
-        expect(page).to have_css("#case_contacts_list .card-content", count: 1)
+        expect(page).to have_css('#case_contacts_list .card-content', count: 1)
       end
     end
 
-    context "when old case contacts are displayed" do
+    context 'when old case contacts are displayed' do
       before do
-        volunteer_2 = create(:volunteer, display_name: "Volunteer 2", casa_org: casa_case.casa_org)
+        volunteer_2 = create(:volunteer, display_name: 'Volunteer 2', casa_org: casa_case.casa_org)
         create(:case_assignment, casa_case: casa_case, volunteer: volunteer_2, active: false, hide_old_contacts: false)
-        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2, occurred_at: DateTime.now - 1)
+        create(:case_contact, contact_made: true, casa_case: casa_case, creator: volunteer_2,
+                              occurred_at: DateTime.now - 1)
       end
 
-      it "displays all cases to the volunteer" do
+      it 'displays all cases to the volunteer' do
         visit casa_case_path(casa_case.id)
-        expect(page).to have_css("#case_contacts_list .card-content", count: 2)
+        expect(page).to have_css('#case_contacts_list .card-content', count: 2)
       end
     end
   end
 
-  context "court order - implementation status symbol" do
+  context 'court order - implementation status symbol' do
     let(:user) { admin }
 
-    it "when implemented" do
+    it 'when implemented' do
       casa_case.case_court_orders[0].update(implementation_status: :implemented)
 
       visit casa_case_path(casa_case)
 
-      expect(page).to have_content("Court Orders")
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
-      expect(page).to have_content("✅")
+      expect(page).to have_content('✅')
     end
 
-    it "when not implemented" do
+    it 'when not implemented' do
       casa_case.case_court_orders[0].update(implementation_status: :unimplemented)
 
       visit casa_case_path(casa_case)
 
-      expect(page).to have_content("Court Orders")
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
-      expect(page).to have_content("❌")
+      expect(page).to have_content('❌')
     end
 
-    it "when partial implemented" do
+    it 'when partial implemented' do
       casa_case.case_court_orders[0].update(implementation_status: :partially_implemented)
 
       visit casa_case_path(casa_case)
 
-      expect(page).to have_content("Court Orders")
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
-      expect(page).to have_content("🕗")
+      expect(page).to have_content('🕗')
     end
 
-    it "when not specified" do
+    it 'when not specified' do
       casa_case.case_court_orders[0].update(implementation_status: nil)
 
       visit casa_case_path(casa_case)
 
-      expect(page).to have_content("Court Orders")
+      expect(page).to have_content('Court Orders')
       expect(page).to have_content(casa_case.case_court_orders[0].text)
-      expect(page).to have_content("❌")
+      expect(page).to have_content('❌')
     end
   end
 end

--- a/spec/system/case_contacts/additional_expenses_spec.rb
+++ b/spec/system/case_contacts/additional_expenses_spec.rb
@@ -1,10 +1,10 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :system do
+RSpec.describe 'CaseContact AdditionalExpenses Form', :flipper, :js, type: :system do
   subject do
     visit new_case_contact_path(casa_case)
     fill_in_contact_details(contact_types: [contact_type.name])
-    fill_in_mileage want_reimbursement: true, miles: 50, address: "123 Params St"
+    fill_in_mileage want_reimbursement: true, miles: 50, address: '123 Params St'
   end
 
   let(:casa_org) { build :casa_org, :all_reimbursements_enabled }
@@ -17,40 +17,42 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     sign_in volunteer
   end
 
-  it "is not rendered when casa org expenses disabled" do
+  it 'is not rendered when casa org expenses disabled' do
     casa_org.update! additional_expenses_enabled: false
 
     subject
-    check "Request travel or other reimbursement"
+    check 'Request travel or other reimbursement'
 
-    expect(page).to have_no_field(class: "expense-amount-input", visible: :all)
-    expect(page).to have_no_field(class: "expense-describe-input", visible: :all)
-    expect(page).to have_no_button("Add Another Expense", visible: :all)
+    expect(page).to have_no_field(class: 'expense-amount-input', visible: :all)
+    expect(page).to have_no_field(class: 'expense-describe-input', visible: :all)
+    expect(page).to have_no_button('Add Another Expense', visible: :all)
   end
 
-  it "is not shown until Reimbursement is checked and Add Another Expense clicked" do
+  it 'is not shown until Reimbursement is checked and Add Another Expense clicked' do
     sign_in volunteer
     visit new_case_contact_path casa_case
     fill_in_contact_details
 
-    expect(page).to have_no_button "Add Another Expense"
-    check "Request travel or other reimbursement"
-    expect(page).to have_no_field(class: "expense-amount-input", visible: :all)
-    expect(page).to have_no_field(class: "expense-describe-input", visible: :all)
-    click_on "Add Another Expense"
-    expect(page).to have_field(class: "expense-describe-input")
-    expect(page).to have_field(class: "expense-amount-input")
+    expect(page).to have_no_button 'Add Another Expense'
+    check 'Request travel or other reimbursement'
+    expect(page).to have_no_field(class: 'expense-amount-input', visible: :all)
+    expect(page).to have_no_field(class: 'expense-describe-input', visible: :all)
+    click_on 'Add Another Expense'
+    expect(page).to have_field(class: 'expense-describe-input')
+    expect(page).to have_field(class: 'expense-amount-input')
   end
 
-  it "does not submit values if reimbursement is cancelled (unchecked)" do
+  it 'does not submit values if reimbursement is cancelled (unchecked)' do
     subject
 
-    click_on "Add Another Expense"
-    fill_expense_fields 5.34, "Lunch"
-    uncheck "Request travel or other reimbursement"
+    click_on 'Add Another Expense'
+    fill_expense_fields 5.34, 'Lunch'
+    uncheck 'Request travel or other reimbursement'
 
-    expect { click_on "Submit" }
-      .to change(CaseContact.active, :count).by(1)
+    expect do
+      click_on 'Submit'
+      expect(page).to have_text('Case contact successfully created')
+    end.to change(CaseContact.active, :count).by(1)
 
     case_contact = CaseContact.active.last
     expect(case_contact.additional_expenses).to be_empty
@@ -58,30 +60,30 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     expect(case_contact.want_driving_reimbursement).to be false
   end
 
-  it "can remove an expense" do
+  it 'can remove an expense' do
     subject
     fill_in_contact_details
-    check "Request travel or other reimbursement"
-    fill_in "case_contact_miles_driven", with: 50
-    fill_in "case_contact_volunteer_address", with: "123 Params St"
+    check 'Request travel or other reimbursement'
+    fill_in 'case_contact_miles_driven', with: 50
+    fill_in 'case_contact_volunteer_address', with: '123 Params St'
 
-    expect {
-      click_on "Add Another Expense"
-      fill_expense_fields 1.50, "1st meal"
-      click_on "Add Another Expense"
-      fill_expense_fields 2.50, "2nd meal"
-      click_on "Add Another Expense"
-      fill_expense_fields 2.00, "3rd meal"
+    expect do
+      click_on 'Add Another Expense'
+      fill_expense_fields 1.50, '1st meal'
+      click_on 'Add Another Expense'
+      fill_expense_fields 2.50, '2nd meal'
+      click_on 'Add Another Expense'
+      fill_expense_fields 2.00, '3rd meal'
 
-      within "#contact-form-expenses" do
-        click_on "Delete", match: :first
+      within '#contact-form-expenses' do
+        click_on 'Delete', match: :first
       end
 
-      expect(page).to have_field(class: "expense-amount-input", count: 2)
+      expect(page).to have_field(class: 'expense-amount-input', count: 2)
 
-      click_on "Submit"
-      expect(page).to have_text("Case contact successfully created")
-    }
+      click_on 'Submit'
+      expect(page).to have_text('Case contact successfully created')
+    end
       .to change(CaseContact.active, :count).by(1)
       .and change(AdditionalExpense, :count).by(2)
 
@@ -89,72 +91,81 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     expect(case_contact.additional_expenses.size).to eq(2)
   end
 
-  it "requires a description for each additional expense" do
+  it 'requires a description for each additional expense' do
     subject
 
-    click_on "Add Another Expense"
+    click_on 'Add Another Expense'
     fill_expense_fields 5.34, nil
 
-    expect { click_on "Submit" }
+    expect do
+      click_on 'Submit'
+      expect(page).to have_text("Other Expense Details can't be blank")
+    end
       .to not_change(CaseContact.active, :count)
       .and not_change(AdditionalExpense, :count)
 
     expect(page).to have_text("Other Expense Details can't be blank")
   end
 
-  context "when editing existing case contact expenses" do
+  context 'when editing existing case contact expenses' do
     subject { visit edit_case_contact_path case_contact }
 
-    let(:case_contact) { create :case_contact, :wants_reimbursement, casa_case:, creator: volunteer, contact_types: [contact_type] }
+    let(:case_contact) do
+      create :case_contact, :wants_reimbursement, casa_case:, creator: volunteer, contact_types: [contact_type]
+    end
     let!(:additional_expenses) do
       [
-        create(:additional_expense, case_contact:, other_expense_amount: 1.11, other_expenses_describe: "First Expense"),
-        create(:additional_expense, case_contact:, other_expense_amount: 2.22, other_expenses_describe: "Second Expense")
+        create(:additional_expense, case_contact:, other_expense_amount: 1.11,
+                                    other_expenses_describe: 'First Expense'),
+        create(:additional_expense, case_contact:, other_expense_amount: 2.22,
+                                    other_expenses_describe: 'Second Expense')
       ]
     end
 
-    it "shows existing expenses in the form" do
+    it 'shows existing expenses in the form' do
       subject
 
-      expect(page).to have_field(class: "expense-amount-input", count: additional_expenses.size)
-      expect(page).to have_field(class: "expense-describe-input", count: additional_expenses.size)
-      expect(page).to have_field(class: "expense-amount-input", with: "1.11")
-      expect(page).to have_field(class: "expense-describe-input", with: "First Expense")
-      expect(page).to have_field(class: "expense-amount-input", with: "2.22")
-      expect(page).to have_field(class: "expense-describe-input", with: "Second Expense")
-      expect(page).to have_button "Add Another Expense"
+      expect(page).to have_field(class: 'expense-amount-input', count: additional_expenses.size)
+      expect(page).to have_field(class: 'expense-describe-input', count: additional_expenses.size)
+      expect(page).to have_field(class: 'expense-amount-input', with: '1.11')
+      expect(page).to have_field(class: 'expense-describe-input', with: 'First Expense')
+      expect(page).to have_field(class: 'expense-amount-input', with: '2.22')
+      expect(page).to have_field(class: 'expense-describe-input', with: 'Second Expense')
+      expect(page).to have_button 'Add Another Expense'
     end
 
-    it "allows removing expenses" do
+    it 'allows removing expenses' do
       subject
 
-      expect(page).to have_css(".expense-amount-input", count: 2)
-      expect(page).to have_css(".expense-describe-input", count: 2)
+      expect(page).to have_css('.expense-amount-input', count: 2)
+      expect(page).to have_css('.expense-describe-input', count: 2)
 
-      expect {
-        within "#contact-form-expenses" do
-          click_on "Delete", match: :first
+      expect do
+        within '#contact-form-expenses' do
+          click_on 'Delete', match: :first
         end
 
-        expect(page).to have_css(".expense-amount-input", count: 1)
-        expect(page).to have_css(".expense-describe-input", count: 1)
+        expect(page).to have_css('.expense-amount-input', count: 1)
+        expect(page).to have_css('.expense-describe-input', count: 1)
 
-        click_on "Submit"
-      }
+        click_on 'Submit'
+        expect(page).to have_text('Case contact')
+      end
         .to not_change(CaseContact.active, :count)
         .and change(AdditionalExpense, :count).by(-1)
 
       expect(case_contact.reload.additional_expenses.size).to eq(1)
     end
 
-    it "can add an expense" do
+    it 'can add an expense' do
       subject
 
-      expect {
-        click_on "Add Another Expense"
-        fill_expense_fields 11.50, "Gas"
-        click_on "Submit"
-      }
+      expect do
+        click_on 'Add Another Expense'
+        fill_expense_fields 11.50, 'Gas'
+        click_on 'Submit'
+        expect(page).to have_text('Case contact')
+      end
         .to change(AdditionalExpense, :count).by(1)
       expect(case_contact.reload.additional_expenses.size).to eq(3)
     end

--- a/spec/system/case_contacts/followups/create_spec.rb
+++ b/spec/system/case_contacts/followups/create_spec.rb
@@ -49,11 +49,15 @@ RSpec.describe "followups/create", :js, type: :system do
 
         click_button "Cancel"
 
+        expect(page).not_to have_selector(".swal2-container")
+
         expect(case_contact.followups.reload.count).to be_zero
       end
 
       it "does nothing when there is no text in the note textarea" do
         click_button "Cancel"
+
+        expect(page).not_to have_selector(".swal2-container")
 
         expect(case_contact.followups.reload.count).to be_zero
       end
@@ -65,11 +69,15 @@ RSpec.describe "followups/create", :js, type: :system do
 
         find(".swal2-close").click
 
+        expect(page).not_to have_selector(".swal2-container")
+
         expect(case_contact.followups.reload.count).to be_zero
       end
 
       it "does nothing when there is no text in the note textarea" do
         find(".swal2-close").click
+
+        expect(page).not_to have_selector(".swal2-container")
 
         expect(case_contact.followups.reload.count).to be_zero
       end

--- a/spec/system/court_dates/edit_spec.rb
+++ b/spec/system/court_dates/edit_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "court_dates/edit", type: :system do
-  context "with date"
+RSpec.describe 'court_dates/edit', type: :system do
+  context 'with date'
   let(:now) { Date.new(2021, 1, 1) }
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
@@ -17,106 +17,106 @@ RSpec.describe "court_dates/edit", type: :system do
     travel_to now
   end
 
-  context "as an admin" do
+  context 'as an admin' do
     before do
       sign_in admin
       visit casa_case_path(casa_case)
-      click_on court_date.date.strftime("%B %-d, %Y")
-      click_on "Edit"
+      click_on court_date.date.strftime('%B %-d, %Y')
+      click_on 'Edit'
     end
 
-    it "shows court orders" do
+    it 'shows court orders' do
       court_order = court_date.case_court_orders.first
 
       expect(page).to have_text(court_order.text)
       expect(page).to have_text(court_order.implementation_status.humanize)
     end
 
-    it "adds a standard court order", :js do
-      select("Family therapy", from: "Court Order Type")
-      click_button("Add a court order")
+    it 'adds a standard court order', :js do
+      select('Family therapy', from: 'Court Order Type')
+      click_button('Add a court order')
 
-      textarea = all("textarea.court-order-text-entry").last
-      expect(textarea.value).to eq("Family therapy")
+      textarea = all('textarea.court-order-text-entry').last
+      expect(textarea.value).to eq('Family therapy')
     end
 
-    it "adds a custom court order", :js do
-      click_button("Add a court order")
+    it 'adds a custom court order', :js do
+      click_button('Add a court order')
 
-      textarea = all("textarea.court-order-text-entry").last
-      expect(textarea.value).to eq("")
+      textarea = all('textarea.court-order-text-entry').last
+      expect(textarea.value).to eq('')
     end
 
-    it "edits past court date", :js do
-      expect(page).to have_text("Editing Court Date")
-      expect(page).to have_text("Case Number:")
+    it 'edits past court date', :js do
+      expect(page).to have_text('Editing Court Date')
+      expect(page).to have_text('Case Number:')
       expect(page).to have_text(casa_case.case_number)
-      expect(page).to have_text("Add Court Date")
-      expect(page).to have_field("court_date_date", with: "2020-12-25")
-      expect(page).to have_text("Add Court Report Due Date")
-      expect(page).to have_field("court_date_court_report_due_date")
-      expect(page).to have_select("Judge")
-      expect(page).to have_select("Hearing type")
+      expect(page).to have_text('Add Court Date')
+      expect(page).to have_field('court_date_date', with: '2020-12-25')
+      expect(page).to have_text('Add Court Report Due Date')
+      expect(page).to have_field('court_date_court_report_due_date')
+      expect(page).to have_select('Judge')
+      expect(page).to have_select('Hearing type')
       expect(page).to have_text("Court Orders - Please check that you didn't enter any youth names")
-      expect(page).to have_text("Add a court order")
+      expect(page).to have_text('Add a court order')
 
       page.find('button[data-action="court-order-form#add"]').click
-      find("#court-orders-list-container").first("textarea").send_keys("Court Order Text One")
+      all('textarea.court-order-text-entry').last.set('Court Order Text One')
 
-      within ".top-page-actions" do
-        click_on "Update"
+      within '.top-page-actions' do
+        click_on 'Update'
       end
-      expect(page).to have_text("Court Order Text One")
+      expect(page).to have_text('Court Order Text One')
     end
 
-    it "can delete a future court date", :js do
+    it 'can delete a future court date', :js do
       visit root_path
-      click_on "Cases"
+      click_on 'Cases'
       click_on casa_case.case_number
 
       expect(CourtDate.count).to eq 2
-      expect(page).to have_content future_court_date.date.strftime("%B %-d, %Y")
-      page.find("a", text: future_court_date.date.strftime("%B %-d, %Y")).click
-      accept_alert "Are you sure?" do
-        page.find("a", text: "Delete Future Court Date").click
+      expect(page).to have_content future_court_date.date.strftime('%B %-d, %Y')
+      page.find('a', text: future_court_date.date.strftime('%B %-d, %Y')).click
+      accept_alert 'Are you sure?' do
+        page.find('a', text: 'Delete Future Court Date').click
       end
-      expect(page).to have_content "Court date was successfully deleted"
+      expect(page).to have_content 'Court date was successfully deleted'
       expect(CourtDate.count).to eq 1
     end
   end
 
-  context "as a supervisor" do
-    it "can delete a future court date", :js do
+  context 'as a supervisor' do
+    it 'can delete a future court date', :js do
       sign_in supervisor
 
       visit root_path
-      click_on "Cases"
+      click_on 'Cases'
       click_on casa_case.case_number
 
       expect(CourtDate.count).to eq 2
-      expect(page).to have_content future_court_date.date.strftime("%B %-d, %Y")
-      page.find("a", text: future_court_date.date.strftime("%B %-d, %Y")).click
-      page.find("a", text: "Delete Future Court Date").click
+      expect(page).to have_content future_court_date.date.strftime('%B %-d, %Y')
+      page.find('a', text: future_court_date.date.strftime('%B %-d, %Y')).click
+      page.find('a', text: 'Delete Future Court Date').click
       page.driver.browser.switch_to.alert.accept
 
-      expect(page).to have_content "Court date was successfully deleted."
+      expect(page).to have_content 'Court date was successfully deleted.'
       expect(CourtDate.count).to eq 1
     end
   end
 
-  context "as a volunteer" do
+  context 'as a volunteer' do
     it "can't delete a future court date as volunteer", :js do
       volunteer.casa_cases = [casa_case]
       sign_in volunteer
 
       visit root_path
-      click_on "Cases"
+      click_on 'Cases'
       click_on casa_case.case_number
 
       expect(CourtDate.count).to eq 2
-      expect(page).to have_content future_court_date.date.strftime("%B %-d, %Y")
-      page.find("a", text: future_court_date.date.strftime("%B %-d, %Y")).click
-      expect(page).not_to have_content "Delete Future Court Date"
+      expect(page).to have_content future_court_date.date.strftime('%B %-d, %Y')
+      page.find('a', text: future_court_date.date.strftime('%B %-d, %Y')).click
+      expect(page).not_to have_content 'Delete Future Court Date'
     end
   end
 end

--- a/spec/system/court_dates/new_spec.rb
+++ b/spec/system/court_dates/new_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "court_dates/new", type: :system do
+RSpec.describe 'court_dates/new', type: :system do
   let(:now) { Date.new(2021, 1, 2) }
   let(:casa_org) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: casa_org) }
@@ -13,47 +13,45 @@ RSpec.describe "court_dates/new", type: :system do
   let(:text) { Faker::Lorem.paragraph(sentence_count: 2) }
 
   before do
-    travel_to now
     sign_in admin
     visit casa_case_path(casa_case)
-    click_link("Add a court date")
+    click_link('Add a court date')
   end
 
-  context "when all fields are filled" do
-    it "is successful", :js do
+  it 'is successful', :js do
+    travel_to now do
       expect(page).to have_content(casa_case.case_number)
 
-      fill_in "court_date_date", with: now
-      fill_in "court_date_court_report_due_date", with: now
-      select judge.name, from: "Judge"
-      select hearing_type.name, from: "Hearing type"
+      fill_in 'court_date_date', with: now
+      fill_in 'court_date_court_report_due_date', with: now
+      select judge.name, from: 'Judge'
+      select hearing_type.name, from: 'Hearing type'
 
-      click_on "Add a court order"
-      text_area = first(:css, "textarea").native
-      text_area.send_keys(text)
-      page.find("select.implementation-status").find(:option, text: "Partially implemented").select_option
+      click_on 'Add a court order'
+      find('textarea').set(text)
+      page.find('select.implementation-status').find(:option, text: 'Partially implemented').select_option
 
-      within ".top-page-actions" do
-        click_on "Create"
+      within '.top-page-actions' do
+        click_on 'Create'
       end
 
-      expect(page).to have_content("Court date was successfully created.")
+      expect(page).to have_content('Court date was successfully created.')
       expect(page).to have_content(casa_case.case_number)
       expect(page).to have_content("Court Report Due Date:\nJanuary 2, 2021")
       expect(page).to have_content(judge.name)
       expect(page).to have_content(hearing_type.name)
       expect(page).to have_content(text)
-      expect(page).to have_content("Partially implemented")
+      expect(page).to have_content('Partially implemented')
     end
   end
 
-  context "without changing default court date" do
-    it "does create a new court_date" do
-      within ".top-page-actions" do
-        click_on "Create"
+  context 'without changing default court date' do
+    it 'does create a new court_date' do
+      within '.top-page-actions' do
+        click_on 'Create'
       end
 
-      expect(page).to have_content("Court date was successfully created.")
+      expect(page).to have_content('Court date was successfully created.')
     end
   end
 end

--- a/spec/system/court_dates/view_spec.rb
+++ b/spec/system/court_dates/view_spec.rb
@@ -1,38 +1,37 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "court_dates/edit", type: :system do
+RSpec.describe 'court_dates/edit', type: :system do
   let(:organization) { create(:casa_org) }
 
   let(:now) { Date.new(2021, 1, 1) }
-  let(:displayed_date_format) { "%B %-d, %Y" }
-  let(:casa_case_number) { "CASA-CASE-NUMBER" }
+  let(:displayed_date_format) { '%B %-d, %Y' }
+  let(:casa_case_number) { 'CASA-CASE-NUMBER' }
   let!(:casa_case) { create(:casa_case, casa_org: organization, case_number: casa_case_number) }
   let(:court_date_as_date_object) { now + 1.week }
   let(:court_report_due_date) { now + 2.weeks }
-  let!(:court_date) { create(:court_date, casa_case: casa_case, court_report_due_date: court_report_due_date, date: court_date_as_date_object) }
+  let!(:court_date) do
+    create(:court_date, casa_case: casa_case, court_report_due_date: court_report_due_date,
+                        date: court_date_as_date_object)
+  end
 
   before do
     travel_to now
   end
 
-  shared_examples "a user able to view court date" do |user_type|
+  shared_examples 'a user able to view court date' do |user_type|
     let(:user) { create(user_type, casa_org: organization) }
 
-    it "can visit the court order page" do
-      if user_type === :volunteer
-        user.casa_cases << casa_case
-      end
+    it 'can visit the court order page' do
+      user.casa_cases << casa_case if user_type === :volunteer
 
       sign_in user
       visit casa_case_court_date_path(casa_case, court_date)
 
-      expect(page).not_to have_text "Sorry, you are not authorized to perform this action."
+      expect(page).not_to have_text 'Sorry, you are not authorized to perform this action.'
     end
 
-    it "displays all information associated with the court date correctly" do
-      if user_type === :volunteer
-        user.casa_cases << casa_case
-      end
+    it 'displays all information associated with the court date correctly' do
+      user.casa_cases << casa_case if user_type === :volunteer
 
       sign_in user
       visit casa_case_court_date_path(casa_case, court_date)
@@ -42,11 +41,11 @@ RSpec.describe "court_dates/edit", type: :system do
       expect(page).to have_text casa_case_number
 
       court_date_court_orders = find(:xpath, "//h6[text()='Court Orders:']/following-sibling::p[1]")
-      expect(court_date_court_orders).to have_text("There are no court orders associated with this court date.")
+      expect(court_date_court_orders).to have_text('There are no court orders associated with this court date.')
       court_date_hearing_type = find(:xpath, "//dt[h6[text()='Hearing Type:']]/following-sibling::dd[1]")
-      expect(court_date_hearing_type).to have_text("None")
+      expect(court_date_hearing_type).to have_text('None')
       court_date_judge = find(:xpath, "//dt[h6[text()='Judge:']]/following-sibling::dd[1]")
-      expect(court_date_judge).to have_text("None")
+      expect(court_date_judge).to have_text('None')
 
       court_order = create(:case_court_order, casa_case: casa_case)
       hearing_type = create(:hearing_type)
@@ -64,40 +63,40 @@ RSpec.describe "court_dates/edit", type: :system do
     end
   end
 
-  context "as a user from an organization not containing the court date" do
+  context 'as a user from an organization not containing the court date' do
     let(:other_organization) { create(:casa_org) }
 
-    xit "does not allow the user to view the court date" do
-      # TODO the app or browser can't gracefully handle the URL
+    xit 'does not allow the user to view the court date' do
+      # TODO: the app or browser can't gracefully handle the URL
       sign_in create(:casa_admin, casa_org: other_organization)
       visit casa_case_court_date_path(casa_case, court_date)
 
-      expect(page).to have_text "Sorry, you are not authorized to perform this action."
+      expect(page).to have_text 'Sorry, you are not authorized to perform this action.'
     end
   end
 
-  context "as a user under the same org as the court date" do
-    context "as a volunteer not assigned to the case associated with the court date" do
+  context 'as a user under the same org as the court date' do
+    context 'as a volunteer not assigned to the case associated with the court date' do
       let(:volunteer_not_assigned_to_case) { create(:volunteer, casa_org: organization) }
 
-      it "does not allow the user to view the court date" do
+      it 'does not allow the user to view the court date' do
         sign_in volunteer_not_assigned_to_case
         visit casa_case_court_date_path(casa_case, court_date)
 
-        expect(page).to have_text "Sorry, you are not authorized to perform this action."
+        expect(page).to have_text 'Sorry, you are not authorized to perform this action.'
       end
     end
 
-    context "as a volunteer assigned to the case associated with the court date" do
-      it_should_behave_like "a user able to view court date", :volunteer
+    context 'as a volunteer assigned to the case associated with the court date' do
+      it_behaves_like 'a user able to view court date', :volunteer
     end
 
-    context "as a supervisor belonging to the same org as the case associated with the court date" do
-      it_should_behave_like "a user able to view court date", :supervisor
+    context 'as a supervisor belonging to the same org as the case associated with the court date' do
+      it_behaves_like 'a user able to view court date', :supervisor
     end
 
-    context "as an admin belonging to the same org as the case associated with the court date" do
-      it_should_behave_like "a user able to view court date", :casa_admin
+    context 'as an admin belonging to the same org as the case associated with the court date' do
+      it_behaves_like 'a user able to view court date', :casa_admin
     end
   end
 end

--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -1,86 +1,90 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "users/passwords/new", type: :system do
+RSpec.describe 'users/passwords/new', type: :system do
   before do
     visit new_user_session_path
-    click_on "Forgot your password?"
+    click_on 'Forgot your password?'
   end
 
-  describe "reset password page" do
-    let!(:user) { create(:user, email: "glados@aperture.labs", phone_number: "+16578900012") }
+  describe 'reset password page' do
+    let!(:user) { create(:user, email: 'glados@aperture.labs', phone_number: '+16578900012') }
 
-    it "displays error messages for non-existent user" do
-      fill_in "Email", with: "tangerine@forward.com"
-      fill_in "Phone number", with: user.phone_number
+    it 'displays error messages for non-existent user' do
+      fill_in 'Email', with: 'tangerine@forward.com'
+      fill_in 'Phone number', with: user.phone_number
 
-      click_on "Send me reset password instructions"
-      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
+      click_on 'Send me reset password instructions'
+      expect(page).to have_content 'If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.'
     end
 
-    it "displays phone number error messages for incorrect formatting" do
-      fill_in "Email", with: user.email
-      fill_in "Phone number", with: "2134567eee"
+    it 'displays phone number error messages for incorrect formatting' do
+      fill_in 'Email', with: user.email
+      fill_in 'Phone number', with: '2134567eee'
 
-      click_on "Send me reset password instructions"
-      expect(page).to have_content "1 error prohibited this User from being saved:"
-      expect(page).to have_text("Phone number must be 10 digits or 12 digits including country code (+1)")
+      click_on 'Send me reset password instructions'
+      expect(page).to have_content '1 error prohibited this User from being saved:'
+      expect(page).to have_text('Phone number must be 10 digits or 12 digits including country code (+1)')
     end
 
-    it "displays error if user tries to submit empty form" do
-      click_on "Send me reset password instructions"
-      expect(page).to have_text("Please enter at least one field.")
+    it 'displays error if user tries to submit empty form' do
+      click_on 'Send me reset password instructions'
+      expect(page).to have_text('Please enter at least one field.')
     end
 
-    it "redirects to sign up page for email" do
-      fill_in "Email", with: user.email
+    it 'redirects to sign up page for email' do
+      fill_in 'Email', with: user.email
 
-      click_on "Send me reset password instructions"
-      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
+      click_on 'Send me reset password instructions'
+      expect(page).to have_content 'If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.'
     end
   end
 
-  describe "reset password email" do
-    let!(:user) { create(:user, type: "Volunteer", email: "glados@aperture.labs") }
+  describe 'reset password email' do
+    let!(:user) { create(:user, type: 'Volunteer', email: 'glados@aperture.labs') }
 
-    it "sends user email" do
-      fill_in "Email", with: user.email
+    it 'sends user email' do
+      fill_in 'Email', with: user.email
 
-      expect { click_on "Send me reset password instructions" }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect do
+        click_on 'Send me reset password instructions'
+        expect(page).to have_content 'If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes.'
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
       expect(ActionMailer::Base.deliveries.last.to_addresses.map(&:address)).to include user.email
     end
 
-    it "has reset password url with token" do
-      fill_in "Email", with: user.email
-      click_on "Send me reset password instructions"
+    it 'has reset password url with token' do
+      fill_in 'Email', with: user.email
+      click_on 'Send me reset password instructions'
 
-      expect(reset_password_link(user.email)).to match(/http:\/\/localhost:3000\/users\/password\/edit\?reset_password_token=.*/)
+      expect(reset_password_link(user.email)).to match(%r{http://localhost:3000/users/password/edit\?reset_password_token=.*})
     end
 
     it "url token matches user's encrypted token" do
-      fill_in "Email", with: user.email
-      click_on "Send me reset password instructions"
+      fill_in 'Email', with: user.email
+      click_on 'Send me reset password instructions'
 
-      token = reset_password_link(user.email).gsub("http://localhost:3000/users/password/edit?reset_password_token=", "")
+      token = reset_password_link(user.email).gsub('http://localhost:3000/users/password/edit?reset_password_token=',
+                                                   '')
       encrypted_token = Devise.token_generator.digest(User, :reset_password_token, token)
       expect(User.find_by(reset_password_token: encrypted_token)).not_to be_nil
     end
 
-    it "user can update password" do
-      fill_in "Email", with: user.email
-      click_on "Send me reset password instructions"
+    it 'user can update password' do
+      fill_in 'Email', with: user.email
+      click_on 'Send me reset password instructions'
 
       visit reset_password_link(user.email)
-      fill_in "New password", with: "new password"
-      fill_in "Confirm new password", with: "new password"
-      click_on "Change my password"
+      fill_in 'New password', with: 'new password'
+      fill_in 'Confirm new password', with: 'new password'
+      click_on 'Change my password'
 
-      expect(page).to have_text("Your password has been changed successfully.")
-      fill_in "Email", with: user.email
-      fill_in "Password", with: "new password"
-      click_on "Log In"
+      expect(page).to have_text('Your password has been changed successfully.')
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: 'new password'
+      click_on 'Log In'
 
       expect(page).to have_text(user.display_name)
-      expect(page).not_to have_text("Sign in")
+      expect(page).not_to have_text('Sign in')
     end
   end
 end

--- a/spec/system/placements/destroy_spec.rb
+++ b/spec/system/placements/destroy_spec.rb
@@ -1,34 +1,34 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "placements/destroy", type: :system do
+RSpec.describe 'placements/destroy', type: :system do
   let(:now) { Date.new(2025, 1, 2) }
   let(:casa_org) { create(:casa_org, :with_placement_types) }
   let(:admin) { create(:casa_admin, casa_org:) }
-  let(:casa_case) { create(:casa_case, casa_org:, case_number: "123") }
-  let(:placement_type) { create(:placement_type, name: "Reunification", casa_org:) }
-  let(:placement) { create(:placement, placement_started_at: "2024-08-15 20:40:44 UTC", casa_case:, placement_type:) }
+  let(:casa_case) { create(:casa_case, casa_org:, case_number: '123') }
+  let(:placement_type) { create(:placement_type, name: 'Reunification', casa_org:) }
+  let(:placement) { create(:placement, placement_started_at: '2024-08-15 20:40:44 UTC', casa_case:, placement_type:) }
 
   before do
     travel_to now
     sign_in admin
     visit casa_case_placements_path(casa_case, placement)
-    click_on "Delete"
+    click_on 'Delete'
   end
 
-  it "does not delete on modal close" do
-    expect(page).to have_text("Delete Placement?")
-    click_on "Close"
+  it 'does not delete on modal close' do
+    expect(page).to have_text('Delete Placement?')
+    click_on 'Close'
 
-    expect(page).to have_text("Reunification")
-    expect(page).to have_text("August 15, 2024 - Present")
+    expect(page).to have_text('Reunification')
+    expect(page).to have_text('August 15, 2024 - Present')
   end
 
-  it "deletes placement" do
-    expect(page).to have_text("Delete Placement?")
-    click_on "Confirm"
+  it 'deletes placement' do
+    expect(page).to have_text('Delete Placement?')
+    click_on 'Confirm'
 
-    expect(page).to have_text("Placement was successfully deleted.")
-    expect(page).not_to have_text("Reunification")
-    expect(page).not_to have_text("August 15, 2024 - Present")
+    expect(page).to have_text('Placement was successfully deleted.')
+    expect(page).not_to have_text('Reunification')
+    expect(page).not_to have_text('August 15, 2024 - Present')
   end
 end

--- a/spec/system/placements/edit_spec.rb
+++ b/spec/system/placements/edit_spec.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "placements/edit", type: :system do
+RSpec.describe 'placements/edit', type: :system do
   let(:now) { Date.new(2025, 1, 2) }
   let(:casa_org) { create(:casa_org, :with_placement_types) }
   let(:admin) { create(:casa_admin, casa_org:) }
-  let(:casa_case) { create(:casa_case, casa_org:, case_number: "123") }
-  let(:placement_type) { create(:placement_type, name: "Reunification", casa_org:) }
-  let(:placement) { create(:placement, placement_started_at: "2024-08-15 20:40:44 UTC", casa_case:, placement_type:) }
+  let(:casa_case) { create(:casa_case, casa_org:, case_number: '123') }
+  let(:placement_type) { create(:placement_type, name: 'Reunification', casa_org:) }
+  let(:placement) { create(:placement, placement_started_at: '2024-08-15 20:40:44 UTC', casa_case:, placement_type:) }
 
   before do
     travel_to now
     sign_in admin
     visit casa_case_placement_path(casa_case, placement)
-    click_link("Edit")
+    click_link('Edit')
   end
 
-  it "updates placement with valid form data", :js do
-    expect(page).to have_content("123")
+  it 'updates placement with valid form data', :js do
+    expect(page).to have_content('123')
 
-    fill_in "Placement Started At", with: now - 5.years
-    select "Kinship", from: "Placement Type"
+    fill_in 'Placement Started At', with: now - 5.years
+    select 'Kinship', from: 'Placement Type'
 
-    click_on "Update"
+    click_on 'Update'
 
-    expect(page).to have_content("Placement was successfully updated.")
-    expect(page).to have_content("123")
-    expect(page).to have_content("January 2, 2020")
-    expect(page).to have_content("Kinship")
+    expect(page).to have_content('Placement was successfully updated.')
+    expect(page).to have_content('123')
+    expect(page).to have_content('January 2, 2020')
+    expect(page).to have_content('Kinship')
   end
 
-  it "rejects placement update with invalid form data" do
-    fill_in "Placement Started At", with: 1000.years.ago
-    click_on "Update"
+  it 'rejects placement update with invalid form data' do
+    fill_in 'Placement Started At', with: 1000.years.ago
+    click_on 'Update'
 
     expect(page).to have_content("1 error prohibited this Placement from being saved:\nPlacement started at cannot be prior to 1/1/1989.")
   end

--- a/spec/system/placements/index_spec.rb
+++ b/spec/system/placements/index_spec.rb
@@ -1,18 +1,19 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "placements", type: :system do
+RSpec.describe 'placements', type: :system do
   let(:now) { Date.new(2025, 1, 2) }
   let(:casa_org) { create(:casa_org, :with_placement_types) }
   let(:admin) { create(:casa_admin, casa_org:) }
-  let(:casa_case) { create(:casa_case, casa_org:, case_number: "123") }
-  let(:placement_current) { create(:placement_type, name: "Reunification", casa_org:) }
-  let(:placement_prev) { create(:placement_type, name: "Kinship", casa_org:) }
-  let(:placement_first) { create(:placement_type, name: "Adoption", casa_org:) }
+  let(:casa_case) { create(:casa_case, casa_org:, case_number: '123') }
+  let(:placement_current) { create(:placement_type, name: 'Reunification', casa_org:) }
+  let(:placement_prev) { create(:placement_type, name: 'Kinship', casa_org:) }
+  let(:placement_first) { create(:placement_type, name: 'Adoption', casa_org:) }
   let(:placements) do
     [
-      create(:placement, placement_started_at: "2024-08-15 20:40:44 UTC", casa_case:, placement_type: placement_current),
-      create(:placement, placement_started_at: "2023-06-02 00:00:00 UTC", casa_case:, placement_type: placement_prev),
-      create(:placement, placement_started_at: "2021-12-25 10:10:10 UTC", casa_case:, placement_type: placement_first)
+      create(:placement, placement_started_at: '2024-08-15 20:40:44 UTC', casa_case:,
+                         placement_type: placement_current),
+      create(:placement, placement_started_at: '2023-06-02 00:00:00 UTC', casa_case:, placement_type: placement_prev),
+      create(:placement, placement_started_at: '2021-12-25 10:10:10 UTC', casa_case:, placement_type: placement_first)
     ]
   end
 
@@ -22,12 +23,12 @@ RSpec.describe "placements", type: :system do
     visit casa_case_placements_path(casa_case, placements)
   end
 
-  it "displays all placements for org" do
-    expect(page).to have_text("Reunification")
-    expect(page).to have_text("August 15, 2024 - Present")
-    expect(page).to have_text("Kinship")
-    expect(page).to have_text("June 2, 2023 - August 15, 2024")
-    expect(page).to have_text("Adoption")
-    expect(page).to have_text("December 25, 2021 - June 2, 2023")
+  it 'displays all placements for org' do
+    expect(page).to have_text('Reunification')
+    expect(page).to have_text('August 15, 2024 - Present')
+    expect(page).to have_text('Kinship')
+    expect(page).to have_text('June 2, 2023 - August 15, 2024')
+    expect(page).to have_text('Adoption')
+    expect(page).to have_text('December 25, 2021 - June 2, 2023')
   end
 end

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe "supervisors/edit", type: :system do
         fill_in "supervisor_date_of_birth", with: "2003/05/06"
 
         click_on "Submit"
+        expect(page).to have_text "Supervisor was successfully updated."
         @supervisor.reload
       end
 

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -1,149 +1,149 @@
-require "rails_helper"
+require 'rails_helper'
 
-RSpec.describe "users/edit", type: :system do
-  context "volunteer user" do
-    it "displays password errors messages when user is unable to set a password with incorrect current password" do
+RSpec.describe 'users/edit', type: :system do
+  context 'volunteer user' do
+    it 'displays password errors messages when user is unable to set a password with incorrect current password' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345"
-      fill_in "New Password", with: "123456789"
-      fill_in "New Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'New Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
-      expect(page).to have_content "1 error prohibited this password change from being saved:"
-      expect(page).to have_text("Current password is incorrect")
+      click_on 'Update Password'
+      expect(page).to have_content '1 error prohibited this password change from being saved:'
+      expect(page).to have_text('Current password is incorrect')
     end
 
-    it "displays password errors messages when user is unable to set a password" do
+    it 'displays password errors messages when user is unable to set a password' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123"
-      fill_in "New Password Confirmation", with: "1234"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123'
+      fill_in 'New Password Confirmation', with: '1234'
 
-      click_on "Update Password"
-      expect(page).to have_content "2 errors prohibited this password change from being saved:"
+      click_on 'Update Password'
+      expect(page).to have_content '2 errors prohibited this password change from being saved:'
       expect(page).to have_text("Password confirmation doesn't match Password")
       expect(page).to have_text("Password is too short (minimum is #{User.password_length.min} characters)")
     end
 
-    it "displays sms notification events for the volunteer user" do
+    it 'displays sms notification events for the volunteer user' do
       organization = create(:casa_org, twilio_enabled: true)
       volunteer = create(:volunteer, casa_org: organization)
 
       SmsNotificationEvent.delete_all
-      SmsNotificationEvent.new(name: "sms_event_test_volunteer", user_type: Volunteer).save
-      SmsNotificationEvent.new(name: "sms_event_test_supervisor", user_type: Supervisor).save
-      SmsNotificationEvent.new(name: "sms_event_test_casa_admin", user_type: CasaAdmin).save
+      SmsNotificationEvent.new(name: 'sms_event_test_volunteer', user_type: Volunteer).save
+      SmsNotificationEvent.new(name: 'sms_event_test_supervisor', user_type: Supervisor).save
+      SmsNotificationEvent.new(name: 'sms_event_test_casa_admin', user_type: CasaAdmin).save
 
       sign_in volunteer
       visit edit_users_path
 
-      expect(page).to have_content "sms_event_test_volunteer"
-      expect(page).not_to have_content "sms_event_test_supervisor"
-      expect(page).not_to have_content "sms_event_test_casa_admin"
+      expect(page).to have_content 'sms_event_test_volunteer'
+      expect(page).not_to have_content 'sms_event_test_supervisor'
+      expect(page).not_to have_content 'sms_event_test_casa_admin'
     end
 
-    it "notifies a user when they update their password" do
+    it 'notifies a user when they update their password' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123456789"
-      fill_in "New Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'New Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
+      click_on 'Update Password'
 
-      expect(page).to have_text("Password was successfully updated.")
+      expect(page).to have_text('Password was successfully updated.')
     end
 
-    it "notifies password changed by email", :aggregate_failures do
+    it 'notifies password changed by email', :aggregate_failures do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123456789"
-      fill_in "Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
+      click_on 'Update Password'
 
-      page.has_content?("Password was successfully updated.")
+      expect(page).to have_content('Password was successfully updated.')
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Your CASA password has been changed.")
+        .to match('Your CASA password has been changed.')
     end
 
-    it "is able to send a confirmation email when Volunteer updates their email" do
+    it 'is able to send a confirmation email when Volunteer updates their email' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Email"
-      expect(page).to have_field("New Email", disabled: false)
+      click_on 'Change Email'
+      expect(page).to have_field('New Email', disabled: false)
 
-      fill_in "current_password_email", with: "12345678"
+      fill_in 'current_password_email', with: '12345678'
 
-      fill_in "New Email", with: "new_volunteer@example.com"
-      click_on "Update Email"
+      fill_in 'New Email', with: 'new_volunteer@example.com'
+      click_on 'Update Email'
 
-      expect(page).to have_content "Click the link in your new email to finalize the email transfer"
+      expect(page).to have_content 'Click the link in your new email to finalize the email transfer'
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to have_text("Click here to confirm your email")
+        .to have_text('Click here to confirm your email')
     end
 
-    it "displays email errors messages when user is unable to set a email with incorrect current password" do
+    it 'displays email errors messages when user is unable to set a email with incorrect current password' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      click_on "Change Email"
+      click_on 'Change Email'
 
-      fill_in "current_password_email", with: "12345"
-      fill_in "New Email", with: "new_volunteer@example.com"
+      fill_in 'current_password_email', with: '12345'
+      fill_in 'New Email', with: 'new_volunteer@example.com'
 
-      click_on "Update Email"
-      expect(page).to have_content "1 error prohibited this Volunteer from being saved:"
-      expect(page).to have_text("Current password is incorrect")
+      click_on 'Update Email'
+      expect(page).to have_content '1 error prohibited this Volunteer from being saved:'
+      expect(page).to have_text('Current password is incorrect')
     end
 
-    it "displays current sign in date" do
+    it 'displays current sign in date' do
       organization = create(:casa_org)
       volunteer = create(
         :volunteer,
         casa_org: organization,
-        last_sign_in_at: "2020-01-01 00:00:00",
-        current_sign_in_at: "2020-01-02 00:00:00"
+        last_sign_in_at: '2020-01-01 00:00:00',
+        current_sign_in_at: '2020-01-02 00:00:00'
       )
 
       sign_in volunteer
@@ -155,417 +155,419 @@ RSpec.describe "users/edit", type: :system do
       expect(page).not_to have_text("Last logged in #{formatted_last_sign_in_at}")
     end
 
-    it "displays Volunteer error message if no communication preference is selected" do
+    it 'displays Volunteer error message if no communication preference is selected' do
       organization = create(:casa_org, twilio_enabled: true)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Volunteer from being saved:"
-      expect(page).to have_text("At least one communication preference must be selected.")
+      uncheck 'user_receive_email_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Volunteer from being saved:'
+      expect(page).to have_text('At least one communication preference must be selected.')
     end
 
-    it "displays Volunteer error message if SMS communication preference is selected without adding a valid phone number" do
+    it 'displays Volunteer error message if SMS communication preference is selected without adding a valid phone number' do
       organization = create(:casa_org, twilio_enabled: true)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      check "user_receive_sms_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Volunteer from being saved:"
-      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
+      uncheck 'user_receive_email_notifications'
+      check 'user_receive_sms_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Volunteer from being saved:'
+      expect(page).to have_text('Must add a valid phone number to receive SMS notifications.')
     end
 
-    it "displays notification events selection as enabled if sms notification preference is selected" do
+    it 'displays notification events selection as enabled if sms notification preference is selected' do
       organization = create(:casa_org, twilio_enabled: true)
       volunteer = create(:volunteer, casa_org: organization)
 
       SmsNotificationEvent.delete_all
-      SmsNotificationEvent.new(name: "sms_event_test_volunteer", user_type: Volunteer).save
-      SmsNotificationEvent.new(name: "sms_event_test_supervisor", user_type: Supervisor).save
-      SmsNotificationEvent.new(name: "sms_event_test_casa_admin", user_type: CasaAdmin).save
+      SmsNotificationEvent.new(name: 'sms_event_test_volunteer', user_type: Volunteer).save
+      SmsNotificationEvent.new(name: 'sms_event_test_supervisor', user_type: Supervisor).save
+      SmsNotificationEvent.new(name: 'sms_event_test_casa_admin', user_type: CasaAdmin).save
 
       sign_in volunteer
       visit edit_users_path
 
-      check "user_receive_sms_notifications"
-      expect(page).to have_field("toggle-sms-notification-event", type: "checkbox", disabled: false)
+      check 'user_receive_sms_notifications'
+      expect(page).to have_field('toggle-sms-notification-event', type: 'checkbox', disabled: false)
     end
 
-    it "displays notification events selection as disabled if sms notification preference is not selected", :js do
+    it 'displays notification events selection as disabled if sms notification preference is not selected', :js do
       organization = create(:casa_org, twilio_enabled: true)
       volunteer = create(:volunteer, casa_org: organization)
 
       SmsNotificationEvent.delete_all
-      SmsNotificationEvent.new(name: "sms_event_test_volunteer", user_type: Volunteer).save
-      SmsNotificationEvent.new(name: "sms_event_test_supervisor", user_type: Supervisor).save
-      SmsNotificationEvent.new(name: "sms_event_test_casa_admin", user_type: CasaAdmin).save
+      SmsNotificationEvent.new(name: 'sms_event_test_volunteer', user_type: Volunteer).save
+      SmsNotificationEvent.new(name: 'sms_event_test_supervisor', user_type: Supervisor).save
+      SmsNotificationEvent.new(name: 'sms_event_test_casa_admin', user_type: CasaAdmin).save
 
       sign_in volunteer
       visit edit_users_path
 
-      uncheck "user_receive_sms_notifications"
-      expect(page).to have_field("toggle-sms-notification-event", type: "checkbox", disabled: true)
+      uncheck 'user_receive_sms_notifications'
+      expect(page).to have_field('toggle-sms-notification-event', type: 'checkbox', disabled: true)
     end
   end
 
   context "when a user's casa organization does not have twilio enabled" do
-    it "disables a users SMS communication checkbox" do
+    it 'disables a users SMS communication checkbox' do
       organization = create(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
 
       sign_in volunteer
       visit edit_users_path
 
-      expect(page).to have_field("Enable Twilio For Text Messaging", type: "checkbox", disabled: true)
+      expect(page).to have_field('Enable Twilio For Text Messaging', type: 'checkbox', disabled: true)
     end
   end
 
-  context "supervisor user" do
-    it "notifies password changed by email", :aggregate_failures do
+  context 'supervisor user' do
+    it 'notifies password changed by email', :aggregate_failures do
       org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123456789"
-      fill_in "Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
+      click_on 'Update Password'
 
-      page.has_content?("Password was successfully updated.")
+      expect(page).to have_content('Password was successfully updated.')
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Your CASA password has been changed.")
+        .to match('Your CASA password has been changed.')
     end
 
-    it "is able to send a confrimation email when supervisor is updating email" do
+    it 'is able to send a confrimation email when supervisor is updating email' do
       org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      click_on "Change Email"
-      expect(page).to have_field("New Email", disabled: false)
+      click_on 'Change Email'
+      expect(page).to have_field('New Email', disabled: false)
 
-      fill_in "current_password_email", with: "12345678"
+      fill_in 'current_password_email', with: '12345678'
 
-      fill_in "New Email", with: "new_supervisor@example.com"
-      click_on "Update Email"
+      fill_in 'New Email', with: 'new_supervisor@example.com'
+      click_on 'Update Email'
 
-      expect(page).to have_content "Click the link in your new email to finalize the email transfer"
+      expect(page).to have_content 'Click the link in your new email to finalize the email transfer'
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Click here to confirm your email")
+        .to match('Click here to confirm your email')
     end
 
-    it "displays email errors messages when user is unable to set a email with incorrect current password" do
+    it 'displays email errors messages when user is unable to set a email with incorrect current password' do
       org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      click_on "Change Email"
+      click_on 'Change Email'
 
-      fill_in "current_password_email", with: "12345"
-      fill_in "New Email", with: "new_supervisor@example"
+      fill_in 'current_password_email', with: '12345'
+      fill_in 'New Email', with: 'new_supervisor@example'
 
-      click_on "Update Email"
-      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
-      expect(page).to have_text("Current password is incorrect")
+      click_on 'Update Email'
+      expect(page).to have_content '1 error prohibited this Supervisor from being saved:'
+      expect(page).to have_text('Current password is incorrect')
     end
 
-    it "displays sms notification events for the supervisor user" do
+    it 'displays sms notification events for the supervisor user' do
       org = create(:casa_org, twilio_enabled: true)
       supervisor = create(:supervisor, casa_org: org)
 
       SmsNotificationEvent.delete_all
-      SmsNotificationEvent.new(name: "sms_event_test_volunteer", user_type: Volunteer).save
-      SmsNotificationEvent.new(name: "sms_event_test_supervisor", user_type: Supervisor).save
-      SmsNotificationEvent.new(name: "sms_event_test_casa_admin", user_type: CasaAdmin).save
+      SmsNotificationEvent.new(name: 'sms_event_test_volunteer', user_type: Volunteer).save
+      SmsNotificationEvent.new(name: 'sms_event_test_supervisor', user_type: Supervisor).save
+      SmsNotificationEvent.new(name: 'sms_event_test_casa_admin', user_type: CasaAdmin).save
 
       sign_in supervisor
       visit edit_users_path
 
-      expect(page).not_to have_content "sms_event_test_volunteer"
-      expect(page).to have_content "sms_event_test_supervisor"
-      expect(page).not_to have_content "sms_event_test_casa_admin"
+      expect(page).not_to have_content 'sms_event_test_volunteer'
+      expect(page).to have_content 'sms_event_test_supervisor'
+      expect(page).not_to have_content 'sms_event_test_casa_admin'
     end
 
-    it "displays Supervisor error message if no communication preference is selected" do
+    it 'displays Supervisor error message if no communication preference is selected' do
       org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
-      expect(page).to have_text("At least one communication preference must be selected.")
+      uncheck 'user_receive_email_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Supervisor from being saved:'
+      expect(page).to have_text('At least one communication preference must be selected.')
     end
 
-    it "displays Supervisor error message if SMS communication preference is selected without adding a valid phone number" do
+    it 'displays Supervisor error message if SMS communication preference is selected without adding a valid phone number' do
       org = create(:casa_org, twilio_enabled: true)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      check "user_receive_sms_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
-      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
+      uncheck 'user_receive_email_notifications'
+      check 'user_receive_sms_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Supervisor from being saved:'
+      expect(page).to have_text('Must add a valid phone number to receive SMS notifications.')
     end
 
-    it "displays Supervisor error message if invalid date of birth" do
+    it 'displays Supervisor error message if invalid date of birth' do
       org = create(:casa_org)
       supervisor = create(:supervisor, casa_org: org)
 
       sign_in supervisor
       visit edit_users_path
 
-      fill_in "Date of birth", with: 8.days.from_now.strftime("%Y/%m/%d")
-      click_on "Update Profile"
-      expect(page).to have_content "1 error prohibited this Supervisor from being saved:"
-      expect(page).to have_text("Date of birth must be in the past.")
+      fill_in 'Date of birth', with: 8.days.from_now.strftime('%Y/%m/%d')
+      click_on 'Update Profile'
+      expect(page).to have_content '1 error prohibited this Supervisor from being saved:'
+      expect(page).to have_text('Date of birth must be in the past.')
     end
   end
 
-  context "when admin" do
-    it "is not able to update the profile without display name as an admin" do
+  context 'when admin' do
+    it 'is not able to update the profile without display name as an admin' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      fill_in "Display name", with: ""
-      click_on "Update Profile"
+      fill_in 'Display name', with: ''
+      click_on 'Update Profile'
       expect(page).to have_text("Display name can't be blank")
     end
 
-    context "shows error for invalid phone number" do
-      it "shows error message for phone number < 12 digits" do
+    context 'shows error for invalid phone number' do
+      it 'shows error message for phone number < 12 digits' do
         org = create(:casa_org)
         admin = create(:casa_admin, casa_org: org)
 
         sign_in admin
         visit edit_users_path
 
-        fill_in "Phone number", with: "+141632489"
-        click_on("Update Profile")
-        expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+        fill_in 'Phone number', with: '+141632489'
+        click_on('Update Profile')
+        expect(page).to have_text 'Phone number must be 10 digits or 12 digits including country code (+1)'
       end
 
-      it "shows error message for phone number > 12 digits" do
+      it 'shows error message for phone number > 12 digits' do
         org = create(:casa_org)
         admin = create(:casa_admin, casa_org: org)
 
         sign_in admin
         visit edit_users_path
 
-        fill_in "Phone number", with: "+141632180923"
-        click_on("Update Profile")
+        fill_in 'Phone number', with: '+141632180923'
+        click_on('Update Profile')
 
-        expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+        expect(page).to have_text 'Phone number must be 10 digits or 12 digits including country code (+1)'
       end
 
-      it "shows error message for bad phone number" do
+      it 'shows error message for bad phone number' do
         org = create(:casa_org)
         admin = create(:casa_admin, casa_org: org)
 
         sign_in admin
         visit edit_users_path
 
-        fill_in("Phone number", with: "+141632u809o")
-        click_on("Update Profile")
+        fill_in('Phone number', with: '+141632u809o')
+        click_on('Update Profile')
 
-        expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+        expect(page).to have_text 'Phone number must be 10 digits or 12 digits including country code (+1)'
       end
 
-      it "shows error message for phone number without country code" do
+      it 'shows error message for phone number without country code' do
         org = create(:casa_org)
         admin = create(:casa_admin, casa_org: org)
 
         sign_in admin
         visit edit_users_path
 
-        fill_in("Phone number", with: "+24163218092")
-        click_on("Update Profile")
-        expect(page).to have_text "Phone number must be 10 digits or 12 digits including country code (+1)"
+        fill_in('Phone number', with: '+24163218092')
+        click_on('Update Profile')
+        expect(page).to have_text 'Phone number must be 10 digits or 12 digits including country code (+1)'
       end
     end
 
-    it "is able to send a confirmation email when Casa Admin updates their email" do
+    it 'is able to send a confirmation email when Casa Admin updates their email' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      click_on "Change Email"
-      expect(page).to have_field("New Email", disabled: false)
+      click_on 'Change Email'
+      expect(page).to have_field('New Email', disabled: false)
 
-      fill_in "current_password_email", with: "12345678"
+      fill_in 'current_password_email', with: '12345678'
 
-      fill_in "New Email", with: "new_admin@example.com"
-      click_on "Update Email"
+      fill_in 'New Email', with: 'new_admin@example.com'
+      click_on 'Update Email'
+
+      expect(page).to have_content 'Click the link in your new email to finalize the email transfer'
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Click here to confirm your email")
+        .to match('Click here to confirm your email')
     end
 
-    it "displays email errors messages when user is unable to set a email with incorrect current password" do
+    it 'displays email errors messages when user is unable to set a email with incorrect current password' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      click_on "Change Email"
+      click_on 'Change Email'
 
-      fill_in "current_password_email", with: "12345"
-      fill_in "New Email", with: "new_admin@example.com"
+      fill_in 'current_password_email', with: '12345'
+      fill_in 'New Email', with: 'new_admin@example.com'
 
-      click_on "Update Email"
-      expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
-      expect(page).to have_text("Current password is incorrect")
+      click_on 'Update Email'
+      expect(page).to have_content '1 error prohibited this Casa admin from being saved:'
+      expect(page).to have_text('Current password is incorrect')
     end
 
-    it "displays password errors messages when admin is unable to set a password" do
+    it 'displays password errors messages when admin is unable to set a password' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123"
-      fill_in "Password Confirmation", with: "1234"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123'
+      fill_in 'Password Confirmation', with: '1234'
 
-      click_on "Update Password"
-      expect(page).to have_content "2 errors prohibited this password change from being saved:"
+      click_on 'Update Password'
+      expect(page).to have_content '2 errors prohibited this password change from being saved:'
       expect(page).to have_text("Password confirmation doesn't match Password")
       expect(page).to have_text("Password is too short (minimum is #{User.password_length.min} characters)")
     end
 
-    it "display success message when admin update password" do
+    it 'display success message when admin update password' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123456789"
-      fill_in "Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
+      click_on 'Update Password'
 
-      expect(page).to have_text("Password was successfully updated.")
+      expect(page).to have_text('Password was successfully updated.')
     end
 
-    it "displays sms notification events for the casa admin user" do
+    it 'displays sms notification events for the casa admin user' do
       org = create(:casa_org, twilio_enabled: true)
       admin = create(:casa_admin, casa_org: org)
 
       SmsNotificationEvent.delete_all
-      SmsNotificationEvent.new(name: "sms_event_test_volunteer", user_type: Volunteer).save
-      SmsNotificationEvent.new(name: "sms_event_test_supervisor", user_type: Supervisor).save
-      SmsNotificationEvent.new(name: "sms_event_test_casa_admin", user_type: CasaAdmin).save
+      SmsNotificationEvent.new(name: 'sms_event_test_volunteer', user_type: Volunteer).save
+      SmsNotificationEvent.new(name: 'sms_event_test_supervisor', user_type: Supervisor).save
+      SmsNotificationEvent.new(name: 'sms_event_test_casa_admin', user_type: CasaAdmin).save
 
       sign_in admin
       visit edit_users_path
 
-      expect(page).not_to have_content "sms_event_test_volunteer"
-      expect(page).not_to have_content "sms_event_test_supervisor"
-      expect(page).to have_content "sms_event_test_casa_admin"
+      expect(page).not_to have_content 'sms_event_test_volunteer'
+      expect(page).not_to have_content 'sms_event_test_supervisor'
+      expect(page).to have_content 'sms_event_test_casa_admin'
     end
 
-    it "notifies password changed by email", :aggregate_failures do
+    it 'notifies password changed by email', :aggregate_failures do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      click_on "Change Password"
+      click_on 'Change Password'
 
-      fill_in "Current Password", with: "12345678"
-      fill_in "New Password", with: "123456789"
-      fill_in "Password Confirmation", with: "123456789"
+      fill_in 'Current Password', with: '12345678'
+      fill_in 'New Password', with: '123456789'
+      fill_in 'Password Confirmation', with: '123456789'
 
-      click_on "Update Password"
+      click_on 'Update Password'
 
-      page.has_content?("Password was successfully updated.")
+      expect(page).to have_content('Password was successfully updated.')
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
       expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Your CASA password has been changed.")
+        .to match('Your CASA password has been changed.')
     end
 
-    it "displays admin error message if no communication preference is selected" do
+    it 'displays admin error message if no communication preference is selected' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
-      expect(page).to have_text("At least one communication preference must be selected.")
+      uncheck 'user_receive_email_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Casa admin from being saved:'
+      expect(page).to have_text('At least one communication preference must be selected.')
     end
 
-    it "displays admin error message if SMS communication preference is selected without adding a valid phone number" do
+    it 'displays admin error message if SMS communication preference is selected without adding a valid phone number' do
       org = create(:casa_org, twilio_enabled: true)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      uncheck "user_receive_email_notifications"
-      check "user_receive_sms_notifications"
-      click_on "Save Preferences"
-      expect(page).to have_content "1 error prohibited this Casa admin from being saved:"
-      expect(page).to have_text("Must add a valid phone number to receive SMS notifications.")
+      uncheck 'user_receive_email_notifications'
+      check 'user_receive_sms_notifications'
+      click_on 'Save Preferences'
+      expect(page).to have_content '1 error prohibited this Casa admin from being saved:'
+      expect(page).to have_text('Must add a valid phone number to receive SMS notifications.')
     end
 
-    it "displays admin error message if invalid date of birth" do
+    it 'displays admin error message if invalid date of birth' do
       org = create(:casa_org)
       admin = create(:casa_admin, casa_org: org)
 
       sign_in admin
       visit edit_users_path
 
-      fill_in "Date of birth", with: 8.days.from_now.strftime("%Y/%m/%d")
-      click_on "Update Profile"
-      expect(page).to have_text("Date of birth must be in the past.")
+      fill_in 'Date of birth', with: 8.days.from_now.strftime('%Y/%m/%d')
+      click_on 'Update Profile'
+      expect(page).to have_text('Date of birth must be in the past.')
     end
   end
 end


### PR DESCRIPTION
Still have 1 flaky test working on getting fixed, but figured I'd open a PR to see if I'm on the right track. Started by changing the tests to test the UI changes instead of just DB so that it is blocking, but that lead me down a rabbit hole of flaky tests. Seems to flip flop between /spec/system/supervisors/edit_spec.rb and spec/system/case_contacts/new_spec.rb.

### What github issue is this PR for, if any?
Resolves #6693

### What changed, and _why_?
* Changes database checks to use UI checks first. Some of the database checks I kept in case you still want them in there after the UI checks
* adds `travel_back` where `travel_to` is used without a block without `travel_back` otherwise than can pollute other specs
* Fixes cases where Capybara methods aren't used (which should block until UI loads) to use Capybara methods
* seems like there's a linter that's forcing formatting so `'` instead of `"`, hopefully that doesn't make diff hard to read.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
rspec with some capybara since that is what the specs are already using.

### Screenshots please :)
Just test suite so not much to show other than code
