### PR TITLE
Fix/paranoia soft delete

### DIFF
--- a/app/models/contact_topic_answer.rb
+++ b/app/models/contact_topic_answer.rb
@@ -1,6 +1,7 @@
 class ContactTopicAnswer < ApplicationRecord
   belongs_to :case_contact
   belongs_to :contact_topic, optional: true
+  acts_as_paranoid
 
   has_one :casa_case, through: :case_contact
   has_one :casa_org, through: :case_contact
@@ -17,6 +18,7 @@ end
 # Table name: contact_topic_answers
 #
 #  id               :bigint           not null, primary key
+#  deleted_at       :datetime
 #  selected         :boolean          default(FALSE), not null
 #  value            :text
 #  created_at       :datetime         not null

--- a/db/migrate/20260414132818_add_deleted_at_to_contact_topic_answers.rb
+++ b/db/migrate/20260414132818_add_deleted_at_to_contact_topic_answers.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToContactTopicAnswers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :contact_topic_answers, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_11_001655) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_132818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -259,6 +259,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_11_001655) do
     t.boolean "selected", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["case_contact_id"], name: "index_contact_topic_answers_on_case_contact_id"
   end
 

--- a/spec/models/contact_topic_answer_spec.rb
+++ b/spec/models/contact_topic_answer_spec.rb
@@ -11,4 +11,19 @@ RSpec.describe ContactTopicAnswer, type: :model do
       create(:contact_topic_answer, value: Faker::Lorem.characters(number: 300))
     }.not_to raise_error
   end
+
+  it "soft deletes record instead of removing it from database" do
+    answer = create(:contact_topic_answer)
+
+    answer.destroy
+
+    expect(answer.deleted_at).not_to be_nil
+    expect(ContactTopicAnswer.with_deleted).to include(answer)
+    expect(ContactTopicAnswer.all).not_to include(answer)
+
+    answer.restore
+
+    expect(answer.deleted_at).to be_nil
+    expect(ContactTopicAnswer.all).to include(answer)
+  end
 end

--- a/spec/requests/contact_topic_answers_spec.rb
+++ b/spec/requests/contact_topic_answers_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "/contact_topic_answers", type: :request do
       answer = ContactTopicAnswer.last
       expect(response_json[:id]).to eq answer.id
       expect(response_json.keys)
-        .to contain_exactly(:id, :contact_topic_id, :value, :case_contact_id, :created_at, :updated_at, :selected)
+        .to contain_exactly(:id, :contact_topic_id, :value, :case_contact_id, :created_at, :updated_at, :selected, :deleted_at)
     end
 
     context "as casa_admin" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6837 

### What changed, and _why_?
`acts_as_paranoid` added to`ContactTopicAnswer` to enable soft deletion. `deleted_at` column introduced via migration to support this.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
A new test in `contact_topic_answer_spec.rb` verifies that a `ContactTopicAnswer` object can be soft-deleted and restored after destruction.

Delete and undelete steps in the UI show that deletion previously removed content permanently, and after the changes the content is restored on undelete.

### Screenshots please :)
Before and after screenshot videos from a browser window.

https://github.com/user-attachments/assets/bc2beef3-cce7-499c-9de3-e3830da5aef1

https://github.com/user-attachments/assets/35f25fcd-2780-4733-b9d4-34db279f58cf


### Feelings gif (optional)
![Squirrel munching with manageable paranoia)](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExM3V0ZGJtNmJpOWFndGM1cDVsZG10a3ZsajFvejN0OWg5bGJxZGtqcCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ycsoFPNmCxInMMqJWO/giphy.gif)
