### PR TITLE
Race Condition Check: spec/system/volunteers/edit and notes/edit_spec.rb specs

### DIFF
--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -358,9 +358,9 @@ RSpec.describe "/volunteers", type: :request do
   end
 
   describe "PATCH /resend_invitation" do
-    before { sign_in admin }
+    it "resends an invitation email as an admin" do
+      sign_in admin
 
-    it "resends an invitation email" do
       expect(volunteer.invitation_created_at.present?).to eq(false)
 
       get resend_invitation_volunteer_path(volunteer)
@@ -370,6 +370,112 @@ RSpec.describe "/volunteers", type: :request do
       expect(Devise.mailer.deliveries.count).to eq(1)
       expect(Devise.mailer.deliveries.first.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
       expect(response).to redirect_to(edit_volunteer_path(volunteer))
+    end
+
+    it "resends an invitation email as a supervisor" do
+      sign_in supervisor
+
+      expect(volunteer.invitation_created_at.present?).to eq(false)
+
+      get resend_invitation_volunteer_path(volunteer)
+      volunteer.reload
+
+      expect(volunteer.invitation_created_at.present?).to eq(true)
+      expect(Devise.mailer.deliveries.count).to eq(1)
+      expect(Devise.mailer.deliveries.first.subject).to eq(I18n.t("devise.mailer.invitation_instructions.subject"))
+      expect(response).to redirect_to(edit_volunteer_path(volunteer))
+    end
+  end
+
+  describe "PATCH /reminder" do
+    describe "as admin" do
+      it "emails the volunteer" do
+        organization = create(:casa_org)
+        admin = create(:casa_admin, casa_org_id: organization.id)
+        supervisor = build(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, supervisor: supervisor, casa_org_id: organization.id)
+
+        sign_in admin
+
+        patch reminder_volunteer_path(volunteer)
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email).not_to be_nil
+        expect(email.to).to eq [volunteer.email]
+        expect(email.subject).to eq("Reminder to input case contacts")
+      end
+
+      it "cc's their supervisor and admin when the 'with_cc` param is present" do
+        admin = create(:casa_admin, casa_org_id: organization.id)
+        supervisor = build(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, supervisor: supervisor, casa_org_id: organization.id)
+
+        sign_in admin
+
+        patch reminder_volunteer_path(volunteer), params: {
+          with_cc: true
+        }
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email).not_to be_nil
+        expect(email.to).to eq [volunteer.email]
+        expect(email.subject).to eq("Reminder to input case contacts")
+        expect(email.cc).to include(volunteer.supervisor.email)
+        expect(email.cc).to include(admin.email)
+      end
+    end
+
+    describe "as supervisor" do
+      it "emails the volunteer" do
+        organization = create(:casa_org)
+        supervisor = build(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, supervisor: supervisor, casa_org_id: organization.id)
+
+        sign_in supervisor
+
+        patch reminder_volunteer_path(volunteer)
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email).not_to be_nil
+        expect(email.to).to eq [volunteer.email]
+        expect(email.subject).to eq("Reminder to input case contacts")
+      end
+
+      it "cc's their supervisor when the 'with_cc` param is present" do
+        organization = create(:casa_org)
+        supervisor = build(:supervisor, casa_org: organization)
+        volunteer = create(:volunteer, supervisor: supervisor, casa_org_id: organization.id)
+
+        sign_in supervisor
+
+        patch reminder_volunteer_path(volunteer), params: {
+          with_cc: true
+        }
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email).not_to be_nil
+        expect(email.to).to eq [volunteer.email]
+        expect(email.subject).to eq("Reminder to input case contacts")
+        expect(email.cc).to eq([supervisor.email])
+      end
+    end
+
+    it "emails the volunteer without a supervisor" do
+      organization = create(:casa_org)
+      volunteer_without_supervisor = create(:volunteer)
+      supervisor = build(:supervisor, casa_org: organization)
+
+      sign_in supervisor
+
+      patch reminder_volunteer_path(volunteer_without_supervisor), params: {
+        with_cc: true
+      }
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email).not_to be_nil
+      expect(email.to).to eq [volunteer_without_supervisor.email]
+      expect(email.subject).to eq("Reminder to input case contacts")
+      expect(email.cc).to be_empty
     end
   end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "volunteers/edit", type: :system do
   it "shows the admin the option to assign an unassigned volunteer to a different active supervisor" do
     organization = create(:casa_org)
     volunteer = create(:volunteer, casa_org: organization)
-    deactivated_supervisor = create(:supervisor, active: false, casa_org: organization, display_name: "Inactive Supervisor")
+    deactivated_supervisor = build(:supervisor, active: false, casa_org: organization, display_name: "Inactive Supervisor")
     active_supervisor = create(:supervisor, active: true, casa_org: organization, display_name: "Active Supervisor")
     admin = create(:casa_admin, casa_org: organization)
 
@@ -295,8 +295,8 @@ RSpec.describe "volunteers/edit", type: :system do
       volunteer = create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id)
       casa_case_1 = create(:casa_case, casa_org: organization, case_number: "CINA1")
       casa_case_2 = create(:casa_case, casa_org: organization, case_number: "CINA2")
