### PR TITLE
Show email confirmation status on user profile page (#6626)

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -56,4 +56,8 @@ class UserDecorator < Draper::Decorator
 
     object.date_of_birth.to_date.to_fs(:slashes)
   end
+
+  def email_confirmation_status
+    object.confirmed? ? "Confirmed" : "Not confirmed"
+  end
 end

--- a/app/views/users/_edit_profile.erb
+++ b/app/views/users/_edit_profile.erb
@@ -11,6 +11,16 @@
   <%= resource&.email %>
 </div>
 <div class="mb-1">
+  <strong class="text-dark">Email confirmation status </strong>
+  <%= resource&.decorate&.email_confirmation_status %>
+</div>
+<% if resource&.unconfirmed_email.present? %>
+  <div class="mb-1">
+    <strong class="text-dark">Pending email confirmation </strong>
+    <%= resource.unconfirmed_email %>
+  </div>
+<% end %>
+<div class="mb-1">
   <strong class="text-dark">Invitation email sent </strong>
   <%= resource&.decorate(context: {format: :edit_profile})&.formatted_invitation_sent_at || "never" %>
 </div>

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -151,4 +151,20 @@ RSpec.describe UserDecorator do
       expect(decorated_user.formatted_date_of_birth).to eq "1991/07/08"
     end
   end
+
+  describe "#email_confirmation_status" do
+    context "when the user's email is confirmed" do
+      it "returns Confirmed" do
+        user.update!(confirmed_at: Time.current)
+        expect(decorated_user.email_confirmation_status).to eq "Confirmed"
+      end
+    end
+
+    context "when the user's email is not confirmed" do
+      it "returns Not confirmed" do
+        user.update_column(:confirmed_at, nil)
+        expect(decorated_user.email_confirmation_status).to eq "Not confirmed"
+      end
+    end
+  end
 end

--- a/spec/system/users/edit_spec.rb
+++ b/spec/system/users/edit_spec.rb
@@ -213,6 +213,27 @@ RSpec.describe "users/edit", type: :system do
       uncheck "user_receive_sms_notifications"
       expect(page).to have_field("toggle-sms-notification-event", type: "checkbox", disabled: true)
     end
+
+    it "displays the email confirmation status" do
+      volunteer = create(:volunteer)
+
+      sign_in volunteer
+      visit edit_users_path
+
+      expect(page).to have_text("Email confirmation status")
+      expect(page).to have_text("Confirmed")
+    end
+
+    it "displays a pending email change awaiting confirmation" do
+      volunteer = create(:volunteer)
+      volunteer.update(email: "new-email@example.com")
+
+      sign_in volunteer
+      visit edit_users_path
+
+      expect(page).to have_text("Pending email confirmation")
+      expect(page).to have_text("new-email@example.com")
+    end
   end
 
   context "when a user's casa organization does not have twilio enabled" do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses part of #6626 (does not auto-close it — see scope note below).

### What changed, and _why_?

Issue #6626 ("Improved Email Understanding") asks for three things on the user page:
1. Show all old emails for the user
2. Show the un/confirmed status of the current email
3. Send the confirmation email to both the old and new addresses on an email change

This PR delivers **item 2 only**, kept deliberately small and self-contained:

- Adds an **"Email confirmation status"** line ("Confirmed" / "Not confirmed") to the account info on the Edit Profile page.
- Adds a **"Pending email confirmation"** line showing the `unconfirmed_email` whenever an email change is awaiting confirmation (Devise reconfirmable).

The status string lives in `UserDecorator#email_confirmation_status` (presentation logic in the decorator, per the project conventions), and the view renders it in `app/views/users/_edit_profile.erb` right next to the existing Email line. No model, migration, controller, or dependency changes — `:confirmable` is already enabled on `User`.

**Scope note (intentionally left as follow-ups):**
- Item 1 (show *all* old emails) needs email-change history/versioning, which is a much larger change.
- Item 3 (dual-send the confirmation email) is the security trade-off the issue itself flags with a "?", so it needs a maintainer/product decision rather than an implementation choice.

I'm happy to open follow-up PRs for either once there's direction.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

- `spec/decorators/user_decorator_spec.rb` — unit specs for `#email_confirmation_status` covering the confirmed and not-confirmed cases.
- `spec/system/users/edit_spec.rb` — system specs verifying the Edit Profile page shows the confirmation status, and shows the pending email when a reconfirmation is in progress.

Commands run locally:
- `bundle exec rspec spec/decorators/user_decorator_spec.rb spec/system/users/edit_spec.rb` → **56 examples, 0 failures**
- `bundle exec standardrb app/decorators/user_decorator.rb spec/decorators/user_decorator_spec.rb spec/system/users/edit_spec.rb` → **clean**
- `bundle exec erb_lint app/views/users/_edit_profile.erb` → **No errors were found in ERB files**

The system specs fail without the view change and pass with it.

### Screenshots please :)

Edit Profile page (`/users/edit`) with the new lines, while an email change is pending confirmation:

> **CASA organization** CASA Org 1
> **Added to system** June 17, 2026 …
> **Email** email1@example.com
> **Email confirmation status** Confirmed
> **Pending email confirmation** new-email@example.com
> **Invitation email sent** never
> …

(Will attach the rendered screenshot in a comment.)
