### PR TITLE
5563 - Replace notification spec stubs with real tests

### DIFF
--- a/spec/notifications/base_notifier_spec.rb
+++ b/spec/notifications/base_notifier_spec.rb
@@ -1,7 +1,89 @@
 require "rails_helper"
 
-RSpec.describe BaseNotifier do
-  # TODO: Add tests for BaseNotifier
+RSpec.describe BaseNotifier, type: :model do
+  # BaseNotifier is a concrete Noticed::Event subclass (not abstract in the Ruby
+  # sense) - `.new`/`.with` both work directly, they just raise on the
+  # unimplemented template methods below.
 
-  pending "add some tests for BaseNotifier"
+  describe "title" do
+    it "raises NotImplementedError" do
+      # NOTE: the source string is missing its closing quote:
+      # "...has not implemented method '#{__method__}" - characterizing as-is.
+      expect { described_class.new.title }.to raise_error(
+        NotImplementedError, "BaseNotifier has not implemented method 'title"
+      )
+    end
+  end
+
+  describe "message" do
+    it "raises NotImplementedError" do
+      expect { described_class.new.message }.to raise_error(
+        NotImplementedError, "BaseNotifier has not implemented method 'message"
+      )
+    end
+  end
+
+  describe "url" do
+    it "raises NotImplementedError" do
+      expect { described_class.new.url }.to raise_error(
+        NotImplementedError, "BaseNotifier has not implemented method 'url"
+      )
+    end
+  end
+
+  describe "read?" do
+    it "delegates to record.read?" do
+      # record is just a plain AR association target here (User has no
+      # read? of its own), so a singleton method stands in for a
+      # verified double.
+      record = create(:user)
+      def record.read?
+        true
+      end
+
+      notifier = described_class.with(record: record)
+
+      expect(notifier.read?).to be true
+    end
+  end
+
+  describe "created_at" do
+    it "delegates to record.created_at" do
+      record = create(:user)
+
+      notifier = described_class.with(record: record)
+
+      expect(notifier.created_at).to eq record.created_at
+    end
+  end
+
+  describe "updated_at" do
+    it "delegates to record.updated_at" do
+      record = create(:user)
+
+      notifier = described_class.with(record: record)
+
+      expect(notifier.updated_at).to eq record.updated_at
+    end
+  end
+
+  describe "created_by" do
+    context "when params includes :created_by" do
+      it "returns the display_name of the created_by param" do
+        user = create(:user, display_name: "Jane Doe")
+
+        notifier = described_class.with(created_by: user)
+
+        expect(notifier.created_by).to eq "Jane Doe"
+      end
+    end
+
+    context "when params does not include :created_by" do
+      it "falls back to the legacy created_by_name param for backward compatibility" do
+        notifier = described_class.with(created_by_name: "Legacy Name")
+
+        expect(notifier.created_by).to eq "Legacy Name"
+      end
+    end
+  end
 end

--- a/spec/notifications/followup_notifier_spec.rb
+++ b/spec/notifications/followup_notifier_spec.rb
@@ -1,7 +1,53 @@
 require "rails_helper"
 
-RSpec.describe FollowupNotifier do
-  # TODO: Add tests for FollowupNotifier
+RSpec.describe FollowupNotifier, type: :model do
+  let(:created_by) { create(:user, display_name: "Ada Lovelace") }
 
-  pending "add some tests for FollowupNotifier"
+  describe "title" do
+    it "returns 'New followup'" do
+      followup = create(:followup, :without_note)
+
+      notifier = FollowupNotifier.with(followup: followup, created_by: created_by)
+
+      expect(notifier.title).to eq "New followup"
+    end
+  end
+
+  describe "url" do
+    it "returns the edit path for the followup's case contact" do
+      followup = create(:followup, :without_note)
+
+      notifier = FollowupNotifier.with(followup: followup, created_by: created_by)
+
+      expect(notifier.url).to eq "/case_contacts/#{followup.case_contact_id}/edit"
+    end
+  end
+
+  describe "message" do
+    context "when the followup has a note" do
+      it "joins the message with newlines and includes the note" do
+        followup = create(:followup, :with_note, note: "Needs signature")
+
+        notifier = FollowupNotifier.with(followup: followup, created_by: created_by)
+
+        expect(notifier.message).to eq(
+          "Ada Lovelace has flagged a Case Contact that needs follow up.\n" \
+          "Note: Needs signature\n" \
+          "Click to see more."
+        )
+      end
+    end
+
+    context "when the followup has no note" do
+      it "joins the message with spaces and omits the note" do
+        followup = create(:followup, :without_note)
+
+        notifier = FollowupNotifier.with(followup: followup, created_by: created_by)
+
+        expect(notifier.message).to eq(
+          "Ada Lovelace has flagged a Case Contact that needs follow up. Click to see more."
+        )
+      end
+    end
+  end
 end

--- a/spec/notifications/followup_resolved_notifier_spec.rb
+++ b/spec/notifications/followup_resolved_notifier_spec.rb
@@ -1,7 +1,44 @@
 require "rails_helper"
 
