### PR TITLE
Fixes Rubocop require/plugin warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 require:
   - standard
-  - rubocop-factory_bot
 
 plugins:
   - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-rspec
   - rubocop-rspec_rails
 


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves https://github.com/rubyforgood/casa/issues/6782

### What changed, and _why_?

When running rubocop, this warning is printed:

```
 rubocop-factory_bot extension supports plugin, specify `plugins: rubocop-factory_bot` instead of `require: rubocop-factory_bot` in /home/runner/work/casa/casa/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```

To fix it, we need to add that library as a plugin: https://docs.rubocop.org/rubocop/latest/plugin_migration_guide.html#for-plugin-users

### How is this **tested**?

CI before: https://github.com/rubyforgood/casa/actions/runs/23155851553/job/67270244414

CI after: https://github.com/rubyforgood/casa/actions/runs/23156788730/job/67273625209
