### PR TITLE
Use protect_from_forgery with: :exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   include Organizational
   include Users::TimeZone
 
-  protect_from_forgery
+  protect_from_forgery with: :exception
   before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!
   before_action :set_current_user


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6920

### What changed, and _why_?

`app/controllers/application_controller.rb:7` was calling `protect_from_forgery` with no `with:` argument, which downgrades the failure mode to `with: :null_session` -- weaker than the Rails 5+ default of `with: :exception` that `ActionController::Base` applies on its own. CodeQL flagged this as alert #60 (`rb/csrf-protection-disabled`, CWE-352).

This PR takes option 2 from the issue: keep the call but make the strategy explicit. That resolves the alert while leaving a self-documenting CSRF setting in place rather than relying on the framework default.

```diff
-  protect_from_forgery
+  protect_from_forgery with: :exception
```

### How is this **tested**? (please write rspec and jest tests!) 💖💪

No new spec is added. The change is the recommended fix from a CodeQL static-analysis alert and brings the call in line with the Rails 5+ default `ActionController::Base` would otherwise apply, so existing controller / request / system specs continue to exercise the CSRF flow with the same effective strategy. CodeQL alert #60 should auto-close after the next scan on `main`.

### Screenshots please :)

n/a -- this is a one-line `application_controller.rb` change with no UI surface.