### PR TITLE
Another three DRY spec refactors (case_contacts_helper_spec.rb, resolve_spec.rb, header.html.erb_spec.rb)

### DIFF
--- a/spec/helpers/case_contacts_helper_spec.rb
+++ b/spec/helpers/case_contacts_helper_spec.rb
@@ -1,5 +1,27 @@
 require "rails_helper"
 
+RSpec.shared_examples "render back link" do |user_role|
+  it "renders back link to home page" do
+    current_user = create(user_role)
+    casa_case = create(:casa_case)
+    allow(helper).to receive(:current_user).and_return(current_user)
+
+    expect(helper.render_back_link(casa_case)).to eq(casa_case_path(casa_case))
+  end
+end
+
+RSpec.shared_examples "if duration_minutes is zero or nil" do
+  it "returns zero if duration_minutes is zero" do
+    case_contact = build(:case_contact, duration_minutes: 0)
+    expect(helper.duration_minutes(case_contact)).to eq(0)
+  end
+
+  it "returns zero if duration_minutes is nil" do
+    case_contact = build(:case_contact, duration_minutes: nil)
+    expect(helper.duration_minutes(case_contact)).to eq(0)
+  end
+end
+
 RSpec.describe CaseContactsHelper, type: :helper do
   describe "#render_back_link" do
     it "renders back link to home page when user is a volunteer" do
@@ -17,21 +39,8 @@ RSpec.describe CaseContactsHelper, type: :helper do
       expect(helper.render_back_link(casa_case)).to eq(root_path)
     end
 
-    it "renders back link to home page when user is a supervisor" do
-      current_user = create(:supervisor)
-      casa_case = create(:casa_case)
-      allow(helper).to receive(:current_user).and_return(current_user)
-
-      expect(helper.render_back_link(casa_case)).to eq(casa_case_path(casa_case))
-    end
-
-    it "renders back link to home page when user is a administrator" do
-      current_user = create(:casa_admin)
-      casa_case = create(:casa_case)
-      allow(helper).to receive(:current_user).and_return(current_user)
-
-      expect(helper.render_back_link(casa_case)).to eq(casa_case_path(casa_case))
-    end
+    it_behaves_like "render back link", :supervisor
+    it_behaves_like "render back link", :casa_admin
   end
 
   describe "#duration_minutes" do
@@ -40,15 +49,7 @@ RSpec.describe CaseContactsHelper, type: :helper do
       expect(helper.duration_minutes(case_contact)).to eq(20)
     end
 
-    it "returns zero if duration_minutes is zero" do
-      case_contact = build(:case_contact, duration_minutes: 0)
-      expect(helper.duration_minutes(case_contact)).to eq(0)
-    end
-
-    it "returns zero if duration_minutes is nil" do
-      case_contact = build(:case_contact, duration_minutes: nil)
-      expect(helper.duration_minutes(case_contact)).to eq(0)
-    end
+    it_behaves_like "if duration_minutes is zero or nil"
   end
 
   describe "#duration_hours" do
@@ -57,15 +58,7 @@ RSpec.describe CaseContactsHelper, type: :helper do
       expect(helper.duration_hours(case_contact)).to eq(1)
     end
 
-    it "returns zero if duration_minutes is zero" do
-      case_contact = build(:case_contact, duration_minutes: 0)
-      expect(helper.duration_hours(case_contact)).to eq(0)
-    end
-
-    it "returns zero if duration_minutes is nil" do
-      case_contact = build(:case_contact, duration_minutes: nil)
-      expect(helper.duration_hours(case_contact)).to eq(0)
-    end
+    it_behaves_like "if duration_minutes is zero or nil"
   end
 
   describe "#show_volunteer_reimbursement" do

--- a/spec/system/case_contacts/followups/resolve_spec.rb
+++ b/spec/system/case_contacts/followups/resolve_spec.rb
@@ -1,5 +1,17 @@
 require "rails_helper"
 
+RSpec.shared_examples "change status of followup to resolved" do
+  it "changes status of followup to resolved" do
+    visit casa_case_path(case_contact.casa_case)
+
+    click_button "Resolve Reminder"
+    expect(page).to have_button("Make Reminder")
+
+    expect(case_contact.followups.count).to eq(1)
+    expect(case_contact.followups.first.resolved?).to be_truthy
+  end
+end
+
 RSpec.describe "followups/resolve", type: :system do
   let(:casa_org) { build(:casa_org) }
   let(:admin) { build(:casa_admin, casa_org: casa_org) }
@@ -13,32 +25,16 @@ RSpec.describe "followups/resolve", type: :system do
 
   before { sign_in admin }
 
-  it "changes status of followup to resolved" do
-    visit casa_case_path(case_contact.casa_case)
-
-    click_button "Resolve Reminder"
-    expect(page).to have_button("Make Reminder")
-
-    expect(case_contact.followups.count).to eq(1)
-    expect(case_contact.followups.first.resolved?).to be_truthy
-  end
-
+  it_behaves_like "change status of followup to resolved"
+  
   context "logged in as admin, followup created by volunteer" do
     let(:cc_creator) { volunteer }
     let(:followup_creator) { volunteer }
 
     before { sign_in admin }
 
