### PR TITLE
Race Condition Check: spec/system/case_contacts/

### DIFF
--- a/spec/system/case_contacts/additional_expenses_spec.rb
+++ b/spec/system/case_contacts/additional_expenses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :system do
+RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, type: :system do
   subject do
     visit new_case_contact_path(casa_case)
     fill_in_contact_details(contact_types: [contact_type.name])
@@ -28,7 +28,7 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     expect(page).to have_no_button("Add Another Expense", visible: :all)
   end
 
-  it "is not shown until Reimbursement is checked and Add Another Expense clicked" do
+  it "is not shown until Reimbursement is checked and Add Another Expense clicked", :js do
     sign_in volunteer
     visit new_case_contact_path casa_case
     fill_in_contact_details
@@ -42,64 +42,64 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
     expect(page).to have_field(class: "expense-amount-input")
   end
 
-  it "does not submit values if reimbursement is cancelled (unchecked)" do
+  it "does not submit values if reimbursement is cancelled (unchecked)", :js do
     subject
 
     click_on "Add Another Expense"
     fill_expense_fields 5.34, "Lunch"
     uncheck "Request travel or other reimbursement"
 
-    expect { click_on "Submit" }
-      .to change(CaseContact.active, :count).by(1)
+    click_on "Submit"
+    expect(page).to have_text("Case contact successfully created")
 
+    expect(CaseContact.active.count).to eq(1)
     case_contact = CaseContact.active.last
     expect(case_contact.additional_expenses).to be_empty
     expect(case_contact.miles_driven).to be_zero
     expect(case_contact.want_driving_reimbursement).to be false
   end
 
-  it "can remove an expense" do
+  it "can remove an expense", :js do
     subject
     fill_in_contact_details
     check "Request travel or other reimbursement"
     fill_in "case_contact_miles_driven", with: 50
     fill_in "case_contact_volunteer_address", with: "123 Params St"
 
-    expect {
-      click_on "Add Another Expense"
-      fill_expense_fields 1.50, "1st meal"
-      click_on "Add Another Expense"
-      fill_expense_fields 2.50, "2nd meal"
-      click_on "Add Another Expense"
-      fill_expense_fields 2.00, "3rd meal"
+    click_on "Add Another Expense"
+    fill_expense_fields 1.50, "1st meal"
+    click_on "Add Another Expense"
+    fill_expense_fields 2.50, "2nd meal"
+    click_on "Add Another Expense"
+    fill_expense_fields 2.00, "3rd meal"
 
-      within "#contact-form-expenses" do
-        click_on "Delete", match: :first
-      end
+    within "#contact-form-expenses" do
+      click_on "Delete", match: :first
+    end
 
-      expect(page).to have_field(class: "expense-amount-input", count: 2)
+    expect(page).to have_field(class: "expense-amount-input", count: 2)
 
-      click_on "Submit"
-      expect(page).to have_text("Case contact successfully created")
-    }
-      .to change(CaseContact.active, :count).by(1)
-      .and change(AdditionalExpense, :count).by(2)
+    click_on "Submit"
+    expect(page).to have_text("Case contact successfully created")
 
     case_contact = CaseContact.active.last
     expect(case_contact.additional_expenses.size).to eq(2)
+    expect(CaseContact.count).to eq(1)
+    expect(AdditionalExpense.count).to eq(2)
   end
 
-  it "requires a description for each additional expense" do
+  it "requires a description for each additional expense", :js do
     subject
 
     click_on "Add Another Expense"
     fill_expense_fields 5.34, nil
 
-    expect { click_on "Submit" }
-      .to not_change(CaseContact.active, :count)
-      .and not_change(AdditionalExpense, :count)
+    click_on "Submit"
 
     expect(page).to have_text("Other Expense Details can't be blank")
+
+    expect(CaseContact.active.count).to eq(0)
+    expect(AdditionalExpense.count).to eq(1)
   end
 
   context "when editing existing case contact expenses" do
@@ -125,38 +125,39 @@ RSpec.describe "CaseContact AdditionalExpenses Form", :flipper, :js, type: :syst
       expect(page).to have_button "Add Another Expense"
     end
 
-    it "allows removing expenses" do
+    it "allows removing expenses", :js do
       subject
 
       expect(page).to have_css(".expense-amount-input", count: 2)
       expect(page).to have_css(".expense-describe-input", count: 2)
 
-      expect {
-        within "#contact-form-expenses" do
-          click_on "Delete", match: :first
-        end
+      within "#contact-form-expenses" do
+        click_on "Delete", match: :first
+      end
 
-        expect(page).to have_css(".expense-amount-input", count: 1)
-        expect(page).to have_css(".expense-describe-input", count: 1)
+      expect(page).to have_css(".expense-amount-input", count: 1)
+      expect(page).to have_css(".expense-describe-input", count: 1)
 
-        click_on "Submit"
-      }
-        .to not_change(CaseContact.active, :count)
-        .and change(AdditionalExpense, :count).by(-1)
+      click_on "Submit"
 
+      expect(page).to have_text(/Case contact .* was successfully updated./)
+
+      expect(CaseContact.active.count).to eq(1)
+      expect(AdditionalExpense.count).to eq(1)
       expect(case_contact.reload.additional_expenses.size).to eq(1)
     end
 
-    it "can add an expense" do
+    it "can add an expense", :js do
       subject
 
-      expect {
-        click_on "Add Another Expense"
-        fill_expense_fields 11.50, "Gas"
-        click_on "Submit"
-      }
-        .to change(AdditionalExpense, :count).by(1)
+      click_on "Add Another Expense"
+      fill_expense_fields 11.50, "Gas"
+      click_on "Submit"
+
+      expect(page).to have_text(/Case contact .* was successfully updated./)
+
       expect(case_contact.reload.additional_expenses.size).to eq(3)
+      expect(AdditionalExpense.count).to eq(3)
     end
   end
 end

