### PR TITLE
#(feat): 6503 New case contacts table column visibility

### DIFF
--- a/app/javascript/__tests__/dashboard.test.js
+++ b/app/javascript/__tests__/dashboard.test.js
@@ -69,12 +69,13 @@ describe('defineCaseContactsTable', () => {
       expect(config.searching).toBe(true)
     })
 
-    it('configures scrollX for horizontal scrolling', () => {
+    it('disables autoWidth so columns do not expand to oversized fixed widths', () => {
       defineCaseContactsTable()
 
       const config = mockDataTable.mock.calls[0][0]
 
-      expect(config.scrollX).toBe(true)
+      expect(config.autoWidth).toBe(false)
+      expect(config.scrollX).toBeUndefined()
     })
 
     it('sets default sort to Date column descending', () => {
@@ -674,7 +675,7 @@ describe('defineCaseContactsTable', () => {
       const config = mockDataTable.mock.calls[0][0]
 
       // Verify all critical config options are present
-      expect(config).toHaveProperty('scrollX')
+      expect(config).toHaveProperty('autoWidth')
       expect(config).toHaveProperty('searching')
       expect(config).toHaveProperty('processing')
       expect(config).toHaveProperty('serverSide')

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -256,6 +256,10 @@ const defineCaseContactsTable = function () {
     })
   })
 
+  $('#cc-columns-toggle').on('click', function () {
+    $('#cc-columns-panel').toggle()
+  })
+
   $('#cc-filter-toggle').on('click', function () {
     $('#cc-filter-panel').toggle()
   })

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -37,6 +37,36 @@ function buildExpandedContent (data) {
 const defineCaseContactsTable = function () {
   const table = $('table#case_contacts').DataTable({
     autoWidth: false,
+    stateSave: true,
+    stateSaveCallback: function (settings, data) {
+      $.ajax({
+        url: '/preference_sets/table_state_update/' + settings.nTable.id + '_table',
+        data: { table_state: JSON.stringify(data) },
+        dataType: 'json',
+        type: 'POST',
+        error: function (jqXHR, textStatus, errorMessage) {
+          console.error(errorMessage)
+        }
+      })
+    },
+    stateSaveParams: function (settings, data) {
+      data.search.search = ''
+      return data
+    },
+    stateLoadCallback: function (settings, callback) {
+      $.ajax({
+        url: '/preference_sets/table_state/' + settings.nTable.id + '_table',
+        dataType: 'json',
+        type: 'GET',
+        success: function (json) { callback(json) }
+      })
+    },
+    initComplete: function () {
+      $('.cc-column-toggle').each(function () {
+        $(this).prop('checked', table.column($(this).data('column-index')).visible())
+      })
+      updateColumnsButtonBadge()
+    },
     searching: true,
     processing: true,
     serverSide: true,
@@ -259,7 +289,7 @@ const defineCaseContactsTable = function () {
   function updateColumnsButtonBadge () {
     const total = $('.cc-column-toggle').length
     const visible = $('.cc-column-toggle:checked').length
-    $('#cc-columns-count').text(`(${visible}/${total})`)
+    $('#cc-columns-count').text(`(${visible}/${total})`).css('visibility', 'visible')
   }
 
   $('#cc-columns-toggle').on('click', function () {

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -36,7 +36,7 @@ function buildExpandedContent (data) {
 
 const defineCaseContactsTable = function () {
   const table = $('table#case_contacts').DataTable({
-    scrollX: true,
+    autoWidth: false,
     searching: true,
     processing: true,
     serverSide: true,
@@ -256,8 +256,31 @@ const defineCaseContactsTable = function () {
     })
   })
 
+  function updateColumnsButtonBadge () {
+    const total = $('.cc-column-toggle').length
+    const visible = $('.cc-column-toggle:checked').length
+    $('#cc-columns-count').text(`(${visible}/${total})`)
+  }
+
   $('#cc-columns-toggle').on('click', function () {
     $('#cc-columns-panel').toggle()
+  })
+
+  $('#cc-columns-update').on('click', function () {
+    $('.cc-column-toggle').each(function () {
+      table.column($(this).data('column-index')).visible($(this).is(':checked'))
+    })
+    updateColumnsButtonBadge()
+    $('#cc-columns-panel').hide()
+  })
+
+  $('#cc-columns-show-all').on('click', function () {
+    $('.cc-column-toggle').prop('checked', true)
+    $('.cc-column-toggle').each(function () {
+      table.column($(this).data('column-index')).visible(true)
+    })
+    updateColumnsButtonBadge()
+    $('#cc-columns-panel').hide()
   })
 
   $('#cc-filter-toggle').on('click', function () {

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -129,6 +129,7 @@ const defineCaseContactsTable = function () {
       },
       { // Medium column (index 5)
         data: 'medium_type',
+        orderable: false,
         render: (data) => data || ''
       },
       { // Created By column (index 6)

--- a/app/models/case_contact.rb
+++ b/app/models/case_contact.rb
@@ -191,6 +191,15 @@ class CaseContact < ApplicationRecord
   LETTER = "letter".freeze
   CONTACT_MEDIUMS = [IN_PERSON, TEXT_EMAIL, VIDEO, VOICE_ONLY, LETTER].freeze
 
+  TOGGLEABLE_COLUMNS = [
+    {key: "relationship", label: "Relationship", index: 4},
+    {key: "medium", label: "Medium", index: 5},
+    {key: "created_by", label: "Created By", index: 6},
+    {key: "contacted", label: "Contacted", index: 7},
+    {key: "topics", label: "Topics", index: 8},
+    {key: "draft", label: "Draft", index: 9}
+  ].freeze
+
   def update_cleaning_contact_types(args)
     transaction do
       contact_types.clear

--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -20,32 +20,6 @@
     <% end %>
   </div>
 
-  <div id="cc-columns-panel" class="card-style mb-3" style="display: none;">
-    <div class="card-content">
-      <div class="row mb-3">
-        <% CaseContact::TOGGLEABLE_COLUMNS.each do |col| %>
-          <div class="col-md-4">
-            <div class="form-check form-switch">
-              <input type="checkbox"
-                     class="form-check-input cc-column-toggle"
-                     id="cc-col-<%= col[:key] %>"
-                     data-column-index="<%= col[:index] %>"
-                     role="switch"
-                     checked>
-              <label class="form-check-label" for="cc-col-<%= col[:key] %>">
-                <%= col[:label] %>
-              </label>
-            </div>
-          </div>
-        <% end %>
-      </div>
-      <div class="d-flex gap-2">
-        <button type="button" id="cc-columns-update" class="main-btn primary-btn btn-sm btn-hover">Update View</button>
-        <button type="button" id="cc-columns-show-all" class="main-btn dark-btn-outline btn-sm btn-hover">Show All</button>
-      </div>
-    </div>
-  </div>
-
   <div id="cc-filter-panel" class="card-style mb-3" style="display: none;">
     <div class="card-content">
       <div class="row mb-3">
@@ -130,6 +104,32 @@
       <div class="d-flex gap-2">
         <button type="button" id="cc-filter-apply" class="main-btn primary-btn btn-sm btn-hover">Apply Filters</button>
         <button type="button" id="cc-filter-reset" class="main-btn dark-btn-outline btn-sm btn-hover">Reset</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="cc-columns-panel" class="card-style mb-3" style="display: none;">
+    <div class="card-content">
+      <div class="row mb-3">
+        <% CaseContact::TOGGLEABLE_COLUMNS.each do |col| %>
+          <div class="col-md-4">
+            <div class="form-check form-switch">
+              <input type="checkbox"
+                     class="form-check-input cc-column-toggle"
+                     id="cc-col-<%= col[:key] %>"
+                     data-column-index="<%= col[:index] %>"
+                     role="switch"
+                     checked>
+              <label class="form-check-label" for="cc-col-<%= col[:key] %>">
+                <%= col[:label] %>
+              </label>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div class="d-flex gap-2">
+        <button type="button" id="cc-columns-update" class="main-btn primary-btn btn-sm btn-hover">Update View</button>
+        <button type="button" id="cc-columns-show-all" class="main-btn dark-btn-outline btn-sm btn-hover">Show All</button>
       </div>
     </div>
   </div>

--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -10,7 +10,7 @@
 
       <button type="button" id="cc-columns-toggle" class="main-btn secondary-btn btn-sm btn-hover">
         <i class="lni lni-list mr-5" aria-hidden="true"></i>
-        Columns <span id="cc-columns-count">(6/6)</span>
+        Columns <span id="cc-columns-count">(<%= CaseContact::TOGGLEABLE_COLUMNS.length %>/<%= CaseContact::TOGGLEABLE_COLUMNS.length %>)</span>
       </button>
     </div>
 
@@ -136,7 +136,7 @@
 </div>
 
 <div class="card-style mb-30">
-  <div class="table-wrapper">
+  <div class="table-wrapper" style="overflow-x: auto">
     <table
       id="case_contacts"
       class="table"

--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -10,7 +10,7 @@
 
       <button type="button" id="cc-columns-toggle" class="main-btn secondary-btn btn-sm btn-hover">
         <i class="lni lni-list mr-5" aria-hidden="true"></i>
-        Columns <span id="cc-columns-count">(<%= CaseContact::TOGGLEABLE_COLUMNS.length %>/<%= CaseContact::TOGGLEABLE_COLUMNS.length %>)</span>
+        Columns <span id="cc-columns-count" style="visibility: hidden">(<%= CaseContact::TOGGLEABLE_COLUMNS.length %>/<%= CaseContact::TOGGLEABLE_COLUMNS.length %>)</span>
       </button>
     </div>
 

--- a/app/views/case_contacts/case_contacts_new_design/index.html.erb
+++ b/app/views/case_contacts/case_contacts_new_design/index.html.erb
@@ -2,15 +2,48 @@
   <h1 class="mb-20">Case Contacts</h1>
 
   <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3" id="cc-filter-toolbar">
-    <button type="button" id="cc-filter-toggle" class="main-btn secondary-btn btn-sm btn-hover">
-      <i class="lni lni-funnel mr-5" aria-hidden="true"></i>
-      Filter
-    </button>
+    <div class="d-flex gap-2">
+      <button type="button" id="cc-filter-toggle" class="main-btn secondary-btn btn-sm btn-hover">
+        <i class="lni lni-funnel mr-5" aria-hidden="true"></i>
+        Filter
+      </button>
+
+      <button type="button" id="cc-columns-toggle" class="main-btn secondary-btn btn-sm btn-hover">
+        <i class="lni lni-list mr-5" aria-hidden="true"></i>
+        Columns <span id="cc-columns-count">(6/6)</span>
+      </button>
+    </div>
 
     <%= link_to new_case_contact_path, class: "main-btn primary-btn btn-sm btn-hover" do %>
       <i class="lni lni-plus mr-10" aria-hidden="true"></i>
       New Case Contact
     <% end %>
+  </div>
+
+  <div id="cc-columns-panel" class="card-style mb-3" style="display: none;">
+    <div class="card-content">
+      <div class="row mb-3">
+        <% CaseContact::TOGGLEABLE_COLUMNS.each do |col| %>
+          <div class="col-md-4">
+            <div class="form-check form-switch">
+              <input type="checkbox"
+                     class="form-check-input cc-column-toggle"
+                     id="cc-col-<%= col[:key] %>"
+                     data-column-index="<%= col[:index] %>"
+                     role="switch"
+                     checked>
+              <label class="form-check-label" for="cc-col-<%= col[:key] %>">
+                <%= col[:label] %>
+              </label>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div class="d-flex gap-2">
+        <button type="button" id="cc-columns-update" class="main-btn primary-btn btn-sm btn-hover">Update View</button>
+        <button type="button" id="cc-columns-show-all" class="main-btn dark-btn-outline btn-sm btn-hover">Show All</button>
+      </div>
+    </div>
   </div>
 
   <div id="cc-filter-panel" class="card-style mb-3" style="display: none;">

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(page).not_to have_css("#cc-columns-panel", visible: true)
     end
 
+    it "opens the columns panel when the Columns button is clicked" do
+      click_button "Columns"
+      expect(page).to have_css("#cc-columns-panel", visible: true)
+    end
+
+    it "closes the columns panel when the Columns button is clicked again" do
+      click_button "Columns"
+      click_button "Columns"
+      expect(page).not_to have_css("#cc-columns-panel", visible: true)
+    end
+
     it "lists all 6 toggleable columns with toggle switches, all on by default" do
       %w[Relationship Medium Contacted Topics Draft].each do |label|
         expect(page).to have_css("#cc-columns-panel .form-switch", text: label, visible: :all)

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(page).not_to have_css("#cc-columns-panel", visible: true)
     end
 
+    it "persists hidden columns across page reloads" do
+      click_button "Columns"
+      uncheck "Medium"
+      click_button "Update View"
+
+      visit case_contacts_new_design_path
+
+      expect(page).not_to have_css("th", text: "Medium")
+      expect(page).to have_button(text: /Columns\s*\(5\/6\)/)
+    end
+
     it "lists all 6 toggleable columns with toggle switches, all on by default" do
       %w[Relationship Medium Contacted Topics Draft].each do |label|
         expect(page).to have_css("#cc-columns-panel .form-switch", text: label, visible: :all)

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -25,6 +25,31 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
     end
   end
 
+  describe "columns panel" do
+    include_context "signed in as admin"
+
+    it "shows a Columns button in the toolbar" do
+      expect(page).to have_button("Columns")
+    end
+
+    it "shows a visible count badge on the Columns button" do
+      expect(page).to have_button(text: /Columns\s*\(6\/6\)/)
+    end
+
+    it "hides the columns panel by default" do
+      expect(page).not_to have_css("#cc-columns-panel", visible: true)
+    end
+
+    it "lists all 6 toggleable columns with toggle switches, all on by default" do
+      %w[Relationship Medium Contacted Topics Draft].each do |label|
+        expect(page).to have_css("#cc-columns-panel .form-switch", text: label, visible: :all)
+        expect(page).to have_field(label, checked: true, visible: :all)
+      end
+      expect(page).to have_css("#cc-columns-panel .form-switch", text: "Created By", visible: :all)
+      expect(page).to have_field("Created By", checked: true, visible: :all)
+    end
+  end
+
   describe "filter panel" do
     let!(:in_person_contact) do
       create(:case_contact, :active, casa_case: casa_case,

--- a/spec/system/case_contacts/case_contacts_new_design_spec.rb
+++ b/spec/system/case_contacts/case_contacts_new_design_spec.rb
@@ -51,6 +51,49 @@ RSpec.describe "Case contacts new design", type: :system, js: true do
       expect(page).not_to have_css("#cc-columns-panel", visible: true)
     end
 
+    it "hides a column when its toggle is switched off and Update View is clicked" do
+      click_button "Columns"
+      uncheck "Medium"
+      click_button "Update View"
+
+      expect(page).not_to have_css("th", text: "Medium")
+    end
+
+    it "shows a column again when its toggle is switched back on and Update View is clicked" do
+      click_button "Columns"
+      uncheck "Medium"
+      click_button "Update View"
+
+      click_button "Columns"
+      check "Medium"
+      click_button "Update View"
+
+      expect(page).to have_css("th", text: "Medium")
+    end
+
+    it "updates the badge count when a column is hidden" do
+      click_button "Columns"
+      uncheck "Medium"
+      click_button "Update View"
+
+      expect(page).to have_button(text: /Columns\s*\(5\/6\)/)
+    end
+
+    it "shows all columns and closes the panel when Show All is clicked" do
+      click_button "Columns"
+      uncheck "Medium"
+      uncheck "Topics"
+      click_button "Update View"
+
+      click_button "Columns"
+      click_button "Show All"
+
+      expect(page).to have_css("th", text: "Medium")
+      expect(page).to have_css("th", text: "Topics")
+      expect(page).to have_button(text: /Columns\s*\(6\/6\)/)
+      expect(page).not_to have_css("#cc-columns-panel", visible: true)
+    end
+
     it "lists all 6 toggleable columns with toggle switches, all on by default" do
       %w[Relationship Medium Contacted Topics Draft].each do |label|
         expect(page).to have_css("#cc-columns-panel .form-switch", text: label, visible: :all)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6503

### What changed, and _why_?

Adds a "Columns" button to the case contacts new design table toolbar that lets users show and hide individual columns.

- **`CaseContact::TOGGLEABLE_COLUMNS`** — a new constant defining the 6 user-configurable columns (Relationship, Medium, Created By, Contacted, Topics, Draft). Date and Case are intentionally fixed and always visible.
- **Columns button** — sits next to the Filter button in the toolbar. Shows a `(X/6)` badge indicating how many columns are currently visible. The badge is rendered invisible on page load and revealed once the correct count is known, preventing a layout flash.
- **Columns panel** — a slide-down panel (same pattern as the Filter panel) with Bootstrap toggle switches for each of the 6 toggleable columns, plus "Update View" and "Show All" buttons. Update View applies the current toggle state; Show All restores all columns immediately.
- **Column alignment** — replaced DataTables' `scrollX: true` with CSS `overflow-x: auto` on the table wrapper. `scrollX` caused header/body misalignment when columns were hidden; the CSS approach provides horizontal scrolling without the split-table mechanism. Also added `autoWidth: false` to prevent DataTables from computing oversized fixed column widths.
- **State persistence** — column visibility is saved to `PreferenceSet#table_state` under the key `case_contacts_table` using DataTables' `stateSave` callbacks, following the same pattern as the volunteers table. State is restored on page load; `initComplete` syncs the toggle switches and badge after the async state load completes.

### How is this **tested**?

Added 10 new system spec examples to `spec/system/case_contacts/case_contacts_new_design_spec.rb` covering:

- Columns button is present in the toolbar
- Badge shows the correct visible/total count
- Panel is hidden by default
- Panel opens and closes on button click
- All 6 toggleable columns are listed with toggle switches, all on by default
- Hiding a column via Update View removes it from the table
- Showing a column again via Update View restores it
- Badge count updates when a column is hidden
- Show All restores all columns and closes the panel
- Column visibility persists across page reloads

### Screen Captures and Recordings

<details>
<summary>Columns button and badge</summary>

<!-- 
Show the toolbar with the Filter and Columns buttons side by side.
The Columns button should display a (6/6) badge on load.
No interaction needed — just the initial state of the toolbar.
-->

</details>

<details>
<summary>Opening and closing the Columns panel</summary>

<!-- 
Click the Columns button to open the panel.
Show the 6 toggle switches, all on by default.
Click the Columns button again to close the panel.
-->

</details>

<details>
<summary>Hiding a column and updating the badge</summary>

<!-- 
Open the Columns panel.
Switch off one or two columns (e.g. Medium, Topics).
Click Update View.
Show that the hidden columns disappear from the table header and body.
Show that the badge on the Columns button updates (e.g. (4/6)).
-->

</details>

<details>
<summary>Restoring columns with Show All</summary>

<!-- 
Start from a state where one or more columns are hidden.
Open the Columns panel.
Click Show All.
Show that all columns reappear, the badge returns to (6/6), and the panel closes.
-->

</details>

<details>
<summary>Column visibility persists across page reloads</summary>

<!-- 
Hide one or two columns and click Update View.
Reload the page.
Show that the hidden columns remain hidden and the badge reflects the correct count.
-->

</details>

### Design Decisions

#### Deviations from the Figma

The Figma design was used as a guide but not followed exactly, for reasons rooted in the existing technical approach.

**Panel instead of a floating popover** — The Figma shows a small floating selector card. I used a slide-down panel consistent with the Filter button already in this view. Both the Filter and Columns controls follow the same open/close pattern, which keeps the toolbar interaction model consistent.

**"Update View" / "Show All" retained** — The Figma's "Update View" and "Show All" buttons were kept, matching the filter panel's "Apply Filters" / "Reset" rhythm. Changes are buffered until Update View is clicked rather than applied immediately on toggle.

**Date and Case are fixed columns** — The Figma's columns selector shows only 6 columns (Relationship, Medium, Created By, Contacted, Topics, Draft). Date and Case are intentionally absent — they are always visible since they form the core identity of a contact row.

**No horizontal scrolling via DataTables** — The Figma did not account for DataTables' `scrollX` feature, which causes header/body misalignment when columns are hidden. I replaced it with CSS `overflow-x: auto` on the table wrapper, which provides equivalent scrolling behaviour without the alignment bug.

**Download button not included** — The Figma toolbar shows Filter, Columns, and Download. The Download button is tracked separately and is out of scope for this PR.

#### Table stays full-width

The table is kept at `width: 100%` rather than shrinking to content width when columns are hidden. When `scrollX: true` was removed, DataTables' default `autoWidth` computed oversized column widths based on content. Setting `autoWidth: false` keeps proportional widths without expanding beyond the card boundary. The tradeoff is that visible columns expand to fill the full card width rather than collapsing to their natural content width — this was an acceptable tradeoff because full-width table borders and a consistently positioned actions column matter more than exact content-width columns.

#### Search term excluded from persisted state

`stateSaveParams` strips the search query before saving to `PreferenceSet#table_state`. Column visibility and sort order are durable preferences; a keyword search is session-intent. If the search term were saved, returning users would land on a filtered subset every time — a confusing and likely unwanted default.

#### Filter and Columns panels can both be open simultaneously

There is no mutual-exclusion logic between the Filter and Columns panels. Each toggle button independently shows or hides its panel. Adding close-the-other behavior was considered but left out — it is a minor UX polish detail not required by the issue and adds coupling between two otherwise independent controls.

### AI Disclosure

This PR was implemented collaboratively with [Claude Code](https://claude.ai/code) (Claude Sonnet 4.6). The working approach:

- I led all design and product decisions: which columns are toggleable, the panel-vs-modal choice, whether to persist state, the deviation from the Figma layout, and the commit strategy.
- Claude analyzed the codebase, identified existing patterns to follow (filter panel, volunteers table column visibility, PreferenceSet persistence), and produced the implementation plan.
- Development followed a red-green TDD rhythm: for each commit, I reviewed failing tests before implementation began and reviewed passing tests and code before committing. I staged and committed all changes.
- Several issues discovered during visual testing (header/body misalignment, table overflow, column expansion, badge flash) were debugged and fixed collaboratively before each commit was finalized.

All commits are co-authored: `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
