### PR TITLE
Race Condition Check: spec/system/devise/passwords/new_spec.rb

### DIFF
--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -45,20 +45,27 @@ RSpec.describe "users/passwords/new", type: :system do
     it "sends user email" do
       fill_in "Email", with: user.email
 
-      expect { click_on "Send me reset password instructions" }.to change { ActionMailer::Base.deliveries.count }.by(1)
-      expect(ActionMailer::Base.deliveries.last.to_addresses.map(&:address)).to include user.email
+      click_on "Send me reset password instructions"
+
+      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq([user.email])
     end
 
     it "has reset password url with token" do
       fill_in "Email", with: user.email
       click_on "Send me reset password instructions"
 
+      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
       expect(reset_password_link(user.email)).to match(/http:\/\/localhost:3000\/users\/password\/edit\?reset_password_token=.*/)
     end
 
     it "url token matches user's encrypted token" do
       fill_in "Email", with: user.email
       click_on "Send me reset password instructions"
+
+      expect(page).to have_content "If the account exists you will receive an email or SMS with instructions on how to reset your password in a few minutes."
 
       token = reset_password_link(user.email).gsub("http://localhost:3000/users/password/edit?reset_password_token=", "")
       encrypted_token = Devise.token_generator.digest(User, :reset_password_token, token)
@@ -80,6 +87,7 @@ RSpec.describe "users/passwords/new", type: :system do
       click_on "Log In"
 
       expect(page).to have_text(user.display_name)
+      expect(page).to have_text("My Cases")
       expect(page).not_to have_text("Sign in")
     end
   end

--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe "users/passwords/new", type: :system do
     end
 
     it "displays error if user tries to submit an empty form" do
-      user = build(:user, email: "glados@example.com", phone_number: "+16578900012")
-
       click_on "Send me reset password instructions"
       expect(page).to have_text("Please enter at least one field.")
     end

--- a/spec/system/devise/passwords/new_spec.rb
+++ b/spec/system/devise/passwords/new_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "users/passwords/new", type: :system do
   end
 
   describe "reset password page" do
-    let!(:user) { create(:user, email: "glados@aperture.labs", phone_number: "+16578900012") }
-
     it "displays error messages for non-existent user" do
-      fill_in "Email", with: "tangerine@forward.com"
+      user = build(:user, email: "glados@example.com", phone_number: "+16578900012")
+
+      fill_in "Email", with: "tangerine@example.com"
       fill_in "Phone number", with: user.phone_number
 
       click_on "Send me reset password instructions"
@@ -18,6 +18,8 @@ RSpec.describe "users/passwords/new", type: :system do
     end
 
     it "displays phone number error messages for incorrect formatting" do
+      user = create(:user, email: "glados@example.com", phone_number: "+16578900012")
+
       fill_in "Email", with: user.email
       fill_in "Phone number", with: "2134567eee"
 
@@ -26,12 +28,16 @@ RSpec.describe "users/passwords/new", type: :system do
       expect(page).to have_text("Phone number must be 10 digits or 12 digits including country code (+1)")
     end
 
-    it "displays error if user tries to submit empty form" do
+    it "displays error if user tries to submit an empty form" do
+      user = build(:user, email: "glados@example.com", phone_number: "+16578900012")
+
       click_on "Send me reset password instructions"
       expect(page).to have_text("Please enter at least one field.")
     end
 
     it "redirects to sign up page for email" do
+      user = build(:user, email: "glados@example.com", phone_number: "+16578900012")
+
       fill_in "Email", with: user.email
 
       click_on "Send me reset password instructions"
@@ -69,7 +75,7 @@ RSpec.describe "users/passwords/new", type: :system do
 
       token = reset_password_link(user.email).gsub("http://localhost:3000/users/password/edit?reset_password_token=", "")
       encrypted_token = Devise.token_generator.digest(User, :reset_password_token, token)
-      expect(User.find_by(reset_password_token: encrypted_token)).not_to be_nil
+      expect(User.find_by(reset_password_token: encrypted_token)).to be_present
     end
 
     it "user can update password" do


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves https://github.com/rubyforgood/casa/issues/6320

### What changed, and _why_?

When github's free CI servers are under heavy load, a race condition
between the page loading and checking the database causes tests to flake.
This is caused by a system test inputting data into a form then
immediately checking the database without waiting for the form to finish submitting.

For every database check in the system files, this ensures it's preceded
by a capybara matcher with automatic waiting or replace the database
check with a check for something to appear on the page.

I also took the opportunity to refactor some small things:
- build instead of create an user to save up test setup time
- assert that an attribute is present instead of not nil (easier to comprehend)
- uses the reserved email domain for tests: `example.com` to be [RFC 2606 compliant](https://www.rfc-editor.org/rfc/rfc2606)