### PR TITLE
Add coverage for CreateAllCasaAdminService

### DIFF
--- a/spec/services/create_all_casa_admin_service_spec.rb
+++ b/spec/services/create_all_casa_admin_service_spec.rb
@@ -1,7 +1,70 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe CreateAllCasaAdminService, type: :service do
-  # TODO: Add tests for CreateAllCasaAdminService
+  let(:user) { build(:user) }
+  let(:params) do
+    ActionController::Parameters.new(
+      {
+        all_casa_admin: {
+          email: "casa_admin23@example.com"
+        }
+      }
+    ).permit!
+  end
 
-  pending "add some tests for CreateAllCasaAdminService"
+  describe "#build" do
+    it "initializes an AllCasaAdmin with the given params and a password" do
+      allow(SecureRandom).to receive(:hex).with(10).and_return("12345678910")
+
+      admin = CreateAllCasaAdminService.new(params, user)
+
+      all_casa_admin = admin.build
+
+      expect(all_casa_admin).to be_instance_of(AllCasaAdmin)
+      expect(all_casa_admin).not_to be_persisted
+      expect(all_casa_admin).to have_attributes(
+        email: params[:all_casa_admin][:email],
+        password: "12345678910"
+      )
+    end
+  end
+
+  describe "#create!" do
+    it "creates an AllCasaAdmin with the given params and sends an invite" do
+      admin = CreateAllCasaAdminService.new(params, user)
+      admin.build
+
+      expect do
+        admin.create!
+      end.to change(AllCasaAdmin, :count).by(1)
+
+      casa_admin = AllCasaAdmin.last
+      expect(casa_admin.invited_by_id).to eq(user.id)
+      expect(casa_admin.invited_by_type).to eq("User")
+      expect(casa_admin).to have_attributes(
+        email: params[:all_casa_admin][:email]
+      )
+    end
+
+    context "when there are errors" do
+      it "does not create an AllCasaAdmin and returns the errors" do
+        params = ActionController::Parameters.new(
+          {
+            all_casa_admin: {
+              email: "invalid_email_format"
+            }
+          }
+        ).permit!
+
+        admin = CreateAllCasaAdminService.new(params, user)
+        admin.build
+
+        expect do
+          admin.create!
+        end.to raise_error(ActiveRecord::RecordInvalid, /email is invalid/i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Closes https://github.com/rubyforgood/casa/issues/6821

### What changed, and _why_?

CreateAllCasaAdminService creates system-wide admin users but has a placeholder spec only.
This commit adds coverage for it since creating users is a critical functionality of the app.