--- a/spec/system/case_contacts/contact_topic_answers_spec.rb
+++ b/spec/system/case_contacts/contact_topic_answers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :system do
+RSpec.describe "CaseContact form ContactTopicAnswers and notes", type: :system do
   subject do
     sign_in user
     visit new_case_contact_path(casa_case)
@@ -12,8 +12,7 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
   let(:user) { volunteer }
 
   let!(:contact_type) { create :contact_type, casa_org: }
-  let(:topic_count) { 2 }
-  let!(:contact_topics) { create_list :contact_topic, topic_count, casa_org: }
+  let!(:contact_topics) { create_list :contact_topic, 2, casa_org: }
   let(:contact_topic_questions) { contact_topics.map(&:question) }
   let(:select_options) { contact_topic_questions + ["Select a discussion topic"] }
 
@@ -36,7 +35,7 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
     expect(notes_section).to have_select(class: topic_select_class, with_options: contact_topic_questions)
   end
 
-  it "adds contact answers for the topics" do
+  it "adds contact answers for the topics", :js do
     subject
     fill_in_contact_details(contact_types: [contact_type.name])
 
@@ -65,22 +64,19 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
     subject
     fill_in_contact_details(contact_types: [contact_type.name])
 
-    expect do
-      using_wait_time 6 do # autosave debounce may be longer than capybara's wait time
-        answer_topic contact_topics.first.question, "First discussion topic answer."
-        within notes_section do
-          expect(page).to have_text "Saved"  # autosave success alert
-          expect(page).to have_no_text "Saved" # wait for clearing of alert
-        end
-        answer_topic contact_topics.first.question, "Changing the first topic answer."
-        within notes_section { expect(page).to have_text "Saved" }
-      end
+    answer_topic contact_topics.first.question, "First discussion topic answer."
+    within notes_section do
+      expect(page).to have_text "Saved"  # autosave success alert
+      expect(page).to have_no_text "Saved" # wait for clearing of alert
+    end
+    answer_topic contact_topics.first.question, "Changing the first topic answer."
+    within notes_section { expect(page).to have_text "Saved" }
 
-      click_on "Submit"
-      expect(page).to have_content("Case contact successfully created.")
-    end.to change(CaseContact.active, :count).by(1)
-      .and change(ContactTopicAnswer, :count).by(0) # answer already exists on page load
+    click_on "Submit"
+    expect(page).to have_content("Case contact successfully created.")
 
+    expect(CaseContact.active.count).to eq(1)
+    expect(ContactTopicAnswer.count).to eq(1)
     case_contact = CaseContact.active.last
     created_answer = ContactTopicAnswer.last
     expect(created_answer.contact_topic).to eq(contact_topics.first)
@@ -89,7 +85,7 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
     expect(case_contact.contact_topic_answers).to include created_answer
   end
 
-  it "prevents adding more answers than topics" do
+  it "prevents adding more answers than topics", :js do
     subject
 
     (contact_topics.size - 1).times do
@@ -99,7 +95,7 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
     expect(notes_section).to have_button("Add Another Discussion Topic", disabled: true)
   end
 
-  it "disables contact topics that are already selected" do
+  it "disables contact topics that are already selected", :js do
     subject
 
     topic_one_question = contact_topics.first.question
@@ -115,7 +111,7 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
   context "when casa org has no contact topics" do
     let(:contact_topics) { [] }
 
-    it "displays a field for contact.notes" do
+    it "displays a field for contact.notes", :js do
       subject
       expect(page).to have_no_button "Add Another Discussion Topic"
       expect(notes_section).to have_field "Additional Notes"
@@ -123,34 +119,32 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
       fill_in_contact_details
       fill_in "Additional Notes", with: "This is a note."
 
-      expect do
-        click_on "Submit"
-        expect(page).to have_content("Case contact successfully created.")
-      end.to change(CaseContact.active, :count).by(1)
+      click_on "Submit"
+      expect(page).to have_content("Case contact successfully created.")
 
       contact = CaseContact.active.last
+      expect(CaseContact.active.count).to eq(1)
       expect(contact.contact_topic_answers).to be_empty
       expect(contact.notes).to eq "This is a note."
     end
 
-    it "saves 'Additional Notes' answer as contact.notes" do
+    it "saves 'Additional Notes' answer as contact.notes", :js do
       subject
       fill_in_contact_details(contact_types: [contact_type.name])
 
       fill_in "Additional Notes", with: "This is a fake a topic answer."
 
-      expect do
-        click_on "Submit"
-        expect(page).to have_text("Case contact successfully created")
-      end.to change(CaseContact.active, :count).by(1)
+      click_on "Submit"
+      expect(page).to have_text("Case contact successfully created")
 
       contact = CaseContact.active.last
+      expect(CaseContact.active.count).to eq(1)
       expect(contact.contact_topic_answers).to be_empty
       expect(contact.notes).to eq "This is a fake a topic answer."
     end
   end
 
-  context "when editing existing an case contact" do
+  context "when editing an existing case contact" do
     subject do
       sign_in user
       visit edit_case_contact_path(case_contact)
@@ -181,46 +175,46 @@ RSpec.describe "CaseContact form ContactTopicAnswers and notes", :js, type: :sys
         )
       end
 
-      it "can remove an existing answer" do
+      it "can remove an existing answer", :js do
         subject
         fill_in_contact_details
 
         expect(notes_section).to have_select(class: topic_select_class, count: 2)
 
-        expect {
-          accept_confirm do
-            notes_section.find_button(text: "Delete", match: :first).click
-          end
+        accept_confirm do
+          notes_section.find_button(text: "Delete", match: :first).click
+        end
 
-          expect(notes_section).to have_select(class: topic_select_class, count: 1, visible: :all)
+        expect(notes_section).to have_select(class: topic_select_class, count: 1, visible: :all)
 
-          click_on "Submit"
-          expect(page).to have_content(/Case contact .* was successfully updated./)
-        }
-          .to change(ContactTopicAnswer, :count).by(-1)
+        click_on "Submit"
+        expect(page).to have_content(/Case contact .* was successfully updated./)
 
         case_contact.reload
