### PR TITLE
Add coverage for Followups and Mileages reports

### DIFF
--- a/app/controllers/followup_reports_controller.rb
+++ b/app/controllers/followup_reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FollowupReportsController < ApplicationController
   after_action :verify_authorized
 

--- a/app/controllers/mileage_reports_controller.rb
+++ b/app/controllers/mileage_reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "csv"
 
 class MileageReportsController < ApplicationController

--- a/spec/controllers/followup_reports_controller_spec.rb
+++ b/spec/controllers/followup_reports_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe FollowupReportsController, type: :controller do
-  # TODO: Add tests for FollowupReportsController
-
-  pending "add some tests for FollowupReportsController"
-end

--- a/spec/controllers/mileage_reports_controller_spec.rb
+++ b/spec/controllers/mileage_reports_controller_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe MileageReportsController, type: :controller do
-  # TODO: Add tests for MileageReportsController
-
-  pending "add some tests for MileageReportsController"
-end

--- a/spec/requests/followup_reports_spec.rb
+++ b/spec/requests/followup_reports_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "FollowupReports", type: :request do
+  describe "GET /index" do
+    context "when the user has access" do
+      let(:admin) { build(:casa_admin) }
+
+      it "returns the CSV report" do
+        sign_in admin
+
+        get followup_reports_path(format: :csv)
+
+        expect(response).to have_http_status(:success)
+        expect(response.header["Content-Type"]).to eq("text/csv")
+        expect(response.headers["Content-Disposition"]).to(
+          match("followup-report-#{Time.current.strftime("%Y-%m-%d")}.csv")
+        )
+      end
+
+      it "adds the correct headers to the csv" do
+        sign_in admin
+
+        get followup_reports_path(format: :csv)
+
+        csv_headers = [
+          "Case Number",
+          "Volunteer Name(s)",
+          "Note Creator Name",
+          "Note"
+        ]
+
+        csv_headers.each { |header| expect(response.body).to include(header) }
+      end
+    end
+
+    context "when the user is not authorized to access" do
+      it "redirects to root and displays an unauthorized message" do
+        volunteer = build(:volunteer)
+        sign_in volunteer
+
+        get followup_reports_path(format: :csv)
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+  end
+end

--- a/spec/requests/mileage_reports_spec.rb
+++ b/spec/requests/mileage_reports_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MileageReports", type: :request do
+  describe "GET /index" do
+    context "when the user has access" do
+      let(:admin) { build(:casa_admin) }
+
+      it "returns the CSV report" do
+        sign_in admin
+
+        get mileage_reports_path(format: :csv)
+
+        expect(response).to have_http_status(:success)
+        expect(response.header["Content-Type"]).to eq("text/csv")
+        expect(response.headers["Content-Disposition"]).to(
+          match("mileage-report-#{Time.current.strftime("%Y-%m-%d")}.csv")
+        )
+      end
+
+      it "adds the correct headers to the csv" do
+        sign_in admin
+
+        get mileage_reports_path(format: :csv)
+
+        csv_headers = [
+          "Contact Types",
+          "Occurred At",
+          "Miles Driven",
+          "Casa Case Number",
+          "Creator Name",
+          "Supervisor Name",
+          "Volunteer Address",
+          "Reimbursed"
+        ]
+
+        csv_headers.each { |header| expect(response.body).to include(header) }
+      end
+    end
+
+    context "when the user is not authorized to access" do
+      it "redirects to root and displays an unauthorized message" do
+        volunteer = build(:volunteer)
+        sign_in volunteer
+
+        get mileage_reports_path(format: :csv)
+
+        expect(response).to redirect_to root_path
+        expect(response.request.flash[:notice]).to eq "Sorry, you are not authorized to perform this action."
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Close https://github.com/rubyforgood/casa/issues/6842

### What changed, and _why_?

Followup report handle CSV exports with authorization and the Mileage report handles
Reimbursement CSV exports. Both have placeholder specs only.

Let's add coverage to ensure they work as expected and no bugs are introduced.

The services that generate the report data have extensive coverage already, so keep this unit test focused on the request, I only tested for the format and the headers.