### PR TITLE
change profiling from GC to old object examination

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,9 @@
+require "objspace"
+
 class HealthController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_authorized
-  before_action :verify_token_for_gc_stats, only: [:gc]
+  before_action :verify_token_for_old_object_stats, only: [:old_objects]
 
   def index
     respond_to do |format|
@@ -13,11 +15,14 @@ class HealthController < ApplicationController
     end
   end
 
-  def gc
-    render body: JSON.pretty_generate([
-      Time.now.in_time_zone("Central Time (US & Canada)").strftime("%H"),
-      GC.stat
-    ]),
+  def old_objects
+    render body: JSON.pretty_generate({
+      largest_old_objects_by_class: get_top_20_hash_keys_by_value_desc(find_largest_old_objects_by_class),
+      most_common_old_object_classes: get_top_20_hash_keys_by_value_desc(find_most_common_old_object_classes),
+      most_common_old_strings: encode_string_hash_to_utf_8(get_top_20_hash_keys_by_value_desc(find_most_common_old_strings)),
+      old_object_count: GC.stat[:old_objects],
+      sample_time: Time.now.in_time_zone("Central Time (US & Canada)").strftime("%H")
+    }),
       content_type: "application/json"
   end
 
@@ -79,7 +84,66 @@ class HealthController < ApplicationController
 
   private
 
-  def verify_token_for_gc_stats
+  def each_old_object
+    ObjectSpace.each_object do |obj|
+      next unless ObjectSpace.dump(obj).include?('"old":true')
+      yield obj
+    rescue NoMethodError
+      next
+    end
+  end
+
+  def encode_string_hash_to_utf_8(hash)
+    hash.map do |str, count|
+      [str.encode("UTF-8", invalid: :replace, undef: :replace, replace: "?"), count]
+    end
+  end
+
+  def find_largest_old_objects_by_class
+    class_sizes = Hash.new(0)
+
+    each_old_object do |obj|
+      klass = obj.class
+      class_sizes[klass] += ObjectSpace.memsize_of(obj)
+    rescue
+      next
+    end
+
+    class_sizes
+  end
+
+  def find_most_common_old_object_classes
+    class_counts = Hash.new(0)
+
+    each_old_object do |obj|
+      klass = obj.class
+      class_counts[klass] += 1
+    rescue
+      next
+    end
+
+    class_counts
+  end
+
+  def find_most_common_old_strings
+    string_counts = Hash.new(0)
+
+    each_old_object do |obj|
+      string_counts[obj] += 1 if obj.is_a?(String) && !obj.frozen?
+    rescue NoMethodError
+      next
+    end
+
+    string_counts
+  end
+
+  def get_top_20_hash_keys_by_value_desc(hash)
+    hash.sort_by do |key, val|
+      -val
+    end.first(20)
+  end
+
+  def verify_token_for_old_object_stats
     gc_access_token = ENV["GC_ACCESS_TOKEN"]
 
     head :forbidden unless params[:token] == gc_access_token && !gc_access_token.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   resources :health, only: %i[index] do
     collection do
       get :case_contacts_creation_times_in_last_week
-      get :gc
+      get :old_objects
       get :monthly_line_graph_data
       get :monthly_unique_users_graph_data
     end

--- a/lib/tasks/post_gc_stat_to_discord.rake
+++ b/lib/tasks/post_gc_stat_to_discord.rake
@@ -3,7 +3,7 @@ desc "Post gc stats to discord channel"
 task post_gc_stat_to_discord: :environment do
   require "net/http"
 
-  url = URI("https://casavolunteertracking.org/health/gc?token=#{ENV["GC_ACCESS_TOKEN"]}")
+  url = URI("https://casavolunteertracking.org/health/old_objects?token=#{ENV["GC_ACCESS_TOKEN"]}")
   response = Net::HTTP.get_response(url)
 
   unless response.is_a?(Net::HTTPSuccess)


### PR DESCRIPTION
### What changed, and _why_?
GC output is too vague. Old objects are objects that survive multiple garbage collections and will hopefully give better hints about what causes the memory leak. It's kind of like output from https://github.com/SamSaffron/memory_profiler

### How is this **tested**? (please write rspec and jest tests!) 💖💪
locally
<img width="722" height="565" alt="image" src="https://github.com/user-attachments/assets/426df170-4548-4bd5-9999-67766d43fb77" />
