### PR TITLE
fix: show all court report topic sections in creation order (#6601)

### DIFF
--- a/app/models/case_court_report_context.rb
+++ b/app/models/case_court_report_context.rb
@@ -106,36 +106,46 @@ class CaseCourtReportContext
   # ]}
   # }
   def court_topics
-    topics = ContactTopic
-      .joins(contact_topic_answers: {case_contact: [:casa_case, :contact_types]}).distinct
-      .where(contact_topics: {exclude_from_court_report: false})
-      .where("casa_cases.id": @casa_case.id)
-      .where("case_contacts.occurred_at": @date_range)
-      .order(:occurred_at, :value)
-      .select(:details, :question, :occurred_at, :value, :contact_made,
-        "STRING_AGG(contact_types.name, ', ' ORDER BY contact_types.name) AS medium_types")
-      .group(:details, :question, :occurred_at, :value, :contact_made)
+    answers_by_topic_id = court_topic_answers
 
-    topics.each_with_object({}) do |topic, hash|
-      hash[topic.question] ||= {
-        answers: [],
+    report_topics(answers_by_topic_id.keys).each_with_object({}) do |topic, hash|
+      hash[topic.question] = {
+        answers: answers_by_topic_id.fetch(topic.id, []),
         topic: topic.question,
         details: topic.details
       }
-
-      formatted_date = CourtReportFormatContactDate.new(topic).format_long
-      answer_value = topic.value.presence || "No Answer Provided"
-      answer = {
-        date: formatted_date,
-        medium: topic.medium_types,
-        value: answer_value
-      }
-
-      hash[topic.question][:answers].push(answer)
     end
   end
 
   private
+
+  def report_topics(answered_topic_ids)
+    ContactTopic
+      .where(casa_org: @casa_case.casa_org, exclude_from_court_report: false)
+      .merge(ContactTopic.active.or(ContactTopic.where(id: answered_topic_ids)))
+      .order(:id)
+  end
+
+  def court_topic_answers
+    answer_rows = ContactTopic
+      .joins(contact_topic_answers: {case_contact: [:casa_case, :contact_types]}).distinct
+      .where("casa_cases.id": @casa_case.id)
+      .where("case_contacts.occurred_at": @date_range)
+      .order(:occurred_at, :value)
+      .select("contact_topics.id", :occurred_at, :value, :contact_made,
+        "STRING_AGG(contact_types.name, ', ' ORDER BY contact_types.name) AS medium_types")
+      .group("contact_topics.id", :occurred_at, :value, :contact_made)
+
+    answer_rows.group_by(&:id).transform_values do |rows|
+      rows.map do |row|
+        {
+          date: CourtReportFormatContactDate.new(row).format_long,
+          medium: row.medium_types,
+          value: row.value.presence || "No Answer Provided"
+        }
+      end
+    end
+  end
 
   def calculate_date_range(args)
     zone = args[:time_zone] ? ActiveSupport::TimeZone.new(args[:time_zone]) : Time.zone

--- a/spec/models/case_court_report_context_spec.rb
+++ b/spec/models/case_court_report_context_spec.rb
@@ -269,6 +269,68 @@ RSpec.describe CaseCourtReportContext, type: :model do
       end
     end
 
+    context "when some topics have no answers" do
+      it "includes every topic, with an empty answer list for unanswered ones" do
+        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[0], value: "Answer 1")
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 2", "Question 3"])
+        expect(court_topics["Question 1"][:answers].pluck(:value)).to eq(["Answer 1"])
+        expect(court_topics["Question 2"][:answers]).to eq([])
+        expect(court_topics["Question 3"][:answers]).to eq([])
+      end
+
+      it "does not include unanswered topics that are inactive" do
+        topics[1].update!(active: false)
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 3"])
+      end
+
+      it "does not include unanswered topics excluded from the court report" do
+        topics[1].update!(exclude_from_court_report: true)
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 3"])
+      end
+
+      it "does not include topics from other organizations" do
+        topics
+        create(:contact_topic, question: "Other Org Question")
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 2", "Question 3"])
+      end
+    end
+
+    context "when answers occur in a different order than the topics were created" do
+      it "orders topics by creation order, not by answer date" do
+        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[2], value: "Earliest answer")
+        create(:contact_topic_answer, case_contact: contacts[1], contact_topic: topics[1], value: "Middle answer")
+        create(:contact_topic_answer, case_contact: contacts[2], contact_topic: topics[0], value: "Latest answer")
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 2", "Question 3"])
+      end
+    end
+
+    context "when an inactive topic has answers" do
+      it "includes the topic and its answers" do
+        topics[1].update!(active: false)
+        create(:contact_topic_answer, case_contact: contacts[0], contact_topic: topics[1], value: "Answer before deactivation")
+
+        court_topics = build(:case_court_report_context, casa_case: casa_case).court_topics
+
+        expect(court_topics.keys).to eq(["Question 1", "Question 2", "Question 3"])
+        expect(court_topics["Question 2"][:answers].pluck(:value)).to eq(["Answer before deactivation"])
+      end
+    end
+
     context "when there are no contact topics" do
       it "returns an empty hash" do
         court_report_context = build(:case_court_report_context, start_date: 45.day.ago.to_s, end_date: 5.day.ago.to_s, casa_case: casa_case)


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #6601

### What changed, and _why_?

`CaseCourtReportContext#court_topics` built the report's topic sections from an inner join on `contact_topic_answers`, which caused two problems visible in generated court reports:

1. **Missing sections** — a contact topic with no answered case contacts in the reporting period was dropped from the report entirely.
2. **Unstable section order** — sections appeared in the order of their first answer's `occurred_at`, so the questions came out in a different order on every report instead of the order the topics were defined.

Now the section list is built from the org's contact topics themselves, ordered by creation (`id`), matching the order of `db/seeds/default_contact_topics.yml` and the ordering already used by `CaseContactsExportCsvService`. Answers in the date range are grouped per topic and attached to their section; topics without answers render with an empty answer list so the question and details still appear in the report.

Behavior preserved/tightened along the way:
- Topics flagged `exclude_from_court_report` stay out of the report (existing spec still passes).
- Inactive/soft-deleted topics that have answers in the range still show their data (as before); inactive topics with no answers are not added.
- Topics are now explicitly scoped to the case's `casa_org`.

Verified against the two production templates attached to the issue by @compwron (Montgomery and Prince George's): both render with all sections present and in order, including sections with no answers.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Six new examples in `spec/models/case_court_report_context_spec.rb` covering: unanswered topics included with empty answers, creation-order sorting regardless of answer dates, inactive/excluded unanswered topics filtered out, inactive-with-answers preserved, and cross-org isolation. All six fail on `main` and pass with this change.

```
bundle exec rspec spec/models/case_court_report_context_spec.rb   # 34 examples, 0 failures
bundle exec rspec spec/models/case_court_report_spec.rb spec/requests/case_court_reports_spec.rb   # 68 examples, 0 failures
bundle exec rspec spec/system/case_court_reports   # 21 examples, 0 failures
bundle exec standardrb app/models/case_court_report_context.rb spec/models/case_court_report_context_spec.rb   # no offenses
```

### Screenshots please :)
No UI change — the fix is in the docx generation context. The rendered output was verified by generating reports from the two production templates attached to the issue and confirming all topic sections appear in creation order, including ones with no case contacts.