-RSpec.describe FollowupResolvedNotifier do
-  # TODO: Add tests for FollowupResolvedNotifier
+RSpec.describe FollowupResolvedNotifier, type: :model do
+  let(:created_by) { create(:user, display_name: "Grace Hopper") }
+  let(:followup) { create(:followup, :without_note) }
 
-  pending "add some tests for FollowupResolvedNotifier"
+  describe "title" do
+    it "returns 'Followup resolved'" do
+      notifier = FollowupResolvedNotifier.with(followup: followup, created_by: created_by)
+
+      expect(notifier.title).to eq "Followup resolved"
+    end
+  end
+
+  describe "message" do
+    it "includes the creator's display name" do
+      notifier = FollowupResolvedNotifier.with(followup: followup, created_by: created_by)
+
+      # NOTE: unlike FollowupNotifier#build_message (which calls the public
+      # `created_by` method), this calls the private `created_by_name` method
+      # directly. Both resolve identically here since `created_by` just
+      # delegates to `created_by_name`, but it's an inconsistency worth
+      # flagging rather than fixing in a test-only PR.
+      expect(notifier.message).to eq "Grace Hopper resolved a follow up. Click to see more."
+    end
+  end
+
+  describe "url" do
+    it "includes the case contact edit path and the notification id" do
+      notifier = FollowupResolvedNotifier.with(followup: followup, created_by: created_by)
+      notifier.save!
+
+      expect(notifier.url).to eq "/case_contacts/#{followup.case_contact_id}/edit?notification_id=#{notifier.id}"
+    end
+
+    it "omits notification_id when the notifier has not been persisted" do
+      # NOTE: characterizing current behavior - Rails drops nil query params,
+      # so an undelivered/unsaved notifier's url has no notification_id at all.
+      notifier = FollowupResolvedNotifier.with(followup: followup, created_by: created_by)
+
+      expect(notifier.url).to eq "/case_contacts/#{followup.case_contact_id}/edit"
+    end
+  end
 end

--- a/spec/notifications/youth_birthday_notifier_spec.rb
+++ b/spec/notifications/youth_birthday_notifier_spec.rb
@@ -1,7 +1,24 @@
 require "rails_helper"
 
-RSpec.describe YouthBirthdayNotifier do
-  # TODO: Add tests for YouthBirthdayNotifier
+RSpec.describe YouthBirthdayNotifier, type: :model do
+  let(:casa_case) { create(:casa_case) }
+  let(:notifier) { YouthBirthdayNotifier.with(casa_case: casa_case) }
 
-  pending "add some tests for YouthBirthdayNotifier"
+  describe "title" do
+    it "returns 'Youth Birthday Notification'" do
+      expect(notifier.title).to eq "Youth Birthday Notification"
+    end
+  end
+
+  describe "message" do
+    it "contains the casa case number" do
+      expect(notifier.message).to include casa_case.case_number
+    end
+  end
+
+  describe "url" do
+    it "returns the casa case path" do
+      expect(notifier.url).to eq "/casa_cases/#{casa_case.id}"
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #5563, intentionally not `Resolves`, since the umbrella has more stubs remaining.

### What changed, and _why_?
Replaces the four `pending "add some tests for X"` stubs in `spec/notifications/` with real specs (one commit per file), following the patterns in `volunteer_birthday_notifier_spec.rb`, `reimbursement_complete_notifier_spec.rb`, and `emancipation_checklist_reminder_notifier_spec.rb`:

- **BaseNotifier** carries the bulk of the coverage: `title`/`message`/`url` each raise `NotImplementedError` on the base, plus the utility methods (`read?`, `created_at`, `updated_at`, `created_by`) that delegate to `record`/`params`, including both branches of `created_by` (the `params[:created_by]` path and the legacy `params[:created_by_name]` fallback)
- **FollowupNotifier** covers `title`, `url`, and both `message` branches (with a note, joined on newlines; without, joined on spaces)
- **FollowupResolvedNotifier** covers `title`, `message`, and `url` in both the persisted and unsaved states
- **YouthBirthdayNotifier** covers `title`, `message`, and `url`

These characterize current behavior; no app code changed. Three `# NOTE:` comments flag oddities left as-is for a separate change: the `NotImplementedError` message string in `base_notifier.rb` is missing its closing quote; `FollowupResolvedNotifier#message` calls the private `created_by_name` directly while `FollowupNotifier` uses the public `created_by`; and `FollowupResolvedNotifier#url`'s `notification_id` param silently drops when the notifier is unsaved (Rails omits nil query params).

One thing worth knowing for reviewers: these specs use `create`, not `build`, for any record passed into `.with(...)`. Noticed serializes `params` through a jsonb column via GlobalID, and that round-trips on the first read of `params`, so an unsaved record raises `ActiveJob::SerializationError`. Only assertions that never touch `params` (for example a bare `title`) can use `build`.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
- `bundle exec rspec spec/notifications/base_notifier_spec.rb spec/notifications/followup_notifier_spec.rb spec/notifications/followup_resolved_notifier_spec.rb spec/notifications/youth_birthday_notifier_spec.rb` gives 19 examples, 0 failures, 0 pending
- `bundle exec standardrb spec/notifications/` reports no offenses
- No `pending` / `skip` / `xit` remains in the four files

### Screenshots please :)
N/A, test-only change, no UI.
