### PR TITLE
chore: disable on-demand asset compilation and normalize Gemfile.lock platforms (#7040)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -695,11 +695,9 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
+  arm64-darwin
   ruby
-  x86_64-darwin-21
-  x86_64-darwin-23
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
+  # Do not fall back to on-demand asset compilation; assets are precompiled at build time.
+  config.assets.compile = false
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :microsoft
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Addresses the two **High priority (real impact)** items of #7040. The remaining medium/low-priority checklist items (npm audit, Ruby patch bump, deprecated packages, install-script allowlist) are left as follow-ups, so this does not close the issue.

### What changed, and _why_?

Two deploy-log hardening items from #7040:

1. **Disabled on-demand asset compilation in production.** The `casa-qa` build log warns that `config.assets.compile = true` in production. Assets are already precompiled at build time (`rake assets:precompile` runs during the build), so on-demand compilation only adds per-request latency and load — and it silently masks a missing precompiled asset instead of failing fast. Set `config.assets.compile = false` in `config/environments/production.rb`, which is the standard Rails production default for a precompiled app.

2. **Normalized `Gemfile.lock` platforms.** The build warns that the platform-specific `ffi-1.17.2` gem is installed while the lockfile only carried OS-version-pinned platforms. Ran `bundle lock --normalize-platforms`, which collapses the version-pinned entries (`arm64-darwin-21/22`, `x86_64-darwin-21/23`) to their generic forms (`arm64-darwin`, `x86_64-darwin`). The `ruby` and `x86_64-linux` (Heroku) platforms are retained and the platform-specific gem specs are unchanged. `bundle check` passes after the change.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

These are production config / lockfile changes with no application-behavior surface, so there is no meaningful RSpec/Jest test to add (the test environment does not load `config/environments/production.rb`, and there is no existing convention in this repo for asserting environment config). Verification instead:

- `ruby -c config/environments/production.rb` → `Syntax OK`.
- `bundle exec standardrb config/environments/production.rb` → exit 0, no offenses.
- `bundle lock --normalize-platforms` produced a minimal diff touching only the `PLATFORMS` block (2 insertions, 4 deletions); `bundle check` → "The Gemfile's dependencies are satisfied".
- Assets continue to be resolved from the precompiled manifest; the build already runs `rake assets:precompile` successfully, so `compile = false` has all referenced assets available.

### Screenshots please :)

Not applicable — no user-facing UI change (production configuration and dependency lockfile only).
