### PR TITLE
Re-enable SPecs for GET case_contacts#leave

### DIFF
--- a/spec/requests/case_contacts_spec.rb
+++ b/spec/requests/case_contacts_spec.rb
@@ -162,14 +162,12 @@ RSpec.describe "/case_contacts", type: :request do
     end
   end
 
-  xdescribe "GET /leave" do
+  describe "GET /leave" do
     subject(:request) do
-      get leave_case_contact_path
+      get leave_case_contacts_form_path
 
       response
     end
-
-    it { is_expected.to redirect_to(case_contacts_path) }
 
     it "redirects back to referer or fallback location" do
       request


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6913

### What changed, and _why_?

We're enabling the spec for `get "case_contacts/leave"`.


### How is this **tested**? (please write rspec and jest tests!) 💖💪

I tested this by running the following:
1. `bundle exec rspec spec/requests/case_contacts_spec.rb:165`
2. `bundle exec rspec spec/requests/case_contacts_spec.rb`

### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
![Forrest Gump waving](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHFxaGcwcHRvZzByNmZsaTNtcWtwbGMyb3hydzlwYmNjbHQyOGhqYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9IgG50Fb7Mi0prBC/giphy.gif)
