### PR TITLE
Fix Jest test failures caused by Node 24 / jsdom incompatibilities

### DIFF
--- a/app/javascript/__tests__/two_minute_warning_session_timeout.test.js
+++ b/app/javascript/__tests__/two_minute_warning_session_timeout.test.js
@@ -13,10 +13,8 @@ describe('session_timeout_poller', () => {
     mockAlert = jest.fn()
     mockReload = jest.fn()
     global.alert = mockAlert
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { reload: mockReload }
-    })
+    delete window.location
+    window.location = { reload: mockReload }
 
     // Set a short timeout for testing (in minutes)
     originalTimeout = global.window.timeout

--- a/app/javascript/__tests__/validated_form.test.js
+++ b/app/javascript/__tests__/validated_form.test.js
@@ -146,12 +146,12 @@ describe('NonDrivingContactMediumWarning', () => {
       $(() => {
         try {
           expect(checkboxContainer.css('background-color')).not.toBe('rgb(255, 248, 225)')
-          expect(milesDrivenInput.css('border')).not.toBe('2px solid #ffc107')
+          expect(milesDrivenInput.css('border')).not.toBe('2px solid rgb(255, 193, 7)')
 
           component.warningHighlightUI('A warning message')
 
           expect(checkboxContainer.css('background-color')).toBe('rgb(255, 248, 225)')
-          expect(milesDrivenInput.css('border')).toBe('2px solid #ffc107')
+          expect(milesDrivenInput.css('border')).toBe('2px solid rgb(255, 193, 7)')
           done()
         } catch (error) {
           done(error)
@@ -163,17 +163,17 @@ describe('NonDrivingContactMediumWarning', () => {
       $(() => {
         try {
           expect(checkboxContainer.css('background-color')).not.toBe('rgb(255, 248, 225)')
-          expect(milesDrivenInput.css('border')).not.toBe('2px solid #ffc107')
+          expect(milesDrivenInput.css('border')).not.toBe('2px solid rgb(255, 193, 7)')
 
           component.warningHighlightUI('A warning message')
 
           expect(checkboxContainer.css('background-color')).toBe('rgb(255, 248, 225)')
-          expect(milesDrivenInput.css('border')).toBe('2px solid #ffc107')
+          expect(milesDrivenInput.css('border')).toBe('2px solid rgb(255, 193, 7)')
 
           component.warningHighlightUI()
 
           expect(checkboxContainer.css('background-color')).not.toBe('rgb(255, 248, 225)')
-          expect(milesDrivenInput.css('border')).not.toBe('2px solid #ffc107')
+          expect(milesDrivenInput.css('border')).not.toBe('2px solid rgb(255, 193, 7)')
 
           done()
         } catch (error) {


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6825

### What changed, and _why_?

Updated two Jest test files to be compatible with Node 24 and newer versions of jsdom. No production code was changed.

**`app/javascript/__tests__/two_minute_warning_session_timeout.test.js`**

Replaced `Object.defineProperty(window, 'location', { writable: true, value: ... })` with `delete window.location` followed by a plain assignment. Newer versions of jsdom define `location` as non-configurable, causing the previous approach to throw `TypeError: Cannot redefine property: location`.

**`app/javascript/__tests__/validated_form.test.js`**

Updated assertions comparing CSS border values from `'2px solid #ffc107'` to `'2px solid rgb(255, 193, 7)'`. Newer versions of jsdom normalize CSS color values to `rgb()` notation when reading them back via jQuery's `.css()`.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

The two previously failing test suites now pass:

```shell
npx jest app/javascript/__tests__/validated_form.test.js app/javascript/__tests__/two_minute_warning_session_timeout.test.js
