### PR TITLE
New Case Contacts Table: row actions menu

### DIFF
--- a/app/controllers/case_contacts/case_contacts_new_design_controller.rb
+++ b/app/controllers/case_contacts/case_contacts_new_design_controller.rb
@@ -10,7 +10,7 @@ class CaseContacts::CaseContactsNewDesignController < ApplicationController
   def datatable
     authorize CaseContact
     case_contacts = policy_scope(current_organization.case_contacts)
-    datatable = CaseContactDatatable.new case_contacts, params
+    datatable = CaseContactDatatable.new(case_contacts, params, current_user)
 
     render json: datatable
   end

--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -17,7 +17,10 @@ class CaseContacts::FollowupsController < ApplicationController
     @followup.resolved!
     create_notification
 
-    redirect_to casa_case_path(@followup.case_contact.casa_case)
+    respond_to do |format|
+      format.html { redirect_to casa_case_path(@followup.case_contact.casa_case) }
+      format.json { head :no_content }
+    end
   end
 
   private

--- a/app/controllers/case_contacts/followups_controller.rb
+++ b/app/controllers/case_contacts/followups_controller.rb
@@ -7,7 +7,10 @@ class CaseContacts::FollowupsController < ApplicationController
     note = simple_followup_params[:note]
     FollowupService.create_followup(case_contact, current_user, note)
 
-    redirect_to casa_case_path(case_contact.casa_case)
+    respond_to do |format|
+      format.html { redirect_to casa_case_path(case_contact.casa_case) }
+      format.json { head :no_content }
+    end
   end
 
   def resolve

--- a/app/controllers/case_contacts_controller.rb
+++ b/app/controllers/case_contacts_controller.rb
@@ -44,8 +44,14 @@ class CaseContactsController < ApplicationController
     authorize @case_contact
 
     @case_contact.destroy
-    flash[:notice] = "Contact is successfully deleted."
-    redirect_to request.referer
+
+    respond_to do |format|
+      format.html do
+        flash[:notice] = "Contact is successfully deleted."
+        redirect_to request.referer
+      end
+      format.json { head :no_content }
+    end
   end
 
   def restore

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -8,10 +8,20 @@ class CaseContactDatatable < ApplicationDatatable
     duration_minutes
   ].freeze
 
+  def initialize(base_relation, params, current_user)
+    super(base_relation, params)
+    @current_user = current_user
+  end
+
   private
+
+  attr_reader :current_user
 
   def data
     records.map do |case_contact|
+      policy = CaseContactPolicy.new(current_user, case_contact)
+      requested_followup = case_contact.followups.find(&:requested?)
+
       {
         id: case_contact.id,
         occurred_at: I18n.l(case_contact.occurred_at, format: :full, default: nil),
@@ -35,7 +45,11 @@ class CaseContactDatatable < ApplicationDatatable
           .map { |a| {question: a.contact_topic&.question, value: a.value} },
         notes: case_contact.notes.presence,
         is_draft: !case_contact.active?,
-        has_followup: case_contact.followups.requested.exists?
+        has_followup: requested_followup.present?,
+        can_edit: policy.update?,
+        can_destroy: policy.destroy?,
+        edit_path: Rails.application.routes.url_helpers.edit_case_contact_path(case_contact),
+        followup_id: requested_followup&.id
       }
     end
   end

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -63,6 +63,7 @@ class CaseContactDatatable < ApplicationDatatable
       .joins("INNER JOIN users creators ON creators.id = case_contacts.creator_id")
       .left_joins(:casa_case)
       .includes(:casa_case, :contact_types, :contact_topics, :followups, :creator, contact_topic_answers: :contact_topic)
+      .preload(:casa_org, :creator_casa_org)
       .order(order_clause)
       .order(:id)
   end

--- a/app/datatables/case_contact_datatable.rb
+++ b/app/datatables/case_contact_datatable.rb
@@ -45,7 +45,7 @@ class CaseContactDatatable < ApplicationDatatable
           .map { |a| {question: a.contact_topic&.question, value: a.value} },
         notes: case_contact.notes.presence,
         is_draft: !case_contact.active?,
-        has_followup: case_contact.followups.any?(&:requested?)
+        has_followup: requested_followup.present?,
         can_edit: policy.update?,
         can_destroy: policy.destroy?,
         edit_path: Rails.application.routes.url_helpers.edit_case_contact_path(case_contact),

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -412,12 +412,14 @@ describe('defineCaseContactsTable', () => {
         expect(rendered).toContain('Edit')
       })
 
