### PR TITLE
Race Condition Check: spec/system/case_court_reports/index_spec.rb

### DIFF
--- a/spec/support/case_court_report_helpers.rb
+++ b/spec/support/case_court_report_helpers.rb
@@ -21,17 +21,4 @@ module CaseCourtReportHelpers
     # Wait for the dropdown to appear
     expect(page).to have_css(".select2-dropdown", visible: :visible)
   end
-
-  # Polls the database until the casa_case has an ActiveStorage court_report attached.
-  # This is used after clicking 'Generate Report' to wait for the background job to complete.
-  def wait_for_report_attachment(casa_case, timeout: 5)
-    casa_case.reload # Ensure we have the latest record
-
-    Timeout.timeout(timeout) do
-      until casa_case.court_reports.attached?
-        sleep 0.2
-        casa_case.reload
-      end
-    end
-  end
 end

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe "case_court_reports/index", type: :system do
 
     # NOTE: select by option VALUE (stable), stub `window.open` to capture the download URL,
     # wait for the button to re-enable (page-level signal), and assert UI state + opened URL.
-    it "generates and attaches a report on success", :aggregate_failures, :js do # rubocop:disable RSpec/ExampleLength
+    it "generates a report and opens the download link on success", :aggregate_failures, :js do # rubocop:disable RSpec/ExampleLength
       transition_case = casa_cases.detect(&:in_transition_age?)
 
       # Stub window.open so we can capture the download URL in the browser

--- a/spec/system/case_court_reports/index_spec.rb
+++ b/spec/system/case_court_reports/index_spec.rb
@@ -148,12 +148,9 @@ RSpec.describe "case_court_reports/index", type: :system do
     end
 
     # NOTE: select by option VALUE (stable), stub `window.open` to capture the download URL,
-    # wait for the ActiveStorage attachment, and assert button state + opened URL.
+    # wait for the button to re-enable (page-level signal), and assert UI state + opened URL.
     it "generates and attaches a report on success", :aggregate_failures, :js do # rubocop:disable RSpec/ExampleLength
       transition_case = casa_cases.detect(&:in_transition_age?)
-
-      # Precondition: no report attached
-      expect(transition_case.court_reports.attached?).to be false
 
       # Stub window.open so we can capture the download URL in the browser
       page.execute_script(<<~JS)
@@ -171,13 +168,12 @@ RSpec.describe "case_court_reports/index", type: :system do
       # Button should be disabled while processing
       expect(page).to have_selector("#btnGenerateReport[disabled]")
 
-      # Wait for the controller to attach the file (allow longer timeout on CI)
-      wait_for_report_attachment(transition_case, timeout: 10)
-      transition_case.reload
+      # Wait for the button to re-enable (report generated successfully)
+      expect(page).not_to have_selector("#btnGenerateReport[disabled]", wait: 10)
 
-      # Postcondition: report attached and button re-enabled
-      expect(transition_case.court_reports.attached?).to be true
-      expect(page).not_to have_selector("#btnGenerateReport[disabled]", visible: :all)
+      # Verify the UI reflects a successful generation
+      expect(page).to have_selector("#btnGenerateReport .lni-download", visible: :visible)
+      expect(page).to have_selector("#spinner", visible: :hidden)
 
       # Verify the browser attempted to open the generated .docx link
       opened_url = page.evaluate_script("window.__last_opened_url")


### PR DESCRIPTION
Resolves #6700

## Summary

- **spec/system/case_court_reports/index_spec.rb**: Replaced 4 database-level assertions (`attached?`, `reload`, `wait_for_report_attachment`) with page-based Capybara checks in the "generates and attaches a report on success" test. The button re-enabling, download icon visibility, and spinner state serve as reliable page-level signals that the report was generated successfully.
- **spec/support/case_court_report_helpers.rb**: Removed the `wait_for_report_attachment` helper method (only used in this one test). The two remaining helpers (`open_court_report_modal`, `open_case_select2_dropdown`) are unchanged.

All other tests in the file already used `expect(page)` exclusively — no changes needed.

## Test plan

- [x] `bundle exec rspec spec/system/case_court_reports/index_spec.rb` passes with 0 failures
- [x] No `reload`, `attached?`, or `wait_for_report_attachment` calls remain in the spec