-    it "changes status of followup to resolved" do
-      visit casa_case_path(case_contact.casa_case)
-
-      click_button "Resolve Reminder"
-      expect(page).to have_button("Make Reminder")
-
-      expect(case_contact.followups.count).to eq(1)
-      expect(case_contact.followups.first.resolved?).to be_truthy
-    end
-
+    it_behaves_like "change status of followup to resolved"
+    
     it "removes followup icon and button changes back to 'Make Reminder'" do
       visit casa_case_path(case_contact.casa_case)
 

--- a/spec/system/case_contacts/followups/resolve_spec.rb
+++ b/spec/system/case_contacts/followups/resolve_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "followups/resolve", type: :system do
   before { sign_in admin }
 
   it_behaves_like "change status of followup to resolved"
-  
+
   context "logged in as admin, followup created by volunteer" do
     let(:cc_creator) { volunteer }
     let(:followup_creator) { volunteer }
@@ -34,7 +34,7 @@ RSpec.describe "followups/resolve", type: :system do
     before { sign_in admin }
 
     it_behaves_like "change status of followup to resolved"
-    
+
     it "removes followup icon and button changes back to 'Make Reminder'" do
       visit casa_case_path(case_contact.casa_case)
 

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe "layout/header", type: :view do
 
       expect(rendered).not_to have_link("Edit Organization")
     end
+
+    it "renders help issue link on the header" do
+      render partial: "layouts/header"
+      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-Volunteers-c24d9d2ef8b249bbbda8192191365039?pvs=4")
+    end
   end
 
   context "notifications" do

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.shared_examples "render user information and header link" do |user_role|
   let(:user) { build_stubbed user_role }
-  
+
   it "renders user information", :aggregate_failures do
     sign_in user
 

--- a/spec/views/layouts/header.html.erb_spec.rb
+++ b/spec/views/layouts/header.html.erb_spec.rb
@@ -1,5 +1,24 @@
 require "rails_helper"
 
+RSpec.shared_examples "render user information and header link" do |user_role|
+  let(:user) { build_stubbed user_role }
+  
+  it "renders user information", :aggregate_failures do
+    sign_in user
+
+    render partial: "layouts/header"
+
+    expect(rendered).to match "<strong>Role: #{user.role}</strong>"
+    expect(rendered).to match CGI.escapeHTML user.display_name
+    expect(rendered).to match CGI.escapeHTML user.email
+  end
+
+  it "renders help issue link on the header" do
+    render partial: "layouts/header"
+    expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
+  end
+end
+
 RSpec.describe "layout/header", type: :view do
   before do
     view.class.include PretenderContext
@@ -14,41 +33,11 @@ RSpec.describe "layout/header", type: :view do
   end
 
   context "when logged in as a casa admin" do
-    let(:user) { build_stubbed :casa_admin }
-
-    it "renders user information", :aggregate_failures do
-      sign_in user
-
-      render partial: "layouts/header"
-
-      expect(rendered).to match "<strong>Role: Casa Admin</strong>"
-      expect(rendered).to match CGI.escapeHTML user.display_name
-      expect(rendered).to match CGI.escapeHTML user.email
-    end
-
-    it "renders help issue link on the header" do
-      render partial: "layouts/header"
-      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
-    end
+    it_behaves_like "render user information and header link", :casa_admin
   end
 
   context "when logged in as a supervisor" do
-    let(:user) { build_stubbed :supervisor }
-
-    it "renders user information", :aggregate_failures do
-      sign_in user
-
-      render partial: "layouts/header"
-
-      expect(rendered).to match "<strong>Role: Supervisor</strong>"
-      expect(rendered).to match CGI.escapeHTML user.display_name
-      expect(rendered).to match CGI.escapeHTML user.email
-    end
-
-    it "renders help issue link on the header" do
-      render partial: "layouts/header"
-      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-3b95705e80c742ffa729ccce7beeabfa")
-    end
+    it_behaves_like "render user information and header link", :supervisor
   end
 
   context "when logged in as a volunteer" do
@@ -70,11 +59,6 @@ RSpec.describe "layout/header", type: :view do
       render partial: "layouts/header"
 
       expect(rendered).not_to have_link("Edit Organization")
-    end
-
-    it "renders help issue link on the header" do
-      render partial: "layouts/header"
-      expect(rendered).to have_link("Help", href: "https://thunder-flower-8c2.notion.site/Casa-Volunteer-Tracking-App-HelpSite-Volunteers-c24d9d2ef8b249bbbda8192191365039?pvs=4")
     end
   end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Relates to #6874 

### What changed, and _why_?
`shared_examples` added because these specs (case_contacts_helper_spec.rb, resolve_spec.rb, header.html.erb_spec.rb) have repeated examples.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
```bash
bundle exec rspec spec/helpers/case_contacts_helper_spec.rb
bundle exec rspec spec/system/case_contacts/followups/resolve_spec.rb
bundle exec rspec spec/views/layouts/header.html.erb_spec.rb
```

### Feelings gif (optional)
![Cactus using umbrella to stay dry](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExanhwNzBybWo2YzV1NzRpbTR4YTF3Nmg5MHA1YTEzMmI4ejl3bWVhbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/IcLGK6jiQNHuQXj3fK/giphy.gif)
