### PR TITLE
Add request specs for mileage and followup reports controllers

### DIFF
--- a/spec/controllers/followup_reports_controller_spec.rb
+++ b/spec/controllers/followup_reports_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe FollowupReportsController, type: :controller do
-  # TODO: Add tests for FollowupReportsController
-
-  pending "add some tests for FollowupReportsController"
-end

--- a/spec/controllers/mileage_reports_controller_spec.rb
+++ b/spec/controllers/mileage_reports_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe MileageReportsController, type: :controller do
-  # TODO: Add tests for MileageReportsController
-
-  pending "add some tests for MileageReportsController"
-end

--- a/spec/requests/followup_reports_spec.rb
+++ b/spec/requests/followup_reports_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "/followup_reports", type: :request do
+  before do
+    travel_to Time.zone.local(2025, 4, 14)
+    sign_in user
+  end
+
+  describe "GET /followup_reports" do
+    context "as casa_admin" do
+      let(:user) { create(:casa_admin) }
+
+      it "renders a csv file to download" do
+        get followup_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(
+          response.headers["Content-Disposition"]
+        ).to include 'attachment; filename="followup-report-2025-04-14.csv'
+      end
+
+      it "includes followup data in csv" do
+        casa_case = create(:casa_case, casa_org: user.casa_org)
+        case_contact = create(:case_contact, casa_case: casa_case)
+        create(:followup, case_contact: case_contact)
+
+        get followup_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(response.body).to include(casa_case.case_number)
+      end
+    end
+
+    context "as supervisor" do
+      let(:user) { create(:supervisor) }
+
+      it "renders a csv file to download" do
+        get followup_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(
+          response.headers["Content-Disposition"]
+        ).to include 'attachment; filename="followup-report-2025-04-14.csv'
+      end
+    end
+
+    context "as volunteer" do
+      let(:user) { create(:volunteer) }
+
+      it "cannot view reports" do
+        get followup_reports_url(format: :csv)
+
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "when not signed in" do
+      let(:user) { create(:volunteer) }
+
+      it "redirects to sign in" do
+        sign_out user
+        get followup_reports_url(format: :csv)
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end

--- a/spec/requests/mileage_reports_spec.rb
+++ b/spec/requests/mileage_reports_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "/mileage_reports", type: :request do
+  before do
+    travel_to Time.zone.local(2025, 4, 14)
+    sign_in user
+  end
+
+  describe "GET /mileage_reports" do
+    context "as casa_admin" do
+      let(:user) { create(:casa_admin) }
+
+      it "renders a csv file to download" do
+        get mileage_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(
+          response.headers["Content-Disposition"]
+        ).to include 'attachment; filename="mileage-report-2025-04-14.csv'
+      end
+
+      it "includes case contact mileage data in csv" do
+        volunteer = create(:volunteer, casa_org: user.casa_org)
+        casa_case = create(:casa_case, casa_org: user.casa_org)
+        create(:case_assignment, volunteer: volunteer, casa_case: casa_case)
+        create(:case_contact,
+          creator: volunteer,
+          casa_case: casa_case,
+          want_driving_reimbursement: true,
+          miles_driven: 25)
+
+        get mileage_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(response.body).to include("25")
+      end
+    end
+
+    context "as supervisor" do
+      let(:user) { create(:supervisor) }
+
+      it "renders a csv file to download" do
+        get mileage_reports_url(format: :csv)
+
+        expect(response).to be_successful
+        expect(
+          response.headers["Content-Disposition"]
+        ).to include 'attachment; filename="mileage-report-2025-04-14.csv'
+      end
+    end
+
+    context "as volunteer" do
+      let(:user) { create(:volunteer) }
+
+      it "cannot view reports" do
+        get mileage_reports_url(format: :csv)
+
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "when not signed in" do
+      let(:user) { create(:volunteer) }
+
+      it "redirects to sign in" do
+        sign_out user
+        get mileage_reports_url(format: :csv)
+
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replace placeholder controller specs (pending stubs) with proper request specs for `MileageReportsController` and `FollowupReportsController`
- Both controllers serve CSV downloads and authorize via `see_reports_page?`
- Follows the same pattern as the existing `case_contact_reports_spec.rb`

## Test plan

- [ ] CI passes all new specs
- [ ] Verify CSV download works for casa_admin and supervisor roles
- [ ] Verify volunteer is redirected (authorization denial)
- [ ] Verify unauthenticated user is redirected to sign in

Addresses #6833