### PR TITLE
test: cover DeliveryMethods::Sms and CustomOrgLinkPolicy::Scope (#6833)

### DIFF
--- a/app/notifications/delivery_methods/sms.rb
+++ b/app/notifications/delivery_methods/sms.rb
@@ -17,7 +17,7 @@ class DeliveryMethods::Sms < Noticed::DeliveryMethod
   private
 
   def sender
-    User.find(params[:followup][:creator_id])
+    @sender ||= User.find(params[:followup][:creator_id])
   end
 
   def case_contact_id

--- a/spec/notifications/delivery_methods/sms_spec.rb
+++ b/spec/notifications/delivery_methods/sms_spec.rb
@@ -1,7 +1,70 @@
 require "rails_helper"
+require "support/stubbed_requests/webmock_helper"
 
 RSpec.describe DeliveryMethods::Sms do
-  # TODO: Add tests for DeliveryMethods::Sms
+  let(:casa_org) { create(:casa_org, twilio_enabled: true) }
+  let(:recipient) { create(:volunteer, casa_org: casa_org, phone_number: "+12222222222") }
+  let(:case_contact) { create(:case_contact) }
+  let(:followup) { create(:followup, creator: sender, case_contact: case_contact) }
+  let(:event) { create(:followup_notifier, params: {followup: followup, created_by: sender}, record: followup) }
+  let(:notification) { create(:notification, event: event, recipient: recipient) }
+  let(:case_contact_edit_url) do
+    "#{Rails.application.credentials[:BASE_URL]}/case_contacts/#{case_contact.id}/edit?notification_id=#{followup.id}"
+  end
 
-  pending "add some tests for DeliveryMethods::Sms"
+  before do
+    allow(event).to receive(:delivery_methods).and_return({sms: Noticed::Deliverable::DeliverBy.new(:sms, {})})
+    WebMockHelper.short_io_stub_sms
+    WebMockHelper.twilio_activation_success_stub
+  end
+
+  def deliver_notification
+    described_class.new.perform(:sms, notification)
+  end
+
+  context "when the sender is a casa admin" do
+    let(:sender) { create(:casa_admin, casa_org: casa_org) }
+
+    it "sends an sms with the flagged case contact message and shortened url" do
+      deliver_notification
+
+      expect(a_request(:post, "https://api.twilio.com/2010-04-01/Accounts/articuno34/Messages.json")
+        .with(body: {
+          From: casa_org.twilio_phone_number,
+          Body: "#{sender.display_name} has flagged a Case Contact that needs follow up. Click to see more: https://42ni.short.gy/jzTwdF",
+          To: recipient.phone_number
+        })).to have_been_made.once
+    end
+
+    it "shortens the case contact edit url" do
+      deliver_notification
+
+      expect(a_request(:post, "https://api.short.io/links")
+        .with(body: {originalURL: case_contact_edit_url, domain: "42ni.short.gy"}.to_json))
+        .to have_been_made.once
+    end
+  end
+
+  context "when the sender is a supervisor" do
+    let(:sender) { create(:supervisor, casa_org: casa_org) }
+
+    it "sends an sms" do
+      deliver_notification
+
+      expect(a_request(:post, "https://api.twilio.com/2010-04-01/Accounts/articuno34/Messages.json"))
+        .to have_been_made.once
+    end
+  end
+
+  context "when the sender is a volunteer" do
+    let(:sender) { create(:volunteer, casa_org: casa_org) }
+
+    it "does not send an sms" do
+      deliver_notification
+
+      expect(a_request(:post, "https://api.twilio.com/2010-04-01/Accounts/articuno34/Messages.json"))
+        .not_to have_been_made
+      expect(a_request(:post, "https://api.short.io/links")).not_to have_been_made
+    end
+  end
 end

--- a/spec/policies/custom_org_link_policy_spec.rb
+++ b/spec/policies/custom_org_link_policy_spec.rb
@@ -18,4 +18,36 @@ RSpec.describe CustomOrgLinkPolicy, type: :policy do
       expect(described_class).not_to permit(volunteer)
     end
   end
+
+  describe "Scope#resolve" do
+    subject(:resolved_scope) { described_class::Scope.new(user, CustomOrgLink.all).resolve }
+
+    let(:casa_org) { create(:casa_org) }
+    let!(:custom_org_link) { create(:custom_org_link, casa_org: casa_org) }
+    let!(:other_org_custom_org_link) { create(:custom_org_link) }
+
+    context "when user is a casa admin" do
+      let(:user) { create(:casa_admin, casa_org: casa_org) }
+
+      it "resolves only links from the admin's organization" do
+        expect(resolved_scope).to contain_exactly(custom_org_link)
+      end
+    end
+
+    context "when user is a supervisor" do
+      let(:user) { create(:supervisor, casa_org: casa_org) }
+
+      it "resolves no links" do
+        expect(resolved_scope).to be_empty
+      end
+    end
+
+    context "when user is a volunteer" do
+      let(:user) { create(:volunteer, casa_org: casa_org) }
+
+      it "resolves no links" do
+        expect(resolved_scope).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #6833

### What changed, and _why_?

Issue #6833 lists `app/notifications/delivery_methods/sms.rb` (43.8% line coverage) and `app/policies/custom_org_link_policy.rb` (50%) among the remaining low-coverage Ruby files (controllers were already handled in #6841 and #6855). This PR covers both:

- **`spec/notifications/delivery_methods/sms_spec.rb`** — replaced the `pending` stub with real specs: an SMS with the flagged-case-contact message and the shortened case contact edit URL is sent via Twilio when the sender is a casa admin or supervisor, and nothing is sent when the sender is a volunteer. Uses the existing `WebMockHelper` short.io/Twilio stubs.
- **`spec/policies/custom_org_link_policy_spec.rb`** — added `Scope#resolve` specs (the previously uncovered half of the policy): casa admins resolve only their own organization's links, supervisors and volunteers resolve none.
- **`app/notifications/delivery_methods/sms.rb`** — memoized `#sender`, which called `User.find` on every invocation (3 queries per delivery). Prosopite, recently enabled for `spec/notifications` in #6994, flags this as an N+1 and fails the new specs without the memoization.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

- `bundle exec rspec spec/notifications/delivery_methods/sms_spec.rb spec/policies/custom_org_link_policy_spec.rb` — 10 examples, 0 failures
- `bundle exec rspec spec/notifications spec/policies spec/services/twilio_service_spec.rb spec/services/short_url_service_spec.rb spec/services/followup_service_spec.rb` — 404 examples, 0 failures, 9 pending
- `bundle exec standardrb` on the three touched files — no offenses

The new SMS specs fail without the memoization change (Prosopite raises `NPlusOneQueriesError`) and pass with it.

### Screenshots please :)
No UI changes — test coverage plus a query memoization.
