### PR TITLE
Replace date string with Date object

### DIFF
--- a/spec/system/mileage_rates/mileage_rates_spec.rb
+++ b/spec/system/mileage_rates/mileage_rates_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "mileage_rates/new", :js, type: :system do
   it "add new mileage rate" do
     click_on "New Mileage Rate"
     expect(page).to have_text("New Mileage Rate")
-    fill_in "Effective date", with: "01/02/2020"
+    fill_in "Effective date", with: Date.new(2020, 1, 2)
     fill_in "Amount", with: 1.35
     uncheck "Currently active?"
     click_on "Save Mileage Rate"


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #6763

### What changed, and _why_?

Replaced a date string `"01/02/2020"` with a `Date` object to ensure consistent date rendering across timezones.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Updated flaky test.

### Screenshots please :)

N/A

