### PR TITLE
New Case Contacts Table: expandable case contact rows

### DIFF
--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -154,3 +154,24 @@
     transform: rotate(180deg);
   }
 }
+
+.expanded-content {
+  padding: 0.75rem 1rem;
+
+  .expanded-topic {
+    margin-bottom: 0.75rem;
+
+    strong {
+      display: block;
+    }
+
+    p {
+      margin: 0.25rem 0 0;
+    }
+  }
+}
+
+.expanded-empty {
+  padding: 0.75rem 1rem;
+  margin: 0;
+}

--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -145,3 +145,12 @@
 .cc-italic {
     font-style: italic;
 }
+
+.expand-toggle {
+  display: inline-block;
+  transition: transform 0.3s;
+
+  &.expanded {
+    transform: rotate(180deg);
+  }
+}

--- a/app/assets/stylesheets/pages/case_contacts.scss
+++ b/app/assets/stylesheets/pages/case_contacts.scss
@@ -148,6 +148,10 @@
 
 .expand-toggle {
   display: inline-block;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  padding: 0;
   transition: transform 0.3s;
 
   &.expanded {

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -29,7 +29,7 @@ class CaseContactDatatable < ApplicationDatatable
         },
         contact_made: case_contact.contact_made,
         duration_minutes: case_contact.duration_minutes,
-        contact_topics: case_contact.contact_topics.map(&:question).join(" | "),
+        contact_topics: case_contact.contact_topics.map(&:question),
         contact_topic_answers: case_contact.contact_topic_answers
                                .reject { |a| a.value.blank? }
                                .map { |a| { question: a.contact_topic&.question, value: a.value } },

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -31,8 +31,8 @@ class CaseContactDatatable < ApplicationDatatable
         duration_minutes: case_contact.duration_minutes,
         contact_topics: case_contact.contact_topics.map(&:question),
         contact_topic_answers: case_contact.contact_topic_answers
-                               .reject { |a| a.value.blank? }
-                               .map { |a| { question: a.contact_topic&.question, value: a.value } },
+          .reject { |a| a.value.blank? }
+          .map { |a| {question: a.contact_topic&.question, value: a.value} },
         notes: case_contact.notes.presence,
         is_draft: !case_contact.active?,
         has_followup: case_contact.followups.requested.exists?

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -30,6 +30,10 @@ class CaseContactDatatable < ApplicationDatatable
         contact_made: case_contact.contact_made,
         duration_minutes: case_contact.duration_minutes,
         contact_topics: case_contact.contact_topics.map(&:question).join(" | "),
+        contact_topic_answers: case_contact.contact_topic_answers
+                               .reject { |a| a.value.blank? }
+                               .map { |a| { question: a.contact_topic&.question, value: a.value } },
+        notes: case_contact.notes.presence,
         is_draft: !case_contact.active?,
         has_followup: case_contact.followups.requested.exists?
       }
@@ -44,7 +48,7 @@ class CaseContactDatatable < ApplicationDatatable
     base_relation
       .joins("INNER JOIN users creators ON creators.id = case_contacts.creator_id")
       .left_joins(:casa_case)
-      .includes(:contact_types, :contact_topics, :followups, :creator)
+      .includes(:contact_types, :contact_topics, :followups, :creator, contact_topic_answers: :contact_topic)
       .order(order_clause)
       .order(:id)
   end

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -154,7 +154,7 @@ describe('defineCaseContactsTable', () => {
       it('renders chevron-down icon', () => {
         const rendered = columns[1].render(null, 'display', {})
 
-        expect(rendered).toBe('<i class="fa-solid fa-chevron-down"></i>')
+        expect(rendered).toBe('<i class="fa-solid fa-chevron-down expand-toggle" style="cursor: pointer;"></i>')
       })
     })
 

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -309,9 +309,33 @@ describe('defineCaseContactsTable', () => {
         expect(columns[8].orderable).toBe(false)
       })
 
