### PR TITLE
5563 - Replace validator spec stubs with real tests

### DIFF
--- a/spec/validators/casa_org_validator_spec.rb
+++ b/spec/validators/casa_org_validator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CasaOrgValidator, type: :validator do
 
       described_class.new.validate(casa_org)
 
-      expect(casa_org.errors.added?(:number, "must be 10 digits or 12 digits including country code (+1)")).to be true
+      expect(casa_org.errors[:number]).to include("must be 10 digits or 12 digits including country code (+1)")
     end
 
     it "adds an error on :number when the twilio phone number contains non-digit characters" do
@@ -20,7 +20,7 @@ RSpec.describe CasaOrgValidator, type: :validator do
 
       described_class.new.validate(casa_org)
 
-      expect(casa_org.errors.added?(:number, "must be 10 digits or 12 digits including country code (+1)")).to be true
+      expect(casa_org.errors[:number]).to include("must be 10 digits or 12 digits including country code (+1)")
     end
 
     it "does not add an error for a valid 12 digit twilio phone number" do

--- a/spec/validators/casa_org_validator_spec.rb
+++ b/spec/validators/casa_org_validator_spec.rb
@@ -1,7 +1,42 @@
 require "rails_helper"
 
 RSpec.describe CasaOrgValidator, type: :validator do
-  # TODO: Add tests for CasaOrgValidator
+  describe "twilio phone number" do
+    # NOTE: the validator adds this error to :number, which is not a real
+    # CasaOrg attribute (the column is :twilio_phone_number) - see
+    # app/validators/casa_org_validator.rb. This looks like a bug, but these
+    # specs characterize the validator's actual current behavior rather than
+    # the presumably intended one.
+    it "adds an error on :number when the twilio phone number is not 10 or 12 digits" do
+      casa_org = build(:casa_org, twilio_phone_number: "12345")
 
-  pending "add some tests for CasaOrgValidator"
+      described_class.new.validate(casa_org)
+
+      expect(casa_org.errors.added?(:number, "must be 10 digits or 12 digits including country code (+1)")).to be true
+    end
+
+    it "adds an error on :number when the twilio phone number contains non-digit characters" do
+      casa_org = build(:casa_org, twilio_phone_number: "+1416eee4325")
+
+      described_class.new.validate(casa_org)
+
+      expect(casa_org.errors.added?(:number, "must be 10 digits or 12 digits including country code (+1)")).to be true
+    end
+
+    it "does not add an error for a valid 12 digit twilio phone number" do
+      casa_org = build(:casa_org, twilio_phone_number: "+15555555555")
+
+      described_class.new.validate(casa_org)
+
+      expect(casa_org.errors[:number]).to be_empty
+    end
+
+    it "does not add an error when the twilio phone number is blank" do
+      casa_org = build(:casa_org, twilio_phone_number: "")
+
+      described_class.new.validate(casa_org)
+
+      expect(casa_org.errors[:number]).to be_empty
+    end
+  end
 end

--- a/spec/validators/court_report_validator_spec.rb
+++ b/spec/validators/court_report_validator_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CourtReportValidator, type: :validator do
   let(:casa_case) { build(:casa_case) }
 
-  # CasaCase#court_report_status= is a custom setter that auto-manages
+  # NOTE: CasaCase#court_report_status= is a custom setter that auto-manages
   # court_report_submitted_at (nils it out for :not_submitted, defaults it
   # to Time.current otherwise - see app/models/casa_case.rb). Assigning
   # court_report_status keeps this order intentional: it must come first,
@@ -39,7 +39,7 @@ RSpec.describe CourtReportValidator, type: :validator do
 
   describe "matching status and submission date" do
     context "when status is not_submitted and submitted_at is nil" do
-      it "adds no error" do
+      it "adds no error", :aggregate_failures do
         casa_case.court_report_status = :not_submitted
         casa_case.court_report_submitted_at = nil
 
@@ -51,7 +51,7 @@ RSpec.describe CourtReportValidator, type: :validator do
     end
 
     context "when status is submitted and submitted_at is present" do
-      it "adds no error" do
+      it "adds no error", :aggregate_failures do
         casa_case.court_report_status = :submitted
         casa_case.court_report_submitted_at = DateTime.now
 

--- a/spec/validators/court_report_validator_spec.rb
+++ b/spec/validators/court_report_validator_spec.rb
@@ -1,7 +1,65 @@
 require "rails_helper"
 
 RSpec.describe CourtReportValidator, type: :validator do
-  # TODO: Add tests for CourtReportValidator
+  let(:casa_case) { build(:casa_case) }
 
