### PR TITLE
fix: redirect cross-org court date access with authorization message (#6914)

### DIFF
--- a/app/controllers/court_dates_controller.rb
+++ b/app/controllers/court_dates_controller.rb
@@ -5,7 +5,7 @@ class CourtDatesController < ApplicationController
   before_action :set_court_date, only: %i[edit show update destroy]
   before_action :require_organization!
 
-  rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }
+  rescue_from ActiveRecord::RecordNotFound, with: :not_authorized_redirect
 
   def show
     authorize @casa_case
@@ -66,9 +66,14 @@ class CourtDatesController < ApplicationController
   def set_casa_case
     @casa_case = current_organization.casa_cases.friendly.find(params[:casa_case_id])
   rescue ActiveRecord::RecordNotFound
+    not_authorized_redirect
+  end
+
+  def not_authorized_redirect
     respond_to do |format|
       format.html { redirect_to casa_cases_path, notice: "Sorry, you are not authorized to perform this action." }
       format.json { render json: {error: "Sorry, you are not authorized to perform this action."}, status: :unauthorized }
+      format.any { head :not_found }
     end
   end
 

--- a/spec/system/court_dates/view_spec.rb
+++ b/spec/system/court_dates/view_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe "court_dates/edit", type: :system do
   context "as a user from an organization not containing the court date" do
     let(:other_organization) { create(:casa_org) }
 
-    xit "does not allow the user to view the court date" do
-      # TODO the app or browser can't gracefully handle the URL
+    it "does not allow the user to view the court date" do
       sign_in create(:casa_admin, casa_org: other_organization)
       visit casa_case_court_date_path(casa_case, court_date)
 


### PR DESCRIPTION
## Summary

Cross-org access to a court date URL now fails gracefully with the standard Pundit authorization message instead of a non-graceful 404/error.

`CourtDatesController` previously declared a controller-local `rescue_from ActiveRecord::RecordNotFound, with: -> { head :not_found }`, which overrode `ApplicationController`'s handling and produced a bare 404 whenever a member lookup missed. `set_casa_case` already scopes through `current_organization.casa_cases` and inline-rescued `RecordNotFound` into a redirect with "Sorry, you are not authorized to perform this action.", but `set_court_date`'s lookup had no such handling, so the failure mode was inconsistent.

This change extracts that existing authorization response into a private `not_authorized_redirect` method and routes the controller's `RecordNotFound` rescue through it, so a court date (or casa case) outside the current organization yields the same authorization redirect the app already uses elsewhere. A `format.any { head :not_found }` branch preserves the prior 404 behavior for the `.docx` report download path.

## Why this matters

CASA is multi-tenant and cross-org data leaks are the most important class of bug to avoid. Issue #6914 (filed by maintainer @compwron) documented this directly: the disabled `xit` example in `spec/system/court_dates/view_spec.rb` carried a TODO noting "the app or browser can't gracefully handle the URL" when a CASA admin from a different organization visits another org's court date. This is the same class of multi-tenancy correctness bug as the prior ContactTypeGroup cross-org fix. The cross-org failure mode is now consistent with the in-org-but-unassigned case in the same spec.

## Testing

- Re-enabled the previously disabled cross-org example (`xit` -> `it`) in `spec/system/court_dates/view_spec.rb` and removed its TODO comment. It asserts a casa_admin in another organization sees the authorization message.
- Existing examples for same-org admin, supervisor, and assigned volunteer continue to assert successful viewing; the in-org unassigned-volunteer example continues to assert the authorization message via Pundit.

Note: this Rails app targets Ruby 4.0.x / Bundler 4.0.x, which was not available in my local environment, so I verified the changes with `ruby -c` (syntax) and by reasoning through the before_action / rescue paths rather than running the full system spec locally. CI will exercise the re-enabled example.

Fixes #6914
