### PR TITLE
New Case Contacts Table: new case contact button

### DIFF
--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -1,8 +1,10 @@
 <div class="title-wrapper pt-30">
-  <div class="row align-items-center">
-      <div class="title mb-30">
-        <h1>Case Contacts</h1>
-      </div>
+  <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-30">
+    <h1>Case Contacts</h1>
+    <%= link_to new_case_contact_path, class: "main-btn primary-btn btn-sm btn-hover" do %>
+      <i class="lni lni-plus mr-10" aria-hidden="true"></i>
+      New Case Contact
+    <% end %>
   </div>
 </div>
 

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Case Contact Table Row Expansion", type: :system, js: true do
+RSpec.describe "Case contacts new design", type: :system, js: true do
   let(:organization) { create(:casa_org) }
   let(:admin) { create(:casa_admin, casa_org: organization) }
   let(:casa_case) { create(:casa_case, casa_org: organization) }
@@ -14,30 +14,71 @@ RSpec.describe "Case Contact Table Row Expansion", type: :system, js: true do
       case_contact: case_contact,
       contact_topic: contact_topic,
       value: "Youth is doing well in school")
+    allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(:new_case_contact_table).and_return(true)
-    sign_in admin
-    visit case_contacts_new_design_path
   end
 
-  it "shows the expanded content after clicking the chevron" do
-    find(".expand-toggle").click
-
-    expect(page).to have_content("What was discussed?")
-    expect(page).to have_content("Youth is doing well in school")
+  shared_context "signed in as admin" do
+    before do
+      sign_in admin
+      visit case_contacts_new_design_path
+    end
   end
 
-  it "shows notes in the expanded content" do
-    find(".expand-toggle").click
+  describe "New Case Contact button" do
+    include_context "signed in as admin"
 
-    expect(page).to have_content("Additional Notes")
-    expect(page).to have_content("Important follow-up needed")
+    it "is visible to an admin" do
+      expect(page).to have_link("New Case Contact", href: new_case_contact_path)
+    end
+
+    it "navigates to the new case contact form when clicked as an admin" do
+      click_link "New Case Contact"
+      expect(page).to have_current_path(%r{/case_contacts/\d+/form/details})
+    end
+
+    context "when signed in as a volunteer" do
+      let(:volunteer) { create(:volunteer, casa_org: organization) }
+
+      before do
+        sign_in volunteer
+        visit case_contacts_new_design_path
+      end
+
+      it "is visible to a volunteer" do
+        expect(page).to have_link("New Case Contact", href: new_case_contact_path)
+      end
+
+      it "navigates to the new case contact form when clicked as a volunteer" do
+        click_link "New Case Contact"
+        expect(page).to have_current_path(%r{/case_contacts/\d+/form/details})
+      end
+    end
   end
 
-  it "hides the expanded content after clicking the chevron again" do
-    find(".expand-toggle").click
-    expect(page).to have_content("Youth is doing well in school")
+  describe "row expansion" do
+    include_context "signed in as admin"
 
-    find(".expand-toggle").click
-    expect(page).to have_no_content("Youth is doing well in school")
+    it "shows the expanded content after clicking the chevron" do
+      find(".expand-toggle").click
+
+      expect(page).to have_content("What was discussed?")
+      expect(page).to have_content("Youth is doing well in school")
+    end
+
+    it "shows notes in the expanded content" do
+      find(".expand-toggle").click
+
+      expect(page).to have_content("Additional Notes")
+      expect(page).to have_content("Important follow-up needed")
+    end
+
+    it "hides the expanded content after clicking the chevron again" do
+      find(".expand-toggle").click
+      expect(page).to have_content("Youth is doing well in school")
+
+      find(".expand-toggle").click
+      expect(page).to have_no_content("Youth is doing well in school")
+    end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6501

### What changed, and _why_?

Added a "New Case Contact" button to the header of the new design case contacts page (`/case_contacts/new_design`). The button links to the existing `new_case_contact_path`, which creates a draft `CaseContact` and redirects to the multi-step form — the same flow used by the old design. No new controller logic or routes were required.

The button:
- Uses `primary-btn` styling to match the shade of blue on other "New" buttons in the app (e.g. "New Volunteer")
- Is positioned top-right of the page header using Bootstrap flex utilities, matching the mockup
- Wraps below the heading on narrow viewports (`flex-wrap gap-2`) rather than being squeezed against it
- Includes `aria-hidden="true"` on the decorative `+` icon so screen readers announce only the link text

The system spec file was also restructured to use a `shared_context "signed in as admin"` pattern, aligning with the approach introduced in https://github.com/rubyforgood/casa/pull/6834 to minimize merge conflicts when that branch lands on main.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

System specs added to `spec/system/case_contacts/case_contacts_new_design_spec.rb` covering:

- Button is visible when signed in as an admin
- Button is visible when signed in as a volunteer
- Clicking the button as an admin navigates to the new case contact form
- Clicking the button as a volunteer navigates to the new case contact form

### Screen recordings

<details>
<summary>Button in use</summary>

https://github.com/user-attachments/assets/bc201298-aca8-4077-9c5e-a1fdd43ced7e

</details>

<details>
<summary>Responsive behavior at different screen sizes</summary>

https://github.com/user-attachments/assets/b987a58d-7928-4649-bbbb-f156999022a9

</details>

### AI Disclosure

This PR was developed collaboratively with [Claude Sonnet 4.6](https://www.anthropic.com/claude) (Claude Code). The AI assisted with:

- Analyzing the existing old design implementation and policy layer to confirm no new controller logic was needed
- Identifying the accessibility gap (`aria-hidden` on decorative icons) and the responsive layout approach (`flex-wrap`)
- Structuring the system specs to align with the `shared_context` pattern from b4758d1 to reduce future merge conflicts
- Writing the specs (red first, then implementation) following a TDD workflow

All code was reviewed and approved by the author before committing.