### PR TITLE
Fix flaky VolunteerPolicy spec by making org assignments explicit

### DIFF
--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -3,13 +3,15 @@ require "rails_helper"
 RSpec.describe VolunteerPolicy do
   subject { described_class }
 
-  let(:admin) { build_stubbed(:casa_admin) }
-  let(:supervisor) { build_stubbed(:supervisor) }
-  let(:volunteer) { build_stubbed(:volunteer) }
+  let(:casa_org) { build_stubbed(:casa_org) }
+  let(:other_org) { build_stubbed(:casa_org) }
+  let(:admin) { build_stubbed(:casa_admin, casa_org: casa_org) }
+  let(:supervisor) { build_stubbed(:supervisor, casa_org: casa_org) }
+  let(:volunteer) { build_stubbed(:volunteer, casa_org: casa_org) }
 
   permissions :edit? do
     context "same org" do
-      let(:record) { build_stubbed(:volunteer, casa_org: admin.casa_org) }
+      let(:record) { build_stubbed(:volunteer, casa_org: casa_org) }
 
       context "when user is a casa admin" do
         it "allows for same org" do
@@ -31,7 +33,7 @@ RSpec.describe VolunteerPolicy do
     end
 
     context "different org" do
-      let(:record) { build_stubbed(:volunteer, casa_org: build_stubbed(:casa_org)) }
+      let(:record) { build_stubbed(:volunteer, casa_org: other_org) }
 
       context "when user is a casa admin" do
         it "does not allow for different org" do
@@ -55,7 +57,7 @@ RSpec.describe VolunteerPolicy do
 
   permissions :index?, :activate?, :create?, :datatable?, :deactivate?, :new?, :show?, :update? do
     context "when user is a casa admin" do
-      let(:record) { build_stubbed(:volunteer, casa_org: admin.casa_org) }
+      let(:record) { build_stubbed(:volunteer, casa_org: casa_org) }
 
       it "allows" do
         expect(subject).to permit(admin, record)
@@ -63,7 +65,7 @@ RSpec.describe VolunteerPolicy do
     end
 
     context "when user is a supervisor" do
-      let(:record) { build_stubbed(:volunteer, casa_org: supervisor.casa_org) }
+      let(:record) { build_stubbed(:volunteer, casa_org: casa_org) }
 
       it "allows" do
         expect(subject).to permit(supervisor, record)


### PR DESCRIPTION
## Summary

Fixes the flaky test `VolunteerPolicy edit? different org when user is a supervisor does not allow` by making all `casa_org` assignments explicit in the spec.

**Root cause:** The user factory default `casa_org { CasaOrg.first || create(:casa_org) }` hits the database even inside `build_stubbed`. When FactoryBot's auto-incrementing stub IDs collide with real DB record IDs, ActiveRecord's `==` (which compares class + ID) causes `same_org?` to return incorrect results non-deterministically.

**Fix:** Introduce shared `let(:casa_org)` and `let(:other_org)` blocks, passed explicitly to all stubbed users and records. This bypasses the factory's DB-hitting default and guarantees deterministic org identity.

Resolves #6770

## Test Plan

- [x] `bundle exec rspec spec/policies/volunteer_policy_spec.rb` — 18 examples, 0 failures
- [x] No new rubocop offenses introduced