### PR TITLE
#6496 n plus one cases cases index

### DIFF
--- a/app/controllers/casa_cases_controller.rb
+++ b/app/controllers/casa_cases_controller.rb
@@ -6,7 +6,7 @@ class CasaCasesController < ApplicationController
 
   def index
     authorize CasaCase
-    org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers)
+    org_cases = current_user.casa_org.casa_cases.includes(:assigned_volunteers, :casa_case_emancipation_categories)
     @casa_cases = policy_scope(org_cases).includes([:hearing_type, :judge])
     @casa_cases_filter_id = policy(CasaCase).can_see_filters? ? "casa-cases" : ""
     @duties = OtherDuty.where(creator_id: current_user.id)

--- a/app/decorators/casa_case_decorator.rb
+++ b/app/decorators/casa_case_decorator.rb
@@ -114,7 +114,7 @@ class CasaCaseDecorator < Draper::Decorator
   end
 
   def emancipation_checklist_count
-    "#{object.casa_case_emancipation_categories.count} / #{EmancipationCategory.count}"
+    "#{object.casa_case_emancipation_categories.size} / #{h.emancipation_category_total_count}"
   end
 
   def show_contact_type?(contact_type_id)

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,4 +1,10 @@
 module EmancipationsHelper
+  # Memoized per request so the casa_cases index doesn't re-issue COUNT(*)
+  # for every transition-age row when rendering the emancipation badge.
+  def emancipation_category_total_count
+    @emancipation_category_total_count ||= EmancipationCategory.count
+  end
+
   def emancipation_category_checkbox_checked(casa_case, emancipation_category)
     case_contains_category?(casa_case, emancipation_category) ? "checked" : nil
   end

--- a/app/helpers/emancipations_helper.rb
+++ b/app/helpers/emancipations_helper.rb
@@ -1,6 +1,6 @@
 module EmancipationsHelper
   # Memoized per request so the casa_cases index doesn't re-issue COUNT(*)
-  # for every transition-age row when rendering the emancipation badge.
+  # for every casa_case row when rendering the emancipation badge.
   def emancipation_category_total_count
     @emancipation_category_total_count ||= EmancipationCategory.count
   end

--- a/spec/decorators/casa_case_decorator_spec.rb
+++ b/spec/decorators/casa_case_decorator_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe CasaCaseDecorator do
 
       expect(casa_case).to(
         receive(:casa_case_emancipation_categories).and_return(
-          double(:categories, count: 2)
+          double(:categories, size: 2)
         )
       )
       expect(EmancipationCategory).to receive(:count).and_return(5)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6496

### What changed, and _why_?

 * use .size instead of .count, eager load the casa_case_emancipation_categories in the controller
 * memoize emancipation category count
   * NOTE: this wasn't strictly part of the ticket, and is probably a trivial cost do do a COUNT(*) on this table since there are a limited number of categories, but was easy to fix and covered in all the same testing, so I added it.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

* ran all tests, but specifically:
  * emancipations_helper_spec
  * casa_cases_decorator_spec

Ran and loaded casa_cases_index page (/casa_cases) as a voluteer and as a supervisor
Ran and loaded case_cases_show page (/casa_cases/cina-10-1002) as a volunteer and as a supervisor.

### Screenshots please :)

Here are screens of the server development log and queries before and after the change.  Annotated where the queries are changed.

| Before fix  | After fix |
| ------------- | ------------- |
| <img alt="before_fix" src="https://github.com/user-attachments/assets/31a2a16c-9aa1-4013-9c82-33abe23b0801" /> | <img alt="after_fix" src="https://github.com/user-attachments/assets/97c1cbca-f9ac-4553-8ff3-9d090044a098" /> | 


