### PR TITLE
Fix email edit form to update immediately instead of pending confirmation

### DIFF
--- a/app/controllers/all_casa_admins/casa_admins_controller.rb
+++ b/app/controllers/all_casa_admins/casa_admins_controller.rb
@@ -22,11 +22,10 @@ class AllCasaAdmins::CasaAdminsController < AllCasaAdminsController
 
   def update
     @casa_admin = CasaAdmin.find(params[:id])
+    @casa_admin.skip_reconfirmation!
     if @casa_admin.update(all_casa_admin_params)
-      notice = check_unconfirmed_email_notice(@casa_admin)
-
       @casa_admin.filter_old_emails!(@casa_admin.email)
-      redirect_to edit_all_casa_admins_casa_org_casa_admin_path(@casa_org), notice: notice
+      redirect_to edit_all_casa_admins_casa_org_casa_admin_path(@casa_org), notice: "Casa admin was successfully updated."
     else
       render :edit, status: :unprocessable_content
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -174,12 +174,4 @@ class ApplicationController < ActionController::Base
       end
     end
   end
-
-  def check_unconfirmed_email_notice(user)
-    notice = "#{user.role} was successfully updated."
-    if user.saved_changes.include?("unconfirmed_email")
-      notice += " Confirmation Email Sent."
-    end
-    notice
-  end
 end

--- a/app/controllers/casa_admins_controller.rb
+++ b/app/controllers/casa_admins_controller.rb
@@ -16,12 +16,11 @@ class CasaAdminsController < ApplicationController
 
   def update
     authorize @casa_admin
+    @casa_admin.skip_reconfirmation!
     if @casa_admin.update(update_casa_admin_params)
-      notice = check_unconfirmed_email_notice(@casa_admin)
-
       @casa_admin.filter_old_emails!(@casa_admin.email)
       respond_to do |format|
-        format.html { redirect_to edit_casa_admin_path(@casa_admin), notice: notice }
+        format.html { redirect_to edit_casa_admin_path(@casa_admin), notice: "Casa Admin was successfully updated." }
         format.json { render json: @casa_admin, status: :ok }
       end
     else

--- a/app/controllers/supervisors_controller.rb
+++ b/app/controllers/supervisors_controller.rb
@@ -49,11 +49,10 @@ class SupervisorsController < ApplicationController
 
   def update
     authorize @supervisor
+    @supervisor.skip_reconfirmation!
     if @supervisor.update(update_supervisor_params)
-      notice = check_unconfirmed_email_notice(@supervisor)
-
       @supervisor.filter_old_emails!(@supervisor.email)
-      redirect_to edit_supervisor_path(@supervisor), notice: notice
+      redirect_to edit_supervisor_path(@supervisor), notice: "Supervisor was successfully updated."
     else
       render :edit, status: :unprocessable_content
     end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -61,11 +61,10 @@ class VolunteersController < ApplicationController
 
   def update
     authorize @volunteer
+    @volunteer.skip_reconfirmation!
     if @volunteer.update(update_volunteer_params)
-      notice = check_unconfirmed_email_notice(@volunteer)
-
       @volunteer.filter_old_emails!(@volunteer.email)
-      redirect_to edit_volunteer_path(@volunteer), notice: notice
+      redirect_to edit_volunteer_path(@volunteer), notice: "Volunteer was successfully updated."
     else
       render :edit, status: :unprocessable_content
     end

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -67,21 +67,19 @@ RSpec.describe "All-Casa Admin", type: :request do
     context "with valid parameters" do
       let(:params) { {all_casa_admin: {email: "casa_admin@example.com"}} }
 
-      it "allows current user to begin to update other casa admin's email and send a confirmation email" do
+      it "allows current user to update other casa admin's email immediately, without requiring confirmation" do
         subject
         casa_admin.reload
