### PR TITLE
Add coverage for Learning hour topics and types

### DIFF
--- a/app/controllers/learning_hour_topics_controller.rb
+++ b/app/controllers/learning_hour_topics_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LearningHourTopicsController < ApplicationController
   before_action :set_learning_hour_topic, only: %i[edit update]
   after_action :verify_authorized
@@ -39,7 +41,7 @@ class LearningHourTopicsController < ApplicationController
   end
 
   def learning_hour_topic_params
-    params.require(:learning_hour_topic).permit(:name, :active).merge(
+    params.require(:learning_hour_topic).permit(:name).merge(
       casa_org: current_organization
     )
   end

--- a/app/controllers/learning_hour_types_controller.rb
+++ b/app/controllers/learning_hour_types_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LearningHourTypesController < ApplicationController
   before_action :set_learning_hour_type, only: %i[edit update]
   after_action :verify_authorized

--- a/spec/controllers/learning_hour_topics_controller_spec.rb
+++ b/spec/controllers/learning_hour_topics_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe LearningHourTopicsController, type: :controller do
-  # TODO: Add tests for LearningHourTopicsController
-
-  pending "add some tests for LearningHourTopicsController"
-end

--- a/spec/controllers/learning_hour_types_controller_spec.rb
+++ b/spec/controllers/learning_hour_types_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe LearningHourTypesController, type: :controller do
-  # TODO: Add tests for LearningHourTypesController
-
-  pending "add some tests for LearningHourTypesController"
-end

--- a/spec/requests/learning_hour_topics_spec.rb
+++ b/spec/requests/learning_hour_topics_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "LearningHourTopics", type: :request do
+  let(:casa_org) { create(:casa_org) }
+  let(:admin) { build(:casa_admin, casa_org:) }
+
+  before do
+    sign_in admin
+  end
+
+  describe "GET /new" do
+    it "returns a successful response" do
+      get new_learning_hour_topic_path
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns a successful response" do
+      learning_hour_topic = create(:learning_hour_topic, casa_org:)
+
+      get edit_learning_hour_topic_path(learning_hour_topic)
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /create" do
+    context "when the params are valid" do
+      it "creates the learning hour topic successfully and redirects to the organization's edit page" do
+        params = {
+          learning_hour_topic: {
+            name: "Social Science"
+          }
+        }
+
+        expect do
+          post learning_hour_topics_path, params: params
+        end.to change(LearningHourTopic, :count).by(1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:notice]).to match(/learning topic was successfully created/i)
+        expect(response).to redirect_to(edit_casa_org_path(casa_org))
+      end
+    end
+
+    context "when the params are not valid" do
+      it "returns an unprocessable_content response" do
+        params = {
+          learning_hour_topic: {
+            name: nil
+          }
+        }
+
+        expect do
+          post learning_hour_topics_path, params: params
+        end.not_to change(LearningHourTopic, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "when the params are valid" do
+      it "updates the learning hour type successfully and redirects to the organization's edit page" do
+        learning_hour_topic = create(:learning_hour_topic, casa_org:, name: "Homeschooling")
+
+        params = {learning_hour_topic: {name: "Remote"}}
+        patch learning_hour_topic_path(learning_hour_topic), params: params
+
+        expect(response).to redirect_to(edit_casa_org_path(casa_org))
+        expect(learning_hour_topic.reload.name).to eq("Remote")
+        expect(flash[:notice]).to match(/learning topic was successfully updated/i)
+      end
+    end
+
+    context "when the params are invalid" do
+      it "returns an unprocessable_content response" do
+        learning_hour_topic = create(:learning_hour_topic, casa_org:, name: "Homeschooling")
+
+        params = {learning_hour_topic: {name: nil}}
+        patch learning_hour_topic_path(learning_hour_topic), params: params
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end

--- a/spec/requests/learning_hour_types_spec.rb
+++ b/spec/requests/learning_hour_types_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "LearningHourTypes", type: :request do
+  let(:casa_org) { create(:casa_org) }
+  let(:admin) { build(:casa_admin, casa_org:) }
+
+  before do
+    sign_in admin
+  end
+
+  describe "GET /new" do
+    it "returns a successful response" do
+      get new_learning_hour_type_path
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns a successful response" do
+      learning_hour_type = create(:learning_hour_type, casa_org:)
+
+      get edit_learning_hour_type_path(learning_hour_type)
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /create" do
+    context "when the params are valid" do
+      it "creates the learning hour type successfully and redirects to the organization's edit page" do
+        params = {
+          learning_hour_type: {
+            name: "Homeschooling",
+            active: true
+          }
+        }
+
+        expect do
+          post learning_hour_types_path, params: params
+        end.to change(LearningHourType, :count).by(1)
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:notice]).to match(/learning type was successfully created/i)
+        expect(response).to redirect_to(edit_casa_org_path(casa_org))
+      end
+    end
+
+    context "when the params are not valid" do
+      it "returns an unprocessable_content response" do
+        params = {
+          learning_hour_type: {
+            active: true
+          }
+        }
+
+        expect do
+          post learning_hour_types_path, params: params
+        end.not_to change(LearningHourType, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "when the params are valid" do
+      it "updates the learning hour type successfully and redirects to the organization's edit page" do
+        learning_hour_type = create(:learning_hour_type, casa_org:, name: "Homeschooling")
+
+        params = {learning_hour_type: {name: "Remote"}}
+        patch learning_hour_type_path(learning_hour_type), params: params
+
+        expect(response).to redirect_to(edit_casa_org_path(casa_org))
+        expect(learning_hour_type.reload.name).to eq("Remote")
+        expect(flash[:notice]).to match(/learning type was successfully updated/i)
+      end
+    end
+
+    context "when the params are invalid" do
+      it "returns an unprocessable_content response" do
+        learning_hour_type = create(:learning_hour_type, casa_org:, name: "Homeschooling")
+
+        params = {learning_hour_type: {name: nil}}
+        patch learning_hour_type_path(learning_hour_type), params: params
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Closes https://github.com/rubyforgood/casa/issues/6840

### What changed, and _why_?

`learning_hour_topics_controller.rb` and `learning_hour_types_controller.rb` do not have any coverage. Let's add coverage to
them so we catch any errors in the future.