+        expect(ContactTopicAnswer.count).to eq(1)
         expect(case_contact.contact_topic_answers.size).to eq(1)
       end
     end
 
-    it "autosaves form with answer inputs" do
-      expect { subject }.to change(CaseContact, :count).by(1)
-      case_contact = CaseContact.last
-      expect(case_contact.casa_case).to eq casa_case
+    it "autosaves form with answer inputs", :js do
+      subject
+
       fill_in_contact_details(
         contact_made: false, medium: "In Person", occurred_on: 1.day.ago.to_date, hours: 1, minutes: 5
       )
 
-      expect {
-        click_on "Add Another Discussion Topic"
-        answer_topic contact_topics.first.question, "Topic One answer."
-        within autosave_alert_div do
-          find(autosave_alert_css, text: autosave_alert_text, wait: 3)
-        end
-      }
-        .to change(ContactTopicAnswer, :count).by(1)
-      case_contact.reload
+      click_on "Add Another Discussion Topic"
+      answer_topic contact_topics.first.question, "Topic One answer."
+      within autosave_alert_div do
+        find(autosave_alert_css, text: autosave_alert_text, wait: 3)
+      end
+
+      expect(page).to have_content("Editing Existing Case Contact")
+
+      expect(CaseContact.count).to eq(1)
+      case_contact = CaseContact.last
+      expect(case_contact.casa_case).to eq casa_case
+      expect(ContactTopicAnswer.count).to eq(1)
       expect(case_contact.contact_topic_answers.size).to eq(1)
       expect(case_contact.contact_topic_answers.last.value).to eq "Topic One answer."
 

--- a/spec/system/case_contacts/drafts_spec.rb
+++ b/spec/system/case_contacts/drafts_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-RSpec.describe "case_contacts/drafts", :js, type: :system do
-  let(:organization) { create(:casa_org) }
-  let(:admin) { create(:casa_admin, casa_org: organization) }
+RSpec.describe "case_contacts/drafts", type: :system do
+  let(:organization) { build(:casa_org) }
+  let(:admin) { build(:casa_admin, casa_org: organization) }
 
   context "with case contacts" do
-    let!(:casa_case) { create(:casa_case, casa_org: organization) }
-    let!(:other_org_case) { create(:case_contact, notes: "NOTE_A") }
-    let!(:past_contact) { create(:case_contact, casa_case: casa_case, occurred_at: 3.weeks.ago, notes: "NOTE_B") }
+    let!(:casa_case) { build(:casa_case, casa_org: organization) }
+    let!(:other_org_case) { build(:case_contact, notes: "NOTE_A") }
+    let!(:past_contact) { build(:case_contact, casa_case: casa_case, occurred_at: 3.weeks.ago, notes: "NOTE_B") }
     let!(:past_contact_draft) { create(:case_contact, :started_status, casa_case: casa_case, occurred_at: 3.weeks.ago, notes: "NOTE_C") }
-    let!(:recent_contact) { create(:case_contact, casa_case: casa_case, occurred_at: 3.days.ago, notes: "NOTE_D") }
+    let!(:recent_contact) { build(:case_contact, casa_case: casa_case, occurred_at: 3.days.ago, notes: "NOTE_D") }
     let!(:recent_contact_draft) { create(:case_contact, :started_status, casa_case: casa_case, occurred_at: 3.days.ago, notes: "NOTE_E") }
 
     it "shows only same orgs drafts" do

--- a/spec/system/case_contacts/edit_spec.rb
+++ b/spec/system/case_contacts/edit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "case_contacts/edit", :js, type: :system do
+RSpec.describe "case_contacts/edit", type: :system do
   let(:organization) { build(:casa_org, :all_reimbursements_enabled) }
   let(:volunteer) { create(:volunteer, :with_single_case, casa_org: organization) }
   let(:casa_case) { volunteer.casa_cases.first }
@@ -18,7 +18,7 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
 
     let(:user) { admin }
 
-    it "admin successfully edits case contact" do
+    it "successfully edits case contact", :js do
       visit edit_case_contact_path(case_contact)
 
       complete_details_page(case_numbers: [], contact_types: [], contact_made: true, medium: "Letter")
@@ -35,10 +35,10 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
       expect(case_contact.contact_made).to be true
     end
 
-    it "admin successfully edits case contact with mileage reimbursement" do
+    it "successfully edits case contact with mileage reimbursement", :js do
       visit edit_case_contact_path(case_contact)
 
-      complete_details_page(case_numbers: [], contact_types: [], contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: "04/04/2020")
+      complete_details_page(case_numbers: [], contact_types: [], contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: Date.new(2020, 4, 4))
       complete_notes_page
       fill_in_expenses_page(miles: 10, want_reimbursement: true, address: "123 str")
 
@@ -55,7 +55,7 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     end
 
     it "does not allow volunteer address edit for case contact with ambiguous volunteer" do
-      create(:case_assignment, casa_case:, volunteer: create(:volunteer, casa_org: organization))
+      create(:case_assignment, casa_case:, volunteer: build(:volunteer, casa_org: organization))
       case_contact.update!(creator: admin)
       expect(casa_case.volunteers).not_to include case_contact.creator
       expect(casa_case.volunteers.size).to be > 1
@@ -73,14 +73,14 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
       let(:other_organization) { build(:casa_org) }
       let(:admin) { create(:casa_admin, casa_org: other_organization) }
 
-      it "fails across organizations", js: false do
+      it "fails across organizations" do
         visit edit_case_contact_path(case_contact)
         expect(page).to have_current_path supervisors_path, ignore_query: true
       end
     end
   end
 
-  it "can update case contact attributes" do
+  it "can update case contact attributes", :js do
     expect(case_contact.active?).to be true
     expect(case_contact.contact_types).to contain_exactly(contact_types.first)
     expect(case_contact.contact_made).to be false
@@ -125,10 +125,10 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     expect(case_contact.volunteer_address).to eq "123 Form St"
   end
 
-  it "is successful with mileage reimbursement on" do
+  it "is successful with mileage reimbursement on", :js do
     visit edit_case_contact_path(case_contact)
 
