### PR TITLE
Scan /spec/notifications for N+1s

### DIFF
--- a/app/notifications/reimbursement_complete_notifier.rb
+++ b/app/notifications/reimbursement_complete_notifier.rb
@@ -17,14 +17,25 @@ class ReimbursementCompleteNotifier < BaseNotifier
   end
 
   def message
-    case_contact = params[:case_contact]
     msg = "Volunteer #{case_contact.creator.display_name}'s request for reimbursement for #{case_contact.miles_driven}mi "
-    msg += " for $#{case_contact.reimbursement_amount} " if case_contact.reimbursement_amount
+    msg += " for $#{reimbursement_amount} " if reimbursement_amount
     msg += "on #{case_contact.occurred_at_display} has been processed and is en route."
     msg
   end
 
   def url
-    case_contacts_path(casa_case_id: params[:case_contact].casa_case_id)
+    case_contacts_path(casa_case_id: case_contact.casa_case_id)
+  end
+
+  private
+
+  def reimbursement_amount
+    return @reimbursement_amount if defined?(@reimbursement_amount)
+
+    @reimbursement_amount = case_contact.reimbursement_amount
+  end
+
+  def case_contact
+    params[:case_contact]
   end
 end

--- a/spec/.prosopite_ignore
+++ b/spec/.prosopite_ignore
@@ -13,4 +13,3 @@ spec/decorators
 spec/policies
 spec/datatables
 spec/mailers
-spec/notifications

--- a/spec/notifications/reimbursement_complete_notifier_spec.rb
+++ b/spec/notifications/reimbursement_complete_notifier_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ReimbursementCompleteNotifier, type: :model do
   describe "title" do
     it "returns 'Reimbursement Approved'" do
-      case_contact = create(:case_contact, :wants_reimbursement)
+      case_contact = build(:case_contact, :wants_reimbursement)
 
       notification = ReimbursementCompleteNotifier.with(case_contact:)
 

--- a/spec/notifications/reimbursement_complete_notifier_spec.rb
+++ b/spec/notifications/reimbursement_complete_notifier_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe ReimbursementCompleteNotifier, type: :model do
+  describe "title" do
+    it "returns 'Reimbursement Approved'" do
+      case_contact = create(:case_contact, :wants_reimbursement)
+
+      notification = ReimbursementCompleteNotifier.with(case_contact:)
+
+      expect(notification.title).to eq("Reimbursement Approved")
+    end
+  end
+
   describe "message" do
     let(:case_contact) { create(:case_contact, :wants_reimbursement) }
 
@@ -18,6 +28,16 @@ RSpec.describe ReimbursementCompleteNotifier, type: :model do
         notification = ReimbursementCompleteNotifier.with(case_contact: case_contact)
         expect(notification.message).to include "$2964"
       end
+    end
+  end
+
+  describe "url" do
+    it "returns the case contacts URL path for the given case contact" do
+      case_contact = create(:case_contact, :wants_reimbursement)
+
+      notification = ReimbursementCompleteNotifier.with(case_contact:)
+
+      expect(notification.url).to eq("/case_contacts?casa_case_id=#{case_contact.casa_case_id}")
     end
   end
 end

--- a/spec/requests/reimbursements_spec.rb
+++ b/spec/requests/reimbursements_spec.rb
@@ -2,14 +2,10 @@ require "rails_helper"
 
 RSpec.describe ReimbursementsController, type: :request do
   let(:admin) { create(:casa_admin) }
-  let(:casa_org) { admin.casa_org }
   let(:case_contact) { create(:case_contact) }
-  let(:notification_double) { instance_double("ReimbursementCompleteNotifier") }
 
   before do
     sign_in(admin)
-    allow(ReimbursementCompleteNotifier).to receive(:with).and_return(notification_double)
-    allow(notification_double).to receive(:deliver)
   end
 
   describe "GET /index" do
@@ -40,10 +36,34 @@ RSpec.describe ReimbursementsController, type: :request do
   describe "PATCH /mark_as_complete" do
     it "changes reimbursement status to complete" do
       patch reimbursement_mark_as_complete_url(case_contact, case_contact: {reimbursement_complete: true})
-      expect(ReimbursementCompleteNotifier).to(have_received(:with).once.with(case_contact: case_contact))
+
       expect(response).to redirect_to(reimbursements_path)
       expect(response).to have_http_status(:redirect)
       expect(case_contact.reload.reimbursement_complete).to be_truthy
+    end
+
+    it "sends a notification to the case_contact's creator" do
+      expect do
+        patch reimbursement_mark_as_complete_url(case_contact, case_contact: {reimbursement_complete: true})
+      end.to change(Noticed::Notification, :count).by(1)
+
+      notification = Noticed::Notification.last
+      expect(notification.recipient).to eq(case_contact.creator)
+    end
+
+    context "when the case contact has a supervisor" do
+      it "sends a notification to the case_contact's creator and supervisor" do
+        supervisor = build(:supervisor)
+        volunteer = build(:volunteer, supervisor:)
+        case_contact = create(:case_contact, creator: volunteer)
+
+        expect do
+          patch reimbursement_mark_as_complete_url(case_contact, case_contact: {reimbursement_complete: true})
+        end.to change(Noticed::Notification, :count).by(2)
+
+        expect(Noticed::Notification.first.recipient).to eq(case_contact.creator)
+        expect(Noticed::Notification.last.recipient).to eq(case_contact.supervisor)
+      end
     end
   end
 

--- a/spec/requests/reimbursements_spec.rb
+++ b/spec/requests/reimbursements_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ReimbursementsController, type: :request do
   let(:admin) { create(:casa_admin) }
   let(:casa_org) { admin.casa_org }
   let(:case_contact) { create(:case_contact) }
-  let(:notification_double) { double("ReimbursementCompleteNotifier") }
+  let(:notification_double) { instance_double("ReimbursementCompleteNotifier") }
 
   before do
     sign_in(admin)


### PR DESCRIPTION
### What github issue is this PR for, if any?

Closes https://github.com/rubyforgood/casa/issues/6912

### What changed, and why?

The error was raised because the query was being made every time it was called twice. By making the query only once, the error is fixed.

I also added more coverage to the notifier, memoized the reimbursement_amount to make sure it's calculated only once and moved some variables to be private methods to keep this class more object-oriented.

I also updated a request spec that uses this notifier to use instance_double instead of double. 
instance_double raises an error if methods are not available in the specified class or arguments have changed, whether a double would still pass if the method is removed.