-        expect(casa_admin.unconfirmed_email).to eq("casa_admin@example.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
+        expect(casa_admin.email).to eq("casa_admin@example.com")
+        expect(casa_admin.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
 
       it { is_expected.to redirect_to edit_all_casa_admins_casa_org_casa_admin_path(casa_org, casa_admin) }
 
       it "shows correct flash message" do
         subject
-        expect(flash[:notice]).to eq("Casa Admin was successfully updated. Confirmation Email Sent.")
+        expect(flash[:notice]).to eq("Casa Admin was successfully updated.")
       end
     end
 

--- a/spec/requests/all_casa_admins/casa_admins_spec.rb
+++ b/spec/requests/all_casa_admins/casa_admins_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "All-Casa Admin", type: :request do
 
       it "shows correct flash message" do
         subject
-        expect(flash[:notice]).to eq("Casa Admin was successfully updated.")
+        expect(flash[:notice]).to eq("Casa admin was successfully updated.")
       end
     end
 

--- a/spec/requests/casa_admins_spec.rb
+++ b/spec/requests/casa_admins_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "/casa_admins", type: :request do
         expect(response.request.flash[:notice]).to eq "Casa Admin was successfully updated."
       end
 
-      it "can update a casa admin user's email and send them a confirmation email", :aggregate_failures do
+      it "can update a casa admin user's email immediately, without requiring confirmation", :aggregate_failures do
         casa_admin = create(:casa_admin)
         expected_email = "admin2@casa.com"
 
@@ -102,11 +102,9 @@ RSpec.describe "/casa_admins", type: :request do
         casa_admin.reload
         expect(response).to have_http_status(:redirect)
 
-        expect(casa_admin.unconfirmed_email).to eq("admin2@casa.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
+        expect(casa_admin.email).to eq("admin2@casa.com")
+        expect(casa_admin.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
 
       it "also respond as json", :aggregate_failures do

--- a/spec/requests/supervisors_spec.rb
+++ b/spec/requests/supervisors_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "/supervisors", type: :request do
         expect(supervisor.phone_number).to eq "+14163218092"
       end
 
-      it "updates supervisor email and sends a confirmation email" do
+      it "updates supervisor email immediately, without requiring confirmation" do
         patch supervisor_path(supervisor), params: {
           supervisor: {email: "newemail@gmail.com"}
         }
@@ -156,11 +156,9 @@ RSpec.describe "/supervisors", type: :request do
         supervisor.reload
         expect(response).to have_http_status(:redirect)
 
-        expect(supervisor.unconfirmed_email).to eq("newemail@gmail.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
+        expect(supervisor.email).to eq("newemail@gmail.com")
+        expect(supervisor.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
 
       it "can set the supervisor to be inactive" do
@@ -195,18 +193,16 @@ RSpec.describe "/supervisors", type: :request do
         expect(supervisor).to be_active
       end
 
-      it "supervisor updates their own email and receives a confirmation email" do
+      it "supervisor updates their own email immediately, without requiring confirmation" do
         patch supervisor_path(supervisor), params: {
           supervisor: {email: "newemail@gmail.com"}
         }
 
         supervisor.reload
         expect(response).to have_http_status(:redirect)
-        expect(supervisor.unconfirmed_email).to eq("newemail@gmail.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
+        expect(supervisor.email).to eq("newemail@gmail.com")
+        expect(supervisor.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
 
       it "cannot change its own type" do

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -239,18 +239,16 @@ RSpec.describe "/volunteers", type: :request do
         expect(volunteer.phone_number).to eq "15463457898"
       end
 
-      it "sends the volunteer a confirmation email upon email change" do
+      it "updates the volunteer's email immediately, without requiring confirmation" do
         patch volunteer_path(volunteer), params: {
           volunteer: {email: "newemail@gmail.com"}
         }
         expect(response).to have_http_status(:redirect)
 
         volunteer.reload
-        expect(volunteer.unconfirmed_email).to eq("newemail@gmail.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
+        expect(volunteer.email).to eq("newemail@gmail.com")
+        expect(volunteer.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
 

--- a/spec/system/casa_admins/edit_spec.rb
+++ b/spec/system/casa_admins/edit_spec.rb
@@ -38,24 +38,14 @@ RSpec.describe "casa_admins/edit", type: :system do
       admin.reload
     end
 
-    it "sends a confirmation email upon submission and does not change the user's displayed email" do
-      expect(ActionMailer::Base.deliveries.count).to eq(1)
-      expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-      expect(ActionMailer::Base.deliveries.first.body.encoded)
-        .to match("Click here to confirm your email")
+    it "updates the email immediately without requiring confirmation" do
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
 
-      expect(page).to have_text "Admin was successfully updated. Confirmation Email Sent."
-      expect(page).to have_field("Email", with: @old_email)
-      admin.reload
-      expect(admin.unconfirmed_email).to eq("new_admin_email@example.com")
-    end
-
-    it "succesfully updates the user email once the user confirms the changes" do
-      admin.confirm
-      visit edit_casa_admin_path(admin)
-
+      expect(page).to have_text "Casa Admin was successfully updated."
       expect(page).to have_field("Email", with: "new_admin_email@example.com")
       admin.reload
+      expect(admin.email).to eq("new_admin_email@example.com")
+      expect(admin.unconfirmed_email).to be_nil
       expect(admin.old_emails).to eq([@old_email])
     end
   end

--- a/spec/system/supervisors/edit_spec.rb
+++ b/spec/system/supervisors/edit_spec.rb
@@ -178,24 +178,14 @@ RSpec.describe "supervisors/edit", type: :system do
         @supervisor.reload
       end
 
-      it "sends a confirmation email to the supervisor and displays current email" do
-        expect(page).to have_text "Supervisor was successfully updated. Confirmation Email Sent."
-        expect(page).to have_field("Email", with: @old_email)
-        expect(@supervisor.unconfirmed_email).to eq("new_supervisor_email@example.com")
-
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
-      end
-
-      it "correctly updates the supervisor email once confirmed" do
-        @supervisor.confirm
-        @supervisor.reload
-        visit edit_supervisor_path(@supervisor)
-
+      it "updates the email immediately without requiring confirmation" do
+        expect(page).to have_text "Supervisor was successfully updated."
         expect(page).to have_field("Email", with: "new_supervisor_email@example.com")
+        expect(@supervisor.email).to eq("new_supervisor_email@example.com")
+        expect(@supervisor.unconfirmed_email).to be_nil
         expect(@supervisor.old_emails).to match([@old_email])
+
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
   describe "updating a volunteer's email" do
     context "with a valid email" do
-      it "sends volunteer a confirmation email and does not change the displayed email" do
+      it "updates the email immediately without requiring confirmation" do
         organization = create(:casa_org)
         admin = create(:casa_admin, casa_org: organization)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
@@ -141,35 +141,13 @@ RSpec.describe "volunteers/edit", type: :system do
         fill_in "Email", with: "newemail@example.com"
         click_on "Submit"
 
-        expect(page).to have_text "Volunteer was successfully updated. Confirmation Email Sent."
-        expect(page).to have_field("Email", with: old_email)
-        expect(volunteer.reload.unconfirmed_email).to eq("newemail@example.com")
-
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Click here to confirm your email")
-      end
-
-      it "succesfully displays the new email once the user confirms" do
-        organization = create(:casa_org)
-        admin = create(:casa_admin, casa_org: organization)
-        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
-        old_email = volunteer.email
-
-        sign_in admin
-        visit edit_volunteer_path(volunteer)
-
-        fill_in "Email", with: "newemail@example.com"
-        click_on "Submit"
-        volunteer.reload
-        volunteer.confirm
-
-        visit edit_volunteer_path(volunteer)
-
+        expect(page).to have_text "Volunteer was successfully updated."
         expect(page).to have_field("Email", with: "newemail@example.com")
-        expect(page).not_to have_field("Email", with: old_email)
+        expect(volunteer.reload.email).to eq("newemail@example.com")
+        expect(volunteer.unconfirmed_email).to be_nil
         expect(volunteer.old_emails).to eq([old_email])
+
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Fixes #6600 — see commit message for details