### PR TITLE
5563 - Replace helper spec stubs with real tests

### DIFF
--- a/spec/helpers/all_casa_admins/casa_orgs_helper_spec.rb
+++ b/spec/helpers/all_casa_admins/casa_orgs_helper_spec.rb
@@ -1,7 +1,16 @@
 require "rails_helper"
 
 RSpec.describe AllCasaAdmins::CasaOrgsHelper, type: :helper do
-  # TODO: Add tests for AllCasaAdmins::CasaOrgsHelper
+  describe "#selected_organization" do
+    it "returns the assigned @casa_org" do
+      casa_org = build(:casa_org)
+      assign(:casa_org, casa_org)
 
-  pending "add some tests for AllCasaAdmins::CasaOrgsHelper"
+      expect(helper.selected_organization).to eq(casa_org)
+    end
+
+    it "returns nil when no @casa_org is assigned" do
+      expect(helper.selected_organization).to be_nil
+    end
+  end
 end

--- a/spec/helpers/api_base_helper_spec.rb
+++ b/spec/helpers/api_base_helper_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe ApiBaseHelper, type: :helper do
-  # TODO: Add tests for ApiBaseHelper
-
-  pending "add some tests for ApiBaseHelper"
+  describe "SHORT_IO" do
+    it "is the short.io API base URL" do
+      expect(ApiBaseHelper::SHORT_IO).to eq("https://api.short.io/")
+    end
+  end
 end

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,7 +1,78 @@
 require "rails_helper"
 
 RSpec.describe DateHelper, type: :helper do
-  # TODO: Add tests for DateHelper
+  describe "JQUERY_MONTH_DAY_YEAR_FORMAT" do
+    it "is the jQuery datepicker month/day/year format" do
+      expect(DateHelper::JQUERY_MONTH_DAY_YEAR_FORMAT).to eq("MM d, yyyy")
+    end
+  end
 
-  pending "add some tests for DateHelper"
+  describe "RUBY_MONTH_DAY_YEAR_FORMAT" do
+    it "is the Ruby strftime month/day/year format" do
+      expect(DateHelper::RUBY_MONTH_DAY_YEAR_FORMAT).to eq("%B %d, %Y")
+    end
+  end
+
+  describe "#validate_date" do
+    it "parses a valid day, month, and year" do
+      expect(helper.validate_date("15", "6", "2021")).to eq(Date.new(2021, 6, 15))
+    end
+
+    it "raises Date::Error when the day is blank" do
+      expect { helper.validate_date("", "6", "2021") }.to raise_error(Date::Error)
+    end
+
+    it "raises Date::Error when the month is blank" do
+      expect { helper.validate_date("15", "", "2021") }.to raise_error(Date::Error)
+    end
+
+    it "raises Date::Error when the year is blank" do
+      expect { helper.validate_date("15", "6", "") }.to raise_error(Date::Error)
+    end
+  end
+
+  describe "#parse_date" do
+    let(:errors) { ActiveModel::Errors.new(double("record")) }
+
+    it "sets the parsed date under the field name when all parts are present" do
+      args = {
+        "court_report_due_date(1i)" => "2021",
+        "court_report_due_date(2i)" => "6",
+        "court_report_due_date(3i)" => "15"
+      }
+
+      result = helper.parse_date(errors, "court_report_due_date", args)
+
+      expect(result[:court_report_due_date]).to eq(Date.new(2021, 6, 15))
+      expect(result).not_to have_key("court_report_due_date(1i)")
+      expect(errors).to be_empty
+    end
+
+    it "adds an error and leaves the date field unset when the date is invalid" do
+      args = {
+        "court_report_due_date(1i)" => "2021",
+        "court_report_due_date(2i)" => "2",
+        "court_report_due_date(3i)" => "31"
+      }
+
+      result = helper.parse_date(errors, "court_report_due_date", args)
+
+      expect(result).not_to have_key(:court_report_due_date)
+      expect(errors[:court_report_due_date]).to include("was not a valid date.")
+    end
+
+    it "strips the date part keys and adds no date when all parts are blank" do
+      args = {
+        "court_report_due_date(1i)" => "",
+        "court_report_due_date(2i)" => "",
+        "court_report_due_date(3i)" => "",
+        "other_field" => "unchanged"
+      }
+
+      result = helper.parse_date(errors, "court_report_due_date", args)
+
+      expect(result).to eq({"other_field" => "unchanged"})
+      expect(errors).to be_empty
+    end
+  end
 end

--- a/spec/helpers/request_header_helper_spec.rb
+++ b/spec/helpers/request_header_helper_spec.rb
@@ -1,7 +1,15 @@
 require "rails_helper"
 
 RSpec.describe RequestHeaderHelper, type: :helper do
