### PR TITLE
Race Condition Check: spec/system/supervisors/edit_spec.rb

### DIFF
--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe "supervisors/edit", type: :system do
       visit edit_supervisor_path(supervisor)
 
       dismiss_confirm do
-        find("a[href='#{deactivate_supervisor_path(supervisor)}']").click
+        click_link "Deactivate Supervisor"
       end
 
       accept_confirm do
-        find("a[href='#{deactivate_supervisor_path(supervisor)}']").click
+        click_link "Deactivate Supervisor"
       end
       expect(page).to have_text("Supervisor was deactivated on")
 
@@ -179,14 +179,14 @@ RSpec.describe "supervisors/edit", type: :system do
       end
 
       it "sends a confirmation email to the supervisor and displays current email" do
+        expect(page).to have_text "Supervisor was successfully updated. Confirmation Email Sent."
+        expect(page).to have_field("Email", with: @old_email)
+        expect(@supervisor.unconfirmed_email).to eq("new_supervisor_email@example.com")
+
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
         expect(ActionMailer::Base.deliveries.first.body.encoded)
           .to match("Click here to confirm your email")
-
-        expect(page).to have_text "Supervisor was successfully updated. Confirmation Email Sent."
-        expect(page).to have_field("Email", with: @old_email)
-        expect(@supervisor.unconfirmed_email).to eq("new_supervisor_email@example.com")
       end
 
       it "correctly updates the supervisor email once confirmed" do

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "supervisors/edit", type: :system do
   context "logged in as an admin" do
     let(:user) { create(:casa_admin, casa_org: organization) }
 
-    it "can edit supervisor by clicking on the edit link from the supervisors list page", :js do
+    it "can edit supervisor by clicking on the edit link from the supervisors list page" do
       supervisor_name = "Leslie Knope"
       create(:supervisor, display_name: supervisor_name, casa_org: organization)
       sign_in user
@@ -22,7 +22,7 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(page).to have_text("Editing Supervisor")
     end
 
-    it "can edit supervisor by clicking on the supervisor's name from the supervisors list page", :js do
+    it "can edit supervisor by clicking on the supervisor's name from the supervisors list page" do
       supervisor_name = "Leslie Knope"
       create(:supervisor, display_name: supervisor_name, casa_org: organization)
       sign_in user
@@ -110,7 +110,7 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(inactive_supervisor.reload).to be_active
     end
 
-    it "can resend invitation to a supervisor", :js do
+    it "can resend invitation to a supervisor" do
       supervisor = create :supervisor, casa_org: organization
 
       sign_in user
@@ -126,7 +126,7 @@ RSpec.describe "supervisors/edit", type: :system do
       expect(deliveries.last.subject).to have_text "CASA Console invitation instructions"
     end
 
-    it "can convert the supervisor to an admin", :js do
+    it "can convert the supervisor to an admin" do
       supervisor = create(:supervisor, casa_org_id: organization.id)
 
       sign_in user
@@ -143,7 +143,7 @@ RSpec.describe "supervisors/edit", type: :system do
     context "logged in as a supervisor" do
       let(:supervisor) { create(:supervisor) }
 
-      it "can't deactivate a supervisor", :js do
+      it "can't deactivate a supervisor" do
         supervisor2 = create :supervisor, casa_org: organization
 
         sign_in supervisor


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves https://github.com/rubyforgood/casa/issues/6317

### What changed, and _why_?

When github's free CI servers are under heavy load, a race condition
between the page loading and checking the database causes tests to flake.
This is caused by a system test inputting data into a form then
immediately checking the database without waiting for the form to finish submitting.

For every database check in the system files, this ensures it's preceded
by a capybara matcher with automatic waiting or replace the database
check with a check for something to appear on the page.

I also took the opportunity to refactor some small things:

- only add `:js` to contexts when necessary since removing it keeps the tests faster
- instead of checking for CSS selectors, change interaction to how the user interacts with buttons