### PR TITLE
Refactor task loading in three data_post_processing specs and fake deploy time in health_spec

### DIFF
--- a/lib/tasks/deployment/99991023145114_store_deploy_time.rake
+++ b/lib/tasks/deployment/99991023145114_store_deploy_time.rake
@@ -1,7 +1,7 @@
 namespace :after_party do
   desc "Deployment task: stores_the_time_of_the_latest_deploy_as_a_file"
   task store_deploy_time: :environment do
-    puts "Running deploy task 'store_deploy_time'" unless Rails.env.test?
+    puts "Running deploy task 'store_deploy_time'"
     pending_files = AfterParty::TaskRecorder.pending_files
 
     down_tasks = pending_files.reject { |item| item.task_name == "store_deploy_time" }

--- a/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "#{Rails.root.join("lib/tasks/data_post_processors/case_contact_populator")}"
+require Rails.root.join("lib/tasks/data_post_processors/case_contact_populator").to_s
 
 RSpec.describe CaseContactPopulator do
   it "does nothing on an empty database" do

--- a/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
@@ -1,12 +1,7 @@
 require "rails_helper"
-require "./lib/tasks/data_post_processors/case_contact_populator"
+require "#{Rails.root}/lib/tasks/data_post_processors/case_contact_populator"
 
 RSpec.describe CaseContactPopulator do
-  before do
-    Rake::Task.clear
-    Casa::Application.load_tasks
-  end
-
   it "does nothing on an empty database" do
     described_class.populate
 

--- a/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "#{Rails.root}/lib/tasks/data_post_processors/case_contact_populator"
+require "#{Rails.root.join("lib/tasks/data_post_processors/case_contact_populator")}"
 
 RSpec.describe CaseContactPopulator do
   it "does nothing on an empty database" do

--- a/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "./lib/tasks/data_post_processors/contact_topic_populator"
+require "#{Rails.root}/lib/tasks/data_post_processors/contact_topic_populator"
 
 RSpec.describe "populates each existing organization with contact groups and types" do
   let(:fake_topics) { [1, 2, 3].map { |i| {"question" => "Question #{i}", "details" => "Details #{i}"} } }
@@ -7,8 +7,6 @@ RSpec.describe "populates each existing organization with contact groups and typ
   let(:org_two) { create(:casa_org) }
 
   before do
-    Rake::Task.clear
-    Casa::Application.load_tasks
 
     allow(ContactTopic).to receive(:default_contact_topics).and_return(fake_topics)
     ContactTopicPopulator.populate

--- a/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "#{Rails.root.join("lib/tasks/data_post_processors/contact_topic_populator")}"
+require Rails.root.join("lib/tasks/data_post_processors/contact_topic_populator").to_s
 
 RSpec.describe "populates each existing organization with contact groups and types" do
   let(:fake_topics) { [1, 2, 3].map { |i| {"question" => "Question #{i}", "details" => "Details #{i}"} } }

--- a/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "#{Rails.root}/lib/tasks/data_post_processors/contact_topic_populator"
+require "#{Rails.root.join("lib/tasks/data_post_processors/contact_topic_populator")}"
 
 RSpec.describe "populates each existing organization with contact groups and types" do
   let(:fake_topics) { [1, 2, 3].map { |i| {"question" => "Question #{i}", "details" => "Details #{i}"} } }
@@ -7,7 +7,6 @@ RSpec.describe "populates each existing organization with contact groups and typ
   let(:org_two) { create(:casa_org) }
 
   before do
-
     allow(ContactTopic).to receive(:default_contact_topics).and_return(fake_topics)
     ContactTopicPopulator.populate
   end

--- a/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
@@ -1,10 +1,7 @@
 require "rails_helper"
+require "#{Rails.root}/lib/tasks/data_post_processors/contact_type_populator"
 
 RSpec.describe "populates each existing organization with contact groups and types" do
-  before do
-    Rake::Task.clear
-    Casa::Application.load_tasks
-  end
 
   it "creates the expected contact groups and contact types for each existing organization" do
     ContactTypePopulator.populate

--- a/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
-require "#{Rails.root}/lib/tasks/data_post_processors/contact_type_populator"
+require "#{Rails.root.join("lib/tasks/data_post_processors/contact_type_populator")}"
 
 RSpec.describe "populates each existing organization with contact groups and types" do
-
   it "creates the expected contact groups and contact types for each existing organization" do
     ContactTypePopulator.populate
 

--- a/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
+++ b/spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
@@ -1,5 +1,5 @@
 require "rails_helper"
-require "#{Rails.root.join("lib/tasks/data_post_processors/contact_type_populator")}"
+require Rails.root.join("lib/tasks/data_post_processors/contact_type_populator").to_s
 
 RSpec.describe "populates each existing organization with contact groups and types" do
   it "creates the expected contact groups and contact types for each existing organization" do

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Health", type: :request do
   before do
-    Casa::Application.load_tasks
-    Rake::Task["after_party:store_deploy_time"].invoke
+    Health.instance.update_attribute(:latest_deploy_time, Time.now)
   end
 
   describe "GET /health" do

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Health", type: :request do
   before do
-    Health.instance.update_attribute(:latest_deploy_time, Time.now)
+    Health.instance.update_attribute(:latest_deploy_time, Time.current)
   end
 
   describe "GET /health" do


### PR DESCRIPTION

### What github issue is this PR for, if any?
Relates to #6874
(DRY Test Code as part of Test Suite Overhaul)

### What changed, and _why_?
DRY refactor of Rake task loading: narrow loading in three `data_post_processing` specs, fake deploy time in `health_spec`, allowing removal of conditional silencing from a deployment task which is no longer called.

These changes avoid repeated loading of the full Rake task suite, which prevents `Tasks::LOCK_FILES` warnings. A failed-task warning is also prevented by no longer invoking the deployment task during test runs.

Source of deploy-time logic used in the test fake, and the failed-task warning:
https://github.com/alanparmenter/casa/blob/ec28640724df46436d39f7b1e7e82ef5ff673384/lib/tasks/deployment/99991023145114_store_deploy_time.rake#L8-L11

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/lib/tasks/data_post_processors/case_contact_populator_spec.rb
bundle exec rspec spec/lib/tasks/data_post_processors/contact_topic_populator_spec.rb
bundle exec rspec spec/lib/tasks/data_post_processors/contact_type_populator_spec.rb
bundle exec rspec spec/requests/health_spec.rb
bundle exec rspec spec
```
### Screenshots please :)
_Before:_
<img width="614" height="83" alt="Screenshot 2026-04-21 at 20 51 37" src="https://github.com/user-attachments/assets/aa3b09e7-0f22-4732-ad87-70b319db7f89" />
_After:_
<img width="617" height="80" alt="Screenshot 2026-04-21 at 20 40 40" src="https://github.com/user-attachments/assets/c234d2db-fc62-4a88-a102-b02480ac52f4" />

### Feelings gif (optional)
![Homer Simpson's Rake of Procrastination](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmt3aG04bHhseGJ3ejdldjR5OTBleXMzanZ5NTZuemwwYnp1Z2d2ciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMWqlZ7Ec6ZwTxm/giphy.gif)
