### PR TITLE
Remove race condition from session system tests

### DIFF
--- a/spec/system/sessions/login_spec.rb
+++ b/spec/system/sessions/login_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "User Login", type: :system do
   %w[volunteer supervisor casa_admin].each do |user_type|
     let!(:user) { create(user_type.to_sym) }
-    it "creates a login activity record on successful login" do
+
+    it "shows the user's email after successful login" do
       visit new_user_session_path
       fill_in "Email", with: user.email
       fill_in "Password", with: "12345678"
@@ -12,13 +13,9 @@ RSpec.describe "User Login", type: :system do
       end
 
       expect(page).to have_text user.email
-
-      login_activity = LoginActivity.last
-      expect(login_activity.user).to eq(user)
-      expect(login_activity.success).to be true
     end
 
-    it "creates a login activity record on failed login" do
+    it "shows an error message after failed login" do
       visit new_user_session_path
       fill_in "Email", with: user.email
       fill_in "Password", with: "wrong_password"
@@ -27,10 +24,6 @@ RSpec.describe "User Login", type: :system do
       end
 
       expect(page).to have_content("Invalid Email or password.")
-
-      login_activity = LoginActivity.last
-      expect(login_activity.success).to be false
-      expect(login_activity.failure_reason).to eq("invalid")
     end
   end
 end


### PR DESCRIPTION
## Issue

Closes #6699

## What changed and why

Replaced database-level `LoginActivity` assertions in `spec/system/sessions/login_spec.rb` with page-level assertions. The DB checks (`LoginActivity.last.user`, `.success`, `.failure_reason`) bypass the browser and can race against slow CI servers.

The page already asserts:
- **Successful login:** user's email is visible on the dashboard
- **Failed login:** "Invalid Email or password." error message is shown

These page-level checks are sufficient for system tests. `LoginActivity` recording is handled by the `authtrail` gem via Devise callbacks — not application code that needs system-level verification.

`destroy_spec.rb` was already clean (all page-level assertions).

## How I tested

- `bundle exec rspec spec/system/sessions/` — 22 examples, 0 failures