### PR TITLE
Scan /mailers for N+1 with Proposite

### DIFF
--- a/spec/.prosopite_ignore
+++ b/spec/.prosopite_ignore
@@ -12,5 +12,4 @@ spec/views
 spec/decorators
 spec/policies
 spec/datatables
-spec/mailers
 spec/notifications

--- a/spec/mailers/supervisor_mailer_spec.rb
+++ b/spec/mailers/supervisor_mailer_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe SupervisorMailer, type: :mailer do
       let!(:volunteer_for_other_supervisor_same_org) { create(:volunteer, last_sign_in_at: 31.days.ago, casa_org: casa_org, supervisor: create(:supervisor, casa_org: casa_org)) }
       let!(:volunteer_for_other_org) { create(:volunteer, last_sign_in_at: 31.days.ago, casa_org: other_org, supervisor: create(:supervisor, casa_org: other_org)) }
 
-      it "display no_recent_sign_in section" do
+      it "displays no_recent_sign_in section", :disable_prosopite do
         expect(mail.body.encoded).to match("volunteers have not signed in or created case contacts in the last 30 days")
         expect(mail.body.encoded).to match(volunteer.display_name)
         expect(mail.body.encoded).not_to match(volunteer_for_other_supervisor_same_org.display_name)
@@ -127,11 +127,9 @@ RSpec.describe SupervisorMailer, type: :mailer do
       end
 
       context "but volunteer has a recent case_contact to its name" do
-        let!(:recent_case_contact) do
+        it "does not display no_recent_sign_in section", :disable_prosopite do
           create(:case_contact, casa_case: casa_case, occurred_at: 29.days.ago, creator: volunteer)
-        end
 
-        it "does not display no_recent_sign_in section" do
           expect(mail.body.encoded).not_to match("volunteers have not signed in or created case contacts in the last 30 days")
         end
       end


### PR DESCRIPTION
The two errors need to be disabled because they
are false positives. The errors are caused by the
user validator which is necessary and can't be
preloaded.

### What github issue is this PR for, if any?

Related to https://github.com/rubyforgood/casa/issues/6912

### What changed, and _why_?

Prosopite is wired to raise on N+1 in tests (spec/support/prosopite.rb), but spec/.prosopite_ignore currently opts out every spec directory — so the gem catches nothing in CI. PROSOPITE_TODO.md tracks known N+1s but is incomplete.

This PR is focused on fixing the /spec/mailers Prosopite errors. To fix them, the tests need to be disabled because they are false positives. The errors are caused by the user validator which is necessary and can't be preloaded.

Now that this directory is enforced, no future PR can silently introduce a N+1s in there.