-  pending "add some tests for CourtReportValidator"
+  # CasaCase#court_report_status= is a custom setter that auto-manages
+  # court_report_submitted_at (nils it out for :not_submitted, defaults it
+  # to Time.current otherwise - see app/models/casa_case.rb). Assigning
+  # court_report_status keeps this order intentional: it must come first,
+  # with court_report_submitted_at assigned after to land on the exact
+  # combination each example below is testing.
+  describe "mismatched status and submission date" do
+    context "when submitted_at is nil and status is not not_submitted" do
+      it "adds a status error" do
+        casa_case.court_report_status = :in_review
+        casa_case.court_report_submitted_at = nil
+
+        described_class.new.validate(casa_case)
+
+        expect(casa_case.errors[:court_report_status]).to include(
+          "Court report submission date can't be nil if status is anything but not_submitted."
+        )
+      end
+    end
+
+    context "when submitted_at is present and status is not_submitted" do
+      it "adds a submitted_at error" do
+        casa_case.court_report_status = :not_submitted
+        casa_case.court_report_submitted_at = DateTime.now
+
+        described_class.new.validate(casa_case)
+
+        expect(casa_case.errors[:court_report_submitted_at]).to include(
+          "Submission date must be nil if court report status is not submitted."
+        )
+      end
+    end
+  end
+
+  describe "matching status and submission date" do
+    context "when status is not_submitted and submitted_at is nil" do
+      it "adds no error" do
+        casa_case.court_report_status = :not_submitted
+        casa_case.court_report_submitted_at = nil
+
+        described_class.new.validate(casa_case)
+
+        expect(casa_case.errors[:court_report_status]).to be_empty
+        expect(casa_case.errors[:court_report_submitted_at]).to be_empty
+      end
+    end
+
+    context "when status is submitted and submitted_at is present" do
+      it "adds no error" do
+        casa_case.court_report_status = :submitted
+        casa_case.court_report_submitted_at = DateTime.now
+
+        described_class.new.validate(casa_case)
+
+        expect(casa_case.errors[:court_report_status]).to be_empty
+        expect(casa_case.errors[:court_report_submitted_at]).to be_empty
+      end
+    end
+  end
 end

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -1,7 +1,87 @@
 require "rails_helper"
 
 RSpec.describe UrlValidator, type: :validator do
-  # TODO: Add tests for UrlValidator
+  let(:validatable_class) do
+    Class.new do
+      include ActiveModel::Model
 
-  pending "add some tests for UrlValidator"
+      attr_accessor :website
+
+      validates :website, url: true
+    end
+  end
+
+  subject(:record) { validatable_class.new(website: url) }
+
+  context "with a valid http url" do
+    let(:url) { "http://example.com" }
+
+    it "is valid" do
+      expect(record).to be_valid
+    end
+  end
+
+  context "with a valid https url" do
+    let(:url) { "https://example.com" }
+
+    it "is valid" do
+      expect(record).to be_valid
+    end
+  end
+
+  context "with a scheme that is not http or https" do
+    let(:url) { "ftp://example.com" }
+
+    it "is invalid with a scheme error", :aggregate_failures do
+      expect(record).not_to be_valid
+      expect(record.errors[:website]).to include("scheme invalid - only http, https allowed")
+    end
+  end
+
+  context "with a missing host" do
+    let(:url) { "http://" }
+
+    it "is invalid with a missing host error", :aggregate_failures do
+      expect(record).not_to be_valid
+      expect(record.errors[:website]).to include("host cannot be blank")
+    end
+  end
+
+  context "with a malformed URI" do
+    let(:url) { "http://exa mple.com" }
+
+    it "is invalid with a format error", :aggregate_failures do
+      expect(record).not_to be_valid
+      expect(record.errors[:website]).to include("format is invalid")
+    end
+  end
+
+  context "with a custom :scheme option" do
+    let(:validatable_class) do
+      Class.new do
+        include ActiveModel::Model
+
+        attr_accessor :website
+
+        validates :website, url: {scheme: "ftp"}
+      end
+    end
+
+    context "when the url uses the allowed custom scheme" do
+      let(:url) { "ftp://example.com" }
+
+      it "is valid" do
+        expect(record).to be_valid
+      end
+    end
+
+    context "when the url uses the default http scheme" do
+      let(:url) { "http://example.com" }
+
+      it "is invalid with a scheme error mentioning the custom scheme", :aggregate_failures do
+        expect(record).not_to be_valid
+        expect(record.errors[:website]).to include("scheme invalid - only ftp allowed")
+      end
+    end
+  end
 end

--- a/spec/validators/user_validator_spec.rb
+++ b/spec/validators/user_validator_spec.rb
@@ -1,7 +1,157 @@
 require "rails_helper"
 
 RSpec.describe UserValidator, type: :validator do
-  # TODO: Add tests for UserValidator
+  # NOTE: several messages asserted below (display name, communication
+  # preferences, date of birth) have a leading space baked into the
+  # validator's error strings. That's not a typo in this spec - it's
+  # existing UserValidator behavior, already characterized in
+  # spec/models/user_spec.rb.
+  describe "phone number" do
+    it "adds an error when the phone number is not 10 or 12 digits" do
+      user = build(:user, phone_number: "12345")
 
