### PR TITLE
test: replace ByOrganizationScope and Roles spec stubs with real tests (#5563)

### DIFF
--- a/spec/models/concerns/by_organization_scope_spec.rb
+++ b/spec/models/concerns/by_organization_scope_spec.rb
@@ -1,7 +1,21 @@
 require "rails_helper"
 
 RSpec.describe ByOrganizationScope, type: :model do
-  # TODO: Add tests for ByOrganizationScope
+  describe ".by_organization" do
+    let(:casa_org) { create(:casa_org) }
+    let(:other_casa_org) { create(:casa_org) }
 
-  pending "add some tests for ByOrganizationScope"
+    let!(:casa_case_in_org) { create(:casa_case, casa_org: casa_org) }
+    let!(:casa_case_in_other_org) { create(:casa_case, casa_org: other_casa_org) }
+
+    it "returns only the records belonging to the given organization" do
+      expect(CasaCase.by_organization(casa_org)).to contain_exactly(casa_case_in_org)
+    end
+
+    it "returns no records for an organization without records" do
+      empty_casa_org = create(:casa_org)
+
+      expect(CasaCase.by_organization(empty_casa_org)).to be_empty
+    end
+  end
 end

--- a/spec/models/concerns/roles_spec.rb
+++ b/spec/models/concerns/roles_spec.rb
@@ -1,7 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Roles, type: :model do
-  # TODO: Add tests for Roles
+  describe "#role" do
+    it "returns the titleized model name for each user type" do
+      expect(build(:volunteer).role).to eq "Volunteer"
+      expect(build(:supervisor).role).to eq "Supervisor"
+      expect(build(:casa_admin).role).to eq "Casa Admin"
+    end
 
-  pending "add some tests for Roles"
+    it "returns the titleized model name for an all casa admin" do
+      expect(build(:all_casa_admin).role).to eq "All Casa Admin"
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #5563 (umbrella — replaces 2 of the remaining stub specs; intentionally not using "Resolves" so the umbrella stays open)

### What changed, and _why_?
Replaced two `pending "add some tests for X"` stub specs (introduced in #6517) with real tests, following the definition of done in the issue body. Both files live in `spec/models/concerns/`, so they are bundled as one themed PR:

- `spec/models/concerns/by_organization_scope_spec.rb` — exercises the `.by_organization` scope through `CasaCase`: records from another `CasaOrg` are excluded, and an org with no records gets an empty result. This concern is the core of the app's multi-tenancy, so it seemed worth covering first.
- `spec/models/concerns/roles_spec.rb` — exercises `#role` for all four including user types: `Volunteer`, `Supervisor`, `CasaAdmin`, and the separate `AllCasaAdmin` model.

No `pending`, `skip`, or `xit` remains in either file.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
This PR is tests. Commands run locally:

- `bundle exec rspec spec/models/concerns/by_organization_scope_spec.rb spec/models/concerns/roles_spec.rb` → 4 examples, 0 failures
- `bundle exec rspec spec/models/concerns/` → 6 examples, 0 failures, 2 pending (the two remaining stub files in that directory, `api_spec.rb` and `CasaCase/validations_spec.rb`, left for follow-up PRs)
- `bundle exec standardrb spec/models/concerns/` → clean

### Screenshots please :)
No UI changes — test-only PR.
