### PR TITLE
Add GitHub Copilot review instructions

### DIFF
--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -1,0 +1,112 @@
+---
+applyTo: "**"
+---
+
+# CASA Code Review Instructions
+
+You are reviewing pull requests for CASA (Court Appointed Special Advocates), a Ruby on Rails application that helps CASA volunteers track their work with youth in foster care. This is an open-source project maintained by Ruby for Good with contributors of all experience levels. Be constructive and kind.
+
+## Tech Stack
+
+- **Backend**: Rails 7.2, Ruby 3.x, PostgreSQL
+- **Frontend**: Stimulus (Hotwire) + Turbo, Bootstrap 5, ESBuild
+- **Auth**: Devise + Devise-Invitable (no UI sign-ups; admin invitation only)
+- **Authorization**: Pundit (policy-based)
+- **Background Jobs**: Delayed Job
+- **Feature Flags**: Flipper
+- **Testing**: RSpec + Capybara (Ruby), Jest (JavaScript)
+- **Linting**: Standard.rb (Ruby), StandardJS (JavaScript), erb-lint (ERB)
+- **View Layer**: ERB templates, ViewComponent, Draper decorators
+
+## Architecture Rules
+
+### Authorization & Multi-Tenancy
+
+- All controller actions must be authorized via Pundit (`authorize` / `policy_scope`).
+- Data must be scoped to the current user's `casa_org`. Never allow cross-organization data access.
+- User roles: `AllCasaAdmin`, `CasaAdmin`, `Supervisor`, `Volunteer`. Each has a separate model (not STI).
+- Permission changes must include or update the corresponding Pundit policy file in `app/policies/`.
+
+### Controllers
+
+- Controllers should be thin. Complex logic belongs in service objects or models.
+- Controllers must call `authorize` and typically use `after_action :verify_authorized`.
+- Use `policy_scope` for index actions to scope records to the current org/user.
+
+### Models
+
+- Models use `include ByOrganizationScope` for org-scoped queries where applicable.
+- Prefer scopes over class methods for query logic.
+- Soft deletes via the Paranoia gem: `destroy` marks records deleted, does not hard-delete.
+- Use Strong Migrations: flag any unsafe migration operations (e.g., removing a column without `safety_assured`, adding an index without `algorithm: :concurrently`).
+
+### Views & Frontend
+
+- Use ERB (not HAML). Complex view logic should live in a Draper decorator (`app/decorators/`), not in the template.
+- Use ViewComponent (`app/components/`) for reusable UI elements.
+- Style with Bootstrap 5 utility classes and existing project SCSS. UI changes should match the rest of the site.
+- JavaScript should use Stimulus controllers. Avoid inline `<script>` tags or jQuery for new code.
+- Email views require inline CSS (email client compatibility — see ADR 0007).
+
+### Services & Decorators
+
+- Service objects live in `app/services/` and follow the pattern: `ServiceName.new(args).perform`.
+- Decorators live in `app/decorators/` and handle presentation logic that doesn't belong in models or views.
+
+## Review Checklist
+
+### Security
+
+- [ ] No mass-assignment vulnerabilities: strong parameters used for all user input.
+- [ ] No raw SQL interpolation — use parameterized queries or ActiveRecord methods.
+- [ ] No `html_safe` or `raw` on user-supplied content (XSS risk).
+- [ ] Pundit authorization is present on all controller actions.
+- [ ] Data is scoped to the user's organization — no cross-tenant leaks.
+- [ ] File uploads validated (type, size) before storage.
+- [ ] Secrets and credentials are not committed.
+
+### Testing
+
+- [ ] New features have tests. Bug fixes include a test that would fail without the fix.
+- [ ] System tests (Capybara) are preferred for UI changes over controller tests (see ADR 0006).
+- [ ] Factories use traits for scenario variations (e.g., `create(:casa_case, :active)`).
+- [ ] Tests cover edge cases: nil/empty values, missing optional fields, special characters.
+- [ ] No `sleep` calls in tests — use Capybara's built-in waiting/retry mechanisms.
+- [ ] Flaky tests are disabled with a tracking issue, not deleted.
+
+### Code Quality
+
+- [ ] Follows Standard.rb style (Ruby) and StandardJS style (JavaScript).
+- [ ] No N+1 queries introduced — use `includes`, `preload`, or `eager_load` as needed.
+- [ ] ActiveRecord collections iterated with `find_each` instead of `each` for large sets.
+- [ ] Multi-record writes wrapped in `ActiveRecord::Base.transaction`.
+- [ ] No business logic in controllers or views — delegate to models, services, or decorators.
+- [ ] Dead code and unused variables removed.
+
+### Pull Request Quality
+
+- [ ] PR references a GitHub issue (`Resolves #XXXX`).
+- [ ] Small, focused diff. Multiple small PRs preferred over one large PR.
+- [ ] Migrations are reversible and safe (no data loss, follows Strong Migrations).
+- [ ] No unrelated formatting changes that inflate the diff.
+
+## What to Flag
+
+- **Authorization gaps**: Any controller action missing `authorize` or `policy_scope`.
+- **Cross-org data access**: Queries that don't scope to `casa_org`.
+- **Missing tests**: New behavior without corresponding test coverage.
+- **N+1 queries**: Loading associations inside loops without eager loading.
+- **Unsafe migrations**: Column removals, type changes, or index additions without safety guards.
+- **XSS vectors**: `html_safe`, `raw`, or `sanitize` misuse on user content.
+- **Large PRs**: Suggest splitting if the diff touches many unrelated areas.
+
+## What NOT to Flag
+
+- Older migration files (2020–2024) — these are excluded from linting intentionally.
+- Minor style issues already handled by Standard.rb or StandardJS linters.
+- Lack of TypeScript — this project uses plain JavaScript with Stimulus.
+- jQuery usage in existing code — new code should use Stimulus, but don't flag legacy jQuery.
+
+## Tone
+
+This is a volunteer-driven open-source project. Contributors range from first-time open source contributors to experienced Rails developers. Be encouraging, explain the "why" behind suggestions, and link to relevant docs or examples in the codebase when possible. Avoid nitpicks on subjective style — trust the linters for formatting.

