### PR TITLE
Fix .github issues: bugs, security, inconsistencies, and gaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,4 +43,4 @@ password for all users: 12345678
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -6,4 +6,4 @@
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -6,4 +6,4 @@
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,4 +31,4 @@ password for all users: 12345678
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly. And [discord](https://discord.gg/qJcw2RZH8Q) for office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -16,4 +16,4 @@ rspec or rspec in docker?
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/ISSUE_TEMPLATE/problem_validation.md
+++ b/.github/ISSUE_TEMPLATE/problem_validation.md
@@ -15,4 +15,4 @@ Please use this template to document problems mentioned by CASA stakeholders so 
 
 ### Questions? Join Slack!
 
-We highly recommend that you join us in [slack](https:https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.
+We highly recommend that you join us in [slack](https://join.slack.com/t/rubyforgood/shared_invite/zt-35218k86r-vlIiWqig54c9t~_LkGpQ7Q) #casa channel to ask questions quickly and hear about office hours (currently Tuesday 5-7pm Pacific), stakeholder news, and upcoming new issues.

--- a/.github/autoapproval.yml
+++ b/.github/autoapproval.yml
@@ -1,2 +1,2 @@
 from_owner:
-  - dependabot-preview
+  - dependabot[bot]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,14 +33,12 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
-        # CodeQL supports ['cpp', 'csharp', 'go', 'java', 'javascript', 'python']
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        language: ['javascript', 'ruby']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -19,6 +19,7 @@ jobs:
   erb_lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/factory_bot_lint.yml
+++ b/.github/workflows/factory_bot_lint.yml
@@ -20,10 +20,11 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       db:
-        image: postgres:12.3
+        image: postgres:14.8
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/.github/workflows/npm_lint_and_test.yml
+++ b/.github/workflows/npm_lint_and_test.yml
@@ -8,7 +8,7 @@ on:
       - '**/*.js'
       - '**/*.json'
       - '**/*.jsx'
-      - 'package.lock.json'
+      - 'package-lock.json'
       - '.github/workflows/*.yml'
   pull_request:
     branches:
@@ -18,12 +18,13 @@ on:
       - '**/*.js'
       - '**/*.json'
       - '**/*.jsx'
-      - 'package.lock.json'
+      - 'package-lock.json'
       - '.github/workflows/*.yml'
 
 jobs:
   npm_lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/rake-after_party.yml
+++ b/.github/workflows/rake-after_party.yml
@@ -20,10 +20,11 @@ on:
 jobs:
   rake-after_party:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       db:
-        image: postgres:12.3
+        image: postgres:14.8
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/.github/workflows/remove-helped-wanted.yml
+++ b/.github/workflows/remove-helped-wanted.yml
@@ -8,6 +8,6 @@ jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@master
+      - uses: andymckay/labeler@1.0.4
         with:
           remove-labels: "Help Wanted"

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -21,6 +21,7 @@ jobs:
   ruby_lint:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,7 @@ jobs:
   brakeman:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/spec_checker.yml
+++ b/.github/workflows/spec_checker.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   spec_checker:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,5 @@ jobs:
         stale-pr-message: "This PR has been open for a long time without any pushes or comments! What's up?"
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        days-before-issue-close: 9999  # don't do it
+        days-before-issue-close: -1
         days-before-pr-close: 30

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: yaml-lint


### PR DESCRIPTION
## Summary

### Bugs / Broken
- **`autoapproval.yml`**: `dependabot-preview` → `dependabot[bot]` (old bot was shut down years ago)
- **Issue templates** (6 files): fix double-protocol Slack URLs (`https:https://` → `https://`)
- **`npm_lint_and_test.yml`**: path trigger typo `package.lock.json` → `package-lock.json` (workflow was silently never firing on lockfile changes)

### Security
- **`remove-helped-wanted.yml`**: pin `andymckay/labeler@master` → `@1.0.4` (mutable ref is a supply-chain risk)

### Inconsistencies
- **`factory_bot_lint.yml`**, **`rake-after_party.yml`**: Postgres `12.3` → `14.8` to match `rspec.yml` (factories were testing against a different DB version than specs)

### Missed Opportunities
- **`codeql-analysis.yml`**: add `ruby` to language matrix (was JS-only; free Ruby security scanning was unused)
- **`dependabot.yml`**: add `docker` ecosystem to track base image updates (`ruby:4.0.2-alpine`, `node:24-alpine`, etc.)
- **Add `timeout-minutes`** to 9 workflows that had none (could hang indefinitely and burn CI minutes):
  - `brakeman`: 10 min
  - `ruby_lint`: 10 min
  - `erb_lint`: 10 min
  - `spec_checker`: 10 min
  - `yaml_lint`: 5 min
  - `npm_lint`: 10 min
  - `factory_bot_lint`: 15 min
  - `rake-after_party`: 15 min
  - `codeql`: 30 min

### Other
- **`stale.yml`**: `days-before-issue-close: 9999` → `-1` (proper way to disable auto-close per stale action docs)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm Slack links in issue templates now work
- [ ] Confirm CodeQL runs for both `javascript` and `ruby` languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)