-      it('renders contact topics string', () => {
-        expect(columns[8].render('Topic 1 | Topic 2')).toBe('Topic 1 | Topic 2')
+      it('renders each topic as a pill badge', () => {
+        const rendered = columns[8].render(['Topic 1', 'Topic 2'])
+        expect(rendered).toContain('<span class="badge badge-pill light-bg text-black">Topic 1</span>')
+        expect(rendered).toContain('<span class="badge badge-pill light-bg text-black">Topic 2</span>')
+      })
+
+      it('renders empty string when there are no topics', () => {
         expect(columns[8].render(null)).toBe('')
+        expect(columns[8].render([])).toBe('')
+      })
+
+      it('shows only the first two topics when there are more than two', () => {
+        const rendered = columns[8].render(['A', 'B', 'C', 'D'])
+        expect(rendered).toContain('>A<')
+        expect(rendered).toContain('>B<')
+        expect(rendered).not.toContain('>C<')
+        expect(rendered).not.toContain('>D<')
+      })
+
+      it('shows a +N More badge for overflow topics', () => {
+        const rendered = columns[8].render(['A', 'B', 'C', 'D'])
+        expect(rendered).toContain('+2 More')
+      })
+
+      it('does not show an overflow badge when there are two or fewer topics', () => {
+        expect(columns[8].render(['A', 'B'])).not.toContain('More')
+        expect(columns[8].render(['A'])).not.toContain('More')
       })
     })
 

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -151,10 +151,10 @@ describe('defineCaseContactsTable', () => {
         expect(columns[1].searchable).toBe(false)
       })
 
-      it('renders chevron-down icon', () => {
+      it('renders chevron-down icon as an accessible button', () => {
         const rendered = columns[1].render(null, 'display', {})
 
-        expect(rendered).toBe('<i class="fa-solid fa-chevron-down expand-toggle" style="cursor: pointer;"></i>')
+        expect(rendered).toBe('<button type="button" class="expand-toggle" aria-expanded="false" aria-label="Expand row details"><i class="fa-solid fa-chevron-down" aria-hidden="true"></i></button>')
       })
     })
 

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -65,7 +65,7 @@ const defineCaseContactsTable = function () {
         data: null,
         orderable: false,
         searchable: false,
-        render: () => '<i class="fa-solid fa-chevron-down expand-toggle" style="cursor: pointer;"></i>'
+        render: () => '<button type="button" class="expand-toggle" aria-expanded="false" aria-label="Expand row details"><i class="fa-solid fa-chevron-down" aria-hidden="true"></i></button>'
       },
       { // Date column (index 2)
         data: 'occurred_at',
@@ -161,10 +161,10 @@ const defineCaseContactsTable = function () {
 
     if (row.child.isShown()) {
       row.child.hide()
-      $(this).removeClass('expanded')
+      $(this).removeClass('expanded').attr('aria-expanded', 'false')
     } else {
       row.child(buildExpandedContent(row.data())).show()
-      $(this).addClass('expanded')
+      $(this).addClass('expanded').attr('aria-expanded', 'true')
     }
   })
 }

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -3,6 +3,21 @@
 const { Notifier } = require('./notifier')
 let pageNotifier
 
