### PR TITLE
Remove bootstrap-select unused library

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,7 +2,6 @@
 import './jQueryGlobalizer.js'
 import '@hotwired/turbo-rails'
 import 'bootstrap'
-import 'bootstrap-select'
 import './sweet-alert-confirm.js'
 import './controllers'
 import 'trix'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "bootstrap": "5.3.6",
         "bootstrap-datepicker": "^1.10.1",
         "bootstrap-scss": "^5.3.8",
-        "bootstrap-select": "^1.13.18",
         "chart.js": "^4.5.1",
         "chartjs-adapter-luxon": "^1.3.1",
         "datatables.net-dt": "^1.13.11",
@@ -103,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1908,7 +1906,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1932,7 +1929,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2566,8 +2562,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
       "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@hotwired/turbo": {
       "version": "8.0.23",
@@ -3316,7 +3311,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3837,7 +3831,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4386,7 +4379,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -4405,16 +4397,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap-scss/-/bootstrap-scss-5.3.8.tgz",
       "integrity": "sha512-lDjTMXl2lRwfhGJY3vmDXlWSk50gg7eW2+zzCQi9tsyeZgD6N5hcmMk3G28F7MvLniJKS9LZV+2YNCxiW8+WIw==",
       "license": "MIT"
-    },
-    "node_modules/bootstrap-select": {
-      "version": "1.13.18",
-      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.13.18.tgz",
-      "integrity": "sha512-V1IzK4rxBq5FrJtkzSH6RmFLFBsjx50byFbfAf8jYyXROWs7ZpprGjdHeoyq2HSsHyjJhMMwjsQhRoYAfxCGow==",
-      "license": "MIT",
-      "peerDependencies": {
-        "bootstrap": ">=3.0.0",
-        "jquery": "1.9.1 - 3"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -4470,7 +4452,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4647,7 +4628,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5439,7 +5419,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5647,7 +5626,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5705,7 +5683,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -5745,7 +5722,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5762,7 +5738,6 @@
       "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8344,8 +8319,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",
@@ -8382,7 +8356,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8733,7 +8706,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
       "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10975,7 +10947,6 @@
       "resolved": "https://registry.npmjs.org/trix/-/trix-2.1.18.tgz",
       "integrity": "sha512-DWOdTsz3n9PO3YBc1R6pGh9MG1cXys/2+rouc/qsISncjc2MBew2UOW8nXh3NjUOjobKsXCIPR6LB02abg2EYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "^3.2.5"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bootstrap": "5.3.6",
     "bootstrap-datepicker": "^1.10.1",
     "bootstrap-scss": "^5.3.8",
-    "bootstrap-select": "^1.13.18",
     "chart.js": "^4.5.1",
     "chartjs-adapter-luxon": "^1.3.1",
     "datatables.net-dt": "^1.13.11",


### PR DESCRIPTION
### What github issue is this PR for, if any?

Resolves #6929

### What changed, and _why_?

This is the first step for upgrading JQuery to v4. `bootstrap-select` is incompatible with JQuery 4, and since it's unused, we can remove it.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

I was able to search and select a case report:

https://github.com/user-attachments/assets/f15a323b-0f8f-4023-a336-7cb7e9542f24


