### PR TITLE
Remove ActionMailer call in casa_cases spec

### DIFF
--- a/spec/system/casa_cases/show_more_spec.rb
+++ b/spec/system/casa_cases/show_more_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "casa_cases/show", :js, type: :system do
 
       click_on "Send Reminder"
 
+      expect(page).to have_current_path(edit_volunteer_path(volunteer))
       expect(page).to have_text("Reminder sent to volunteer")
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
   end
 
@@ -47,8 +47,8 @@ RSpec.describe "casa_cases/show", :js, type: :system do
 
       click_on "Send Reminder"
 
+      expect(page).to have_current_path(edit_volunteer_path(volunteer))
       expect(page).to have_text("Reminder sent to volunteer")
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #6703

### What changed, and _why_?

The only `casa_case` spec files which contained calls to `ActionMailer` was `spec/system/casa_cases/show_more_spec.rb`. The assertion that used `ActionMailer` was right after an assertion that checks the presence of the `"Reminder sent to volunteer"` notice, so the test is already asserting that mail was sent successfully. I added an assertion that the page is on the `edit_volunteer_path` page just for clarity of the expected behaviour in the test but this may be unnecessary.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Updated `spec/system/casa_cases/show_more_spec.rb`.