+const MAX_VISIBLE_TOPIC_PILLS = 2
+
+function buildTopicPills (topics) {
+  if (!topics || topics.length === 0) return ''
+  const visible = topics.slice(0, MAX_VISIBLE_TOPIC_PILLS)
+  const overflowCount = topics.length - visible.length
+  const pills = visible
+    .map(topic => `<span class="badge badge-pill light-bg text-black">${topic}</span>`)
+    .join(' ')
+  const overflowPill = overflowCount > 0
+    ? ` <span class="badge badge-pill light-bg text-black">+${overflowCount} More</span>`
+    : ''
+  return pills + overflowPill
+}
+
 function buildExpandedContent (data) {
   const answers = (data.contact_topic_answers || [])
     .map(answer => `<div class="expanded-topic"><strong>${answer.question}</strong><p>${answer.value}</p></div>`)
@@ -120,7 +135,7 @@ const defineCaseContactsTable = function () {
       { // Topics column (index 8)
         data: 'contact_topics',
         orderable: false,
-        render: (data) => data || ''
+        render: (data) => buildTopicPills(data)
       },
       { // Draft column (index 9)
         data: 'is_draft',

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -3,8 +3,22 @@
 const { Notifier } = require('./notifier')
 let pageNotifier
 
+function buildExpandedContent (data) {
+  const answers = (data.contact_topic_answers || [])
+    .map(answer => `<li><strong>${answer.question}:</strong> ${answer.value}</li>`)
+    .join('')
+
+  const notes = data.notes && data.notes.trim()
+    ? `<li><strong>Additional Notes:</strong> ${data.notes}</li>`
+    : ''
+
+  if (!answers && !notes) return '<p>No additional details.</p>'
+
+  return `<ul>${answers}${notes}</ul>`
+}
+
 const defineCaseContactsTable = function () {
-  $('table#case_contacts').DataTable({
+  const table = $('table#case_contacts').DataTable({
     scrollX: true,
     searching: true,
     processing: true,
@@ -36,7 +50,7 @@ const defineCaseContactsTable = function () {
         data: null,
         orderable: false,
         searchable: false,
-        render: () => '<i class="fa-solid fa-chevron-down"></i>'
+        render: () => '<i class="fa-solid fa-chevron-down expand-toggle" style="cursor: pointer;"></i>'
       },
       { // Date column (index 2)
         data: 'occurred_at',
@@ -124,6 +138,19 @@ const defineCaseContactsTable = function () {
         render: () => '<i class="fas fa-ellipsis-v"></i>'
       }
     ]
+  })
+
+  $('table#case_contacts tbody').on('click', '.expand-toggle', function () {
+    const tr = $(this).closest('tr')
+    const row = table.row(tr)
+
+    if (row.child.isShown()) {
+      row.child.hide()
+      $(this).removeClass('expanded')
+    } else {
+      row.child(buildExpandedContent(row.data())).show()
+      $(this).addClass('expanded')
+    }
   })
 }
 

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -5,16 +5,16 @@ let pageNotifier
 
 function buildExpandedContent (data) {
   const answers = (data.contact_topic_answers || [])
-    .map(answer => `<li><strong>${answer.question}:</strong> ${answer.value}</li>`)
+    .map(answer => `<div class="expanded-topic"><strong>${answer.question}</strong><p>${answer.value}</p></div>`)
     .join('')
 
   const notes = data.notes && data.notes.trim()
-    ? `<li><strong>Additional Notes:</strong> ${data.notes}</li>`
+    ? `<div class="expanded-topic"><strong>Additional Notes</strong><p>${data.notes}</p></div>`
     : ''
 
-  if (!answers && !notes) return '<p>No additional details.</p>'
+  if (!answers && !notes) return '<p class="expanded-empty">No additional details.</p>'
 
-  return `<ul>${answers}${notes}</ul>`
+  return `<div class="expanded-content">${answers}${notes}</div>`
 }
 
 const defineCaseContactsTable = function () {

--- a/spec/requests/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/requests/case_contacts/case_contacts_new_design_spec.rb
@@ -177,6 +177,68 @@ RSpec.describe "/case_contacts_new_design", type: :request do
           expect(response).to have_http_status(:unauthorized)
         end
       end
+
+      context "expanded content fields" do
+        let(:contact_topic) { create(:contact_topic, casa_org: organization) }
+        let(:case_contact_with_details) do
+          create(:case_contact, :active, casa_case: casa_case, notes: "Important follow-up")
+        end
+
+        before do
+          create(:contact_topic_answer,
+            case_contact: case_contact_with_details,
+            contact_topic: contact_topic,
+            value: "Youth is doing well")
+        end
+
+        it "includes contact_topic_answers in the response" do
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_details.id.to_s }
+          expect(record[:contact_topic_answers]).to be_an(Array)
+          expect(record[:contact_topic_answers].first[:value]).to eq("Youth is doing well")
+        end
+
+        it "includes the topic question in contact_topic_answers" do
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_details.id.to_s }
+          expect(record[:contact_topic_answers].first[:question]).to eq(contact_topic.question)
+        end
+
+        it "includes notes in the response" do
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_details.id.to_s }
+          expect(record[:notes]).to eq("Important follow-up")
+        end
+
+        it "omits blank topic answer values" do
+          create(:contact_topic_answer,
+            case_contact: case_contact_with_details,
+            contact_topic: contact_topic,
+            value: "")
+
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_details.id.to_s }
+          expect(record[:contact_topic_answers].map { |a| a[:value] }).to all(be_present)
+        end
+
+        it "returns a blank value for notes when notes are empty" do
+          case_contact_without_notes = create(:case_contact, :active, casa_case: casa_case, notes: "")
+
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_without_notes.id.to_s }
+          expect(record[:notes]).to be_blank
+        end
+      end
     end
   end
 end

--- a/spec/requests/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/requests/case_contacts/case_contacts_new_design_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "/case_contacts_new_design", type: :request do
 
           json = JSON.parse(response.body, symbolize_names: true)
           record = json[:data].find { |d| d[:id] == case_contact_with_details.id.to_s }
-          expect(record[:contact_topic_answers].map { |a| a[:value] }).to all(be_present)
+          expect(record[:contact_topic_answers].pluck(:value)).to all(be_present)
         end
 
         it "returns a blank value for notes when notes are empty" do

--- a/spec/requests/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/requests/case_contacts/case_contacts_new_design_spec.rb
@@ -239,6 +239,31 @@ RSpec.describe "/case_contacts_new_design", type: :request do
           expect(record[:notes]).to be_blank
         end
       end
+
+      context "contact_topics field" do
+        let(:contact_topic) { create(:contact_topic, casa_org: organization) }
+        let(:case_contact_with_topics) { create(:case_contact, :active, casa_case: casa_case) }
+
+        before do
+          case_contact_with_topics.contact_topics << contact_topic
+        end
+
+        it "returns contact_topics as an array of strings" do
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_topics.id.to_s }
+          expect(record[:contact_topics]).to be_an(Array)
+        end
+
+        it "includes the topic question in the array" do
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          record = json[:data].find { |d| d[:id] == case_contact_with_topics.id.to_s }
+          expect(record[:contact_topics]).to include(contact_topic.question)
+        end
+      end
     end
   end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Case Contact Table Row Expansion", type: :system, js: true do