-      case_assignment_1 = create(:case_assignment, volunteer: volunteer, casa_case: casa_case_1)
-      case_assignment_2 = create(:case_assignment, volunteer: volunteer, casa_case: casa_case_2)
+      case_assignment_1 = build(:case_assignment, volunteer: volunteer, casa_case: casa_case_1)
+      case_assignment_2 = build(:case_assignment, volunteer: volunteer, casa_case: casa_case_2)
 
       case_assignment_1.active = false
       case_assignment_2.active = false

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -659,7 +659,6 @@ RSpec.describe "volunteers/edit", type: :system do
   context "logged in as a supervisor" do
     it "can save notes about a volunteer" do
       organization = create(:casa_org)
-      admin = create(:casa_admin, casa_org_id: organization.id)
       volunteer = create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id)
       supervisor = volunteer.supervisor
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -140,16 +140,15 @@ RSpec.describe "volunteers/edit", type: :system do
 
         fill_in "Email", with: "newemail@example.com"
         click_on "Submit"
-        volunteer.reload
+
+        expect(page).to have_text "Volunteer was successfully updated. Confirmation Email Sent."
+        expect(page).to have_field("Email", with: old_email)
+        expect(volunteer.reload.unconfirmed_email).to eq("newemail@example.com")
 
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
           .to match("Click here to confirm your email")
-
-        expect(page).to have_text "Volunteer was successfully updated. Confirmation Email Sent."
-        expect(page).to have_field("Email", with: old_email)
-        expect(volunteer.unconfirmed_email).to eq("newemail@example.com")
       end
 
       it "succesfully displays the new email once the user confirms" do
@@ -481,6 +480,8 @@ RSpec.describe "volunteers/edit", type: :system do
       uncheck "with_cc"
       click_on "Send Reminder"
 
+      expect(page).to have_content("Reminder sent to volunteer")
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.cc).to be_empty
     end
@@ -496,6 +497,8 @@ RSpec.describe "volunteers/edit", type: :system do
       check "with_cc"
       click_on "Send Reminder"
 
+      expect(page).to have_content("Reminder sent to volunteer")
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)
     end
@@ -510,6 +513,8 @@ RSpec.describe "volunteers/edit", type: :system do
 
       check "with_cc"
       click_on "Send Reminder"
+
+      expect(page).to have_content("Reminder sent to volunteer")
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.cc).to be_empty
@@ -530,6 +535,8 @@ RSpec.describe "volunteers/edit", type: :system do
 
       click_on "Send Reminder"
 
+      expect(page).to have_content("Reminder sent to volunteer")
+
       expect(ActionMailer::Base.deliveries.count).to eq(1)
     end
 
@@ -542,6 +549,8 @@ RSpec.describe "volunteers/edit", type: :system do
       visit edit_volunteer_path(volunteer)
       check "with_cc"
       click_on "Send Reminder"
+
+      expect(page).to have_content("Reminder sent to volunteer")
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       expect(ActionMailer::Base.deliveries.first.cc).to include(volunteer.supervisor.email)

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -617,9 +617,6 @@ RSpec.describe "volunteers/edit", type: :system do
       organization = create(:casa_org)
       admin = create(:casa_admin, casa_org_id: organization.id)
       volunteer = create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id)
-      volunteer.notes.create(creator: admin, content: "Note_1")
-      volunteer.notes.create(creator: admin, content: "Note_2")
-      volunteer.notes.create(creator: admin, content: "Note_3")
 
       sign_in admin
       visit edit_volunteer_path(volunteer)
@@ -665,9 +662,6 @@ RSpec.describe "volunteers/edit", type: :system do
       admin = create(:casa_admin, casa_org_id: organization.id)
       volunteer = create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id)
       supervisor = volunteer.supervisor
-      volunteer.notes.create(creator: admin, content: "Note_1")
-      volunteer.notes.create(creator: admin, content: "Note_2")
-      volunteer.notes.create(creator: admin, content: "Note_3")
 
       sign_in supervisor
       visit edit_volunteer_path(volunteer)

--- a/spec/system/volunteers/notes/edit_spec.rb
+++ b/spec/system/volunteers/notes/edit_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "volunteers/notes/edit", type: :system do
   let(:organization) { create(:casa_org) }
-  let(:admin) { create(:casa_admin, casa_org_id: organization.id) }
+  let(:admin) { build(:casa_admin, casa_org_id: organization.id) }
   let(:volunteer) { create(:volunteer, :with_assigned_supervisor, casa_org_id: organization.id) }
   let(:note) { volunteer.notes.create(creator: admin, content: "Good job.") }
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Related https://github.com/rubyforgood/casa/issues/6698

### What changed, and _why_?

These tests were pretty good and have a few opportunities to reduce race condition issues. Since I was reviewing them, I took the opportunity to improve the tests by:

- defaulting to building instead of creating factories as much as possible
- adding unit tests for resend invitations and reminders to volunteers
- move/add browser assertions before asserting against the mailer checks to prevent race conditions issues
- removes unused factories