### PR TITLE
DO NOT MERGE Hotfix: pin cgi so Azure blob signing works on Ruby 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ gem "blueprinter" # JSON serialization
 gem "bugsnag" # Error tracking in production
 gem "caxlsx", "~> 4.5" # Excel spreadsheets - TODO can we remove this version restriction?
 gem "caxlsx_rails", "~> 0.7.1" # Excel spreadsheets - TODO can we remove this version restriction?
+# Ruby 4.0 ships a cgi stdlib with only escape/unescape; azure-storage-common needs the
+# full library's CGI.parse to sign blob URLs. Rails 8 no longer pulls cgi in transitively,
+# so without this the stripped stdlib wins and every Active Storage read/write 500s. See #7093.
+gem "cgi", "~> 0.5.1"
 gem "cssbundling-rails", "~> 1.4" # CSS compilation
 gem "delayed_job_active_record" # Background job processing
 gem "devise" # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     caxlsx_rails (0.7.2)
       actionpack (>= 6.1)
       caxlsx (>= 4.0)
+    cgi (0.5.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     cliver (0.3.2)
@@ -717,6 +718,7 @@ DEPENDENCIES
   capybara-screenshot
   caxlsx (~> 4.5)
   caxlsx_rails (~> 0.7.1)
+  cgi (~> 0.5.1)
   cssbundling-rails (~> 1.4)
   database_cleaner-active_record
   delayed_job_active_record


### PR DESCRIPTION
Ruby 4.0's stdlib cgi ships only escape/unescape, and azure-storage-common signs both uploads and download URLs with CGI.parse. Rails 8 stopped pulling cgi in transitively, so the stripped stdlib won and every Active Storage read and write started returning a 500 — court report generation and download, org logos, profile pictures.

Branched off b7b87cd6, the commit currently in production, and carries nothing but the pin so it can ship without the design rebuild sitting on main.

Refs #7093

### What github issue is this PR for, if any?
Resolves #XXXX

### What changed, and _why_?


### How is this **tested**? (please write rspec and jest tests!) 💖💪
_Note: if you see a flake in your test build in github actions, please post in slack #casa "Flaky test: <link to failed build>" :) 💪_
_Note: We love [capybara](https://rubydoc.info/github/teamcapybara/capybara) tests! If you are writing both haml/js and ruby, please try to test your work with tests at every level including system tests like https://github.com/rubyforgood/casa/tree/main/spec/system_ 


### Screenshots please :)
_Run your local server and take a screenshot of your work! Try to include the URL of the page as well as the contents of the page._ 


### Feelings gif (optional)
_What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:_
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`
