### PR TITLE
Pin cgi to 0.5.x and add a regression guard for Azure blob signing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,10 @@ gem "bugsnag" # Error tracking in production
 gem "caxlsx", "~> 4.5" # Excel spreadsheets - TODO can we remove this version restriction?
 gem "caxlsx_rails", "~> 0.7.1" # Excel spreadsheets - TODO can we remove this version restriction?
 # Ruby 4.0 ships a cgi stdlib with only escape/unescape; azure-storage-common needs the
-# full library's CGI.parse to sign blob URLs. Remove when azure-storage-blob is dropped.
-gem "cgi", "~> 0.4.2"
+# full library's CGI.parse to sign blob URLs. Rails 8 no longer pulls cgi in transitively,
+# so without this the stripped stdlib wins and every Active Storage read/write 500s.
+# Guarded by spec/lib/azure_storage_signing_spec.rb. Remove when azure-storage-blob is dropped.
+gem "cgi", "~> 0.5.1"
 gem "cssbundling-rails", "~> 1.4" # CSS compilation
 gem "delayed_job_active_record" # Background job processing
 gem "devise" # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     caxlsx_rails (0.7.2)
       actionpack (>= 6.1)
       caxlsx (>= 4.0)
-    cgi (0.4.2)
+    cgi (0.5.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     cliver (0.3.2)
@@ -722,7 +722,7 @@ DEPENDENCIES
   capybara-screenshot
   caxlsx (~> 4.5)
   caxlsx_rails (~> 0.7.1)
-  cgi (~> 0.4.2)
+  cgi (~> 0.5.1)
   cssbundling-rails (~> 1.4)
   database_cleaner-active_record
   delayed_job_active_record

--- a/spec/lib/azure_storage_signing_spec.rb
+++ b/spec/lib/azure_storage_signing_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+require "azure/storage/blob"
+
+# Production stores every attachment on Azure (config.active_storage.service = :microsoft),
+# and azure-storage-common signs both uploads and download URLs with CGI.parse. Ruby 4.0's
+# stdlib cgi ships only escape/unescape, so the Gemfile has to pin the real cgi gem back in
+# — Rails 8 stopped pulling it in transitively. When that pin goes missing, every Active
+# Storage read and write 500s in production while CI stays green, because the test
+# environment uses Disk storage and never touches this code.
+#
+# See https://github.com/rubyforgood/casa/issues/7093
+RSpec.describe "Azure Storage request signing" do
+  let(:account_name) { "casaaccount" }
+  let(:access_key) { Base64.strict_encode64("not-a-real-key") }
+
+  it "has the full CGI library, not Ruby 4.0's escape-only stdlib" do
+    expect(CGI).to respond_to(:parse)
+  end
+
+  # Exercised by CaseCourtReportsController#save_report when it attaches the .docx.
+  it "signs an upload request" do
+    signer = Azure::Storage::Common::Core::Auth::SharedKey.new(account_name, access_key)
+    uri = URI("https://#{account_name}.blob.core.windows.net/casa/report.docx?comp=block&blockid=abc")
+
+    signature = signer.sign(:put, uri, {"Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document"})
+
+    expect(signature).to start_with("#{account_name}:")
+  end
+
+  # Exercised by active_storage/blobs/redirect#show when a user downloads the report.
+  it "signs a download URL" do
+    generator = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(account_name, access_key)
+    uri = URI("https://#{account_name}.blob.core.windows.net/casa/report.docx")
+
+    signed_uri = generator.signed_uri(uri, false, service: "b", permissions: "r", expiry: "2050-01-01T00:00:00Z")
+
+    expect(signed_uri.query).to include("sig=")
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Refs #7093 (does not resolve it on its own — see "Deploy note" below)

### What changed, and _why_?

Two hardening follow-ups to the `cgi` pin added in #7088, from the root-cause work on #7093.

**1. Pin `cgi` forward to `~> 0.5.1` instead of back to `~> 0.4.2`.**

Ruby 4.0's stdlib `cgi` ships only `cgi.rb`, `cgi/util.rb` and `cgi/escape.rb` — there is no `cgi/core.rb`, so `CGI.parse` does not exist:

```
$ ruby --disable-gems -e 'require "cgi"; puts CGI.respond_to?(:parse)'
false
```

`azure-storage-common` calls `CGI.parse` in two places, and production stores every attachment on Azure (`config.active_storage.service = :microsoft`):

| call site | signs | breaks |
|---|---|---|
| `azure/core/auth/shared_key.rb:117` | upload requests | `casa_case.court_reports.attach(...)` → "Generate report" |
| `.../auth/shared_access_signature_generator.rb:382` | SAS download URLs | `active_storage/blobs/redirect#show` → downloading the .docx, org logos, profile pictures |

The pin is what puts a real `cgi` gem back on the load path. Reaching back to 0.4.2 isn't necessary though — the gem still ships the full library at 0.5.x (`lib/cgi/core.rb` is present), and pinning forward avoids compiling an older C extension against Ruby 4.0 during the Heroku build. Resolves to `cgi (0.5.2)`. Verified against the real signer:

```
$ bundle exec ruby -e 'require "azure/storage/blob"; require "uri"
  puts "cgi #{Gem.loaded_specs["cgi"].version} — #{CGI.method(:parse).source_location.first}"
  k = Azure::Storage::Common::Core::Auth::SharedKey.new("acct", "a2V5")
  puts k.send(:canonicalized_resource, URI("https://acct.blob.core.windows.net/c/f.docx?comp=block&blockid=abc"))'
cgi 0.5.2 — .../gems/cgi-0.5.2/lib/cgi/core.rb
/acct/c/f.docx
blockid:abc
comp:block
```

**2. Add a regression guard.**

Nothing in CI would have caught this outage. The test environment uses Disk storage (`config/storage.yml`), so the Azure signing path is never exercised — the suite stayed green the whole time production was 500ing on every attachment.

`spec/lib/azure_storage_signing_spec.rb` calls both real signing entry points with a dummy account, no network. If `cgi` ever falls out of the lock again — which is exactly how this happened, Rails 8 stopped pulling it in transitively — the build fails instead of production.

### Deploy note

This PR is the *hardening*, not the outage fix. The functional fix (#7088) has been on `main` since 2026-07-30; production is still running 2026-07-14 code and is still returning 500s for every blob:

```
$ curl -s -o /dev/null -w "%{http_code}" "https://casavolunteertracking.org/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTI0OCwicHVyIjoiYmxvYl9pZCJ9fQ==--e36a834ec8498e117f9bddd855a53668825891b3/CASA%20LOGO.jpg"
500
```

Merging this changes nothing for users until something ships to prod. See #7093 for the deploy options — notably that `main` currently also carries three PRs of the Tailwind design rebuild, so a hotfix off the deployed commit may be preferable to shipping everything at once.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

```
$ bundle exec rspec spec/lib/azure_storage_signing_spec.rb
Azure Storage request signing
  has the full CGI library, not Ruby 4.0's escape-only stdlib
  signs an upload request
  signs a download URL

3 examples, 0 failures
```

And confirmed the guard actually fails on the real defect, by removing `CGI.parse` the way the stripped stdlib does:

```
$ bundle exec ruby -e 'require "azure/storage/blob"; require "base64"; require "uri"
  class << CGI; undef_method :parse; end
  Azure::Storage::Common::Core::Auth::SharedKey.new("casaaccount", Base64.strict_encode64("k"))
    .sign(:put, URI("https://casaaccount.blob.core.windows.net/casa/report.docx?comp=block"), {})'
NoMethodError: undefined method 'parse' for class CGI
```

That is character-for-character the error the Voices for Children Montgomery users reported.

### Screenshots please :)

No UI change — this is a dependency pin plus a spec.
