### PR TITLE
5563 - Replace policy spec stubs with real tests

### DIFF
--- a/spec/policies/fund_request_policy_spec.rb
+++ b/spec/policies/fund_request_policy_spec.rb
@@ -1,7 +1,30 @@
 require "rails_helper"
 
 RSpec.describe FundRequestPolicy, type: :policy do
-  # TODO: Add tests for FundRequestPolicy
+  subject { described_class }
 
-  pending "add some tests for FundRequestPolicy"
+  let(:casa_admin) { build_stubbed(:casa_admin) }
+  let(:supervisor) { build_stubbed(:supervisor) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+
+  # NOTE: this policy is intentionally open - new?/create? are unconditionally
+  # true, so there is no denied role. Access is constrained upstream by the
+  # controller (FundRequestsController#verify_casa_case).
+  permissions :new?, :create? do
+    it "permits casa_admins" do
+      expect(subject).to permit(casa_admin)
+    end
+
+    it "permits supervisors" do
+      expect(subject).to permit(supervisor)
+    end
+
+    it "permits volunteers" do
+      expect(subject).to permit(volunteer)
+    end
+
+    it "permits a nil user" do
+      expect(subject).to permit(nil)
+    end
+  end
 end

--- a/spec/policies/learning_hour_topic_policy_spec.rb
+++ b/spec/policies/learning_hour_topic_policy_spec.rb
@@ -1,7 +1,23 @@
 require "rails_helper"
 
 RSpec.describe LearningHourTopicPolicy, type: :policy do
-  # TODO: Add tests for LearningHourTopicPolicy
+  subject { described_class }
 
-  pending "add some tests for LearningHourTopicPolicy"
+  let(:casa_admin) { build_stubbed(:casa_admin) }
+  let(:supervisor) { build_stubbed(:supervisor) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+
+  permissions :new?, :create?, :edit?, :update? do
+    it "permits casa_admins" do
+      expect(subject).to permit(casa_admin)
+    end
+
+    it "does not permit supervisors" do
+      expect(subject).not_to permit(supervisor)
+    end
+
+    it "does not permit volunteers" do
+      expect(subject).not_to permit(volunteer)
+    end
+  end
 end

--- a/spec/policies/learning_hour_type_policy_spec.rb
+++ b/spec/policies/learning_hour_type_policy_spec.rb
@@ -1,7 +1,23 @@
 require "rails_helper"
 
 RSpec.describe LearningHourTypePolicy, type: :policy do
-  # TODO: Add tests for LearningHourTypePolicy
+  subject { described_class }
 
-  pending "add some tests for LearningHourTypePolicy"
+  let(:casa_admin) { build_stubbed(:casa_admin) }
+  let(:supervisor) { build_stubbed(:supervisor) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+
+  permissions :new?, :create?, :edit?, :update? do
+    it "permits casa_admins" do
+      expect(subject).to permit(casa_admin)
+    end
+
+    it "does not permit supervisors" do
+      expect(subject).not_to permit(supervisor)
+    end
+
+    it "does not permit volunteers" do
+      expect(subject).not_to permit(volunteer)
+    end
+  end
 end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -1,7 +1,23 @@
 require "rails_helper"
 
 RSpec.describe NotePolicy, type: :policy do
-  # TODO: Add tests for NotePolicy
+  subject { described_class }
 
-  pending "add some tests for NotePolicy"
+  let(:casa_admin) { build_stubbed(:casa_admin) }
+  let(:supervisor) { build_stubbed(:supervisor) }
+  let(:volunteer) { build_stubbed(:volunteer) }
+
+  permissions :create?, :edit?, :update?, :destroy? do
+    it "permits casa_admins" do
+      expect(subject).to permit(casa_admin)
+    end
+
+    it "permits supervisors" do
+      expect(subject).to permit(supervisor)
+    end
+
+    it "does not permit volunteers" do
+      expect(subject).not_to permit(volunteer)
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #5563 — intentionally not `Resolves`, since the umbrella has more stubs remaining.

### What changed, and _why_?
Replaces the four `pending "add some tests for X"` stubs in `spec/policies/` with real specs (one commit per file), using the pundit-matchers `permissions` DSL and `build_stubbed`, following the patterns in `checklist_item_policy_spec.rb` and `custom_org_link_policy_spec.rb`:

- **NotePolicy** — `create?` / `edit?` / `update?` / `destroy?` (all delegate to `admin_or_supervisor?`): casa_admin and supervisor permitted, volunteer denied
- **FundRequestPolicy** — `new?` / `create?` are intentionally unconditional; the spec pins that all roles (and even a nil user) are permitted, with a NOTE explaining access is constrained upstream by `FundRequestsController#verify_casa_case`
- **LearningHourTopicPolicy / LearningHourTypePolicy** — empty policy classes; specs characterize the inherited admin-only contract (`new?` / `create?` / `edit?` / `update?`) their controllers rely on: casa_admin permitted, supervisor and volunteer denied

Coverage matches each controller's authorized actions exactly. None of these policies define a `Scope` or `permitted_attributes`, so no org-scoping specs apply.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
- `bundle exec rspec spec/policies/note_policy_spec.rb spec/policies/fund_request_policy_spec.rb spec/policies/learning_hour_topic_policy_spec.rb spec/policies/learning_hour_type_policy_spec.rb` → 13 examples, 0 failures, 0 pending
- `bundle exec standardrb spec/policies/` → no offenses
- No `pending` / `skip` / `xit` remains in the four files

### Screenshots please :)
N/A — test-only change, no UI.