-    complete_details_page(contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: "04/04/2020")
+    complete_details_page(contact_made: true, medium: "In Person", hours: 1, minutes: 45, occurred_on: Date.new(2020, 4, 4))
     complete_notes_page
     fill_in_expenses_page(miles: 10, want_reimbursement: true, address: "123 str")
 
@@ -144,11 +144,10 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     expect(case_contact.contact_made).to be true
   end
 
-  it "autosaves notes" do
+  it "autosaves notes", :js do
     autosave_alert_div = "#contact-form-notes"
     autosave_alert_css = 'small[role="alert"]'
     autosave_alert_text = "Saved!"
-    autosave_wait_time = 4
 
     case_contact = create(:case_contact, duration_minutes: 105, casa_case: casa_case, creator: volunteer, notes: "Hello from the other side")
     visit edit_case_contact_path(case_contact)
@@ -159,26 +158,27 @@ RSpec.describe "case_contacts/edit", :js, type: :system do
     fill_in "Additional Notes", with: "Hello world"
 
     within autosave_alert_div do
-      find(autosave_alert_css, text: autosave_alert_text, wait: autosave_wait_time)
+      find(autosave_alert_css, text: autosave_alert_text)
     end
     expect(case_contact.reload.notes).to eq "Hello world"
   end
 
   context "when 'Create Another' option is checked" do
-    it "creates a duplicate case contact for the second contact" do
+    it "creates a duplicate case contact for the second contact", :js do
       case_contact_draft_ids = case_contact.draft_case_ids
       visit edit_case_contact_path(case_contact)
 
       check "Create Another"
 
-      expect do
-        click_on "Submit"
-        expect(page).to have_text("successfully updated")
-      end.to change(CaseContact.started, :count).by(1)
-      new_case_contact = CaseContact.last
-      expect(new_case_contact.draft_case_ids).to match_array(case_contact_draft_ids)
+      click_on "Submit"
+
+      expect(page).to have_text("successfully updated")
       expect(page).to have_text "New Case Contact"
       expect(page).to have_text casa_case.case_number
+
+      expect(CaseContact.started.count).to eq(1)
+      new_case_contact = CaseContact.last
+      expect(new_case_contact.draft_case_ids).to match_array(case_contact_draft_ids)
     end
   end
 end

--- a/spec/system/case_contacts/followups/create_spec.rb
+++ b/spec/system/case_contacts/followups/create_spec.rb
@@ -49,11 +49,15 @@ RSpec.describe "followups/create", :js, type: :system do
 
         click_button "Cancel"
 
+        expect(page).not_to have_text(note)
+
         expect(case_contact.followups.reload.count).to be_zero
       end
 
       it "does nothing when there is no text in the note textarea" do
         click_button "Cancel"
+
+        expect(page).not_to have_text(note)
 
         expect(case_contact.followups.reload.count).to be_zero
       end
@@ -65,11 +69,15 @@ RSpec.describe "followups/create", :js, type: :system do
 
         find(".swal2-close").click
 
+        expect(page).not_to have_text(note)
+
         expect(case_contact.followups.reload.count).to be_zero
       end
 
       it "does nothing when there is no text in the note textarea" do
         find(".swal2-close").click
+
+        expect(page).not_to have_text(note)
 
         expect(case_contact.followups.reload.count).to be_zero
       end

--- a/spec/system/case_contacts/followups/resolve_spec.rb
+++ b/spec/system/case_contacts/followups/resolve_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "followups/resolve", :js, type: :system do
-  let(:casa_org) { create(:casa_org) }
-  let(:admin) { create(:casa_admin, casa_org: casa_org) }
+RSpec.describe "followups/resolve", type: :system do
+  let(:casa_org) { build(:casa_org) }
+  let(:admin) { build(:casa_admin, casa_org: casa_org) }
   let(:supervisor) { build(:supervisor, casa_org: casa_org) }
   let(:volunteer) { build(:volunteer, casa_org: casa_org) }
   let(:casa_case) { create(:casa_case, casa_org: casa_org) }
@@ -29,7 +29,7 @@ RSpec.describe "followups/resolve", :js, type: :system do
 
     before { sign_in admin }
 
-    it "changes status of followup to resolved" do # TODO make test not flaky
+    it "changes status of followup to resolved" do
       visit casa_case_path(case_contact.casa_case)
 
       click_button "Resolve Reminder"
@@ -40,12 +40,9 @@ RSpec.describe "followups/resolve", :js, type: :system do
     end
 
     it "removes followup icon and button changes back to 'Make Reminder'" do
-      sign_in admin
       visit casa_case_path(case_contact.casa_case)
 
       click_button "Resolve Reminder"
-      expect(page).to have_button("Make Reminder")
-
       expect(page).to have_button("Make Reminder")
     end
   end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe "case_contacts/index", :js, type: :system do
+RSpec.describe "case_contacts/index", type: :system do
   subject { visit case_contacts_path }
 
   let(:volunteer) { build(:volunteer, display_name: "Bob Loblaw", casa_org: organization) }
-  let(:organization) { create(:casa_org) }
+  let(:organization) { build(:casa_org) }
 
   before { sign_in volunteer }
 
@@ -14,19 +14,9 @@ RSpec.describe "case_contacts/index", :js, type: :system do
     let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
 
     context "without filter" do
-      let(:case_contacts) do
-        [
-          create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 2.days.ago),
-          create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 1.days.ago),
-          create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.now,
-            contact_types: [create(:contact_type, name: "Most Recent Case Contact")]),
-          create(:case_contact, :started_status, creator: volunteer, casa_case: casa_case, occurred_at: 3.days.ago,
-            contact_types: [create(:contact_type, name: "DRAFT Case Contact")])
-        ]
-      end
-
       it "can see case creator in card" do
-        case_contacts
+        create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 2.days.ago)
+
         subject
 
         within(".full-card", match: :first) do
@@ -35,14 +25,16 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       end
 
       it "can navigate to edit volunteer page" do
