### PR TITLE
Prosopite /helpers fixes

### DIFF
--- a/spec/.prosopite_ignore
+++ b/spec/.prosopite_ignore
@@ -12,6 +12,5 @@ spec/views
 spec/decorators
 spec/policies
 spec/datatables
-spec/helpers
 spec/mailers
 spec/notifications

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe NotificationsHelper, type: :helper do
       patch_note_2 = create(:patch_note, note: "Patch Note 2", patch_note_type: patch_note_type_b)
       patch_note_3 = create(:patch_note, note: "Patch Note 3", patch_note_type: patch_note_type_b)
 
-      patch_notes_hash = helper.patch_notes_as_hash_keyed_by_type_name(PatchNote.all)
+      patch_notes_hash = helper.patch_notes_as_hash_keyed_by_type_name(PatchNote.includes(:patch_note_type).all)
 
       expect(patch_notes_hash).to have_key(patch_note_type_a.name)
       expect(patch_notes_hash).to have_key(patch_note_type_b.name)

--- a/spec/helpers/ui_helper_spec.rb
+++ b/spec/helpers/ui_helper_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe UiHelper, type: :helper do
   describe "#grouped_options_for_assigning_case" do
     before do
-      @casa_cases = create_list(:casa_case, 4)
-      @volunteer = create(:volunteer, casa_org: @casa_cases[0].casa_org)
+      @casa_case = create(:casa_case)
+      @volunteer = create(:volunteer, casa_org: @casa_case.casa_org)
       current_user = create(:supervisor)
       allow(helper).to receive(:current_user).and_return(current_user)
     end


### PR DESCRIPTION
### What github issue is this PR for, if any?

Related to https://github.com/rubyforgood/casa/issues/6912

### What changed, and _why_?

`Prosopite` is wired to raise on N+1 in tests (`spec/support/prosopite.rb`), but `spec/.prosopite_ignore` currently opts out every spec directory — so the gem catches nothing in CI. `PROSOPITE_TODO.md` tracks known N+1s but is incomplete.

This PR is focused on fixing the /spec/helpers Prosopite errors. Please see each individual commit for more details on each file.

Now that these directories are enforced, no future PR can silently introduce a N+1s in them.

Note: I re-organized the test so it didn't use an instance variable as per Rubocop's recommendation. Then, I changed the UiHelper to use the instance given as the param instead of an instance variable. I tested the Volunteers edit page where this is used and it's working as before, but let me know if I am missing something.