### PR TITLE
Fix: Trim whitespace from email before processing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -120,7 +120,7 @@ class UsersController < ApplicationController
   end
 
   def update_user_email
-    @user.update({email: email_params[:email]})
+    @user.update({email: email_params[:email]&.strip})
     @user.filter_old_emails!(@user.email)
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -258,6 +258,18 @@ RSpec.describe "/users", type: :request do
           expect(ActionMailer::Base.deliveries.last.body.encoded)
             .to match("Click here to confirm your email")
         end
+
+        it "strips whitespace from email" do
+          patch update_email_users_path(user),
+            params: {
+              user: {
+                current_password: "12345678",
+                email: "  newemail@example.com  "
+              }
+            }
+          user.confirm
+          expect(user.email).to eq("newemail@example.com")
+        end
       end
 
       context "when failure" do


### PR DESCRIPTION
Resolves #6689

## Summary
- Added `&.strip` to email parameter in `update_user_email` method to remove leading/trailing whitespace
- Added test case to verify whitespace is stripped from email input

## Problem
When users accidentally include leading or trailing spaces in their email address while updating their profile, the system would attempt to process the email with whitespace intact, resulting in errors.

## Solution
Strip whitespace from the email parameter before processing, similar to standard email input sanitization practices.

## Testing
- Added new test case `strips whitespace from email` in `spec/requests/users_spec.rb`
- All existing tests continue to pass

## How to Test
1. Sign in as a volunteer
2. Go to profile edit page
3. Enter email with leading/trailing spaces: `  test@example.com  `
4. Submit the form
5. Email should be saved as `test@example.com` (without spaces)