### PR TITLE
Restore visible focus indicator for keyboard tab navigation

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -20,11 +20,11 @@ body {
   -moz-box-sizing: border-box;
   box-sizing: border-box; }
 
-a:focus,
-input:focus,
-textarea:focus,
-button:focus,
-.btn:focus,
+a:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible),
+button:focus:not(:focus-visible),
+.btn:focus:not(:focus-visible),
 .btn.focus,
 .btn:not(:disabled):not(.disabled).active,
 .btn:not(:disabled):not(.disabled):active {
@@ -33,6 +33,14 @@ button:focus,
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none; }
+
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+button:focus-visible,
+.btn:focus-visible {
+  outline: 2px solid #4a6cf7;
+  outline-offset: 2px; }
 
 a:hover {
   color: #4a6cf7; }


### PR DESCRIPTION
Closes #6065

## Why

The blanket `:focus` rule near the top of `public/assets/css/main.css` strips both `outline` and `box-shadow` from anchors, inputs, textareas, buttons, and the Bootstrap `.btn` family. With both indicators gone, keyboard users get zero visual feedback while tabbing through forms - the case-contact form was the example in the issue but it affects the whole app. That is a WCAG 2.4.7 (Focus Visible) failure on a tool whose users include CASA volunteers and supervisors who do rely on keyboard navigation.

## What

Scope the existing reset to `:focus:not(:focus-visible)` so mouse click-focus still looks clean, and add a sibling `:focus-visible` rule that draws a 2px outline in the project blue (`#4a6cf7`) with 2px offset.

```css
a:focus:not(:focus-visible),
input:focus:not(:focus-visible),
textarea:focus:not(:focus-visible),
button:focus:not(:focus-visible),
.btn:focus:not(:focus-visible),
...

a:focus-visible,
input:focus-visible,
textarea:focus-visible,
button:focus-visible,
.btn:focus-visible {
  outline: 2px solid #4a6cf7;
  outline-offset: 2px;
}
```

`.btn.focus` and `.btn:active`/`.btn.active` are left on the reset rule because those are Bootstrap state classes, not the `:focus` pseudo-class - they shouldn't gain an outline just for being the active item.

## Notes

- `:focus-visible` browser support is now universal (Chrome 86+, Firefox 85+, Safari 15.4+). Older browsers fall back silently to the still-present `:focus` rule.
- The other `outline: none` declarations later in the file (`.select-style-{1,2,3} .select-position select:focus` at lines 1226 / 1286 / 1340) are scoped to styled selects that change `border-color` on focus, so they still communicate focus and are out of scope here.

## Verification

`bin/dev`, log in as `volunteer1@example.com`, navigate to a case, click "Create New Contact" and tab through the form - every input and the submit button now shows the blue outline. Mouse clicks do not.