### PR TITLE
DRY up another admin, supervisor and volunteer spec using shared_examples (volunteer_policy_spec.rb)

### DIFF
--- a/spec/policies/volunteer_policy_spec.rb
+++ b/spec/policies/volunteer_policy_spec.rb
@@ -109,25 +109,23 @@ RSpec.describe VolunteerPolicy do
       let(:casa_org) { create(:casa_org) }
       let(:another_casa_org) { create(:casa_org) }
 
-      context "when admin" do
-        let(:user) { build_stubbed(:casa_admin, casa_org: casa_org) }
+      shared_examples "volunteer scope with user" do |factory|
+        let(:user) { build_stubbed(factory, casa_org: casa_org) }
 
         it { is_expected.to include(volunteer1) }
         it { is_expected.not_to include(another_org_volunteer) }
+      end
+
+      context "when admin" do
+        include_examples "volunteer scope with user", :casa_admin
       end
 
       context "when supervisor" do
-        let(:user) { build_stubbed(:supervisor, casa_org: casa_org) }
-
-        it { is_expected.to include(volunteer1) }
-        it { is_expected.not_to include(another_org_volunteer) }
+        include_examples "volunteer scope with user", :supervisor
       end
 
       context "when volunteer" do
-        let(:user) { build_stubbed(:volunteer, casa_org: casa_org) }
-
-        it { is_expected.to include(volunteer1) }
-        it { is_expected.not_to include(another_org_volunteer) }
+        include_examples "volunteer scope with user", :volunteer
       end
     end
   end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #6874 

### What changed, and _why_?
Using shared_examples to remove duplication in admin, supervisor and volunteer tests.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/policies/volunteer_policy_spec.rb
``` 

### Feelings gif (optional)
![Cactus in rain with umbrella](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWdlamRiMjl1dzZobG10Y282eThldTJwa3ZxdHJ1bXN1M21jdHk3byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
