### PR TITLE
Fix warnings when running the tests locally

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -801,4 +801,4 @@ RUBY VERSION
    ruby 3.3.10p183
 
 BUNDLED WITH
-   2.6.6
+   4.0.6


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves https://github.com/rubyforgood/casa/issues/6726

### What changed, and _why_?

There are a bunch of warnings being generated when running the tests locally:

```
casa % bundle exec rspec
Run options: exclude {:ci_only=>true}

Randomized with seed 6314
......................./opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: already initialized constant Cssbundling::Tasks::LOCK_FILES
/opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: previous definition of LOCK_FILES was here
./opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: already initialized constant Cssbundling::Tasks::LOCK_FILES
/opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: previous definition of LOCK_FILES was here
./opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: already initialized constant Cssbundling::Tasks::LOCK_FILES
/opt/homebrew/lib/ruby/gems/3.3.0/gems/cssbundling-rails-1.4.3/lib/tasks/cssbundling/build.rake:24: warning: previous definition of LOCK_FILES was here
```

After upgrading bundler to the latest version, the warnings get resolved locally. In CI, because they run in parallel it seems, these warnings still get printed out. But this changes keeps local env cleaner and the project up to date wit the latest Bundler version.

Running the tests locally after this update:

```
casa % bundle exec rspec
Run options: exclude {:ci_only=>true}

Randomized with seed 48450

.........................................................................................................................................................
......................................
```