### PR TITLE
Three more DRY spec refactors (casa_cases_spec.rb, reports_spec.rb, new_spec.rb)

### DIFF
--- a/spec/requests/casa_cases_spec.rb
+++ b/spec/requests/casa_cases_spec.rb
@@ -1,5 +1,21 @@
 require "rails_helper"
 
+RSpec.shared_examples "casa_case access control" do |user_role|
+  it "renders a successful response" do
+    get casa_case_url(casa_case)
+    expect(response).to be_successful
+  end
+
+  it "fails across organizations" do
+    other_org = build(:casa_org)
+    other_case = create(:casa_case, casa_org: other_org)
+
+    get casa_case_url(other_case)
+    expect(response).to be_redirect
+    expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
+  end
+end
+
 RSpec.describe "/casa_cases", type: :request do
   let(:date_in_care) { Date.today }
   let(:organization) { build(:casa_org) }
@@ -514,19 +530,7 @@ RSpec.describe "/casa_cases", type: :request do
     let!(:case_assignment) { create(:case_assignment, volunteer: user, casa_case: casa_case) }
 
     describe "GET /show" do
-      it "renders a successful response" do
-        get casa_case_url(casa_case)
-        expect(response).to be_successful
-      end
-
-      it "fails across organizations" do
-        other_org = build(:casa_org)
-        other_case = create(:casa_case, casa_org: other_org)
-
-        get casa_case_url(other_case)
-        expect(response).to be_redirect
-        expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
-      end
+      include_examples "casa_case access control"
     end
 
     describe "GET /new" do
@@ -652,19 +656,7 @@ RSpec.describe "/casa_cases", type: :request do
     let(:user) { create(:supervisor, casa_org: organization) }
 
     describe "GET /show" do
-      it "renders a successful response" do
-        get casa_case_url(casa_case)
-        expect(response).to be_successful
-      end
-
-      it "fails across organizations" do
-        other_org = build(:casa_org)
-        other_case = create(:casa_case, casa_org: other_org)
-
-        get casa_case_url(other_case)
-        expect(response).to be_redirect
-        expect(flash[:notice]).to eq("Sorry, you are not authorized to perform this action.")
-      end
+      include_examples "casa_case access control"
     end
 
     describe "GET /new" do

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -1,5 +1,13 @@
 require "rails_helper"
 
+RSpec.shared_examples "successful authentication" do |user_role|
+  before do
+    sign_in build(user_role)
+  end
+
+  it { is_expected.to be_successful }
+end
+
 RSpec.describe "/reports", type: :request do
   describe "GET #index" do
     subject do
@@ -8,19 +16,11 @@ RSpec.describe "/reports", type: :request do
     end
 
     context "while signed in as an admin" do
-      before do
-        sign_in build(:casa_admin)
-      end
-
-      it { is_expected.to be_successful }
+      include_examples "successful authentication", :casa_admin
     end
 
     context "while signed in as a supervisor" do
-      before do
-        sign_in build(:supervisor)
-      end
-
-      it { is_expected.to be_successful }
+      include_examples "successful authentication", :supervisor
     end
 
     context "while signed in as a volunteer" do

--- a/spec/system/supervisors/new_spec.rb
+++ b/spec/system/supervisors/new_spec.rb
@@ -2,6 +2,18 @@
 
 require "rails_helper"
 
+RSpec.shared_examples "user redirect with error" do |user_role|
+  let(:user) { create(user_role) }
+
+  before { sign_in user }
+
+  it "redirects the user with an error message" do
+    visit new_supervisor_path
+
+    expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
+  end
+end
+
 RSpec.describe "supervisors/new", type: :system do
   context "when logged in as an admin" do
     let(:admin) { create(:casa_admin) }
@@ -80,26 +92,10 @@ RSpec.describe "supervisors/new", type: :system do
   end
 
   context "when logged in as a supervisor" do
-    let(:supervisor) { create(:supervisor) }
-
-    before { sign_in supervisor }
-
-    it "redirects the user with an error message" do
-      visit new_supervisor_path
-
-      expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
-    end
+    include_examples "user redirect with error", :supervisor
   end
 
   context "when logged in as a volunteer" do
-    let(:volunteer) { create(:volunteer) }
-
-    before { sign_in volunteer }
-
-    it "redirects the user with an error message" do
-      visit new_supervisor_path
-
-      expect(page).to have_selector(".alert", text: "Sorry, you are not authorized to perform this action.")
-    end
+    include_examples "user redirect with error", :volunteer
   end
 end


### PR DESCRIPTION
shared_examples for volunteer, supervisor and admin user roles

### What github issue is this PR for, if any?
Relates to #6874 

### What changed, and _why_?
`shared_examples` added because these specs (casa_cases_spec.rb, reports_spec.rb, new_spec.rb) have repeated examples.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/requests/casa_cases_spec.rb
bundle exec rspec spec/requests/reports_spec.rb
bundle exec rspec spec/system/supervisors/new_spec.rb
```

### Feelings gif (optional)
![Cactus staying DRY](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExbGdwNzVrMDRpYmtvZnA0dXl0ZTZidXY5YmhxaW55Nm83MTc5bTNvcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
