### PR TITLE
🔒 Harden GitHub Actions: pin actions to SHAs and disable persisted checkout credentials

### DIFF
--- a/.github/workflows/add-labels-based-on-column.yml
+++ b/.github/workflows/add-labels-based-on-column.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add help wanted labels
     steps:
       - name: Add help wanted labels
-        uses: rubyforgood/add-label-to-cards@v3.3
+        uses: rubyforgood/add-label-to-cards@62e1346cb6a1837c82e1c2919562d54dd2893ddf # v3.3
         id: add-help-wanted-labels
         with:
           columns_labels: >

--- a/.github/workflows/after-deploy.yml
+++ b/.github/workflows/after-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     name: On Deploy
     steps:
       - name: After Deploy
-        uses: Firelemons/on-deploy@v2.2.1
+        uses: Firelemons/on-deploy@852d81d797e1e230da7617a3e3784971fda7a047 # v2.2.1
         with:
           project_name: "CASA Volunteer Portal"
           done_column_card_limit: "16"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,11 +42,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.36.0
+        uses: github/codeql-action/init@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +59,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4.36.0
+        uses: github/codeql-action/autobuild@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -71,4 +73,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.36.0
+        uses: github/codeql-action/analyze@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0

--- a/.github/workflows/combine_and_report.yml
+++ b/.github/workflows/combine_and_report.yml
@@ -10,10 +10,12 @@ jobs:
     steps:
       - name: Checkout Project
         if: ${{ !cancelled() }}
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download artifacts
         if: ${{ !cancelled() }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -39,13 +41,13 @@ jobs:
 
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2
         with:
           paths: |
             test_reports/**/rspec*.xml
       - name: Set job status
         if: ${{ steps.test_summary.outputs.failed > 0 }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             core.setFailed('There are test failures')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,9 @@ jobs:
       TEST_MAX_DURATION: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Create downloads folder
         run: |
           mkdir -p tmp/downloads
@@ -43,7 +45,7 @@ jobs:
 
       - name: Archive selenium screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium-screenshots
           path: |

--- a/.github/workflows/erb_lint.yml
+++ b/.github/workflows/erb_lint.yml
@@ -22,10 +22,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 

--- a/.github/workflows/factory_bot_lint.yml
+++ b/.github/workflows/factory_bot_lint.yml
@@ -36,10 +36,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 

--- a/.github/workflows/issue-auto-close-done.yml
+++ b/.github/workflows/issue-auto-close-done.yml
@@ -8,7 +8,7 @@ jobs:
   set-state:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/issue-states@v3
+      - uses: dessant/issue-states@a1bd84606ef48dca24ce24140e068516a74b3e0b # v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           open-issue-columns: ''

--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -10,7 +10,7 @@ jobs:
     name: Unassign issues
     steps:
       - name: Unassign issues
-        uses: rubyforgood/unassign-issues@v1.3
+        uses: rubyforgood/unassign-issues@f3d8461c2a3ea67cc4a015ca50737a4f865460d7 # v1.3
         id: unassign_issues
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -23,7 +23,7 @@ jobs:
       - name: Print the warned issues
         run: echo "Warned issues = ${{steps.unassign_issues.outputs.warned_issues}}"
       - name: Move unassigned issues from In Progress to To Do
-        uses: bjthompson805/move-issues@v1
+        uses: bjthompson805/move-issues@ced196f41b6124cc51ea64bdd43587527a457624 # v1
         id: move_issues
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,6 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/npm_lint_and_test.yml
+++ b/.github/workflows/npm_lint_and_test.yml
@@ -27,9 +27,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/rake-after_party.yml
+++ b/.github/workflows/rake-after_party.yml
@@ -36,10 +36,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 

--- a/.github/workflows/remove-helped-wanted.yml
+++ b/.github/workflows/remove-helped-wanted.yml
@@ -8,6 +8,6 @@ jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@1.0.4
+      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         with:
           remove-labels: "Help Wanted"

--- a/.github/workflows/remove-label-based-on-column.yml
+++ b/.github/workflows/remove-label-based-on-column.yml
@@ -10,7 +10,7 @@ jobs:
     name: Remove help wanted labels based on column
     steps:
       - name: Remove help wanted labels based on column
-        uses: rubyforgood/remove-label-from-cards@2.0
+        uses: rubyforgood/remove-label-from-cards@186f170a25e437b6b172a4f274d2492dd14bfb4e # 2.0
         id: remove-help-wanted-labels
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -37,15 +37,17 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 
       - name: Set up JS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: '.nvmrc'
           cache: "npm"
@@ -79,14 +81,14 @@ jobs:
         run: |
           RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rspec
 
-      - uses: qltysh/qlty-action/coverage@v2.2.0
+      - uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: coverage/.resultset.json
 
       - name: Archive selenium screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: selenium-screenshots
           path: |

--- a/.github/workflows/ruby_lint.yml
+++ b/.github/workflows/ruby_lint.yml
@@ -24,10 +24,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,10 +24,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
 

--- a/.github/workflows/spec_checker.yml
+++ b/.github/workflows/spec_checker.yml
@@ -22,9 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
         with:
           bundler-cache: true
       - name: rake test_checker

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "This issue has been open without changes for a long time! What's up?"

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -8,6 +8,6 @@ jobs:
     name: TOC Generator
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/toc-generator@v4
+      - uses: technote-space/toc-generator@ce21845a0177fd1288cada589dd4efd2e46a27ca # v4
         with:
           CREATE_PR: true

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@ae1abb2821b567e96742aa776f7b62c9b6a26bc8 # v3


### PR DESCRIPTION
### What changed, and why?

Hardens the workflow supply chain across `.github/workflows/` by:

- **Pinning every third-party action to an immutable commit SHA** (with a trailing version comment for readability), so a compromised or retagged action release can't silently run in CI.
- **Setting `persist-credentials: false` on all `actions/checkout` steps**, so later run steps and third-party actions in the same job don't inherit the repo token.

This follows the GitHub-recommended supply-chain hardening guidance (pin actions by full-length commit SHA) and applies it repo-wide.

Pinned SHAs:
- `actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0` (# v6.0.3)
- `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (# v6)
- `actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (# v8)
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (# v7)
- `actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553` (# v9)
- `actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9` (# v5)
- `actions/stale@5bef64f19d7facfb25b37b414482c7164d639639` (# v9)
- `github/codeql-action@f52b05f4acaaa234e44466e66d29050e135ea9ef` (# v4.36.0) — init/autobuild/analyze
- `ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74` (# v1)
- `qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899` (# v2.2.0)
- `test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5` (# v2)
- `ibiqlik/action-yamllint@ae1abb2821b567e96742aa776f7b62c9b6a26bc8` (# v3)
- `technote-space/toc-generator@ce21845a0177fd1288cada589dd4efd2e46a27ca` (# v4)
- `dessant/issue-states@a1bd84606ef48dca24ce24140e068516a74b3e0b` (# v3)
- `andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90` (# 1.0.4)
- `Firelemons/on-deploy@852d81d797e1e230da7617a3e3784971fda7a047` (# v2.2.1)
- `bjthompson805/move-issues@ced196f41b6124cc51ea64bdd43587527a457624` (# v1)
- `rubyforgood/add-label-to-cards@62e1346cb6a1837c82e1c2919562d54dd2893ddf` (# v3.3)
- `rubyforgood/remove-label-from-cards@186f170a25e437b6b172a4f274d2492dd14bfb4e` (# 2.0)
- `rubyforgood/unassign-issues@f3d8461c2a3ea67cc4a015ca50737a4f865460d7` (# v1.3)

### How is this tested?

Validated that all `.github/workflows/*.yml` files still parse as valid YAML and that every `uses:` reference is pinned to a 40-char commit SHA. No runtime behavior change is expected beyond the hardening described above — each SHA corresponds to the exact tag already in use.

### What are the risks / what can go wrong?

Low risk. These jobs only need the checked-out files and do not rely on a persisted checkout token for subsequent steps. Pins point to the same released versions previously referenced by tag.

### Screenshots please for UI-changing code 🎨

N/A — workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)