-        case_contacts
         subject
 
         expect(page).to have_no_link("Bob Loblaw")
       end
 
       it "allows the volunteer to delete a draft they created" do
-        case_contacts
+        create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 2.days.ago)
+        create(:case_contact, :started_status, creator: volunteer, casa_case: casa_case, occurred_at: 3.days.ago,
+          contact_types: [build(:contact_type, name: "DRAFT Case Contact")])
+
         subject
 
         card = find(".container-fluid.mb-1", text: "DRAFT Case Contact")
@@ -57,7 +49,11 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       end
 
       it "displays the contact type groups" do
-        case_contacts
+        create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: Time.zone.now,
+          contact_types: [build(:contact_type, name: "Most Recent Case Contact")])
+        create(:case_contact, :started_status, creator: volunteer, casa_case: casa_case, occurred_at: 3.days.ago,
+          contact_types: [build(:contact_type, name: "DRAFT Case Contact")])
+
         subject
 
         expect(page).to have_text("Most Recent Case Contact")
@@ -67,7 +63,7 @@ RSpec.describe "case_contacts/index", :js, type: :system do
 
     describe "automated filtering case contacts" do
       describe "by date of contact" do
-        it "only shows the contacts with the correct date" do
+        it "only shows the contacts with the correct date", :js do
           yesterday = Time.zone.yesterday
           day_before_yesterday = yesterday - 1.day
           today = Time.zone.today
@@ -97,10 +93,11 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       describe "by casa_case_id" do
         subject { visit case_contacts_path(casa_case_id: casa_case.id) }
 
-        let!(:case_contact) { create(:case_contact, :details_status, creator: volunteer, draft_case_ids: [casa_case.id]) }
-        let!(:other_casa_case) { create(:casa_case, casa_org: organization, case_number: "CINA-2") }
+        let!(:other_casa_case) { build(:casa_case, casa_org: organization, case_number: "CINA-2") }
 
         it "displays the draft" do
+          create(:case_contact, :details_status, creator: volunteer, draft_case_ids: [casa_case.id])
+
           subject
 
           expect(page).to have_no_content "You have no case contacts for this case."
@@ -116,9 +113,9 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       end
 
       describe "by hide drafts" do
-        it "does not show draft contacts" do
-          create(:case_contact, creator: volunteer, casa_case: casa_case)
-          create(:case_contact, :started_status, creator: volunteer, casa_case: casa_case)
+        it "does not show draft contacts", :js do
+          build(:case_contact, creator: volunteer, casa_case: casa_case)
+          build(:case_contact, :started_status, creator: volunteer, casa_case: casa_case)
           subject
 
           check "Hide drafts"
@@ -136,7 +133,7 @@ RSpec.describe "case_contacts/index", :js, type: :system do
           expect(page).to have_field "Hide drafts", type: :checkbox
         end
 
-        it "does not expand menu when filtering only by sticky filter" do
+        it "does not expand menu when filtering only by sticky filter", :js do
           check "Hide drafts"
 
           expect(page).to have_field "Hide drafts", type: :checkbox
@@ -175,14 +172,14 @@ RSpec.describe "case_contacts/index", :js, type: :system do
       end
     end
 
-    it "can show only case contacts for one case" do
+    it "can show only case contacts for one case", :js do
       yesterday = Time.zone.yesterday
       day_before_yesterday = yesterday - 1.day
       today = Time.zone.today
       create(:case_contact, creator: volunteer, casa_case: casa_case, notes: "Case 1 Notes", occurred_at: day_before_yesterday)
 
       another_case_number = "CINA-2"
-      another_case = create(:casa_case, casa_org: organization, case_number: another_case_number)
+      another_case = build(:casa_case, casa_org: organization, case_number: another_case_number)
       create(:case_assignment, volunteer: volunteer, casa_case: another_case)
       create(:case_contact, creator: volunteer, casa_case: another_case, notes: "Case 2 Notes", occurred_at: today)
 
@@ -236,17 +233,18 @@ RSpec.describe "case_contacts/index", :js, type: :system do
     end
 
     describe "contact notes" do
-      let(:contact_topics) { create_list(:contact_topic, 2, casa_org: organization) }
+      let(:contact_topics) { build_list(:contact_topic, 2, casa_org: organization) }
       let(:contact_topic) { contact_topics.first }
-      let(:case_contact) { create(:case_contact, casa_case:, creator: volunteer) }
+      let(:case_contact) { build(:case_contact, casa_case:, creator: volunteer) }
       let!(:contact_topic_answer) do
         create(:contact_topic_answer, case_contact:, contact_topic:)
       end
+
       let(:user) { volunteer }
 
       before { sign_in user }
 
-      it "show topic answers and allows expanding to show full answer" do
+      it "show topic answers and allows expanding to show full answer", :js do
         subject
 
         expect(page).to have_text contact_topics.first.question

--- a/spec/system/case_contacts/new_spec.rb
+++ b/spec/system/case_contacts/new_spec.rb
@@ -1,15 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "case_contacts/new", :js, type: :system do
+RSpec.describe "case_contacts/new", type: :system do
   subject { visit new_case_contact_path casa_case }
 
-  let(:casa_org) { create :casa_org }
-  let(:contact_type_group) { create :contact_type_group, casa_org: }
+  let(:casa_org) { build :casa_org }
+  let(:contact_type_group) { build :contact_type_group, casa_org: }
   let!(:school_contact_type) { create :contact_type, contact_type_group:, name: "School" }
-  let(:contact_types) { [school_contact_type] }
 
   let(:volunteer) { create :volunteer, :with_single_case, casa_org: }
-  let(:casa_admin) { create :casa_admin, casa_org: }
+  let(:casa_admin) { build :casa_admin, casa_org: }
   let(:casa_case) { volunteer.casa_cases.first }
   let(:case_number) { casa_case.case_number }
 
@@ -18,13 +17,17 @@ RSpec.describe "case_contacts/new", :js, type: :system do
   before { sign_in user }
 
   it "page load creates a case_contact with status: 'started' & draft_case_ids: [casa_case.id]" do
