### PR TITLE
Race condition check: new volunteers system spec

### DIFF
--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -394,6 +394,21 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
+  describe 'invitation' do
+    it 'delivers an email invite' do
+      volunteer = build(:volunteer, email: "new_volunteer@example.com")
+      volunteer.invite!
+
+      email = ActionMailer::Base.deliveries.last
+
+      expect(email).not_to be_nil
+      expect(email.to).to eq ["new_volunteer@example.com"]
+      expect(email.subject).to eq("CASA Console invitation instructions")
+      expect(email.html_part.body.encoded).to match(/your new Volunteer account/i)
+      expect(Volunteer.find_by(email: "new_volunteer@example.com").invitation_created_at).to be_present
+    end
+  end
+
   describe "#learning_hours_spent_in_one_year" do
     let(:volunteer) { create :volunteer }
     let(:learning_hour_type) { create :learning_hour_type }

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -394,8 +394,8 @@ RSpec.describe Volunteer, type: :model do
     end
   end
 
-  describe 'invitation' do
-    it 'delivers an email invite' do
+  describe "invitation" do
+    it "delivers an email invite" do
       volunteer = build(:volunteer, email: "new_volunteer@example.com")
       volunteer.invite!
 

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe Volunteer, type: :model do
       expect(email.to).to eq ["new_volunteer@example.com"]
       expect(email.subject).to eq("CASA Console invitation instructions")
       expect(email.html_part.body.encoded).to match(/your new Volunteer account/i)
-      expect(Volunteer.find_by(email: "new_volunteer@example.com").invitation_created_at).to be_present
+      expect(volunteer.reload.invitation_created_at).to be_present
     end
   end
 

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "volunteers/new", type: :system do
   context "when supervisor" do
     let(:supervisor) { create(:supervisor) }
 
-    it "lets Supervisor create new volunteer" do
+    it "creates a new volunteer", :js do
       sign_in supervisor
       visit new_volunteer_path
 
@@ -33,9 +33,12 @@ RSpec.describe "volunteers/new", type: :system do
       fill_in "Display name", with: "New Volunteer Display Name 2"
       fill_in "Date of birth", with: Date.new(2000, 1, 2)
 
-      expect do
-        click_on "Create Volunteer"
-      end.to change(User, :count).by(1)
+      click_on "Create Volunteer"
+
+      visit volunteers_path
+      expect(page).to have_text("New Volunteer Display Name 2")
+      expect(page).to have_text("new_volunteer2@example.com")
+      expect(page).to have_text("Active")
     end
   end
 

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "volunteers/new", type: :system do
     end
 
     it "displays learning hour topic when enabled", :js do
-      organization = create(:casa_org, learning_topic_active: true)
+      organization = build(:casa_org, learning_topic_active: true)
       volunteer = create(:volunteer, casa_org: organization)
   
       sign_in volunteer
@@ -41,7 +41,7 @@ RSpec.describe "volunteers/new", type: :system do
     end
 
     it "does not display learning hour topic when disabled", :js do
-      organization = create(:casa_org)
+      organization = build(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
   
       sign_in volunteer

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "volunteers/new", type: :system do
     it "displays learning hour topic when enabled", :js do
       organization = build(:casa_org, learning_topic_active: true)
       volunteer = create(:volunteer, casa_org: organization)
-  
+
       sign_in volunteer
       visit new_learning_hour_path
       expect(page).to have_text("Learning Topic")
@@ -43,7 +43,7 @@ RSpec.describe "volunteers/new", type: :system do
     it "does not display learning hour topic when disabled", :js do
       organization = build(:casa_org)
       volunteer = create(:volunteer, casa_org: organization)
-  
+
       sign_in volunteer
       visit new_learning_hour_path
       expect(page).not_to have_text("Learning Topic")

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -1,27 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "volunteers/new", type: :system do
-  context "when admin" do
-    let(:admin) { create(:casa_admin) }
-
-    it "creates a new volunteer and sends invitation" do
-      sign_in admin
-      visit new_volunteer_path
-
-      fill_in "Email", with: "new_volunteer@example.com"
-      fill_in "Display name", with: "New Volunteer Display Name"
-      fill_in "Date of birth", with: Date.new(2001, 8, 8)
-
-      click_on "Create Volunteer"
-
-      last_email = ActionMailer::Base.deliveries.last
-      expect(last_email.to).to eq ["new_volunteer@example.com"]
-      expect(last_email.subject).to have_text "CASA Console invitation instructions"
-      expect(last_email.html_part.body.encoded).to have_text "your new Volunteer account."
-      expect(Volunteer.find_by(email: "new_volunteer@example.com").invitation_created_at).not_to be_nil
-    end
-  end
-
   context "when supervisor" do
     let(:supervisor) { create(:supervisor) }
 

--- a/spec/system/volunteers/new_spec.rb
+++ b/spec/system/volunteers/new_spec.rb
@@ -43,32 +43,31 @@ RSpec.describe "volunteers/new", type: :system do
   end
 
   context "volunteer user" do
-    let(:volunteer) { create(:volunteer) }
-
-    before { sign_in volunteer }
-
     it "redirects the user with an error message" do
+      volunteer = create(:volunteer)
+      sign_in volunteer
+
       visit new_volunteer_path
 
       expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
     end
-  end
 
-  it "displays learning hour topic for volunteers when enabled", :js do
-    organization = create(:casa_org, learning_topic_active: true)
-    volunteer = create(:volunteer, casa_org: organization)
+    it "displays learning hour topic when enabled", :js do
+      organization = create(:casa_org, learning_topic_active: true)
+      volunteer = create(:volunteer, casa_org: organization)
+  
+      sign_in volunteer
+      visit new_learning_hour_path
+      expect(page).to have_text("Learning Topic")
+    end
 
-    sign_in volunteer
-    visit new_learning_hour_path
-    expect(page).to have_text("Learning Topic")
-  end
-
-  it "learning hour topic hidden when disabled", :js do
-    organization = create(:casa_org)
-    volunteer = create(:volunteer, casa_org: organization)
-
-    sign_in volunteer
-    visit new_learning_hour_path
-    expect(page).not_to have_text("Learning Topic")
+    it "does not display learning hour topic when disabled", :js do
+      organization = create(:casa_org)
+      volunteer = create(:volunteer, casa_org: organization)
+  
+      sign_in volunteer
+      visit new_learning_hour_path
+      expect(page).not_to have_text("Learning Topic")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Related https://github.com/rubyforgood/casa/issues/6698

### What changed, and _why_?

- refactors test checks for what the user sees in the page to avoid hitting the database
- moves email invitation test to a model test. The system test was not checking for anything on the page. This test is better placed at the model level, since it's related to business logic.
- reorganizes volunteer test under the same context
- defaults to building an organization factory instead of creating, which is usually slower

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Everything is a test ⭐ 
