### PR TITLE
Stop rendering raw exceptions when court report generation fails

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CaseCourtReportsController < ApplicationController
+  GENERATION_FAILED_MESSAGE = "Something went wrong generating this report. The CASA team has been notified. Please try again in a few minutes."
+
   before_action :set_casa_case, only: %i[show]
   after_action :verify_authorized
   skip_after_action :verify_policy_scoped # TODO: index should call policy_scope; remove this skip once it does
@@ -47,11 +49,16 @@ class CaseCourtReportsController < ApplicationController
         end
       end
     end
-  rescue Zip::Error
+  rescue Zip::Error => e
+    # Keep the actionable message, but a broken org template is still something we want to hear about.
+    report_generation_error(e)
+
     error_messages = generate_error("Template is not found")
     render json: {status: :not_found, error_messages: error_messages}, status: :not_found
   rescue => e
-    error_messages = generate_error(e.to_s)
+    report_generation_error(e)
+
+    error_messages = generate_error(GENERATION_FAILED_MESSAGE)
     render json: {status: :unprocessable_content, error_messages: error_messages}, status: :unprocessable_content
   end
 
@@ -104,6 +111,18 @@ class CaseCourtReportsController < ApplicationController
         io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
       )
     end
+  end
+
+  # Report the exception rather than rendering it. This used to pass e.to_s straight to the
+  # user, so when Azure blob signing broke, an office manager's screen read
+  # "undefined method 'parse' for class CGI" and nothing reached Bugsnag. See #7093.
+  def report_generation_error(error)
+    case_number = params.dig(:case_court_report, :case_number)
+
+    Bugsnag.notify(error) do |event|
+      event.add_metadata(:court_report, {case_number: case_number, user_id: current_user&.id})
+    end
+    Rails.logger.error("Court report generation failed for case #{case_number}: #{error.class}: #{error.message}")
   end
 
   def generate_error(message)

--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CaseCourtReportsController < ApplicationController
-  GENERATION_FAILED_MESSAGE = "Something went wrong generating this report. The CASA team has been notified. Please try again in a few minutes."
+  GENERATION_FAILED_MESSAGE = "Something went wrong generating this report. Please use the bug reporting form linked at the bottom of this page, or notify casa@rubyforgood.org"
 
   before_action :set_casa_case, only: %i[show]
   after_action :verify_authorized
@@ -113,9 +113,7 @@ class CaseCourtReportsController < ApplicationController
     end
   end
 
-  # Report the exception rather than rendering it. This used to pass e.to_s straight to the
-  # user, so when Azure blob signing broke, an office manager's screen read
-  # "undefined method 'parse' for class CGI" and nothing reached Bugsnag. See #7093.
+  # Report the exception rather than rendering it, so devs get technical details and users are spared them.
   def report_generation_error(error)
     case_number = params.dig(:case_court_report, :case_number)
 

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -270,14 +270,28 @@ RSpec.describe "/case_court_reports", type: :request do
     end
 
     context "when an unpredictable error occurs" do
+      let(:error) { NoMethodError.new("undefined method 'parse' for class CGI") }
+
       before do
-        expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise StandardError.new("Unexpected Error")
+        allow(Bugsnag).to receive(:notify).and_call_original
+        expect_any_instance_of(CaseCourtReportsController).to receive(:save_report).and_raise error
       end
 
       it { is_expected.to have_http_status(:unprocessable_content) }
 
-      it "shows the correct error message" do
-        expect(request.parsed_body["error_messages"]).to include("Unexpected Error")
+      it "shows a generic error message" do
+        expect(request.parsed_body["error_messages"]).to include(CaseCourtReportsController::GENERATION_FAILED_MESSAGE)
+      end
+
+      # An office manager once read "undefined method 'parse' for class CGI" off her screen. See #7093.
+      it "does not leak the exception to the user" do
+        expect(request.parsed_body["error_messages"]).not_to include("undefined method")
+      end
+
+      it "reports the exception to Bugsnag" do
+        request
+
+        expect(Bugsnag).to have_received(:notify).with(error)
       end
     end
   end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -283,7 +283,6 @@ RSpec.describe "/case_court_reports", type: :request do
         expect(request.parsed_body["error_messages"]).to include(CaseCourtReportsController::GENERATION_FAILED_MESSAGE)
       end
 
-      # An office manager once read "undefined method 'parse' for class CGI" off her screen. See #7093.
       it "does not leak the exception to the user" do
         expect(request.parsed_body["error_messages"]).not_to include("undefined method")
       end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Refs #7093 (the observability half — the functional fix is #7095 / the hotfix branch)

### What changed, and _why_?

`CaseCourtReportsController#generate` rescued everything and passed the exception straight to the user:

```ruby
rescue => e
  error_messages = generate_error(e.to_s)
```

That is how `undefined method 'parse' for class CGI` ended up being read off an office manager's screen in #7093. Two problems with it:

1. **Users see Ruby internals.** Nothing in that string tells them what to do, and it looks alarming.
2. **Nobody else sees anything at all.** The exception was swallowed by the rescue, so Bugsnag never heard about it. Active Storage had been failing on every attachment for weeks and the only signal we got was a stakeholder emailing to say reports were broken.

Now the exception is reported with the case number and user id attached, logged, and users get:

> Something went wrong generating this report. The CASA team has been notified. Please try again in a few minutes.

**One judgement call worth flagging:** I also added reporting to the `Zip::Error` branch. It keeps its existing "Template is not found" wording, which is actionable and worth keeping, but a broken org court report template is something we'd want to hear about rather than swallow — and #7093's triage notes show template problems have bitten this org before (#1826 / #2265 / #3698). Easy to drop that hunk if you'd rather keep this PR to the one rescue.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

Extended the existing "when an unpredictable error occurs" context in `spec/requests/case_court_reports_spec.rb`. It now raises the actual production exception and asserts all three things that went wrong:

```
when an unpredictable error occurs
  is expected to respond with status code :unprocessable_content (422)
  shows a generic error message
  does not leak the exception to the user
  reports the exception to Bugsnag
```

Full file: 29 examples, 3 failures — all three are the pre-existing `Sprockets::Rails::Helper::AssetNotPrecompiledError: Asset 'tailwind.css' was not declared to be precompiled in production` failures on the index action. Verified they fail identically on unmodified `main`, so they are not from this change, but they do mean the court reports index spec is currently red on `main` and probably wants its own issue.

### Screenshots please :)

No layout change — same flash component, different text. Before / after of the string a user sees:

```
- undefined method 'parse' for class CGI
+ Something went wrong generating this report. The CASA team has been notified. Please try again in a few minutes.
```
