### PR TITLE
Fix UserParameters#without being a no-op

### DIFF
--- a/app/values/user_parameters.rb
+++ b/app/values/user_parameters.rb
@@ -49,7 +49,9 @@ class UserParameters < SimpleDelegator
   end
 
   def without(*keys)
+    keys = keys.map(&:to_s)
     params.reject! { |key| keys.include?(key) }
+    self
   end
 
   private

--- a/spec/values/user_parameters_spec.rb
+++ b/spec/values/user_parameters_spec.rb
@@ -1,7 +1,75 @@
 require "rails_helper"
 
 RSpec.describe UserParameters do
-  # TODO: Add tests for UserParameters
+  def build_params(attrs)
+    ActionController::Parameters.new(user: attrs)
+  end
 
-  pending "add some tests for UserParameters"
+  describe "#without" do
+    it "removes the given keys and is chainable" do
+      params = build_params(display_name: "Jane", active: "false", type: "Volunteer")
+
+      result = described_class.new(params).without(:active, :type)
+
+      expect(result).to be_a(described_class)
+      expect(result.to_h).to eq("display_name" => "Jane")
+    end
+
+    it "removes keys even when the params only has string keys" do
+      params = build_params(display_name: "Jane", active: "false")
+
+      result = described_class.new(params).without(:active)
+
+      expect(result.to_h).to eq("display_name" => "Jane")
+    end
+
+    it "supports further chaining after without" do
+      params = build_params(display_name: "Jane", active: "false", password: "old")
+
+      result = described_class.new(params).without(:active).with_password("new-password")
+
+      expect(result.to_h).to eq("display_name" => "Jane", "password" => "new-password")
+    end
+  end
+
+  describe "#without_type" do
+    it "removes the type key" do
+      params = build_params(display_name: "Jane", type: "Volunteer")
+
+      result = described_class.new(params).without_type
+
+      expect(result.to_h).to eq("display_name" => "Jane")
+    end
+  end
+
+  describe "#without_active" do
+    it "removes the active key" do
+      params = build_params(display_name: "Jane", active: "false")
+
+      result = described_class.new(params).without_active
+
+      expect(result.to_h).to eq("display_name" => "Jane")
+    end
+  end
+
+  describe "#with_organization" do
+    it "sets casa_org_id" do
+      params = build_params(display_name: "Jane")
+      organization = create(:casa_org)
+
+      result = described_class.new(params).with_organization(organization)
+
+      expect(result.to_h).to eq("display_name" => "Jane", "casa_org_id" => organization.id)
+    end
+  end
+
+  describe "#with_password" do
+    it "sets password" do
+      params = build_params(display_name: "Jane")
+
+      result = described_class.new(params).with_password("secret123")
+
+      expect(result.to_h).to eq("display_name" => "Jane", "password" => "secret123")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #7067 — `UserParameters#without` compared symbol keys against `ActionController::Parameters#reject!`'s string keys, so its condition was always false and the method silently removed nothing. It also didn't return `self`, breaking the builder chain.

The only caller, `CreateCasaAdminService#build`, calls `.without(:active, :type)` expecting both to be stripped before `CasaAdmin.new`. Because the call was a no-op:
- Any authenticated user could set `active=false` on a new admin via an extra field in the create request (DB default is `true`).
- Passing `type=<sibling class>` raised an unrescued `ActiveRecord::SubclassNotFound` (500), since Rails' STI guard is the only thing preventing type escalation.

## Fix

`without` now stringifies the incoming keys before comparing (matching how `reject!` yields keys), and returns `self` so it can still be chained.

Also replaces the pending stub in `spec/values/user_parameters_spec.rb` with real coverage for `without`, `without_type`, `without_active`, `with_organization`, and `with_password`.

## Test plan
- [ ] `bundle exec rspec spec/values/user_parameters_spec.rb`
- [ ] Manually verify: as a volunteer/supervisor, `POST /casa_admins` with an extra `type` or `active` field no longer leaks through