### PR TITLE
Adding reimbursement status badge

### DIFF
--- a/app/decorators/case_contact_decorator.rb
+++ b/app/decorators/case_contact_decorator.rb
@@ -23,8 +23,16 @@ class CaseContactDecorator < Draper::Decorator
     object.miles_driven.zero? ? nil : "#{object.miles_driven} miles driven"
   end
 
-  def reimbursement
-    object.want_driving_reimbursement ? "Reimbursement" : nil
+  # Text for the reimbursement status badge shown on the case contact card so
+  # volunteers can see at a glance whether their reimbursement is still pending
+  # or has been completed, without having to ask their supervisor.
+  def reimbursement_status_text
+    object.reimbursement_complete? ? "Reimbursement Complete" : "Reimbursement Pending"
+  end
+
+  # Bootstrap badge color for the reimbursement status.
+  def reimbursement_status_badge_type
+    object.reimbursement_complete? ? :success : :warning
   end
 
   def contact_made
@@ -40,8 +48,7 @@ class CaseContactDecorator < Draper::Decorator
       I18n.l(object.occurred_at, format: :full, default: nil),
       duration_minutes,
       contact_made,
-      miles_traveled,
-      reimbursement
+      miles_traveled
     ].compact.join(" | ")
   end
 

--- a/app/views/case_contacts/_case_contact.html.erb
+++ b/app/views/case_contacts/_case_contact.html.erb
@@ -13,6 +13,17 @@
               <% if !contact.active? %>
                 <span class="badge badge-pill light-bg text-black">Draft</span>
               <% end %>
+              <% if contact.want_driving_reimbursement? %>
+                <% decorated_contact = contact.decorate %>
+                <span class="ms-auto">
+                  <%= render BadgeComponent.new(
+                    text: decorated_contact.reimbursement_status_text,
+                    type: decorated_contact.reimbursement_status_badge_type,
+                    rounded: true,
+                    margin: false
+                  ) %>
+                </span>
+              <% end %>
               <%= link_to("undelete", restore_case_contact_path(contact.id), method: :post, data: { turbo: false },
                           class: "btn btn-info") if policy(contact).restore? && contact.deleted? %>
             </h5>

--- a/spec/decorators/case_contact_decorator_spec.rb
+++ b/spec/decorators/case_contact_decorator_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe CaseContactDecorator do
         case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | 1 hour 39 minutes | No Contact Made | 100 miles driven | Reimbursement"
+          "December 1, 2020 | 1 hour 39 minutes | No Contact Made | 100 miles driven"
         )
       end
     end
@@ -166,8 +166,44 @@ RSpec.describe CaseContactDecorator do
         case_contact.contact_types = [contact_type]
 
         expect(case_contact.decorate.subheading).to eq(
-          "December 1, 2020 | 1 hour 39 minutes | 100 miles driven | Reimbursement"
+          "December 1, 2020 | 1 hour 39 minutes | 100 miles driven"
         )
+      end
+    end
+  end
+
+  describe "#reimbursement_status_text" do
+    context "when the reimbursement has not been completed" do
+      let(:case_contact) { build(:case_contact, reimbursement_complete: false) }
+
+      it "returns pending text" do
+        expect(case_contact.decorate.reimbursement_status_text).to eq("Reimbursement Pending")
+      end
+    end
+
+    context "when the reimbursement has been completed" do
+      let(:case_contact) { build(:case_contact, reimbursement_complete: true) }
+
+      it "returns complete text" do
+        expect(case_contact.decorate.reimbursement_status_text).to eq("Reimbursement Complete")
+      end
+    end
+  end
+
+  describe "#reimbursement_status_badge_type" do
+    context "when the reimbursement has not been completed" do
+      let(:case_contact) { build(:case_contact, reimbursement_complete: false) }
+
+      it "returns the warning badge type" do
+        expect(case_contact.decorate.reimbursement_status_badge_type).to eq(:warning)
+      end
+    end
+
+    context "when the reimbursement has been completed" do
+      let(:case_contact) { build(:case_contact, reimbursement_complete: true) }
+
+      it "returns the success badge type" do
+        expect(case_contact.decorate.reimbursement_status_badge_type).to eq(:success)
       end
     end
   end

--- a/spec/system/case_contacts/index_spec.rb
+++ b/spec/system/case_contacts/index_spec.rb
@@ -61,6 +61,44 @@ RSpec.describe "case_contacts/index", type: :system do
       end
     end
 
+    describe "reimbursement status" do
+      it "shows a pending badge when the reimbursement has not been completed" do
+        create(:case_contact, :wants_reimbursement, creator: volunteer, casa_case: casa_case,
+          occurred_at: 2.days.ago, reimbursement_complete: false)
+
+        subject
+
+        within(".full-card", match: :first) do
+          expect(page).to have_text("Reimbursement Pending")
+          expect(page).to have_no_text("Reimbursement Complete")
+        end
+      end
+
+      it "shows a complete badge when the reimbursement has been completed" do
+        create(:case_contact, :wants_reimbursement, creator: volunteer, casa_case: casa_case,
+          occurred_at: 2.days.ago, reimbursement_complete: true)
+
+        subject
+
+        within(".full-card", match: :first) do
+          expect(page).to have_text("Reimbursement Complete")
+          expect(page).to have_no_text("Reimbursement Pending")
+        end
+      end
+
+      it "shows no reimbursement badge when reimbursement was not requested" do
+        create(:case_contact, creator: volunteer, casa_case: casa_case, occurred_at: 2.days.ago,
+          want_driving_reimbursement: false)
+
+        subject
+
+        within(".full-card", match: :first) do
+          expect(page).to have_no_text("Reimbursement Pending")
+          expect(page).to have_no_text("Reimbursement Complete")
+        end
+      end
+    end
+
     describe "automated filtering case contacts" do
       describe "by date of contact" do
         it "only shows the contacts with the correct date", :js do


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses #7041 


### What changed, and _why_?
Added a ui feature to let volunteers know the current state of reimbursements to reduce emails to supervisors



### How is this **tested**? (please write rspec and jest tests!) 💖💪
Added new unit tests in spec/system/case_contacts/index_spec.rb and spec/decorators/case_contact_decorator_spec.rb to cover the new added content/feature


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 
<img width="1085" height="425" alt="Screenshot 2026-07-15 at 12 19 30 PM" src="https://github.com/user-attachments/assets/399c5d69-b838-4f99-835f-a99ec177cc45" />
<img width="1141" height="423" alt="Screenshot 2026-07-15 at 12 22 05 PM" src="https://github.com/user-attachments/assets/78eabe45-08b2-46d5-b5aa-056487805776" />

