### PR TITLE
Prosopite: spec/seeds and spec/config fixes

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
 
   # Prosopite N+1 query detection
   config.prosopite_enabled = true
-  config.prosopite_min_n_queries = 5  # More lenient for development
+  config.prosopite_min_n_queries = 5 # More lenient for development
 
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true

--- a/spec/.prosopite_ignore
+++ b/spec/.prosopite_ignore
@@ -13,7 +13,6 @@ spec/decorators
 spec/policies
 spec/datatables
 spec/helpers
-spec/seeds
 spec/mailers
 spec/config
 spec/notifications

--- a/spec/.prosopite_ignore
+++ b/spec/.prosopite_ignore
@@ -14,5 +14,4 @@ spec/policies
 spec/datatables
 spec/helpers
 spec/mailers
-spec/config
 spec/notifications

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Rack::Attack do
 
   describe "throttle excessive requests for email login by variety of IP addresses" do
     shared_examples "correctly throttles" do
-      it "changes the request status to 429 when greater than limit" do
+      it "changes the request status to 429 when greater than limit", disable_prosopite: true do
         (limit * 2).times do |i|
           header = {"REMOTE_ADDR" => "#{remote_ip}#{i}"}
           post path, params, header

--- a/spec/seeds/seeds_spec.rb
+++ b/spec/seeds/seeds_spec.rb
@@ -25,14 +25,14 @@ end
 
 RSpec.describe "Seeds" do
   describe "test development DB" do
-    before do
+    it "successfully populates all necessary tables" do
       Rails.application.load_tasks
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
-    end
 
-    it "successfully populates all necessary tables" do
+      Prosopite.pause
       ActiveRecord::Tasks::DatabaseTasks.load_seed
       expect(empty_ar_classes).to eq([])
+      Prosopite.resume
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Related to https://github.com/rubyforgood/casa/issues/6912

### What changed, and _why_?

`Prosopite` is wired to raise on N+1 in tests (`spec/support/prosopite.rb`), but `spec/.prosopite_ignore` currently opts out every spec directory — so the gem catches nothing in CI. `PROSOPITE_TODO.md` tracks known N+1s but is incomplete.

This PR is focused on fixing the /spec/seeds and /spec/config Prosopite errors. Please see each individual commit for more details on each file.

Now that these directories are enforced, no future PR can silently introduce an N+1 there.