-  pending "add some tests for UserValidator"
+      described_class.new.validate(user)
+
+      expect(user.errors[:phone_number]).to include("must be 10 digits or 12 digits including country code (+1)")
+    end
+
+    it "does not add a phone number error for a valid 10 digit number" do
+      user = build(:user, phone_number: "4165551234")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:phone_number]).to be_empty
+    end
+
+    it "does not add a phone number error when blank" do
+      user = build(:user, phone_number: "")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:phone_number]).to be_empty
+    end
+  end
+
+  describe "display name" do
+    it "adds an error when display_name is blank" do
+      user = build(:user, display_name: "")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:display_name]).to include(" can't be blank")
+    end
+
+    it "does not add an error when display_name is present" do
+      user = build(:user, display_name: "Jane Doe")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:display_name]).to be_empty
+    end
+  end
+
+  describe "communication preferences" do
+    it "adds a base error when neither email nor sms notifications are selected" do
+      user = build(:user, receive_email_notifications: false, receive_sms_notifications: false)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to include(" At least one communication preference must be selected.")
+    end
+
+    it "does not add an error when email notifications are selected" do
+      user = build(:user, receive_email_notifications: true, receive_sms_notifications: false)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+
+    it "does not add an error when sms notifications are selected and a phone number is present" do
+      user = build(:user, receive_email_notifications: false, receive_sms_notifications: true, phone_number: "4165551234")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+  end
+
+  describe "phone number required for sms notifications" do
+    it "adds a base error when sms notifications are on but phone number is blank" do
+      user = build(:user, receive_sms_notifications: true, phone_number: "")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to include(" Must add a valid phone number to receive SMS notifications.")
+    end
+
+    it "does not add that error when sms notifications are off" do
+      user = build(:user, receive_sms_notifications: false, phone_number: "")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).not_to include(" Must add a valid phone number to receive SMS notifications.")
+    end
+  end
+
+  describe "date of birth" do
+    it "adds a base error when date_of_birth is in the future" do
+      user = build(:user, date_of_birth: 10.days.from_now)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to include(" Date of birth must be in the past.")
+    end
+
+    it "adds a base error when date_of_birth is before 1920-01-01" do
+      user = build(:user, date_of_birth: "1919-12-31".to_date)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to include(" Date of birth must be on or after 1/1/1920.")
+    end
+
+    it "does not add an error for a valid past date of birth" do
+      user = build(:user, date_of_birth: 30.years.ago)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+
+    it "does not validate date_of_birth when it is blank" do
+      user = build(:user, date_of_birth: nil)
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+  end
+
+  describe "email uniqueness" do
+    it "adds a base error when another user already has the same email" do
+      create(:user, email: "duplicate@example.com")
+      user = build(:user, email: "duplicate@example.com")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to include(I18n.t("activerecord.errors.messages.email_uniqueness"))
+    end
+
+    it "does not add an error when the email is unique" do
+      user = build(:user, email: "unique@example.com")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+
+    it "does not add an error when validating the existing record against itself" do
+      user = create(:user, email: "self@example.com")
+
+      described_class.new.validate(user)
+
+      expect(user.errors[:base]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #5563 — intentionally not `Resolves`, since the umbrella has more stubs remaining.

### What changed, and _why_?
Replaces the four `pending "add some tests for X"` stubs in `spec/validators/` with real specs (one commit per file):

- **UrlValidator** — valid http/https, disallowed scheme, missing host, malformed URI, and the custom `scheme:` option (allowed + rejected)
- **UserValidator** — phone number, display name, communication preferences, SMS-requires-phone, date of birth, and email uniqueness branches
- **CasaOrgValidator** — twilio phone number length / format / valid / blank branches
- **CourtReportValidator** — both mismatch error branches plus both valid status/submitted_at combinations

The specs characterize current behavior. Two oddities are signposted with NOTE comments rather than silently ratified: `CasaOrgValidator` adds its error to `:number`, which isn't a real `CasaOrg` attribute (the column is `twilio_phone_number`), and `UserValidator`'s error strings have a leading space baked in (already characterized in `spec/models/user_spec.rb`).

### How is this **tested**? (please write rspec and jest tests!) 💖💪
- `bundle exec rspec spec/validators/` → 32 examples, 0 failures, 0 pending
- `bundle exec standardrb spec/validators/` → no offenses
- no `pending` / `skip` / `xit` remains in the four files

### Screenshots please :)
N/A — test-only change, no UI.

---
**Follow-up candidates** (happy to open separate issues if maintainers agree these are bugs):
- `CasaOrgValidator` error key `:number` → should likely be `:twilio_phone_number`
- `CourtReportValidator` is wired up with a `fields:` option it never reads
- `UserValidator` error message strings have a leading space