### PR TITLE
fix: require button click to trigger intentional test exception

### DIFF
--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -2,8 +2,12 @@
 
 class ErrorController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_after_action :verify_authorized
 
   def index
+  end
+
+  def create
     raise StandardError.new "This is an intentional test exception"
   end
 end

--- a/app/views/error/index.html.erb
+++ b/app/views/error/index.html.erb
@@ -1,6 +1,7 @@
 <div class="card text-center">
   <div class="card-body">
-    <h1 class="card-title" style="color:red">We're sorry, but something went wrong.</h1>
-    <p class="card-text" style="color:grey">If you are the application owner check the logs for more information.</p>
+    <h1 class="card-title">Intentional Error Test</h1>
+    <p class="card-text" style="color:grey">Click the button below to trigger an intentional test exception.</p>
+    <%= button_to "Trigger Exception", error_path, method: :post, class: "btn btn-danger", data: { turbo: false } %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,6 +241,7 @@ Rails.application.routes.draw do
   end
 
   get "/error", to: "error#index"
+  post "/error", to: "error#create"
 
   namespace :api do
     namespace :v1 do

--- a/spec/requests/error_spec.rb
+++ b/spec/requests/error_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "/error", type: :request do
-  it "raises an error causing an internal server error" do
-    expect {
+  describe "GET /error" do
+    it "renders the error test page" do
       get error_path
-    }.to raise_error(StandardError, /This is an intentional test exception/)
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /error" do
+    it "raises an error causing an internal server error" do
+      expect {
+        post error_path
+      }.to raise_error(StandardError, /This is an intentional test exception/)
+    end
   end
 end


### PR DESCRIPTION
## What changed

Resolves #6749

Previously, visiting `/error` immediately raised a `StandardError`, meaning the error page view never actually rendered. Now the page renders with a button that must be clicked to trigger the exception.

## Changes

- **`ErrorController`**: `index` action now renders the page; new `create` action raises the exception
- **`config/routes.rb`**: Added `POST /error` route for the button action
- **`app/views/error/index.html.erb`**: Updated view with a "Trigger Exception" button
- **`spec/requests/error_spec.rb`**: Updated tests — GET renders successfully, POST raises the exception

## Proof
<img width="1470" height="894" alt="Screenshot 2026-03-07 at 1 31 35 PM" src="https://github.com/user-attachments/assets/dae657c8-0c34-4c27-9461-e32891dd25fc" />
<img width="1470" height="875" alt="Screenshot 2026-03-07 at 1 31 47 PM" src="https://github.com/user-attachments/assets/50cefe3f-98ab-4bd1-9adc-5d9017a75e86" />

