### PR TITLE
DRY up a further admin, supervisor and volunteer spec using shared_examples (learning_hours_spec.rb)

### DIFF
--- a/spec/requests/learning_hours_spec.rb
+++ b/spec/requests/learning_hours_spec.rb
@@ -3,6 +3,24 @@ require "rails_helper"
 RSpec.describe "LearningHours", type: :request do
   let(:volunteer) { create(:volunteer) }
 
+  shared_examples "test request with user" do |factory|
+    let(:user) { create(factory) }
+
+    before { sign_in user }
+
+    describe "GET /index" do
+      it "succeeds" do
+        get learning_hours_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "displays the time completed column" do
+        get learning_hours_path
+        expect(response.body).to include("Time Completed YTD")
+      end
+    end
+  end
+
   context "as a volunteer user" do
     before { sign_in volunteer }
 
@@ -27,38 +45,10 @@ RSpec.describe "LearningHours", type: :request do
   end
 
   context "as a supervisor user" do
-    let(:supervisor) { create(:supervisor) }
-
-    before { sign_in supervisor }
-
-    describe "GET /index" do
-      it "succeeds" do
-        get learning_hours_path
-        expect(response).to have_http_status(:success)
-      end
-
-      it "displays the time completed column" do
-        get learning_hours_path
-        expect(response.body).to include("Time Completed YTD")
-      end
-    end
+    include_examples "test request with user", :supervisor
   end
 
   context "as an admin user" do
-    let(:admin) { create(:casa_admin) }
-
-    before { sign_in admin }
-
-    describe "GET /index" do
-      it "succeeds" do
-        get learning_hours_path
-        expect(response).to have_http_status(:success)
-      end
-
-      it "displays the time completed column" do
-        get learning_hours_path
-        expect(response.body).to include("Time Completed YTD")
-      end
-    end
+    include_examples "test request with user", :casa_admin
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Related to #6874 

### What changed, and why?
Using `shared_examples` to remove duplication in admin, supervisor and volunteer tests.

### How is this tested? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/requests/learning_hours_spec.rb
```

### Feelings gif (optional)
![Dry cactus with umbrella](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeGcybWpxOXVwd3NsNXQzaGxnYzE5NzJidHJicWZxcGR5cmc4c2dqdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
