### PR TITLE
DRY refactor in other_duties_spec for redirects to root paths

### DIFF
--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -25,14 +25,7 @@ RSpec.describe "/other_duties", type: :request do
     end
 
     context "when admin" do
-      it "redirects to root path" do
-        admin = create(:casa_admin)
-
-        sign_in admin
-        get new_other_duty_path
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "redirect to root (new)", :casa_admin
     end
   end
 

--- a/spec/requests/other_duties_spec.rb
+++ b/spec/requests/other_duties_spec.rb
@@ -1,5 +1,55 @@
 require "rails_helper"
 
+RSpec.shared_examples "/new redirect to root" do |user_role|
+  it "redirects to root" do
+    user = create(user_role)
+
+    sign_in user
+    get new_other_duty_path
+
+    expect(response).to redirect_to root_path
+  end
+end
+
+RSpec.shared_examples "/create redirect to root" do |user_role|
+  it "does not create record and redirects to root" do
+    user = create(user_role)
+
+    sign_in user
+
+    expect {
+      post other_duties_path, params: {other_duty: attributes_for(:other_duty)}
+    }.not_to change(OtherDuty, :count)
+
+    expect(response).to redirect_to root_path
+  end
+end
+
+RSpec.shared_examples "/edit redirect to root" do |user_role|
+  it "redirects to root path" do
+    user = create(user_role)
+    duty = create(:other_duty)
+
+    sign_in user
+    get edit_other_duty_path(duty)
+
+    expect(response).to redirect_to root_path
+  end
+end
+
+RSpec.shared_examples "/update redirect to root" do |user_role|
+  it "does not update the duty and redirects to root path" do
+    user = create(user_role)
+    other_duty = create(:other_duty, notes: "Test 1")
+
+    sign_in user
+    patch other_duty_path(other_duty), params: {other_duty: {notes: "Test 2"}}
+
+    expect(other_duty.reload.notes).to eq("Test 1")
+    expect(response).to redirect_to root_path
+  end
+end
+
 RSpec.describe "/other_duties", type: :request do
   describe "GET /new" do
     context "when volunteer" do
@@ -14,18 +64,11 @@ RSpec.describe "/other_duties", type: :request do
     end
 
     context "when supervisor" do
-      it "redirects to root path" do
-        supervisor = create(:supervisor)
-
-        sign_in supervisor
-        get new_other_duty_path
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/new redirect to root", :supervisor
     end
 
     context "when admin" do
-      include_examples "redirect to root (new)", :casa_admin
+      include_examples "/new redirect to root", :casa_admin
     end
   end
 
@@ -59,31 +102,11 @@ RSpec.describe "/other_duties", type: :request do
     end
 
     context "when supervisor" do
-      it "does not create record and redirects to root" do
-        supervisor = create(:supervisor)
-
-        sign_in supervisor
-
-        expect {
-          post other_duties_path, params: {other_duty: attributes_for(:other_duty)}
-        }.not_to change(OtherDuty, :count)
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/create redirect to root", :supervisor
     end
 
     context "when admin" do
-      it "does not create record and redirects to root" do
-        admin = create(:casa_admin)
-
-        sign_in admin
-
-        expect {
-          post other_duties_path, params: {other_duty: attributes_for(:other_duty)}
-        }.not_to change(OtherDuty, :count)
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/create redirect to root", :casa_admin
     end
   end
 
@@ -102,40 +125,16 @@ RSpec.describe "/other_duties", type: :request do
       end
 
       context "when viewing other's record" do
-        it "redirects to root path" do
-          volunteer = create(:volunteer)
-          duty = create(:other_duty)
-
-          sign_in volunteer
-          get edit_other_duty_path(duty)
-
-          expect(response).to redirect_to root_path
-        end
+        include_examples "/edit redirect to root", :volunteer
       end
     end
 
     context "when supervisor" do
-      it "redirects to root path" do
-        supervisor = create(:supervisor)
-        duty = create(:other_duty)
-
-        sign_in supervisor
-        get edit_other_duty_path(duty)
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/edit redirect to root", :supervisor
     end
 
     context "when admin" do
-      it "redirects to root path" do
-        admin = create(:casa_admin)
-        duty = create(:other_duty)
-
-        sign_in admin
-        get edit_other_duty_path(duty)
-
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/edit redirect to root", :casa_admin
     end
   end
 
@@ -162,49 +161,21 @@ RSpec.describe "/other_duties", type: :request do
           sign_in volunteer
           patch other_duty_path(other_duty), params: {other_duty: {notes: ""}}
 
-          expect(other_duty.reload.notes).to eq "Test 1"
           expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end
 
     context "when volunteer updating other person's record" do
-      it "does not update the duty and redirects to root path" do
-        volunteer = create(:volunteer)
-        other_duty = create(:other_duty, notes: "Test 1")
-
-        sign_in volunteer
-        patch other_duty_path(other_duty), params: {other_duty: {notes: "Test 2"}}
-
-        expect(other_duty.reload.notes).to eq("Test 1")
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/update redirect to root", :volunteer
     end
 
     context "when supervisor" do
-      it "does not update the duty and redirects to root path" do
-        supervisor = create(:supervisor)
-        other_duty = create(:other_duty, notes: "Test 1")
-
-        sign_in supervisor
-        patch other_duty_path(other_duty), params: {other_duty: {notes: "Test 2"}}
-
-        expect(other_duty.reload.notes).to eq("Test 1")
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/update redirect to root", :supervisor
     end
 
     context "when admin" do
-      it "does not update the duty and redirects to root path" do
-        admin = create(:casa_admin)
-        other_duty = create(:other_duty, notes: "Test 1")
-
-        sign_in admin
-        patch other_duty_path(other_duty), params: {other_duty: {notes: "Test 2"}}
-
-        expect(other_duty.reload.notes).to eq("Test 1")
-        expect(response).to redirect_to root_path
-      end
+      include_examples "/update redirect to root", :casa_admin
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6893 

### What changed, and _why_?
`shared_examples` in volunteer, supervisor and admin tests for redirects to root paths. This targets the majority of the repetition, without over-fitting to awkward volunteer tests by adding extra helpers to accommodate them. Feedback welcome on the trade-off between repetition and readability which remains, since more could be done here or in other specs with similar patterns.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/requests/other_duties_spec
```

### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
![DRY cactus](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWdjc2x5MG9obzR4cnphcjdwbGJsMXhjbTVvZDZ2OWp3YXh6Y3kxNyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