+  let(:organization) { create(:casa_org) }
+  let(:admin) { create(:casa_admin, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
+  let(:contact_topic) { create(:contact_topic, casa_org: organization, question: "What was discussed?") }
+  let!(:case_contact) do
+    create(:case_contact, :active, casa_case: casa_case, notes: "Important follow-up needed")
+  end
+
+  before do
+    create(:contact_topic_answer,
+      case_contact: case_contact,
+      contact_topic: contact_topic,
+      value: "Youth is doing well in school")
+    allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(true)
+    sign_in admin
+    visit case_contacts_new_design_path
+  end
+
+  it "shows the expanded content after clicking the chevron" do
+    find(".expand-toggle").click
+
+    expect(page).to have_content("What was discussed?")
+    expect(page).to have_content("Youth is doing well in school")
+  end
+
+  it "shows notes in the expanded content" do
+    find(".expand-toggle").click
+
+    expect(page).to have_content("Additional Notes")
+    expect(page).to have_content("Important follow-up needed")
+  end
+
+  it "hides the expanded content after clicking the chevron again" do
+    find(".expand-toggle").click
+    expect(page).to have_content("Youth is doing well in school")
+
+    find(".expand-toggle").click
+    expect(page).to have_no_content("Youth is doing well in school")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6498

### What changed, and _why_?

Implements expand/collapse functionality for rows in the new case contacts table.

**`app/datatables/case_contact_datatable.rb`**
- Added `contact_topic_answers` and `notes` to the JSON response so the browser has the data it needs to render expanded content
- Added `contact_topic_answers: :contact_topic` to the `includes` in `raw_records` to avoid N+1 queries

**`app/javascript/src/dashboard.js`**
- Updated the chevron column render to add the `expand-toggle` CSS class and a pointer cursor
- Captured the DataTable instance in a variable so the click handler can reference it
- Added a delegated click handler using the DataTables Child Rows API (`row.child()`) to show/hide expanded content on chevron click
- Added `buildExpandedContent()` to build the expanded row HTML from the row's JSON data, matching the structure of the Figma design (topic heading followed by answer paragraph)

**`app/assets/stylesheets/pages/case_contacts.scss`**
- Added `expand-toggle` styles with a 0.3s CSS rotation animation for the chevron (matching the existing sidebar pattern)
- Added `expanded-content` and `expanded-topic` styles to match [the Figma layout](https://www.figma.com/design/fVC7VShMu4P2FK6FexQKXI/Case-Contact-Table?node-id=1818-12386&p=f&t=M0xmv7bjCW3dVT99-0)

The DataTables Child Rows API is used rather than Bootstrap collapse or manual DOM insertion because DataTables replaces the entire `<tbody>` via AJAX on initialization. When this happens, any server-rendered or manually inserted rows are destroyed. `row.child()` inserts rows that DataTables manages itself, so they persist correctly.

**Topics column pill styling.** While working on this issue I noticed the Topics column was rendering as a raw pipe-delimited string. I did not see an issue that covers the Topics column, so I updated the render for each topic to be a `badge-pill` chip (matching the existing Draft badge style) with a `+N More` overflow indicator when there are more than two topics. I am happy to pull this into a separate issue and PR if that is preferred.

### How is this **tested**?
**Request specs** — added to `spec/requests/case_contacts/case_contacts_new_design_spec.rb`:
- `contact_topic_answers` is present and is an array in the datatable JSON response
- Topic question is included in each answer
- `notes` is included in the response
- Blank answer values are omitted
- Notes is blank when the field is empty
- `contact_topics` is returned as an array of strings (not a pipe-delimited string)
- The topic question is included in the array

**System specs** — added `spec/system/case_contacts/case_contacts_new_design_spec.rb`:
- Clicking the chevron shows contact topic answer content in the expanded row
- Clicking the chevron shows notes in the expanded row
- Clicking the chevron a second time hides the expanded content

**Jest** — updated `app/javascript/__tests__/dashboard.test.js`:

- Updated chevron render expectation to reflect the `expand-toggle` class
- Topics column: each topic renders as a `badge-pill` chip
- Topics column: renders empty string when there are no topics
- Topics column: shows only the first two topics when there are more than two
- Topics column: shows a `+N More` badge for overflow topics
- Topics column: no overflow badge when there are two or fewer topics

### Screenshots

Screen recording updated after commit fb31759.

<details>

<summary>Screen recording of collapsible sections</summary>


https://github.com/user-attachments/assets/dcbf0a04-9d1f-4273-8540-065d4ab96d74


</details>

### AI Disclosure

This PR was implemented with the assistance of [Claude Code](https://claude.ai/code) (Anthropic, claude-sonnet-4-6). The AI was used to:

- Analyze the codebase and Figma designs to inform the implementation approach
- Draft and iterate on code changes across the datatable, JavaScript, and stylesheet files
- Write and run RSpec request specs, system specs, and Jest tests
- Investigate the DataTables Child Rows API as the correct architectural approach for this use case

All generated code was reviewed and committed by the author.