### PR TITLE
Update Dependabot config to remove sass ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # Keep this locked to 1.77.6 until
-      # bootstrap 5.3.4 is out to silence
-      # sass deprecation warnings
-      # https://getbootstrap.com/docs/versions/
-      - dependency-name: "sass"
-        versions: ["1.77.*", "1.78.*"]
 
   - package-ecosystem: "bundler"
     directory: "/"


### PR DESCRIPTION
Removed ignore rules for sass dependency in Dependabot config.

### What github issue is this PR for, if any?
Resolves #XXXX

### What changed, and _why_?


### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
