### PR TITLE
5979 learning hours bug

### DIFF
--- a/app/controllers/learning_hours_controller.rb
+++ b/app/controllers/learning_hours_controller.rb
@@ -5,6 +5,7 @@ class LearningHoursController < ApplicationController
   def index
     authorize LearningHour
     @learning_hours = policy_scope(LearningHour)
+    @learning_hours = LearningHoursDashboardRowsService.new(current_user).perform
   end
 
   def show

--- a/app/controllers/learning_hours_controller.rb
+++ b/app/controllers/learning_hours_controller.rb
@@ -4,8 +4,9 @@ class LearningHoursController < ApplicationController
 
   def index
     authorize LearningHour
-    @learning_hours = policy_scope(LearningHour)
-    @learning_hours = LearningHoursDashboardRowsService.new(current_user).perform
+    @learning_hours = LearningHoursDashboardRowsService
+      .new(current_user, policy_scope(LearningHour))
+      .perform
   end
 
   def show

--- a/app/services/learning_hours_dashboard_rows_service.rb
+++ b/app/services/learning_hours_dashboard_rows_service.rb
@@ -1,0 +1,35 @@
+class LearningHoursDashboardRowsService
+  def initialize(user)
+    @user = user
+  end
+
+  def perform
+    case @user
+    when Volunteer
+      @user.learning_hours
+    when Supervisor
+      supervisor_rows
+    when CasaAdmin
+      LearningHour.all_volunteers_learning_hours(@user.casa_org_id)
+    else
+      raise "unrecognized role #{@user.type}"
+    end
+  end
+
+  private
+
+  def supervisor_rows
+    totals_by_user_id =
+      LearningHour
+        .supervisor_volunteers_learning_hours(@user.id)
+        .index_by { |row| row.user_id }
+
+    @user.volunteers.map do |volunteer|
+      totals_by_user_id[volunteer.id] || OpenStruct.new(
+        user_id: volunteer.id,
+        display_name: volunteer.display_name,
+        total_time_spent: 0
+      )
+    end
+  end
+end

--- a/app/services/learning_hours_dashboard_rows_service.rb
+++ b/app/services/learning_hours_dashboard_rows_service.rb
@@ -1,12 +1,13 @@
 class LearningHoursDashboardRowsService
-  def initialize(user)
+  def initialize(user, learning_hours_scope)
     @user = user
+    @learning_hours_scope = learning_hours_scope
   end
 
   def perform
     case @user
     when Volunteer
-      @user.learning_hours
+      @learning_hours_scope
     when Supervisor
       supervisor_rows
     when CasaAdmin

--- a/spec/services/learning_hours_dashboard_rows_service_spec.rb
+++ b/spec/services/learning_hours_dashboard_rows_service_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe LearningHoursDashboardRowsService do
+  describe "#perform" do
+    subject(:rows) { described_class.new(user, learning_hours_scope).perform }
+
+    let(:learning_hours_scope) { LearningHour.none }
+
+    context "when the user is a volunteer" do
+      let(:user) { create(:volunteer) }
+      let(:learning_hours_scope) { LearningHour.where(user: user) }
+      let!(:learning_hour) { create(:learning_hour, user: user) }
+
+      it "returns the authorized learning hours scope" do
+        expect(rows).to contain_exactly(learning_hour)
+      end
+    end
+
+    context "when the user is a supervisor" do
+      let(:casa_org) { create(:casa_org) }
+      let(:user) do
+        create(
+          :supervisor,
+          casa_org: casa_org,
+          volunteers: [volunteer_with_hours, zero_hour_volunteer]
+        )
+      end
+      let(:volunteer_with_hours) do
+        create(:volunteer, casa_org: casa_org, display_name: "Volunteer With Hours")
+      end
+      let(:zero_hour_volunteer) do
+        create(:volunteer, casa_org: casa_org, display_name: "Zero Hour Volunteer")
+      end
+
+      before do
+        create(:learning_hour, user: volunteer_with_hours, duration_hours: 1, duration_minutes: 25)
+        create(:learning_hour, user: volunteer_with_hours, duration_hours: 2, duration_minutes: 35)
+      end
+
+      it "returns learning hour totals for assigned volunteers with hours" do
+        volunteer_row = rows.find { |row| row.user_id == volunteer_with_hours.id }
+
+        expect(volunteer_row.display_name).to eq("Volunteer With Hours")
+        expect(volunteer_row.total_time_spent).to eq(240)
+      end
+
+      it "returns zero-hour rows for assigned volunteers without learning hours" do
+        zero_hour_row = rows.find { |row| row.user_id == zero_hour_volunteer.id }
+
+        expect(zero_hour_row.display_name).to eq("Zero Hour Volunteer")
+        expect(zero_hour_row.total_time_spent).to eq(0)
+      end
+    end
+
+    context "when the user is a casa admin" do
+      let(:casa_org) { create(:casa_org) }
+      let(:user) { create(:casa_admin, casa_org: casa_org) }
+      let(:volunteer) { create(:volunteer, casa_org: casa_org, display_name: "Admin Volunteer") }
+
+      before do
+        create(:learning_hour, user: volunteer, duration_hours: 3, duration_minutes: 15)
+      end
+
+      it "returns learning hour totals for the admin organization" do
+        expect(rows.length).to eq(1)
+        expect(rows.first.user_id).to eq(volunteer.id)
+        expect(rows.first.display_name).to eq("Admin Volunteer")
+        expect(rows.first.total_time_spent).to eq(195)
+      end
+    end
+  end
+end

--- a/spec/system/learning_hours/index_spec.rb
+++ b/spec/system/learning_hours/index_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Learning Hours Index", type: :system do
 
   context "when the user is a supervisor or admin" do
     let(:user) { supervisor }
+    let(:zero_hour_volunteer) { supervisor.volunteers.second }
 
     before do
       visit learning_hours_path
@@ -34,6 +35,14 @@ RSpec.describe "Learning Hours Index", type: :system do
       expect(page).to have_content(volunteer.display_name)
       expect(page).to have_content("Time Completed")
       expect(page).to have_content("#{volunteer.learning_hours.sum(:duration_hours)} hours")
+    end
+
+    it "displays assigned volunteers with no learning hours as zero hours" do
+      expect(page).to have_content(zero_hour_volunteer.display_name)
+
+      within("tr", text: zero_hour_volunteer.display_name) do
+        expect(page).to have_content("0 hours 0 minutes")
+      end
     end
 
     it "when clicking on a volunteer's name it redirects to the `learning_hours_volunteer_path` for the volunteer" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #5979

### What changed, and _why_?
Added a new service to correctly route learning hours by role (follows similar pattern to policy).

The change is for the `Supervisor` role, which now utilizes the learning hours query to get learning hours but also merges with all of the Supervisor's volunteers to show volunteers with 0 hours (since they would not show up in learning_hours since they don't have any!)

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Added test for this specific case, a new spec file for the added service, and locally tested (see screenshots)

### Screenshots please :)
Before change/on `main`:
<img width="1099" height="424" alt="image" src="https://github.com/user-attachments/assets/951a5566-2797-409f-bb4f-0150b2d52519" />

Added a new volunteer, set to Supervisor, and so they have 0 learning hours.

After change/on `5979-learning-hours-bug`:
<img width="1066" height="444" alt="image" src="https://github.com/user-attachments/assets/f8cb0d1c-2071-4e62-890f-f5e6f2f24851" />