### PR TITLE
Fix learning_hour test for date that is not in the future

### DIFF
--- a/spec/models/learning_hour_spec.rb
+++ b/spec/models/learning_hour_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe LearningHour, type: :model do
   end
 
   it "has date that is not in the future" do
-    learning_hour = build_stubbed(:learning_hour, occurred_at: 1.day.from_now.strftime("%d %b %Y"))
+    learning_hour = build_stubbed(:learning_hour, occurred_at: 1.day.from_now)
     expect(learning_hour).not_to be_valid
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
No Issue. Small fix.

### What changed, and _why_?
Pass a datetime, not a String, for comparison in `occurred_at_not_in_future`. String formatting with `strftime` was inappropriate for testing this function.

https://github.com/rubyforgood/casa/blob/10fb1a929d953319e1cafc87dc19acff3c5090e0/app/models/learning_hour.rb#L41-L47

### How is this **tested**? (please write rspec and jest tests!) 💖💪
`bundle exec rspec ./spec/models/learning_hour_spec.rb`

### Screenshots please :)
Before:
<img width="592" height="90" alt="Screenshot 2026-04-19 at 01 11 27" src="https://github.com/user-attachments/assets/6e2418e6-8662-490f-b73c-bf7e21184459" />

After:
<img width="595" height="204" alt="Screenshot 2026-04-19 at 01 09 19" src="https://github.com/user-attachments/assets/7cc00e31-df86-4041-b9d2-2dd07d3c05d1" />

<img width="800" height="600" alt="Screenshot 2026-04-19 at 01 52 51 (2)" src="https://github.com/user-attachments/assets/7d122e3e-bd59-4f28-b1b0-3d97d05e45c7" />

### Feelings gif (optional)
![Mr Bean time](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2ljcmt1cjBvZnNoc3Ezc2lkeGdiMnZkN2R5aG1qdDc2aW5kZ3djcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QBd2kLB5qDmysEXre9/giphy.gif)