--- a/.github/instructions/ruby.instructions.md
+++ b/.github/instructions/ruby.instructions.md
@@ -1,0 +1,140 @@
+---
+applyTo: "**/*.rb"
+---
+
+# Ruby / Rails Review Instructions
+
+## Authorization (Pundit)
+
+Every controller action that reads or writes data must be authorized.
+
+```ruby
+# Required pattern
+def index
+  authorize Model
+  @records = policy_scope(current_organization.models)
+end
+
+def show
+  authorize @record
+end
+```
+
+- Controllers must include `after_action :verify_authorized` (with exceptions listed in `except:`).
+- Index actions must use `policy_scope` to scope records to the current organization.
+- Custom policy methods are called with `authorize @record, :custom_action?`.
+- Policy files live in `app/policies/`. Permission changes must update the corresponding policy.
+- Policies define `permitted_attributes` that return role-based field lists — check that new fields are added there when models gain attributes.
+
+Flag: any controller action missing `authorize` or `policy_scope`.
+
+## Multi-Tenancy
+
+All data access must be scoped to the user's `casa_org`.
+
+- Models include `ByOrganizationScope` which provides `.by_organization(casa_org)`.
+- Policy scopes must filter by organization: `scope.by_organization(user.casa_org)`.
+- `current_organization` (from the `Organizational` concern) returns the signed-in user's org.
+
+Flag: queries that could return records from another organization.
+
+## Controllers
+
+- Keep controllers thin. Business logic belongs in models or service objects (`app/services/`).
+- Complex view logic belongs in Draper decorators (`app/decorators/`), not controllers or ERB.
+- Use parameter objects (`app/values/`) for strong params when the logic is non-trivial. They follow a builder pattern: `FooParameters.new(params).with_password(pw).without_active`.
+- Standard flash pattern:
+  ```ruby
+  if @record.save
+    redirect_to path, notice: "Record created successfully."
+  else
+    render :new, status: :unprocessable_content
+  end
+  ```
+- Use `respond_to` blocks when supporting multiple formats (HTML, JSON, CSV).
+- Set up models with `before_action :set_model` and list exceptions in `except:`.
+
+## Models
+
+- Prefer scopes over class methods for query logic.
+- Scope naming: descriptive, chainable (`.active`, `.by_organization`, `.with_assigned_cases`).
+- Use `find_each` (not `each`) when iterating over ActiveRecord collections.
+- Wrap multi-record writes in `ActiveRecord::Base.transaction`.
+- Enums use the prefix syntax: `enum :status, {active: 0, inactive: 1}, prefix: :status`.
+- Soft deletes via Paranoia — `destroy` marks as deleted, does not hard-delete.
+- Extract complex validations into concern modules (e.g., `CasaCase::Validations`).
+- Associations with conditions use lambdas:
+  ```ruby
+  has_many :active_assignments, -> { active }, class_name: "CaseAssignment"
+  ```
+- `accepts_nested_attributes_for` with `reject_if` guards for blank entries.
+
+## Services
+
+Service objects follow a consistent pattern:
+
+```ruby
+class MyService
+  def initialize(args)
+    @args = args
+  end
+
+  def perform
+    # single responsibility logic
+  end
+end
+```
+
+Called as `MyService.new(args).perform`. Services should preload associations to avoid N+1 queries.
+
+## Decorators
+
+- Draper decorators in `app/decorators/` handle presentation logic.
+- Access view helpers via `h.helper_method` inside decorators.
+- Called via `.decorate` on model instances or collections.
+
+Flag: presentation logic (formatting dates, conditional display text) in models or controllers.
+
+## Concerns
+
+- Use `extend ActiveSupport::Concern` for shared behavior.
+- `included do ... end` block for validations, scopes, callbacks.
+- Place model concerns in `app/models/concerns/`, controller concerns in `app/controllers/concerns/`.
+
+## Migrations
+
+- Must be reversible.
+- Use Strong Migrations: flag unsafe operations (removing columns without `safety_assured`, adding indexes without `algorithm: :concurrently` on large tables, changing column types).
+- New columns with NOT NULL constraints need a default value or a multi-step migration.
+
+## Common Anti-Patterns to Flag
+
+- **N+1 queries**: Loading associations inside loops without `includes`, `preload`, or `eager_load`.
+- **Cross-org data leaks**: Queries missing organization scope.
+- **Business logic in views**: ERB files with complex conditionals or calculations — should be in a decorator.
+- **Fat controllers**: More than a few lines of logic — extract to a service or model method.
+- **Raw SQL interpolation**: Use parameterized queries or ActiveRecord methods.
+- **`html_safe` / `raw` on user input**: XSS risk.
+- **Missing authorization**: Controller actions without `authorize`.
+- **`.each` on AR collections**: Use `find_each` for batch processing.
+- **Unscoped `destroy`**: Verify soft-delete behavior is intended; Paranoia intercepts `destroy`.
+
+## Testing (RSpec)
+
+- System tests (Capybara) are preferred for UI flows over controller tests.
+- Model tests use shoulda-matchers for associations and validations:
+  ```ruby
+  it { is_expected.to have_many(:case_assignments).dependent(:destroy) }
+  it { is_expected.to validate_uniqueness_of(:case_number).scoped_to(:casa_org_id) }
+  ```
+- Use `build` for unit tests, `create` only when persistence is needed.
+- Use `let` for lazy evaluation, `let!` when the record must exist before the test runs.
+- Factory traits for scenario variations: `create(:casa_case, :active)`.
+- Context blocks describe the scenario: `context "when the user is a supervisor"`.
+- Test edge cases: nil values, empty strings, special characters, missing optional fields.
+- No `sleep` in tests — use Capybara's built-in waiting.
+- Flaky tests are disabled with a tracking issue (`xit` + comment), never deleted.
+
+## Style
+
+This project uses Standard.rb (not vanilla RuboCop). Do not flag style issues that Standard.rb handles automatically (spacing, string quotes, trailing commas). Focus review on logic, security, and architecture.


### PR DESCRIPTION
## Summary
- Adds `.github/instructions/copilot-review.instructions.md` with project-wide review guidance covering security (Pundit auth, XSS, cross-org leaks), testing requirements, code quality, and PR standards
- Adds `.github/instructions/ruby.instructions.md` with Ruby/Rails-specific review guidance covering controller conventions, model patterns, service objects, decorators, migrations, and RSpec patterns
- Both files are tailored to CASA's architecture and conventions so Copilot reviews flag real issues instead of generic style noise

## Test plan
- [ ] Verify the instruction files render correctly on GitHub
- [ ] Open a test PR touching a Ruby file and confirm Copilot review references the instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)