-    expect { subject }.to change(CaseContact.started, :count).by(1)
+    subject
+
+    expect(page).to have_content("New Case Contact")
+
+    expect(CaseContact.started.count).to eq(1)
     case_contact = CaseContact.started.last
     expect(case_contact.draft_case_ids).to contain_exactly(casa_case.id)
     expect(case_contact.casa_case_id).to be_nil
   end
 
-  it "saves entered details and updates status to 'active'" do
+  it "saves entered details and updates status to 'active'", :js do
     subject
 
     expect(page).to have_text "New Case Contact"
@@ -70,42 +73,43 @@ RSpec.describe "case_contacts/new", :js, type: :system do
         hours: 1, minutes: 45
       )
 
-      expect do
-        click_on "Submit"
-        expect(page).to have_text("Medium type can't be blank")
-      end.not_to change(CaseContact, :count)
+      click_on "Submit"
 
+      expect(page).to have_text("Medium type can't be blank")
       expect(page).to have_field("case_contact_duration_hours", with: 1)
       expect(page).to have_field("case_contact_duration_minutes", with: 45)
       expect(page).to have_field("case_contact_contact_made", with: "1")
       expect(page).to have_field(class: "contact-form-type-checkbox", with: school_contact_type.id, checked: true)
+
+      expect(CaseContact.count).to eq(1)
     end
   end
 
   describe "contact types" do
-    # TODO: Fix this test
-    it "requires a contact type" do
+    it "requires a contact type", :js do
+      contact_types = [school_contact_type]
       subject
 
       fill_in_contact_details(contact_types: nil)
 
-      expect do
-        click_on "Submit"
-        expect(page).to have_text("Contact Type must be selected")
-      end.to not_change(CaseContact.active, :count)
+      click_on "Submit"
+
+      expect(page).to have_text("Contact Type must be selected")
+      expect(CaseContact.active.count).to eq(0)
 
       check contact_types.first.name
-      expect do
-        click_on "Submit"
-        expect(page).to have_text("Case contact successfully created.")
-      end.to change(CaseContact.active, :count).by(1)
+
+      click_on "Submit"
+      expect(page).to have_text("Case contact successfully created.")
+
+      expect(CaseContact.active.count).to eq(1)
     end
 
     it "does not display empty contact groups or hidden contact types" do
       create(:contact_type, name: "Shown Checkbox", contact_type_group:)
-      create(:contact_type_group, name: "Empty Group", casa_org:)
+      build(:contact_type_group, name: "Empty Group", casa_org:)
       grp_with_hidden = build(:contact_type_group, name: "OnlyHiddenTypes", casa_org:)