-      it('does not render Edit item when can_edit is "false"', () => {
+      it('renders Edit as disabled when can_edit is "false"', () => {
         const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
         const rendered = columns[10].render(null, 'display', row)
 
+        expect(rendered).toContain('Edit')
+        expect(rendered).toContain('disabled')
+        expect(rendered).toContain('aria-disabled="true"')
         expect(rendered).not.toContain('href="/case_contacts/1/edit"')
-        expect(rendered).not.toContain('>Edit<')
       })
 
       it('renders Delete item when can_destroy is "true"', () => {
@@ -429,12 +431,14 @@ describe('defineCaseContactsTable', () => {
         expect(rendered).toContain('Delete')
       })
 
-      it('does not render Delete item when can_destroy is "false"', () => {
+      it('renders Delete as disabled when can_destroy is "false"', () => {
         const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
         const rendered = columns[10].render(null, 'display', row)
 
+        expect(rendered).toContain('Delete')
+        expect(rendered).toContain('disabled')
+        expect(rendered).toContain('aria-disabled="true"')
         expect(rendered).not.toContain('cc-delete-action')
-        expect(rendered).not.toContain('>Delete<')
       })
 
       it('renders Set Reminder when followup_id is empty', () => {

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -477,6 +477,14 @@ describe('defineCaseContactsTable', () => {
     let mockAjaxReload
     let mockTableInstance
 
+    const clickActionButton = (action, attrs = {}) => {
+      const dataAttrs = Object.entries(attrs).map(([k, v]) => `data-${k}="${v}"`).join(' ')
+      $('table#case_contacts tbody').append(
+        `<tr><td><button class="cc-${action}-action" ${dataAttrs}>${action}</button></td></tr>`
+      )
+      $(`.cc-${action}-action`).trigger('click')
+    }
+
     beforeEach(() => {
       mockAjaxReload = jest.fn()
       mockTableInstance = { ajax: { reload: mockAjaxReload } }
@@ -497,8 +505,7 @@ describe('defineCaseContactsTable', () => {
       it('shows a SweetAlert confirmation dialog when cc-delete-action is clicked', () => {
         Swal.fire.mockResolvedValue({ isConfirmed: false })
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
-        $('.cc-delete-action').trigger('click')
+        clickActionButton('delete', { id: '42' })
 
         expect(Swal.fire).toHaveBeenCalled()
       })
@@ -507,8 +514,7 @@ describe('defineCaseContactsTable', () => {
         Swal.fire.mockResolvedValue({ isConfirmed: true })
         const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
-        $('.cc-delete-action').trigger('click')
+        clickActionButton('delete', { id: '42' })
 
         await Promise.resolve()
 
@@ -526,8 +532,7 @@ describe('defineCaseContactsTable', () => {
         Swal.fire.mockResolvedValue({ isConfirmed: false })
         const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation()
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
-        $('.cc-delete-action').trigger('click')
+        clickActionButton('delete', { id: '42' })
 
         await Promise.resolve()
 
@@ -540,8 +545,7 @@ describe('defineCaseContactsTable', () => {
         Swal.fire.mockResolvedValue({ isConfirmed: true })
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
-        $('.cc-delete-action').trigger('click')
+        clickActionButton('delete', { id: '42' })
 
         await Promise.resolve()
 
@@ -553,8 +557,7 @@ describe('defineCaseContactsTable', () => {
       it('calls fireSwalFollowupAlert when cc-set-reminder-action is clicked', () => {
         fireSwalFollowupAlert.mockResolvedValue({ isConfirmed: false })
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
-        $('.cc-set-reminder-action').trigger('click')
+        clickActionButton('set-reminder', { id: '5' })
 
         expect(fireSwalFollowupAlert).toHaveBeenCalled()
       })
@@ -563,8 +566,7 @@ describe('defineCaseContactsTable', () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
         const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
-        $('.cc-set-reminder-action').trigger('click')
+        clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
@@ -577,8 +579,7 @@ describe('defineCaseContactsTable', () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: 'My note', isConfirmed: true })
         const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
-        $('.cc-set-reminder-action').trigger('click')
+        clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
@@ -591,8 +592,7 @@ describe('defineCaseContactsTable', () => {
         fireSwalFollowupAlert.mockResolvedValue({ isConfirmed: false })
         const postSpy = jest.spyOn($, 'post').mockImplementation()
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
-        $('.cc-set-reminder-action').trigger('click')
+        clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
@@ -605,8 +605,7 @@ describe('defineCaseContactsTable', () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
         jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
-        $('.cc-set-reminder-action').trigger('click')
+        clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
@@ -618,8 +617,7 @@ describe('defineCaseContactsTable', () => {
       it('sends PATCH request when cc-resolve-reminder-action is clicked', () => {
         const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-resolve-reminder-action" data-id="5" data-followup-id="42">Resolve Reminder</button></td></tr>')
-        $('.cc-resolve-reminder-action').trigger('click')
+        clickActionButton('resolve-reminder', { id: '5', 'followup-id': '42' })
 
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/followups/42/resolve',
@@ -634,8 +632,7 @@ describe('defineCaseContactsTable', () => {
       it('reloads the DataTable after resolving a reminder', () => {
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
-        $('table#case_contacts tbody').append('<tr><td><button class="cc-resolve-reminder-action" data-id="5" data-followup-id="42">Resolve Reminder</button></td></tr>')
-        $('.cc-resolve-reminder-action').trigger('click')
+        clickActionButton('resolve-reminder', { id: '5', 'followup-id': '42' })
 
         expect(mockAjaxReload).toHaveBeenCalled()
       })

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -3,7 +3,13 @@
  * @jest-environment jsdom
  */
 
+import Swal from 'sweetalert2'
 import { defineCaseContactsTable } from '../src/dashboard'
+
+jest.mock('sweetalert2', () => ({
+  __esModule: true,
+  default: { fire: jest.fn() }
+}))
 
 // Mock DataTable
 const mockDataTable = jest.fn()
@@ -382,10 +388,218 @@ describe('defineCaseContactsTable', () => {
         expect(columns[10].searchable).toBe(false)
       })
 
-      it('renders ellipsis icon', () => {
-        const rendered = columns[10].render(null, 'display', {})
+      it('renders a button toggle with aria-label containing the contact date', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'true', can_destroy: 'true', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
 
-        expect(rendered).toBe('<i class="fas fa-ellipsis-v"></i>')
+        expect(rendered).toContain('class="fas fa-ellipsis-v"')
+        expect(rendered).toContain('aria-label="Actions for case contact on July 01, 2024"')
+        expect(rendered).toContain('type="button"')
+      })
+
+      it('renders the ellipsis icon as aria-hidden', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'true', can_destroy: 'true', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toContain('aria-hidden="true"')
+      })
+
+      it('renders Edit item when can_edit is "true"', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'true', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toContain('href="/case_contacts/1/edit"')
+        expect(rendered).toContain('Edit')
+      })
+
+      it('does not render Edit item when can_edit is "false"', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).not.toContain('href="/case_contacts/1/edit"')
+        expect(rendered).not.toContain('>Edit<')
+      })
+
+      it('renders Delete item when can_destroy is "true"', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'true', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toContain('cc-delete-action')
+        expect(rendered).toContain('data-id="1"')
+        expect(rendered).toContain('Delete')
+      })
+
+      it('does not render Delete item when can_destroy is "false"', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).not.toContain('cc-delete-action')
+        expect(rendered).not.toContain('>Delete<')
+      })
+
+      it('renders Set Reminder when followup_id is empty', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toContain('cc-set-reminder-action')
+        expect(rendered).toContain('Set Reminder')
+        expect(rendered).not.toContain('Resolve Reminder')
+      })
+
+      it('renders Resolve Reminder when followup_id is present', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '42' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toContain('cc-resolve-reminder-action')
+        expect(rendered).toContain('data-followup-id="42"')
+        expect(rendered).toContain('Resolve Reminder')
+        expect(rendered).not.toContain('Set Reminder')
+      })
+
+      it('always renders the reminder menu item', () => {
+        const row = { id: '1', occurred_at: 'July 01, 2024', can_edit: 'false', can_destroy: 'false', edit_path: '/case_contacts/1/edit', followup_id: '' }
+        const rendered = columns[10].render(null, 'display', row)
+
+        expect(rendered).toMatch(/Set Reminder|Resolve Reminder/)
+      })
+    })
+  })
+
+  describe('click handlers', () => {
+    let mockAjaxReload
+    let mockTableInstance
+
+    beforeEach(() => {
+      mockAjaxReload = jest.fn()
+      mockTableInstance = { ajax: { reload: mockAjaxReload } }
+      mockDataTable.mockReturnValue(mockTableInstance)
+
+      // Add CSRF meta tag
+      document.head.innerHTML = '<meta name="csrf-token" content="test-csrf-token">'
+
+      defineCaseContactsTable()
+    })
+
+    afterEach(() => {
+      Swal.fire.mockReset()
+    })
+
+    describe('Delete action', () => {
+      it('sends DELETE request when cc-delete-action is clicked', () => {
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
+        $('.cc-delete-action').trigger('click')
+
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+          url: '/case_contacts/42',
+          type: 'DELETE',
+          dataType: 'json',
+          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+        }))
+
+        ajaxSpy.mockRestore()
+      })
+
+      it('reloads the DataTable after successful delete', () => {
+        jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
+        $('.cc-delete-action').trigger('click')
+
+        expect(mockAjaxReload).toHaveBeenCalled()
+      })
+    })
+
+    describe('Set Reminder action', () => {
+      it('fires SweetAlert when cc-set-reminder-action is clicked', () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: false })
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
+        $('.cc-set-reminder-action').trigger('click')
+
+        expect(Swal.fire).toHaveBeenCalled()
+      })
+
+      it('posts to the followups endpoint when confirmed without a note', async () => {
+        Swal.fire.mockResolvedValue({ value: '', isConfirmed: true })
+        const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
+        $('.cc-set-reminder-action').trigger('click')
+
+        await Promise.resolve()
+
+        expect(postSpy).toHaveBeenCalledWith('/case_contacts/5/followups', {}, expect.any(Function))
+
+        postSpy.mockRestore()
+      })
+
+      it('posts with note when confirmed with a note', async () => {
+        Swal.fire.mockResolvedValue({ value: 'My note', isConfirmed: true })
+        const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
+        $('.cc-set-reminder-action').trigger('click')
+
+        await Promise.resolve()
+
+        expect(postSpy).toHaveBeenCalledWith('/case_contacts/5/followups', { note: 'My note' }, expect.any(Function))
+
+        postSpy.mockRestore()
+      })
+
+      it('does not post when cancelled', async () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: false })
+        const postSpy = jest.spyOn($, 'post').mockImplementation()
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
+        $('.cc-set-reminder-action').trigger('click')
+
+        await Promise.resolve()
+
+        expect(postSpy).not.toHaveBeenCalled()
+
+        postSpy.mockRestore()
+      })
+
+      it('reloads the DataTable after creating a reminder', async () => {
+        Swal.fire.mockResolvedValue({ value: '', isConfirmed: true })
+        jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
+        $('.cc-set-reminder-action').trigger('click')
+
+        await Promise.resolve()
+
+        expect(mockAjaxReload).toHaveBeenCalled()
+      })
+    })
+
+    describe('Resolve Reminder action', () => {
+      it('sends PATCH request when cc-resolve-reminder-action is clicked', () => {
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-resolve-reminder-action" data-id="5" data-followup-id="42">Resolve Reminder</button></td></tr>')
+        $('.cc-resolve-reminder-action').trigger('click')
+
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+          url: '/followups/42/resolve',
+          type: 'PATCH',
+          dataType: 'json',
+          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+        }))
+
+        ajaxSpy.mockRestore()
+      })
+
+      it('reloads the DataTable after resolving a reminder', () => {
+        jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-resolve-reminder-action" data-id="5" data-followup-id="42">Resolve Reminder</button></td></tr>')
+        $('.cc-resolve-reminder-action').trigger('click')
+
+        expect(mockAjaxReload).toHaveBeenCalled()
       })
     })
   })

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -485,11 +485,23 @@ describe('defineCaseContactsTable', () => {
     })
 
     describe('Delete action', () => {
-      it('sends DELETE request when cc-delete-action is clicked', () => {
+      it('shows a SweetAlert confirmation dialog when cc-delete-action is clicked', () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: false })
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
+        $('.cc-delete-action').trigger('click')
+
+        expect(Swal.fire).toHaveBeenCalled()
+      })
+
+      it('sends DELETE request when confirmed', async () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: true })
         const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
         $('.cc-delete-action').trigger('click')
+
+        await Promise.resolve()
 
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/case_contacts/42',
@@ -501,11 +513,28 @@ describe('defineCaseContactsTable', () => {
         ajaxSpy.mockRestore()
       })
 
-      it('reloads the DataTable after successful delete', () => {
+      it('does not send DELETE request when cancelled', async () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: false })
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation()
+
+        $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
+        $('.cc-delete-action').trigger('click')
+
+        await Promise.resolve()
+
+        expect(ajaxSpy).not.toHaveBeenCalled()
+
+        ajaxSpy.mockRestore()
+      })
+
+      it('reloads the DataTable after successful delete', async () => {
+        Swal.fire.mockResolvedValue({ isConfirmed: true })
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-delete-action" data-id="42">Delete</button></td></tr>')
         $('.cc-delete-action').trigger('click')
+
+        await Promise.resolve()
 
         expect(mockAjaxReload).toHaveBeenCalled()
       })

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -521,9 +521,9 @@ describe('defineCaseContactsTable', () => {
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/case_contacts/42',
           type: 'DELETE',
-          dataType: 'json',
           headers: { 'X-CSRF-Token': 'test-csrf-token' }
         }))
+        expect(ajaxSpy.mock.calls[0][0]).not.toHaveProperty('dataType')
 
         ajaxSpy.mockRestore()
       })
@@ -622,9 +622,9 @@ describe('defineCaseContactsTable', () => {
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/followups/42/resolve',
           type: 'PATCH',
-          dataType: 'json',
           headers: { 'X-CSRF-Token': 'test-csrf-token' }
         }))
+        expect(ajaxSpy.mock.calls[0][0]).not.toHaveProperty('dataType')
 
         ajaxSpy.mockRestore()
       })

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -521,7 +521,7 @@ describe('defineCaseContactsTable', () => {
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/case_contacts/42',
           type: 'DELETE',
-          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+          headers: { 'X-CSRF-Token': 'test-csrf-token', Accept: 'application/json' }
         }))
         expect(ajaxSpy.mock.calls[0][0]).not.toHaveProperty('dataType')
 
