### PR TITLE
Update volunteer email without reconfirmation

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -73,6 +73,8 @@ class VolunteersController < ApplicationController
 
   def update
     authorize @volunteer
+    skip_volunteer_email_reconfirmation
+
     if @volunteer.update(update_volunteer_params)
       notice = check_unconfirmed_email_notice(@volunteer)
 
@@ -222,6 +224,13 @@ class VolunteersController < ApplicationController
     VolunteerParameters
       .new(params)
       .without_active
+  end
+
+  def skip_volunteer_email_reconfirmation
+    return unless update_volunteer_params[:email].present?
+    return if update_volunteer_params[:email] == @volunteer.email
+
+    @volunteer.skip_reconfirmation!
   end
 
   def volunteers_phone_number

--- a/spec/requests/volunteers_spec.rb
+++ b/spec/requests/volunteers_spec.rb
@@ -222,18 +222,16 @@ RSpec.describe "/volunteers", type: :request do
         expect(volunteer.phone_number).to eq "15463457898"
       end
 
-      it "sends the volunteer a confirmation email upon email change" do
+      it "updates the volunteer email without requiring reconfirmation" do
         patch volunteer_path(volunteer), params: {
           volunteer: {email: "newemail@gmail.com"}
         }
         expect(response).to have_http_status(:redirect)
 
         volunteer.reload
-        expect(volunteer.unconfirmed_email).to eq("newemail@gmail.com")
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Confirm my email")
+        expect(volunteer.email).to eq("newemail@gmail.com")
+        expect(volunteer.unconfirmed_email).to be_nil
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
 

--- a/spec/system/volunteers/edit_spec.rb
+++ b/spec/system/volunteers/edit_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "volunteers/edit", type: :system do
 
   describe "updating a volunteer's email" do
     context "with a valid email" do
-      it "sends volunteer a confirmation email and does not change the displayed email" do
+      it "updates the volunteer email immediately" do
         organization = create(:casa_org)
         admin = create(:casa_admin, casa_org: organization)
         volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
@@ -141,35 +141,13 @@ RSpec.describe "volunteers/edit", type: :system do
         fill_in "Email", with: "newemail@example.com"
         click_on "Submit"
 
-        expect(page).to have_text "Volunteer was successfully updated. Confirmation Email Sent."
-        expect(page).to have_field("Email", with: old_email)
-        expect(volunteer.reload.unconfirmed_email).to eq("newemail@example.com")
-
-        expect(ActionMailer::Base.deliveries.count).to eq(1)
-        expect(ActionMailer::Base.deliveries.first).to be_a(Mail::Message)
-        expect(ActionMailer::Base.deliveries.first.body.encoded)
-          .to match("Confirm my email")
-      end
-
-      it "succesfully displays the new email once the user confirms" do
-        organization = create(:casa_org)
-        admin = create(:casa_admin, casa_org: organization)
-        volunteer = create(:volunteer, :with_assigned_supervisor, casa_org: organization)
-        old_email = volunteer.email
-
-        sign_in admin
-        visit edit_volunteer_path(volunteer)
-
-        fill_in "Email", with: "newemail@example.com"
-        click_on "Submit"
-        volunteer.reload
-        volunteer.confirm
-
-        visit edit_volunteer_path(volunteer)
-
+        expect(page).to have_text "Volunteer was successfully updated."
         expect(page).to have_field("Email", with: "newemail@example.com")
         expect(page).not_to have_field("Email", with: old_email)
+        expect(volunteer.reload.email).to eq("newemail@example.com")
+        expect(volunteer.unconfirmed_email).to be_nil
         expect(volunteer.old_emails).to eq([old_email])
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## Summary
- make admin/supervisor volunteer email edits update the volunteer record immediately
- skip Devise reconfirmation only for the volunteer admin edit flow when the email actually changes
- update request and system specs so the form no longer expects a confirmation email or pending `unconfirmed_email`

## Issue
Fixes #6600.

## Testing
- `ruby -c app/controllers/volunteers_controller.rb`
- `ruby -c spec/requests/volunteers_spec.rb`
- `ruby -c spec/system/volunteers/edit_spec.rb`
- `git diff --check`

I could not run the focused RSpec files locally because the system Ruby/Bundler on this machine cannot satisfy the Bundler version locked by the repo: `Could not find 'bundler' (4.0.6)`.
