### PR TITLE
Change invitation set password form title

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="password-box px-4 pb-3">
-  <h2 class="my-3">Send invitation</h2>
+  <h2 class="my-3">Set password</h2>
 
   <%= form_with(model: resource, as: resource_name, url: invitation_path(resource_name), local: true, html: {method: :put}) do |f| %>
     <%= render "/shared/error_messages", resource: resource %>

--- a/spec/views/devise/invitations/edit.html.erb_spec.rb
+++ b/spec/views/devise/invitations/edit.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "users/invitations/edit", type: :view do
+  it "displays title" do
+    render template: "devise/invitations/edit"
+    expect(rendered).to have_text("Set password")
+  end
+
+  it "displays fields for user to set password" do
+    render template: "devise/invitations/edit"
+    expect(rendered).to have_field("user_invitation_token", type: :hidden)
+    expect(rendered).to have_text("Password")
+    expect(rendered).to have_field("user_password")
+    expect(rendered).to have_text("Password confirmation")
+    expect(rendered).to have_field("user_password_confirmation")
+    expect(rendered).to have_button("Set my password")
+  end
+end

--- a/spec/views/devise/invitations/new.html.erb_spec.rb
+++ b/spec/views/devise/invitations/new.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "users/invitations/new", type: :view do
+  it "displays title" do
+    render template: "devise/invitations/new"
+    expect(rendered).to have_text("Send invitation")
+  end
+
+  it "displays fields for inviting a user" do
+    render template: "devise/invitations/new"
+    expect(rendered).to have_text("Email")
+    expect(rendered).to have_field("user_email")
+    expect(rendered).to have_button("Send an invitation")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rubyforgood/casa/issues/6768

When I click on the invitation email link to set up my password, the form says "Send invitation", but the form is for setting up a password.

Updates the form title and adds view tests for users setting their passwords and sending an invite forms.

Also, filed a flaky test bug issue: https://github.com/rubyforgood/casa/issues/6770