-      create(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
+      build(:contact_type, name: "Hidden", active: false, contact_type_group: grp_with_hidden)
 
       subject
 
@@ -127,14 +131,14 @@ RSpec.describe "case_contacts/new", :js, type: :system do
 
       it "shows only the casa case's contact types" do
         therapist_contact_type = create :contact_type, contact_type_group:, name: "Therapist"
-        expect(casa_org.contact_types).to contain_exactly(school_contact_type, therapist_contact_type, *casa_case_contact_types)
-        expect(casa_case_contact_types).not_to include([school_contact_type, therapist_contact_type])
 
         subject
 
         expect(page).to have_field(class: "contact-form-type-checkbox", with: casa_case_contact_types.first.id)
         expect(page).to have_field(class: "contact-form-type-checkbox", with: casa_case_contact_types.last.id)
         expect(page).to have_field(class: "contact-form-type-checkbox", count: casa_case_contact_types.size) # (no others)
+        expect(casa_org.contact_types).to contain_exactly(school_contact_type, therapist_contact_type, *casa_case_contact_types)
+        expect(casa_case_contact_types).not_to include([school_contact_type, therapist_contact_type])
       end
     end
   end
@@ -151,8 +155,6 @@ RSpec.describe "case_contacts/new", :js, type: :system do
     let(:notes_section_selector) { "#contact-form-notes" }
     let(:autosave_alert_div) { "#contact-form-notes" }
     let(:autosave_alert_css) { 'small[role="alert"]' }
-    let(:autosave_alert_text) { "Saved!" }
-    let(:autosave_wait_time) { 3 }
 
     it "does not show topic questions that are inactive or soft deleted in select" do
       contact_topics
@@ -166,60 +168,59 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       end
     end
 
-    it "autosaves notes & answers" do
+    it "autosaves notes & answers", :js do
       contact_topics
-      expect { subject }.to change(CaseContact.started, :count).by(1)
-      case_contact = CaseContact.started.last
+      subject
 
       complete_details_page(
         case_numbers: [case_number], contact_types: %w[School], contact_made: true,
-        medium: "In Person", occurred_on: "04/04/2020", hours: 1, minutes: 45
+        medium: "In Person", occurred_on: Date.new(2020, 4, 4), hours: 1, minutes: 45
       )
 
       answer_topic "Active Topic", "Hello world"
 
       within autosave_alert_div do
-        find(autosave_alert_css, text: autosave_alert_text, wait: autosave_wait_time)
+        find(autosave_alert_css, text: "Saved!")
       end
 
-      expect(case_contact.reload.contact_topic_answers.first.value).to eq "Hello world"
+      expect(page.find(".contact-topic-answer-input")&.value).to eq("Hello world")
     end
 
     context "when org has no contact topics" do
-      # TODO: Fix this test
-      it "allows entering contact notes" do
-        expect(casa_org.contact_topics.size).to eq 0
+      it "allows entering contact notes", :js do
         subject
 
         fill_in_contact_details contact_types: %w[School]
 
         fill_in "Additional Notes", with: "This is the note"
 
-        expect {
-          click_on "Submit"
-          expect(page).to have_text("Case contact successfully created.")
-        }.to change(CaseContact.active, :count).by(1)
+        click_on "Submit"
 
+        expect(page).to have_text("Case contact successfully created.")
+
+        expect(casa_org.contact_topics.size).to eq 0
+        expect(CaseContact.active.count).to eq 1
         case_contact = CaseContact.active.last
         expect(case_contact.contact_topic_answers).to be_empty
         expect(case_contact.notes).to eq "This is the note"
       end
 
       it "guides volunteer to contact admin" do
-        expect(casa_org.contact_topics.size).to eq 0
         subject
 
         expect(page).to have_text("Your organization has not set any Court Report Topics yet. Contact your admin to learn more.")
+        expect(CaseContact.active.count).to eq(0)
       end
 
       context "with admin user" do
+        let(:casa_admin) { create(:casa_admin, casa_org: casa_org) }
         let(:user) { casa_admin }
 
         it "shows the admin the contact topics link" do
-          expect(casa_org.contact_topics.size).to eq 0
           subject
 
           expect(page).to have_link("Manage Case Contact Topics")
+          expect(CaseContact.active.count).to eq(0)
         end
       end
 
@@ -228,10 +229,10 @@ RSpec.describe "case_contacts/new", :js, type: :system do
         let(:user) { supervisor }
 
         it "guides supervisor to contact admin" do
-          expect(casa_org.contact_topics.size).to eq 0
           subject
 
           expect(page).to have_text("Your organization has not set any Court Report Topics yet. Contact your admin to learn more.")
+          expect(CaseContact.active.count).to eq(0)
         end
       end
     end
@@ -245,15 +246,13 @@ RSpec.describe "case_contacts/new", :js, type: :system do
     let(:miles_driven_input) { "case_contact_miles_driven" }
     let(:volunteer_address_input) { "case_contact_volunteer_address" }
     let(:add_expense_button_text) { "Add Another Expense" }
-    let(:expense_amount_class) { "expense-amount-input" }
-    let(:expense_describe_class) { "expense-describe-input" }
 
     before do
       allow(Flipper).to receive(:enabled?).with(:show_additional_expenses).and_return(true)
       allow(Flipper).to receive(:enabled?).with(:reimbursement_warning, casa_org).and_call_original
     end
 
-    it "is not shown until 'Request travel or other reimbursement' is checked" do
+    it "is not shown until 'Request travel or other reimbursement' is checked", :js do
       subject
 
       expect(page).to have_no_field(miles_driven_input)
@@ -267,7 +266,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       expect(page).to have_button(add_expense_button_text)
     end
 
-    it "clears mileage info if reimbursement unchecked" do
+    it "clears mileage info if reimbursement unchecked", :js do
       subject
       fill_in_contact_details contact_types: %w[School]
 
@@ -276,17 +275,17 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       fill_in volunteer_address_input, with: "123 Example St"
       uncheck reimbursement_checkbox
 
-      expect {
-        click_on "Submit"
-        expect(page).to have_text("Case contact successfully created.")
-      }.to change(CaseContact.active, :count).by(1)
-      case_contact = CaseContact.active.last
+      click_on "Submit"
 
+      expect(page).to have_text("Case contact successfully created.")
+
+      expect(CaseContact.active.count).to eq(1)
+      case_contact = CaseContact.active.last
       expect(case_contact.want_driving_reimbursement).to be false
       expect(case_contact.miles_driven).to be_zero
     end
 
-    it "saves mileage and address information" do # TODO make test not flaky
+    it "saves mileage and address information", :js do
       subject
       fill_in_contact_details contact_types: %w[School]
 
@@ -295,12 +294,12 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       fill_in miles_driven_input, with: 50
       fill_in volunteer_address_input, with: "123 Example St"
 
-      expect {
-        click_on "Submit"
-        expect(page).to have_text("Case contact successfully created.")
-      }.to change(CaseContact.active, :count).by(1)
-      case_contact = CaseContact.active.last
+      click_on "Submit"
 
+      expect(page).to have_text("Case contact successfully created.")
+
+      expect(CaseContact.active.count).to eq(1)
+      case_contact = CaseContact.active.last
       expect(case_contact.want_driving_reimbursement).to be true
       expect(case_contact.volunteer_address).to eq "123 Example St"
       expect(case_contact.miles_driven).to eq 50
@@ -308,14 +307,17 @@ RSpec.describe "case_contacts/new", :js, type: :system do
 
     it "does not accept decimal mileage" do
       subject
-      complete_details_page
 
       check reimbursement_checkbox
 
       fill_in miles_driven_input, with: 50.5
       fill_in volunteer_address_input, with: "123 Example St"
 
-      expect { click_on "Submit" }.not_to change(CaseContact.active, :count)
+      click_on "Submit"
+
+      expect(page).to have_text("No changes have been saved")
+
+      expect(CaseContact.active.count).to eq(0)
     end
 
     it "requires inputs if checkbox checked" do
@@ -324,16 +326,15 @@ RSpec.describe "case_contacts/new", :js, type: :system do
 
       check reimbursement_checkbox
 
-      expect {
-        click_on "Submit"
-        expect(page).to have_text("Must enter a valid mailing address for the reimbursement")
-      }.not_to change(CaseContact.active, :count)
-      expect(page).to have_text("Must enter miles driven to receive driving reimbursement")
+      click_on "Submit"
+
+      expect(page).to have_text("Must enter a valid mailing address for the reimbursement")
+
+      expect(CaseContact.active.count).to eq(0)
     end
 
     context "when volunteer case assignment reimbursement is false" do
-      let(:volunteer) { create :volunteer, :with_disallow_reimbursement, casa_org: }
-      let(:casa_case) { volunteer.casa_cases.last }
+      let(:volunteer) { build :volunteer, :with_disallow_reimbursement, casa_org: }
 
       it "does not show reimbursement section" do
         subject
@@ -366,7 +367,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
     context "when casa org additional expenses false" do
       before { casa_org.update! additional_expenses_enabled: false }
 
-      it "enables mileage reimbursement but does shows additional expenses" do
+      it "enables mileage reimbursement but does shows additional expenses", :js do
         subject
 
         complete_details_page(case_numbers: [case_number], contact_types: %w[School])
@@ -383,7 +384,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
     end
 
     context "when casa org does not allow mileage or expense reimbursement" do
-      let(:casa_org) { create :casa_org, show_driving_reimbursement: false, additional_expenses_enabled: false }
+      let(:casa_org) { build :casa_org, show_driving_reimbursement: false, additional_expenses_enabled: false }
 
       it "does not show reimbursement section" do
         subject
@@ -399,29 +400,30 @@ RSpec.describe "case_contacts/new", :js, type: :system do
   end
 
   context "when 'Create Another' is checked" do
-    it "redirects to the new CaseContact form with the same case selected" do
+    it "redirects to the new CaseContact form with the same case selected", :js do
       subject
+
       complete_details_page(
         case_numbers: [case_number], contact_types: %w[School], contact_made: true,
         medium: "In Person", occurred_on: Date.today, hours: 1, minutes: 45
       )
 
       check "Create Another"
-      expect {
-        click_on "Submit"
-        expect(page).to have_text "Case contact successfully created."
-      }
-        .to change(CaseContact, :count).by(1)
-      # .to change(CaseContact.active, :count).by(1)
-      # .and change(CaseContact.started, :count).by(1)
+      click_on "Submit"
+
+      expect(page).to have_text "Case contact successfully created."
+      expect(page).to have_text "New Case Contact"
+      expect(page).to have_text case_number
+
+      expect(CaseContact.active.count).to eq(1)
+      expect(CaseContact.started.count).to eq(1)
+
       submitted_case_contact = CaseContact.active.last
       next_case_contact = CaseContact.started.last
 
-      expect(page).to have_text "New Case Contact"
       expect(submitted_case_contact.reload.metadata["create_another"]).to be true
       # new contact uses draft_case_ids from the original & form selects them
       expect(next_case_contact.draft_case_ids).to eq [casa_case.id]
-      expect(page).to have_text case_number
       # default values for other attributes (not from the last contact)
       expect(next_case_contact.status).to eq "started"
       expect(next_case_contact.miles_driven).to be_zero
@@ -432,7 +434,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       expect(next_case_contact.contact_made).to be true
     end
 
-    it "does not reset referring location" do
+    it "does not reset referring location", :js do
       visit casa_case_path casa_case
       # referrer will be set by CaseContactsController#new to casa_case_path(casa_case)
       click_on "New Case Contact"
@@ -457,7 +459,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       let(:case_number_two) { casa_case_two.case_number }
       let!(:draft_case_ids) { [casa_case.id, casa_case_two.id] }
 
-      it "redirects to the new CaseContact form with the same cases selected" do
+      it "redirects to the new CaseContact form with the same cases selected", :js do
         expect {
           visit new_case_contact_path(casa_case, {draft_case_ids:})
           expect(page).to have_content("Record New Case Contact")
@@ -489,12 +491,12 @@ RSpec.describe "case_contacts/new", :js, type: :system do
   end
 
   context "when volunteer has multiple cases" do
-    let!(:volunteer) { create(:volunteer, :with_casa_cases, casa_org:) }
-    let!(:first_case) { volunteer.casa_cases.first }
-    let!(:second_case) { volunteer.casa_cases.second }
+    let(:volunteer) { create(:volunteer, :with_casa_cases, casa_org:) }
+    let(:first_case) { volunteer.casa_cases.first }
+    let(:second_case) { volunteer.casa_cases.second }
 
     describe "case default selection" do
-      it "selects no cases" do
+      it "selects no cases", :js do
         subject
 
         expect(page).to have_no_text(first_case.case_number)
@@ -502,7 +504,7 @@ RSpec.describe "case_contacts/new", :js, type: :system do
       end
 
       context "when there are params defined" do
-        it "select the cases defined in the params" do
+        it "select the cases defined in the params", :js do
           visit new_case_contact_path(case_contact: {casa_case_id: first_case.id})
 
           expect(page).to have_text(first_case.case_number)
@@ -513,21 +515,18 @@ RSpec.describe "case_contacts/new", :js, type: :system do
   end
 
   context "when volunteer has one case" do
-    let!(:first_case) { volunteer.casa_cases.first }
+    let(:first_case) { volunteer.casa_cases.first }
 
     it "selects the only case" do
-      expect(volunteer.casa_cases.size).to eq 1
-
       subject
 
       expect(page).to have_text(first_case.case_number)
+      expect(volunteer.casa_cases.size).to eq 1
     end
   end
 
   context "with admin user" do
-    let(:user) { casa_admin }
-
-    it "can create CaseContact" do
+    it "can create CaseContact", :js do
       subject
 
       complete_details_page(
@@ -535,10 +534,11 @@ RSpec.describe "case_contacts/new", :js, type: :system do
         medium: "Video", occurred_on: Date.new(2020, 4, 5), hours: 1, minutes: 45
       )
 
-      expect {
-        click_on "Submit"
-        expect(page).to have_text "Case contact successfully created."
-      }.to change(CaseContact.active, :count).by(1)
+      click_on "Submit"
+
+      expect(page).to have_text "Case contact successfully created."
+
+      expect(CaseContact.active.count).to eq(1)
       contact = CaseContact.active.last
       expect(contact.casa_case_id).to eq casa_case.id
       expect(contact.contact_types.map(&:name)).to include("School")


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves https://github.com/rubyforgood/casa/issues/6701

### What changed, and _why_?

When github's free CI servers are under heavy load, a race condition between the page loading and checking the database causes tests to flake. This is caused by a system test inputting data into a form then immediately checking the database without waiting for the form to finish submitting.

For every database check in the system files, this ensures it's preceded by a capybara matcher with automatic waiting, such as checking for assertions after the page loads before checking for DB values, or replaced the database
check with a check for something to appear on the page.

I also took the opportunity to refactor some small things to save up test setup time:

- build factories instead of creating as much as possible
- require `:js` only when necessary
- remove unused variables and factories
- keep necessary factories close to where they are used to avoid creating extra factories when not needed
- updates Date string to Date objects (these were flaky locally) - similar to https://github.com/rubyforgood/casa/pull/6764