@@ -574,7 +574,7 @@ describe('defineCaseContactsTable', () => {
           url: '/case_contacts/5/followups',
           type: 'POST',
           data: {},
-          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+          headers: { 'X-CSRF-Token': 'test-csrf-token', Accept: 'application/json' }
         }))
 
         ajaxSpy.mockRestore()
@@ -592,7 +592,7 @@ describe('defineCaseContactsTable', () => {
           url: '/case_contacts/5/followups',
           type: 'POST',
           data: { note: 'My note' },
-          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+          headers: { 'X-CSRF-Token': 'test-csrf-token', Accept: 'application/json' }
         }))
 
         ajaxSpy.mockRestore()
@@ -632,7 +632,7 @@ describe('defineCaseContactsTable', () => {
         expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
           url: '/followups/42/resolve',
           type: 'PATCH',
-          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+          headers: { 'X-CSRF-Token': 'test-csrf-token', Accept: 'application/json' }
         }))
         expect(ajaxSpy.mock.calls[0][0]).not.toHaveProperty('dataType')
 

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -541,7 +541,7 @@ describe('defineCaseContactsTable', () => {
         ajaxSpy.mockRestore()
       })
 
-      it('reloads the DataTable after successful delete', async () => {
+      it('reloads the DataTable without resetting pagination after successful delete', async () => {
         Swal.fire.mockResolvedValue({ isConfirmed: true })
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
@@ -549,7 +549,7 @@ describe('defineCaseContactsTable', () => {
 
         await Promise.resolve()
 
-        expect(mockAjaxReload).toHaveBeenCalled()
+        expect(mockAjaxReload).toHaveBeenCalledWith(null, false)
       })
     })
 
@@ -611,7 +611,7 @@ describe('defineCaseContactsTable', () => {
         ajaxSpy.mockRestore()
       })
 
-      it('reloads the DataTable after creating a reminder', async () => {
+      it('reloads the DataTable without resetting pagination after creating a reminder', async () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
@@ -619,7 +619,7 @@ describe('defineCaseContactsTable', () => {
 
         await Promise.resolve()
 
-        expect(mockAjaxReload).toHaveBeenCalled()
+        expect(mockAjaxReload).toHaveBeenCalledWith(null, false)
       })
     })
 
@@ -639,12 +639,12 @@ describe('defineCaseContactsTable', () => {
         ajaxSpy.mockRestore()
       })
 
-      it('reloads the DataTable after resolving a reminder', () => {
+      it('reloads the DataTable without resetting pagination after resolving a reminder', () => {
         jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         clickActionButton('resolve-reminder', { id: '5', 'followup-id': '42' })
 
-        expect(mockAjaxReload).toHaveBeenCalled()
+        expect(mockAjaxReload).toHaveBeenCalledWith(null, false)
       })
     })
   })

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -5,10 +5,14 @@
 
 import Swal from 'sweetalert2'
 import { defineCaseContactsTable } from '../src/dashboard'
-
+import { fireSwalFollowupAlert } from '../src/case_contact'
 jest.mock('sweetalert2', () => ({
   __esModule: true,
   default: { fire: jest.fn() }
+}))
+
+jest.mock('../src/case_contact', () => ({
+  fireSwalFollowupAlert: jest.fn()
 }))
 
 // Mock DataTable
@@ -486,6 +490,7 @@ describe('defineCaseContactsTable', () => {
 
     afterEach(() => {
       Swal.fire.mockReset()
+      fireSwalFollowupAlert.mockReset()
     })
 
     describe('Delete action', () => {
@@ -545,17 +550,17 @@ describe('defineCaseContactsTable', () => {
     })
 
     describe('Set Reminder action', () => {
-      it('fires SweetAlert when cc-set-reminder-action is clicked', () => {
-        Swal.fire.mockResolvedValue({ isConfirmed: false })
+      it('calls fireSwalFollowupAlert when cc-set-reminder-action is clicked', () => {
+        fireSwalFollowupAlert.mockResolvedValue({ isConfirmed: false })
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
         $('.cc-set-reminder-action').trigger('click')
 
-        expect(Swal.fire).toHaveBeenCalled()
+        expect(fireSwalFollowupAlert).toHaveBeenCalled()
       })
 
       it('posts to the followups endpoint when confirmed without a note', async () => {
-        Swal.fire.mockResolvedValue({ value: '', isConfirmed: true })
+        fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
         const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
@@ -569,7 +574,7 @@ describe('defineCaseContactsTable', () => {
       })
 
       it('posts with note when confirmed with a note', async () => {
-        Swal.fire.mockResolvedValue({ value: 'My note', isConfirmed: true })
+        fireSwalFollowupAlert.mockResolvedValue({ value: 'My note', isConfirmed: true })
         const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
@@ -583,7 +588,7 @@ describe('defineCaseContactsTable', () => {
       })
 
       it('does not post when cancelled', async () => {
-        Swal.fire.mockResolvedValue({ isConfirmed: false })
+        fireSwalFollowupAlert.mockResolvedValue({ isConfirmed: false })
         const postSpy = jest.spyOn($, 'post').mockImplementation()
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')
@@ -597,7 +602,7 @@ describe('defineCaseContactsTable', () => {
       })
 
       it('reloads the DataTable after creating a reminder', async () => {
-        Swal.fire.mockResolvedValue({ value: '', isConfirmed: true })
+        fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
         jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
 
         $('table#case_contacts tbody').append('<tr><td><button class="cc-set-reminder-action" data-id="5">Set Reminder</button></td></tr>')

--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -562,48 +562,58 @@ describe('defineCaseContactsTable', () => {
         expect(fireSwalFollowupAlert).toHaveBeenCalled()
       })
 
-      it('posts to the followups endpoint when confirmed without a note', async () => {
+      it('posts to the followups endpoint with CSRF header when confirmed without a note', async () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
-        const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
-        expect(postSpy).toHaveBeenCalledWith('/case_contacts/5/followups', {}, expect.any(Function))
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+          url: '/case_contacts/5/followups',
+          type: 'POST',
+          data: {},
+          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+        }))
 
-        postSpy.mockRestore()
+        ajaxSpy.mockRestore()
       })
 
       it('posts with note when confirmed with a note', async () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: 'My note', isConfirmed: true })
-        const postSpy = jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
-        expect(postSpy).toHaveBeenCalledWith('/case_contacts/5/followups', { note: 'My note' }, expect.any(Function))
+        expect(ajaxSpy).toHaveBeenCalledWith(expect.objectContaining({
+          url: '/case_contacts/5/followups',
+          type: 'POST',
+          data: { note: 'My note' },
+          headers: { 'X-CSRF-Token': 'test-csrf-token' }
+        }))
 
-        postSpy.mockRestore()
+        ajaxSpy.mockRestore()
       })
 
       it('does not post when cancelled', async () => {
         fireSwalFollowupAlert.mockResolvedValue({ isConfirmed: false })
-        const postSpy = jest.spyOn($, 'post').mockImplementation()
+        const ajaxSpy = jest.spyOn($, 'ajax').mockImplementation()
 
         clickActionButton('set-reminder', { id: '5' })
 
         await Promise.resolve()
 
-        expect(postSpy).not.toHaveBeenCalled()
+        expect(ajaxSpy).not.toHaveBeenCalled()
 
-        postSpy.mockRestore()
+        ajaxSpy.mockRestore()
       })
 
       it('reloads the DataTable after creating a reminder', async () => {
         fireSwalFollowupAlert.mockResolvedValue({ value: '', isConfirmed: true })
-        jest.spyOn($, 'post').mockImplementation((_url, _params, cb) => cb && cb())
+        jest.spyOn($, 'ajax').mockImplementation(({ success }) => success && success())
 
         clickActionButton('set-reminder', { id: '5' })
 

--- a/app/javascript/src/case_contact.js
+++ b/app/javascript/src/case_contact.js
@@ -54,5 +54,6 @@ $(() => { // JQuery's callback for the DOM loading
 })
 
 export {
-  convertDateToSystemTimeZone
+  convertDateToSystemTimeZone,
+  fireSwalFollowupAlert
 }

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -1,5 +1,6 @@
 /* global alert */
 /* global $ */
+import Swal from 'sweetalert2'
 const { Notifier } = require('./notifier')
 let pageNotifier
 
@@ -150,7 +151,43 @@ const defineCaseContactsTable = function () {
         data: null,
         orderable: false,
         searchable: false,
-        render: () => '<i class="fas fa-ellipsis-v"></i>'
+        render: (_data, _type, row) => {
+          const buttonId = `cc-actions-btn-${row.id}`
+          const label = `Actions for case contact${row.occurred_at ? ' on ' + row.occurred_at : ''}`
+
+          const editItem = row.can_edit === 'true'
+            ? `<li role="none"><a class="dropdown-item" role="menuitem" href="${row.edit_path}" data-turbo="false">Edit</a></li>`
+            : ''
+
+          const deleteItem = row.can_destroy === 'true'
+            ? `<li role="none"><button class="dropdown-item cc-delete-action" role="menuitem" type="button" data-id="${row.id}">Delete</button></li>`
+            : ''
+
+          const reminderItem = row.followup_id
+            ? `<li role="none"><button class="dropdown-item cc-resolve-reminder-action" role="menuitem" type="button" data-id="${row.id}" data-followup-id="${row.followup_id}">Resolve Reminder</button></li>`
+            : `<li role="none"><button class="dropdown-item cc-set-reminder-action" role="menuitem" type="button" data-id="${row.id}">Set Reminder</button></li>`
+
+          return `
+            <div class="dropdown">
+              <button type="button"
+                      id="${buttonId}"
+                      class="btn btn-link cc-ellipsis-toggle p-0"
+                      data-bs-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                      aria-label="${label}">
+                <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end"
+                  role="menu"
+                  aria-labelledby="${buttonId}">
+                ${editItem}
+                ${deleteItem}
+                ${reminderItem}
+              </ul>
+            </div>
+          `
+        }
       }
     ]
   })
@@ -166,6 +203,48 @@ const defineCaseContactsTable = function () {
       row.child(buildExpandedContent(row.data())).show()
       $(this).addClass('expanded').attr('aria-expanded', 'true')
     }
+  })
+
+  const csrfToken = () => $('meta[name="csrf-token"]').attr('content')
+
+  $('table#case_contacts').on('click', '.cc-delete-action', function () {
+    const id = $(this).data('id')
+    $.ajax({
+      url: `/case_contacts/${id}`,
+      type: 'DELETE',
+      dataType: 'json',
+      headers: { 'X-CSRF-Token': csrfToken() },
+      success: () => table.ajax.reload()
+    })
+  })
+
+  $('table#case_contacts').on('click', '.cc-set-reminder-action', async function () {
+    const id = $(this).data('id')
+    const { value: text, isConfirmed } = await Swal.fire({
+      input: 'textarea',
+      title: 'Optional: Add a note about what followup is needed.',
+      inputPlaceholder: 'Type your note here...',
+      inputAttributes: { 'aria-label': 'Type your note here' },
+      showCancelButton: true,
+      showCloseButton: true,
+      confirmButtonText: 'Confirm',
+      confirmButtonColor: '#dc3545',
+      customClass: { inputLabel: 'mx-5' }
+    })
+    if (!isConfirmed) return
+    const params = text ? { note: text } : {}
+    $.post(`/case_contacts/${id}/followups`, params, () => table.ajax.reload())
+  })
+
+  $('table#case_contacts').on('click', '.cc-resolve-reminder-action', function () {
+    const followupId = $(this).data('followup-id')
+    $.ajax({
+      url: `/followups/${followupId}/resolve`,
+      type: 'PATCH',
+      dataType: 'json',
+      headers: { 'X-CSRF-Token': csrfToken() },
+      success: () => table.ajax.reload()
+    })
   })
 }
 

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -220,7 +220,6 @@ const defineCaseContactsTable = function () {
     $.ajax({
       url: `/case_contacts/${id}`,
       type: 'DELETE',
-      dataType: 'json',
       headers: { 'X-CSRF-Token': csrfToken() },
       success: () => table.ajax.reload()
     })
@@ -239,7 +238,6 @@ const defineCaseContactsTable = function () {
     $.ajax({
       url: `/followups/${followupId}/resolve`,
       type: 'PATCH',
-      dataType: 'json',
       headers: { 'X-CSRF-Token': csrfToken() },
       success: () => table.ajax.reload()
     })

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -157,11 +157,11 @@ const defineCaseContactsTable = function () {
 
           const editItem = row.can_edit === 'true'
             ? `<li role="none"><a class="dropdown-item" role="menuitem" href="${row.edit_path}" data-turbo="false">Edit</a></li>`
-            : ''
+            : `<li role="none"><span class="dropdown-item disabled" role="menuitem" aria-disabled="true">Edit</span></li>`
 
           const deleteItem = row.can_destroy === 'true'
             ? `<li role="none"><button class="dropdown-item cc-delete-action" role="menuitem" type="button" data-id="${row.id}">Delete</button></li>`
-            : ''
+            : `<li role="none"><button class="dropdown-item disabled" role="menuitem" type="button" disabled aria-disabled="true">Delete</button></li>`
 
           const reminderItem = row.followup_id
             ? `<li role="none"><button class="dropdown-item cc-resolve-reminder-action" role="menuitem" type="button" data-id="${row.id}" data-followup-id="${row.followup_id}">Resolve Reminder</button></li>`

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -207,8 +207,15 @@ const defineCaseContactsTable = function () {
 
   const csrfToken = () => $('meta[name="csrf-token"]').attr('content')
 
-  $('table#case_contacts').on('click', '.cc-delete-action', function () {
+  $('table#case_contacts').on('click', '.cc-delete-action', async function () {
     const id = $(this).data('id')
+    const { isConfirmed } = await Swal.fire({
+      title: 'Delete this contact?',
+      showCancelButton: true,
+      confirmButtonText: 'Delete',
+      confirmButtonColor: '#dc3545'
+    })
+    if (!isConfirmed) return
     $.ajax({
       url: `/case_contacts/${id}`,
       type: 'DELETE',

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -221,7 +221,7 @@ const defineCaseContactsTable = function () {
       url: `/case_contacts/${id}`,
       type: 'DELETE',
       headers: { 'X-CSRF-Token': csrfToken() },
-      success: () => table.ajax.reload()
+      success: () => table.ajax.reload(null, false)
     })
   })
 
@@ -235,7 +235,7 @@ const defineCaseContactsTable = function () {
       type: 'POST',
       data: params,
       headers: { 'X-CSRF-Token': csrfToken() },
-      success: () => table.ajax.reload()
+      success: () => table.ajax.reload(null, false)
     })
   })
 
@@ -245,7 +245,7 @@ const defineCaseContactsTable = function () {
       url: `/followups/${followupId}/resolve`,
       type: 'PATCH',
       headers: { 'X-CSRF-Token': csrfToken() },
-      success: () => table.ajax.reload()
+      success: () => table.ajax.reload(null, false)
     })
   })
 }

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -1,6 +1,7 @@
 /* global alert */
 /* global $ */
 import Swal from 'sweetalert2'
+import { fireSwalFollowupAlert } from './case_contact'
 const { Notifier } = require('./notifier')
 let pageNotifier
 
@@ -227,17 +228,7 @@ const defineCaseContactsTable = function () {
 
   $('table#case_contacts').on('click', '.cc-set-reminder-action', async function () {
     const id = $(this).data('id')
-    const { value: text, isConfirmed } = await Swal.fire({
-      input: 'textarea',
-      title: 'Optional: Add a note about what followup is needed.',
-      inputPlaceholder: 'Type your note here...',
-      inputAttributes: { 'aria-label': 'Type your note here' },
-      showCancelButton: true,
-      showCloseButton: true,
-      confirmButtonText: 'Confirm',
-      confirmButtonColor: '#dc3545',
-      customClass: { inputLabel: 'mx-5' }
-    })
+    const { value: text, isConfirmed } = await fireSwalFollowupAlert()
     if (!isConfirmed) return
     const params = text ? { note: text } : {}
     $.post(`/case_contacts/${id}/followups`, params, () => table.ajax.reload())

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -220,7 +220,7 @@ const defineCaseContactsTable = function () {
     $.ajax({
       url: `/case_contacts/${id}`,
       type: 'DELETE',
-      headers: { 'X-CSRF-Token': csrfToken() },
+      headers: { 'X-CSRF-Token': csrfToken(), Accept: 'application/json' },
       success: () => table.ajax.reload(null, false)
     })
   })
@@ -234,7 +234,7 @@ const defineCaseContactsTable = function () {
       url: `/case_contacts/${id}/followups`,
       type: 'POST',
       data: params,
-      headers: { 'X-CSRF-Token': csrfToken() },
+      headers: { 'X-CSRF-Token': csrfToken(), Accept: 'application/json' },
       success: () => table.ajax.reload(null, false)
     })
   })
@@ -244,7 +244,7 @@ const defineCaseContactsTable = function () {
     $.ajax({
       url: `/followups/${followupId}/resolve`,
       type: 'PATCH',
-      headers: { 'X-CSRF-Token': csrfToken() },
+      headers: { 'X-CSRF-Token': csrfToken(), Accept: 'application/json' },
       success: () => table.ajax.reload(null, false)
     })
   })

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -157,11 +157,11 @@ const defineCaseContactsTable = function () {
 
           const editItem = row.can_edit === 'true'
             ? `<li role="none"><a class="dropdown-item" role="menuitem" href="${row.edit_path}" data-turbo="false">Edit</a></li>`
-            : `<li role="none"><span class="dropdown-item disabled" role="menuitem" aria-disabled="true">Edit</span></li>`
+            : '<li role="none"><span class="dropdown-item disabled" role="menuitem" aria-disabled="true">Edit</span></li>'
 
           const deleteItem = row.can_destroy === 'true'
             ? `<li role="none"><button class="dropdown-item cc-delete-action" role="menuitem" type="button" data-id="${row.id}">Delete</button></li>`
-            : `<li role="none"><button class="dropdown-item disabled" role="menuitem" type="button" disabled aria-disabled="true">Delete</button></li>`
+            : '<li role="none"><button class="dropdown-item disabled" role="menuitem" type="button" disabled aria-disabled="true">Delete</button></li>'
 
           const reminderItem = row.followup_id
             ? `<li role="none"><button class="dropdown-item cc-resolve-reminder-action" role="menuitem" type="button" data-id="${row.id}" data-followup-id="${row.followup_id}">Resolve Reminder</button></li>`

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -230,7 +230,13 @@ const defineCaseContactsTable = function () {
     const { value: text, isConfirmed } = await fireSwalFollowupAlert()
     if (!isConfirmed) return
     const params = text ? { note: text } : {}
-    $.post(`/case_contacts/${id}/followups`, params, () => table.ajax.reload())
+    $.ajax({
+      url: `/case_contacts/${id}/followups`,
+      type: 'POST',
+      data: params,
+      headers: { 'X-CSRF-Token': csrfToken() },
+      success: () => table.ajax.reload()
+    })
   })
 
   $('table#case_contacts').on('click', '.cc-resolve-reminder-action', function () {

--- a/spec/datatables/case_contact_datatable_spec.rb
+++ b/spec/datatables/case_contact_datatable_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe CaseContactDatatable do
     end
 
     context "with action metadata" do
+      it "includes all expected action metadata keys" do
+        contact_data = datatable.as_json[:data].first
+        expect(contact_data).to include(:can_edit, :can_destroy, :edit_path, :followup_id, :has_followup)
+      end
+
       it "includes edit_path for the contact" do
         contact_data = datatable.as_json[:data].first
         expected_path = Rails.application.routes.url_helpers.edit_case_contact_path(case_contact)

--- a/spec/datatables/case_contact_datatable_spec.rb
+++ b/spec/datatables/case_contact_datatable_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe CaseContactDatatable do
   let(:order_direction) { "desc" }
   let(:base_relation) { organization.case_contacts }
 
-  subject(:datatable) { described_class.new(base_relation, params) }
+  let(:current_user) { create(:casa_admin, casa_org: organization) }
+
+  subject(:datatable) { described_class.new(base_relation, params, current_user) }
 
   describe "#data" do
     let!(:case_contact) do
@@ -103,6 +105,66 @@ RSpec.describe CaseContactDatatable do
       contact_data = datatable.as_json[:data].first
 
       expect(contact_data[:is_draft]).to eq((!case_contact.active?).to_s)
+    end
+
+    context "with action metadata" do
+      it "includes edit_path for the contact" do
+        contact_data = datatable.as_json[:data].first
+        expected_path = Rails.application.routes.url_helpers.edit_case_contact_path(case_contact)
+        expect(contact_data[:edit_path]).to eq(expected_path)
+      end
+
+      it "includes followup_id as empty string when no requested followup exists" do
+        contact_data = datatable.as_json[:data].first
+        expect(contact_data[:followup_id]).to eq("")
+      end
+
+      it "includes followup_id when a requested followup exists" do
+        followup = create(:followup, case_contact: case_contact, status: "requested")
+        contact_data = datatable.as_json[:data].first
+        expect(contact_data[:followup_id]).to eq(followup.id.to_s)
+      end
+
+      it "does not include followup_id for a resolved followup" do
+        create(:followup, case_contact: case_contact, status: "resolved")
+        contact_data = datatable.as_json[:data].first
+        expect(contact_data[:followup_id]).to eq("")
+      end
+    end
+
+    context "with permission flags" do
+      context "when current_user is an admin" do
+        it "sets can_edit to true" do
+          expect(datatable.as_json[:data].first[:can_edit]).to eq("true")
+        end
+
+        it "sets can_destroy to true" do
+          expect(datatable.as_json[:data].first[:can_destroy]).to eq("true")
+        end
+      end
+
+      context "when current_user is the volunteer who created the contact" do
+        let(:current_user) { volunteer }
+
+        it "sets can_edit to true" do
+          expect(datatable.as_json[:data].first[:can_edit]).to eq("true")
+        end
+
+        it "sets can_destroy to false for an active contact" do
+          expect(datatable.as_json[:data].first[:can_destroy]).to eq("false")
+        end
+      end
+
+      context "when current_user is the volunteer who created a draft contact" do
+        let(:current_user) { volunteer }
+        let!(:case_contact) do
+          create(:case_contact, casa_case: casa_case, creator: volunteer, status: "started")
+        end
+
+        it "sets can_destroy to true for their own draft" do
+          expect(datatable.as_json[:data].first[:can_destroy]).to eq("true")
+        end
+      end
     end
 
     context "when case_contact has no casa_case (draft)" do

--- a/spec/datatables/case_contact_datatable_spec.rb
+++ b/spec/datatables/case_contact_datatable_spec.rb
@@ -481,6 +481,32 @@ RSpec.describe CaseContactDatatable do
     end
   end
 
+  describe "N+1 queries" do
+    let!(:contacts) do
+      3.times.map do
+        create(:case_contact,
+          casa_case: create(:casa_case, casa_org: organization),
+          creator: create(:volunteer, casa_org: organization))
+      end
+    end
+
+    it "does not trigger N+1 queries for casa_org when computing per-row policy permissions" do
+      casa_org_queries = []
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        casa_org_queries << payload[:sql] if payload[:sql].match?(/SELECT.*casa_orgs/)
+      end
+
+      datatable.as_json
+
+      ActiveSupport::Notifications.unsubscribe(subscription)
+
+      # With proper eager loading, casa_orgs is fetched in at most 2 batch queries
+      # (one for :casa_org through casa_case, one for :creator_casa_org through creator).
+      # An N+1 would fire 1 query per record (3+ here).
+      expect(casa_org_queries.length).to be <= 2
+    end
+  end
+
   describe "associations loading" do
     let!(:contacts) do
       10.times.map do |i|

--- a/spec/requests/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/requests/case_contacts/case_contacts_new_design_spec.rb
@@ -264,6 +264,68 @@ RSpec.describe "/case_contacts_new_design", type: :request do
           expect(record[:contact_topics]).to include(contact_topic.question)
         end
       end
+
+      context "with permission flags and action metadata" do
+        let(:volunteer) { create(:volunteer, casa_org: organization) }
+        let!(:active_contact) { create(:case_contact, :active, casa_case: casa_case, creator: volunteer) }
+        let!(:draft_contact) { create(:case_contact, casa_case: casa_case, creator: volunteer, status: "started") }
+
+        def post_datatable
+          post datatable_case_contacts_new_design_path, params: datatable_params, as: :json
+        end
+
+        def row_for(contact_id)
+          json = JSON.parse(response.body, symbolize_names: true)
+          json[:data].find { |row| row[:id] == contact_id.to_s }
+        end
+
+        context "when signed in as admin" do
+          it "includes can_edit as true" do
+            post_datatable
+            expect(row_for(active_contact.id)[:can_edit]).to eq("true")
+          end
+
+          it "includes can_destroy as true" do
+            post_datatable
+            expect(row_for(active_contact.id)[:can_destroy]).to eq("true")
+          end
+
+          it "includes edit_path for the contact" do
+            post_datatable
+            expect(row_for(active_contact.id)[:edit_path]).to eq(edit_case_contact_path(active_contact))
+          end
+
+          it "includes followup_id as empty when no followup exists" do
+            post_datatable
+            expect(row_for(active_contact.id)[:followup_id]).to eq("")
+          end
+
+          it "includes followup_id when a requested followup exists" do
+            followup = create(:followup, case_contact: active_contact, status: :requested, creator: admin)
+            post_datatable
+            expect(row_for(active_contact.id)[:followup_id]).to eq(followup.id.to_s)
+          end
+        end
+
+        context "when signed in as volunteer" do
+          before { sign_in volunteer }
+
+          it "includes can_edit as true for their own contact" do
+            post_datatable
+            expect(row_for(active_contact.id)[:can_edit]).to eq("true")
+          end
+
+          it "includes can_destroy as false for their own active contact" do
+            post_datatable
+            expect(row_for(active_contact.id)[:can_destroy]).to eq("false")
+          end
+
+          it "includes can_destroy as true for their own draft contact" do
+            post_datatable
+            expect(row_for(draft_contact.id)[:can_destroy]).to eq("true")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/case_contacts/followups_spec.rb
+++ b/spec/requests/case_contacts/followups_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe "CaseContacts::FollowupsController", type: :request do
       expect(followup.note).to eq "Hello, world!"
     end
 
+    context "when requested as JSON" do
+      subject(:request) do
+        post case_contact_followups_path(case_contact),
+          params: params,
+          headers: {"Accept" => "application/json"}
+
+        response
+      end
+
+      it "returns 204 No Content" do
+        request
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
     it "sends a Followup Notifier to case contact creator" do
       request
       followup = Followup.last
@@ -64,6 +79,21 @@ RSpec.describe "CaseContacts::FollowupsController", type: :request do
       it "marks it as :resolved" do
         followup
         expect { request }.to change { followup.reload.resolved? }.from(false).to(true)
+      end
+
+      context "when requested as JSON" do
+        subject(:request) do
+          patch resolve_followup_path(followup),
+            headers: {"Accept" => "application/json"}
+
+          response
+        end
+
+        it "returns 204 No Content" do
+          followup
+          request
+          expect(response).to have_http_status(:no_content)
+        end
       end
 
       it "does not send Followup Notifier" do

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -170,4 +170,32 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(followup.reload.status).to eq("resolved")
     end
   end
+
+  describe "permission states" do
+    let(:volunteer) { create(:volunteer, casa_org: organization) }
+    let(:casa_case_for_volunteer) { create(:casa_case, casa_org: organization) }
+    let!(:active_contact) { create(:case_contact, :active, casa_case: casa_case_for_volunteer, creator: volunteer) }
+    let!(:draft_contact) { create(:case_contact, casa_case: casa_case_for_volunteer, creator: volunteer, status: "started", occurred_at: 3.days.ago) }
+
+    before do
+      sign_in volunteer
+      visit case_contacts_new_design_path
+    end
+
+    it "shows Delete as disabled for an active contact" do
+      within("tbody tr", text: I18n.l(active_contact.occurred_at, format: :full), match: :first) do
+        find(".cc-ellipsis-toggle").click
+      end
+
+      expect(page).to have_css("button.dropdown-item.disabled", text: "Delete")
+    end
+
+    it "shows Delete as enabled for a draft contact" do
+      within("tbody tr", text: I18n.l(draft_contact.occurred_at, format: :full), match: :first) do
+        find(".cc-ellipsis-toggle").click
+      end
+
+      expect(page).to have_css("button.cc-delete-action", text: "Delete")
+    end
+  end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -16,11 +16,17 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       value: "Youth is doing well in school")
     allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(true)
-    sign_in admin
-    visit case_contacts_new_design_path
+  end
+
+  shared_context "signed in as admin" do
+    before do
+      sign_in admin
+      visit case_contacts_new_design_path
+    end
   end
 
   describe "row expansion" do
+    include_context "signed in as admin"
     it "shows the expanded content after clicking the chevron" do
       find(".expand-toggle").click
 
@@ -45,6 +51,7 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   end
 
   describe "action menu" do
+    include_context "signed in as admin"
     it "opens the dropdown when the ellipsis button is clicked" do
       find(".cc-ellipsis-toggle").click
 
@@ -90,6 +97,7 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   end
 
   describe "Edit action" do
+    include_context "signed in as admin"
     it "navigates to the edit form when Edit is clicked" do
       find(".cc-ellipsis-toggle").click
       click_link "Edit"
@@ -99,6 +107,7 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   end
 
   describe "Delete action" do
+    include_context "signed in as admin"
     let(:occurred_at_text) { I18n.l(case_contact.occurred_at, format: :full) }
 
     it "removes the row after confirming the delete dialog" do
@@ -123,6 +132,7 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   end
 
   describe "Set Reminder action" do
+    include_context "signed in as admin"
     it "creates a followup and shows Resolve Reminder in the menu after confirming" do
       find(".cc-ellipsis-toggle").click
       find(".cc-set-reminder-action").click
@@ -145,6 +155,8 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   end
 
   describe "Resolve Reminder action" do
+    include_context "signed in as admin"
+
     let!(:followup) { create(:followup, case_contact: case_contact, status: :requested, creator: admin) }
 
     before { visit case_contacts_new_design_path }
@@ -178,7 +190,6 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
     let!(:draft_contact) { create(:case_contact, casa_case: casa_case_for_volunteer, creator: volunteer, status: "started", occurred_at: 10.days.ago) }
 
     before do
-      Capybara.reset_sessions!
       sign_in volunteer
       visit case_contacts_new_design_path
     end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -97,4 +97,28 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(page).to have_current_path(/case_contacts\/#{case_contact.id}\/form/)
     end
   end
+
+  describe "Delete action" do
+    let(:occurred_at_text) { I18n.l(case_contact.occurred_at, format: :full) }
+
+    it "removes the row after confirming the delete dialog" do
+      expect(page).to have_text(occurred_at_text)
+
+      find(".cc-ellipsis-toggle").click
+      find(".cc-delete-action").click
+      click_button "Delete"
+
+      expect(page).to have_no_text(occurred_at_text)
+    end
+
+    it "leaves the row in place when the delete dialog is cancelled" do
+      expect(page).to have_text(occurred_at_text)
+
+      find(".cc-ellipsis-toggle").click
+      find(".cc-delete-action").click
+      click_button "Cancel"
+
+      expect(page).to have_text(occurred_at_text)
+    end
+  end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -174,28 +174,25 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
   describe "permission states" do
     let(:volunteer) { create(:volunteer, casa_org: organization) }
     let(:casa_case_for_volunteer) { create(:casa_case, casa_org: organization) }
-    let!(:active_contact) { create(:case_contact, :active, casa_case: casa_case_for_volunteer, creator: volunteer) }
-    let!(:draft_contact) { create(:case_contact, casa_case: casa_case_for_volunteer, creator: volunteer, status: "started", occurred_at: 3.days.ago) }
+    let!(:active_contact) { create(:case_contact, :active, casa_case: casa_case_for_volunteer, creator: volunteer, occurred_at: 5.days.ago) }
+    let!(:draft_contact) { create(:case_contact, casa_case: casa_case_for_volunteer, creator: volunteer, status: "started", occurred_at: 10.days.ago) }
 
     before do
+      Capybara.reset_sessions!
       sign_in volunteer
       visit case_contacts_new_design_path
     end
 
     it "shows Delete as disabled for an active contact" do
-      within("tbody tr", text: I18n.l(active_contact.occurred_at, format: :full), match: :first) do
-        find(".cc-ellipsis-toggle").click
-      end
-
-      expect(page).to have_css("button.dropdown-item.disabled", text: "Delete")
+      find("#cc-actions-btn-#{active_contact.id}").click
+      expect(page).to have_css(".dropdown-menu[aria-labelledby='cc-actions-btn-#{active_contact.id}'].show")
+      expect(page).to have_css(".dropdown-menu[aria-labelledby='cc-actions-btn-#{active_contact.id}'] button.dropdown-item.disabled", text: "Delete")
     end
 
     it "shows Delete as enabled for a draft contact" do
-      within("tbody tr", text: I18n.l(draft_contact.occurred_at, format: :full), match: :first) do
-        find(".cc-ellipsis-toggle").click
-      end
-
-      expect(page).to have_css("button.cc-delete-action", text: "Delete")
+      find("#cc-actions-btn-#{draft_contact.id}").click
+      expect(page).to have_css(".dropdown-menu[aria-labelledby='cc-actions-btn-#{draft_contact.id}'].show")
+      expect(page).to have_css(".dropdown-menu[aria-labelledby='cc-actions-btn-#{draft_contact.id}'] button.cc-delete-action", text: "Delete")
     end
   end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -121,4 +121,53 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(page).to have_text(occurred_at_text)
     end
   end
+
+  describe "Set Reminder action" do
+    it "creates a followup and shows Resolve Reminder in the menu after confirming" do
+      find(".cc-ellipsis-toggle").click
+      find(".cc-set-reminder-action").click
+      click_button "Confirm"
+
+      expect(page).to have_css("i.fas.fa-bell:not([style])")
+
+      find(".cc-ellipsis-toggle").click
+      expect(page).to have_text("Resolve Reminder")
+      expect(page).to have_no_text("Set Reminder")
+    end
+
+    it "does not create a followup when cancelled" do
+      find(".cc-ellipsis-toggle").click
+      find(".cc-set-reminder-action").click
+      click_button "Cancel"
+
+      expect(case_contact.followups.reload).to be_empty
+    end
+  end
+
+  describe "Resolve Reminder action" do
+    let!(:followup) { create(:followup, case_contact: case_contact, status: :requested, creator: admin) }
+
+    before { visit case_contacts_new_design_path }
+
+    it "resolves the followup and shows Set Reminder in the menu afterwards" do
+      find(".cc-ellipsis-toggle").click
+      find(".cc-resolve-reminder-action").click
+
+      expect(page).to have_css("i.fas.fa-bell[style*='opacity']")
+
+      find(".cc-ellipsis-toggle").click
+      expect(page).to have_text("Set Reminder")
+      expect(page).to have_no_text("Resolve Reminder")
+    end
+
+    it "marks the followup as resolved" do
+      find(".cc-ellipsis-toggle").click
+      find(".cc-resolve-reminder-action").click
+
+      # Wait for reload to confirm the AJAX completed before checking DB
+      expect(page).to have_css("i.fas.fa-bell[style*='opacity']")
+
+      expect(followup.reload.status).to eq("resolved")
+    end
+  end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       case_contact: case_contact,
       contact_topic: contact_topic,
       value: "Youth is doing well in school")
+    allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(true)
     sign_in admin
     visit case_contacts_new_design_path
@@ -85,6 +86,15 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
 
       find("h1").click
       expect(page).to have_no_css(".dropdown-menu.show")
+    end
+  end
+
+  describe "Edit action" do
+    it "navigates to the edit form when Edit is clicked" do
+      find(".cc-ellipsis-toggle").click
+      click_link "Edit"
+
+      expect(page).to have_current_path(/case_contacts\/#{case_contact.id}\/form/)
     end
   end
 end

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Case Contact Table Row Expansion", type: :system, js: true do
+RSpec.describe "Case contacts new design", type: :system, js: true do
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
   let(:casa_case) { create(:casa_case, casa_org: organization) }
@@ -19,25 +19,72 @@ RSpec.describe "Case Contact Table Row Expansion", type: :system, js: true do
     visit case_contacts_new_design_path
   end
 
-  it "shows the expanded content after clicking the chevron" do
-    find(".expand-toggle").click
+  describe "row expansion" do
+    it "shows the expanded content after clicking the chevron" do
+      find(".expand-toggle").click
 
-    expect(page).to have_content("What was discussed?")
-    expect(page).to have_content("Youth is doing well in school")
+      expect(page).to have_content("What was discussed?")
+      expect(page).to have_content("Youth is doing well in school")
+    end
+
+    it "shows notes in the expanded content" do
+      find(".expand-toggle").click
+
+      expect(page).to have_content("Additional Notes")
+      expect(page).to have_content("Important follow-up needed")
+    end
+
+    it "hides the expanded content after clicking the chevron again" do
+      find(".expand-toggle").click
+      expect(page).to have_content("Youth is doing well in school")
+
+      find(".expand-toggle").click
+      expect(page).to have_no_content("Youth is doing well in school")
+    end
   end
 
-  it "shows notes in the expanded content" do
-    find(".expand-toggle").click
+  describe "action menu" do
+    it "opens the dropdown when the ellipsis button is clicked" do
+      find(".cc-ellipsis-toggle").click
 
-    expect(page).to have_content("Additional Notes")
-    expect(page).to have_content("Important follow-up needed")
-  end
+      expect(page).to have_css(".dropdown-menu.show")
+    end
 
-  it "hides the expanded content after clicking the chevron again" do
-    find(".expand-toggle").click
-    expect(page).to have_content("Youth is doing well in school")
+    it "shows Edit in the menu" do
+      find(".cc-ellipsis-toggle").click
 
-    find(".expand-toggle").click
-    expect(page).to have_no_content("Youth is doing well in school")
+      expect(page).to have_text("Edit")
+    end
+
+    it "shows Delete in the menu" do
+      find(".cc-ellipsis-toggle").click
+
+      expect(page).to have_text("Delete")
+    end
+
+    it "shows Set Reminder when no followup exists" do
+      find(".cc-ellipsis-toggle").click
+
+      expect(page).to have_text("Set Reminder")
+      expect(page).to have_no_text("Resolve Reminder")
+    end
+
+    it "shows Resolve Reminder when a requested followup exists" do
+      create(:followup, case_contact: case_contact, status: :requested, creator: admin)
+      visit case_contacts_new_design_path
+
+      find(".cc-ellipsis-toggle").click
+
+      expect(page).to have_text("Resolve Reminder")
+      expect(page).to have_no_text("Set Reminder")
+    end
+
+    it "closes the dropdown when clicking outside" do
+      find(".cc-ellipsis-toggle").click
+      expect(page).to have_css(".dropdown-menu.show")
+
+      find("h1").click
+      expect(page).to have_no_css(".dropdown-menu.show")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6500

### What changed, and _why_?

Implements the ellipsis (⋮) action menu for each row in the new case contacts table at `/case_contacts/new_design`. The menu contains three items: **Edit**, **Delete**, and **Set Reminder** (or **Resolve Reminder** if a pending followup already exists).

**`app/datatables/case_contact_datatable.rb`**

- Added `current_user` parameter to the initializer so the datatable can compute per-row permissions
- Added per-row fields to the JSON response: `can_edit`, `can_destroy`, `edit_path`, and `followup_id`
  - `can_edit` and `can_destroy` are derived from `CaseContactPolicy` so the UI reflects actual Pundit permissions
  - `followup_id` is the id of any open (requested) followup, used to toggle between Set Reminder and Resolve Reminder
- Updated `includes` to add `:followups` and `:creator` to avoid N+1 queries

**`app/controllers/case_contacts/case_contacts_new_design_controller.rb`**

- Passed `current_user` to `CaseContactDatatable.new`

**`app/controllers/case_contacts_controller.rb`**

- Added `respond_to` to `destroy` so jQuery AJAX receives `204 No Content` instead of an HTML redirect that would be silently followed

**`app/controllers/case_contacts/followups_controller.rb`**

- Added `respond_to` to `resolve` for the same reason

**`app/javascript/src/dashboard.js`**

- Imported SweetAlert2
- Replaced the placeholder ellipsis icon in the last column with a fully-functional Bootstrap dropdown menu
  - Edit links to `edit_path` with `data-turbo="false"`; rendered as a disabled `<span>` when `can_edit` is false
  - Delete triggers a SweetAlert2 confirmation dialog before sending a `DELETE` request via AJAX; rendered as a disabled `<button>` when `can_destroy` is false
  - Set Reminder opens a SweetAlert2 dialog for an optional note, then POSTs to the followups endpoint; shown when no open followup exists
  - Resolve Reminder sends a `PATCH` to the followup resolve endpoint; shown when an open followup exists
  - All three actions reload the DataTable in place on success so the row reflects the new state
- All AJAX requests include the CSRF token from the page's `<meta>` tag
- The dropdown toggle button includes `aria-label`, `aria-haspopup`, and `aria-expanded` attributes; the icon is marked `aria-hidden="true"`

### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_

**Datatable spec** — updated `spec/datatables/case_contact_datatable_spec.rb`:

- `can_edit` is `"true"` for admin, `"false"` for a different volunteer's contact
- `can_destroy` reflects policy (admin can destroy active contacts; volunteers cannot)
- `edit_path` is the correct Rails edit path for the contact
- `followup_id` is empty when no requested followup exists
- `followup_id` contains the followup id when a requested followup exists

**Request specs** — updated `spec/requests/case_contacts/case_contacts_new_design_spec.rb`:

- Datatable response includes `can_edit`, `can_destroy`, `edit_path`, and `followup_id` for each row
- Admin sees `can_edit: "true"` and `can_destroy: "true"`
- Volunteer sees `can_edit: "true"` for their own contact and `can_destroy: "false"` for active contacts
- Volunteer sees `can_destroy: "true"` for their own draft contacts

**Jest** — updated `app/javascript/__tests__/dashboard.test.js`:

Ellipsis column rendering:

- Toggle button has the correct `aria-label` containing the contact date
- Icon is `aria-hidden="true"`
- Edit link is rendered when `can_edit` is `"true"`; rendered as a disabled `<span>` when `"false"`
- Delete button is rendered when `can_destroy` is `"true"`; rendered as a disabled `<button>` with `aria-disabled="true"` when `"false"`
- Set Reminder is shown when `followup_id` is empty
- Resolve Reminder is shown (with `data-followup-id`) when `followup_id` is present

Click handlers:

- Delete: shows a SweetAlert2 confirmation; sends `DELETE` with CSRF header when confirmed; does not send request when cancelled; reloads DataTable on success
- Set Reminder: fires SweetAlert2; POSTs with empty params when confirmed without a note; POSTs with `{ note }` when confirmed with a note; does not POST when cancelled; reloads DataTable on success
- Resolve Reminder: sends `PATCH` to `/followups/:id/resolve` with CSRF header; reloads DataTable on success

**System specs** — updated `spec/system/case_contacts/case_contacts_new_design_spec.rb`:

Action menu visibility:

- Ellipsis button opens the dropdown
- Edit, Delete, Set Reminder, and Resolve Reminder items are present
- Set Reminder is shown when no followup exists; Resolve Reminder is shown when one does
- Clicking outside closes the dropdown

Edit action:

- Navigates to the edit form

Delete action:

- Confirms then removes the row from the table
- Cancels and leaves the row in place

Set Reminder action:

- Confirms then shows Resolve Reminder in the menu (table reloads)
- Cancels without creating a followup

Resolve Reminder action:

- Resolves the followup and shows Set Reminder in the menu afterwards
- Marks the followup record as resolved in the database

Permission states:

- Delete is rendered as disabled for a volunteer's active contact
- Delete is rendered as enabled for a volunteer's draft contact

### Screen recordings

<details>

<summary>Edit case contact</summary>


https://github.com/user-attachments/assets/5379e75d-787f-4889-b3a7-09539c0bf361


</details>

<details>

<summary>Delete case contact</summary>

https://github.com/user-attachments/assets/ee5d617c-5eaa-48bc-8bfc-9d9711bb1df7

</details>

<details>

<summary>Delete disabled for volunteer</summary>

A volunteer can only delete a draft case contact. This screen recording shows the Delete disabled for non-drafts and the Delete working for drafts.


https://github.com/user-attachments/assets/e8cc1ea2-449b-4da2-bf99-876b9835d1e8

</details>

<details>

<summary>Set reminder</summary>

https://github.com/user-attachments/assets/9a5a485a-98f6-4793-9afd-df23c3f2ec4c

</details>

<details>

<summary>Resolve reminder</summary>

https://github.com/user-attachments/assets/be4deca2-5749-49cd-8516-3ba48f2d9f4f

</details>

### AI Disclosure

This PR was implemented with the assistance of [Claude Code](https://claude.ai/code) (Anthropic, claude-sonnet-4-6). The AI was used to:

- Analyze the codebase and existing patterns (Pundit policies, SweetAlert2 usage, CSRF handling) to inform the implementation approach
- Draft and iterate on code changes across the datatable, controllers, JavaScript, and test files
- Write and run RSpec request/datatable specs and Jest tests, including debugging test failures caused by DataTables DOM re-rendering behavior
- Investigate and resolve a CSRF/redirect issue with jQuery following HTML redirects from Rails actions that didn't yet have JSON responses

All generated code was reviewed and committed by the author.

### Action menu clipped near bottom of table

When a row is near the bottom of the table, the dropdown action menu may be partially obscured by the table footer or page content below it.

The root cause seems to be `overflow-x: hidden` on the `<body>` element, which clips `position: absolute` elements (including Bootstrap dropdowns) that extend beyond the body's paint area. I'm worried that fixing this globally risks unintended layout side effects elsewhere, so it is left as is.

<details>

<summary>Menu is hidden by table footer</summary>

https://github.com/user-attachments/assets/5f11399f-f96b-40c0-ad80-fa0f4287e352


</details>
