### PR TITLE
DRY up admin, supervisor and volunteer spec using shared_examples (devise_mailer_preview_spec.rb)

### DIFF
--- a/spec/mailers/previews/devise_mailer_preview_spec.rb
+++ b/spec/mailers/previews/devise_mailer_preview_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 require Rails.root.join("lib/mailers/previews/devise_mailer_preview").to_s
 
+RSpec.shared_examples "invitation instructions" do |factory|
+  let!(:record) { create(factory) }
+  let(:message) { subject.send(:"invitation_instructions_as_#{factory}") }
+
+  it { expect(message.to).to eq [record.email] }
+end
+
 RSpec.describe DeviseMailerPreview do
   let(:subject) { described_class.new }
   let!(:user) { create(:user) }
@@ -29,30 +36,18 @@ RSpec.describe DeviseMailerPreview do
   end
 
   describe "#invitation_instructions_as_all_casa_admin" do
-    let!(:all_casa_admin) { create(:all_casa_admin) }
-    let(:message) { subject.invitation_instructions_as_all_casa_admin }
-
-    it { expect(message.to).to eq [all_casa_admin.email] }
+    it_behaves_like "invitation instructions", :all_casa_admin
   end
 
   describe "#invitation_instructions_as_casa_admin" do
-    let!(:casa_admin) { create(:casa_admin) }
-    let(:message) { subject.invitation_instructions_as_casa_admin }
-
-    it { expect(message.to).to eq [casa_admin.email] }
+    it_behaves_like "invitation instructions", :casa_admin
   end
 
   describe "#invitation_instructions_as_supervisor" do
-    let!(:supervisor) { create(:supervisor) }
-    let(:message) { subject.invitation_instructions_as_supervisor }
-
-    it { expect(message.to).to eq [supervisor.email] }
+    it_behaves_like "invitation instructions", :supervisor
   end
 
   describe "#invitation_instructions_as_volunteer" do
-    let!(:volunteer) { create(:volunteer) }
-    let(:message) { subject.invitation_instructions_as_volunteer }
-
-    it { expect(message.to).to eq [volunteer.email] }
+    it_behaves_like "invitation instructions", :volunteer
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #6874 

### What changed, and _why_?
Using `shared_examples` to remove duplication in admin, supervisor and volunteer tests.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/mailers/previews/devise_mailer_preview_spec.rb
```

### Feelings gif (optional)
![Cactus with umbrella in the rain](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG4wZXV0Y3RrYjh5Ymhqd2c1dWlzYnhub2w2anUycnVrYmx3dGdkOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