-  # TODO: Add tests for RequestHeaderHelper
+  describe "ACCEPT_JSON" do
+    it "is the JSON accept header" do
+      expect(RequestHeaderHelper::ACCEPT_JSON).to eq({"Accept" => "application/json"})
+    end
+  end
 
-  pending "add some tests for RequestHeaderHelper"
+  describe "CONTENT_TYPE_JSON" do
+    it "is the JSON content type header" do
+      expect(RequestHeaderHelper::CONTENT_TYPE_JSON).to eq({"Content-Type" => "application/json"})
+    end
+  end
 end

--- a/spec/helpers/template_helper_spec.rb
+++ b/spec/helpers/template_helper_spec.rb
@@ -1,7 +1,67 @@
 require "rails_helper"
 
 RSpec.describe TemplateHelper, type: :helper do
-  # TODO: Add tests for TemplateHelper
+  describe "#sanitize_opening_tags" do
+    it "strips attributes down to the tag name" do
+      expect(helper.sanitize_opening_tags(["<div class=\"foo\">"])).to eq(["<div>"])
+    end
 
-  pending "add some tests for TemplateHelper"
+    it "leaves tags without attributes untouched" do
+      expect(helper.sanitize_opening_tags(["<div>"])).to eq(["<div>"])
+    end
+
+    it "removes self-closing tags" do
+      expect(helper.sanitize_opening_tags(["<div>", "<br>", "<img src=\"foo\">"])).to eq(["<div>"])
+    end
+  end
+
+  describe "#sanitize_closing_tags" do
+    it "strips surrounding whitespace and slashes from closing tags" do
+      expect(helper.sanitize_closing_tags(["  </div>  "])).to eq(["<div>"])
+    end
+
+    it "leaves normal closing tags untouched" do
+      expect(helper.sanitize_closing_tags(["</div>"])).to eq(["<div>"])
+    end
+  end
+
+  describe "#validate_closing_tags_exist" do
+    it "returns true when every opening tag has a matching closing tag" do
+      content = "<div><span>hello</span></div>"
+
+      expect(helper.validate_closing_tags_exist(content)).to be true
+    end
+
+    it "returns false when a closing tag is missing" do
+      content = "<div><span>hello</div>"
+
+      expect(helper.validate_closing_tags_exist(content)).to be false
+    end
+
+    it "ignores self-closing tags that require no closing tag" do
+      content = "<div><img src=\"foo\"><br></div>"
+
+      expect(helper.validate_closing_tags_exist(content)).to be true
+    end
+  end
+
+  describe "#active_if" do
+    it "returns 'active' when the condition is truthy" do
+      expect(helper.active_if(true)).to eq("active")
+    end
+
+    it "returns nil when the condition is falsy" do
+      expect(helper.active_if(false)).to be_nil
+    end
+  end
+
+  describe "#active_if_status" do
+    it "returns 'active' when the status is complete" do
+      expect(helper.active_if_status("complete")).to eq("active")
+    end
+
+    it "returns nil when the status is not complete" do
+      expect(helper.active_if_status("in_progress")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Part of #5563, intentionally not `Resolves` — 16 stub specs remain after this.

### What changed, and _why_?
Replaces five `pending "add some tests for X"` stubs under `spec/helpers/` with
real specs (one commit per file), following existing helper-spec style
(`mileage_rates_helper_spec.rb`, `court_dates_helper_spec.rb`):

- **DateHelper** — the substantive one: `validate_date` (parses valid parts,
  raises `Date::Error` on any blank part) and `parse_date` (the Rails
  multiparameter `(1i)/(2i)/(3i)` happy path, the invalid-date path that adds a
  model error and leaves the field unset, and the all-blank case that strips the
  date-part keys and adds no date)
- **TemplateHelper** — tag sanitize/validate helpers and `active_if` /
  `active_if_status`
- **AllCasaAdmins::CasaOrgsHelper** — `selected_organization` returns the
  assigned `@casa_org` (and `nil` when unassigned)
- **RequestHeaderHelper / ApiBaseHelper** — constant-value pins; these modules
  define only constants, so a value assertion is the available real coverage

No production code changed.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
- `bundle exec rspec spec/helpers/{request_header,template,date,api_base}_helper_spec.rb spec/helpers/all_casa_admins/casa_orgs_helper_spec.rb`
  → 26 examples, 0 failures
- `bundle exec standardrb` on the five files → no offenses
- No `pending` / `skip` / `xit` remains in any of them

### Screenshots please :)
N/A — test-only change, no UI.

### Feelings gif (optional)
N/A
