### PR TITLE
refactor(tests): clean up notes_spec shared examples after #6927

### DIFF
--- a/spec/requests/notes_spec.rb
+++ b/spec/requests/notes_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "/volunteers/notes", type: :request do
-  RSpec.shared_examples "create" do
-    let(:organization) { create(:casa_org) }
+  let(:organization) { create(:casa_org) }
 
+  shared_examples "create" do
+    # Caller must define: let(:user)
     context "when in the same organization" do
       it "can create a note for volunteer" do
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
@@ -33,13 +34,12 @@ RSpec.describe "/volunteers/notes", type: :request do
     end
   end
 
-  RSpec.shared_examples "edit" do
-    let(:organization) { create(:casa_org) }
-
+  shared_examples "edit" do
+    # Caller must define: let(:user)
     context "when in the same organization" do
       let(:volunteer) { create(:volunteer, :with_assigned_supervisor, casa_org: organization) }
 
-      it "is successful if note belongs for volunteer" do
+      it "is successful if note belongs to volunteer" do
         note = create(:note, notable: volunteer)
 
         sign_in user
@@ -73,9 +73,8 @@ RSpec.describe "/volunteers/notes", type: :request do
     end
   end
 
-  RSpec.shared_examples "update" do
-    let(:organization) { create(:casa_org) }
-
+  shared_examples "update" do
+    # Caller must define: let(:user)
     context "when in the same organization" do
       it "updates note and redirects to edit volunteer page" do
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
@@ -104,9 +103,8 @@ RSpec.describe "/volunteers/notes", type: :request do
     end
   end
 
-  RSpec.shared_examples "delete" do
-    let(:organization) { create(:casa_org) }
-
+  shared_examples "delete" do
+    # Caller must define: let(:user)
     context "when in the same organization" do
       it "can delete notes about a volunteer" do
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
@@ -138,7 +136,7 @@ RSpec.describe "/volunteers/notes", type: :request do
   end
 
   describe "POST /create" do
-    context "when logged in as admin" do
+    context "when logged in as an admin" do
       it_behaves_like "create" do
         let(:user) { create(:casa_admin, casa_org: organization) }
       end
@@ -150,37 +148,35 @@ RSpec.describe "/volunteers/notes", type: :request do
       end
     end
 
-    context "when logged in as volunteer" do
+    context "when logged in as a volunteer" do
       it "cannot create a note" do
-        organization = create(:casa_org)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
 
         sign_in volunteer
-        expect {
+        expect do
           post volunteer_notes_path(volunteer), params: {note: {content: "Very nice!"}}
-        }.not_to change(Note, :count)
+        end.not_to change(Note, :count)
         expect(response).to redirect_to root_path
       end
     end
   end
 
   describe "GET /edit" do
-    context "when logged in as admin" do
+    context "when logged in as an admin" do
       it_behaves_like "edit" do
         let(:user) { create(:casa_admin, casa_org: organization) }
       end
     end
 
-    context "when logged in as supervisor" do
+    context "when logged in as a supervisor" do
       it_behaves_like "edit" do
         let(:user) { create(:supervisor, casa_org: organization) }
       end
     end
 
-    context "when logged in as volunteer" do
+    context "when logged in as a volunteer" do
       context "when note belongs to volunteer" do
         it "redirects to root path" do
-          organization = create(:casa_org)
           volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
           note = create(:note, notable: volunteer)
 
@@ -209,7 +205,6 @@ RSpec.describe "/volunteers/notes", type: :request do
     context "when logged in as a volunteer" do
       context "when updating note belonging to volunteer" do
         it "does not update note and redirects to root path" do
-          organization = create(:casa_org)
           volunteer = create(:volunteer, casa_org: organization)
           note = create(:note, notable: volunteer, content: "Good job.")
 
@@ -242,9 +237,9 @@ RSpec.describe "/volunteers/notes", type: :request do
         note = create(:note, notable: volunteer)
 
         sign_in volunteer
-        expect {
+        expect do
           delete volunteer_note_path(volunteer, note)
-        }.not_to change(Note, :count)
+        end.not_to change(Note, :count)
         expect(response).to redirect_to root_path
       end
     end


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #6927, addressing review feedback:

- **Scope shared_examples locally.** Drop the `RSpec.` prefix on `RSpec.shared_examples` so the generic names `"create"`/`"edit"`/`"update"`/`"delete"` aren't registered globally and won't collide with shared examples in other spec files.
- **Document the implicit `user` contract.** Each shared example block now opens with `# Caller must define: let(:user)` so future contributors know what to provide alongside `it_behaves_like`.
- **Fix typo regression.** `"is successful if note belongs for volunteer"` → `"... belongs to volunteer"` (the original wording).
- **Normalize `expect` style.** The two volunteer-only inlined tests still used `expect { ... }.not_to change(...)` curly-block style; the rest of the file uses `expect do ... end.not_to change(...)`. Made them consistent.
- **Hoist `let(:organization)`.** It was redeclared in all four shared example blocks; now defined once on the outer `RSpec.describe` and inherited. The two inlined volunteer tests that did their own `organization = create(:casa_org)` now use the let too.
- **Normalize context names.** The four `describe` blocks had a mix of `"as admin"` / `"as a supervisor"` / `"as an admin"`. All now read `"when logged in as an admin"` / `"as a supervisor"` / `"as a volunteer"`.

Net diff: +19 / −24, no behavioral changes.

## Test plan

- [ ] `bundle exec rspec spec/requests/notes_spec.rb` — all 14 examples should pass.
- [ ] Spot-check the rspec output: each `it_behaves_like` should produce contexts under each role; descriptions should read naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)