### PR TITLE
Fix binary court report downloads

### DIFF
--- a/app/controllers/case_court_reports_controller.rb
+++ b/app/controllers/case_court_reports_controller.rb
@@ -24,8 +24,11 @@ class CaseCourtReportsController < ApplicationController
     respond_to do |format|
       format.docx do
         @casa_case.latest_court_report.open do |file|
-          # TODO test this .read being present, we've broken it twice now
-          send_data File.read(file.path), type: :docx, disposition: "attachment", status: :ok
+          send_data File.binread(file.path),
+            type: :docx,
+            filename: "#{@casa_case.case_number}.docx",
+            disposition: "attachment",
+            status: :ok
         end
       end
     end

--- a/spec/requests/case_court_reports_spec.rb
+++ b/spec/requests/case_court_reports_spec.rb
@@ -53,13 +53,14 @@ RSpec.describe "/case_court_reports", type: :request do
       end
 
       let(:casa_case) { volunteer.casa_cases.first }
+      let(:case_number) { "#C-15-JV-24-191" }
+      let(:report_bytes) { Rails.root.join("spec/fixtures/files/default_past_court_date_template.docx").binread }
 
       before do
-        Tempfile.create do |t|
-          casa_case.court_reports.attach(
-            io: File.open(t.path), filename: "#{casa_case.case_number}.docx"
-          )
-        end
+        casa_case.update!(case_number: case_number)
+        casa_case.court_reports.attach(
+          io: StringIO.new(report_bytes), filename: "stored-report.docx"
+        )
       end
 
       it "authorizes action" do
@@ -73,6 +74,15 @@ RSpec.describe "/case_court_reports", type: :request do
 
       it "send response with a status :ok" do
         expect(request).to have_http_status(:ok)
+      end
+
+      it "sends the stored report bytes using the case number as the filename", :aggregate_failures do
+        expect(request.body).to eq(report_bytes)
+        expect(request.body.bytesize).to eq(casa_case.latest_court_report.blob.byte_size)
+        expect(request.body).to start_with("PK\x03\x04".b)
+        expect(request.headers["Content-Disposition"]).to include(
+          %(attachment; filename="#{casa_case.case_number}.docx")
+        )
       end
     end
 


### PR DESCRIPTION
### What github issue is this PR for, if any?
Resolves #7099

### What changed, and _why_?

- Read the stored DOCX with `File.binread`, so the response body remains binary (`ASCII-8BIT`) instead of being tagged as invalid UTF-8 text.
- Pass `#{@casa_case.case_number}.docx` explicitly to `send_data`, so escaped characters in the request URL cannot alter the downloaded filename.
- Replace the empty temporary attachment in the request spec with a real DOCX fixture and verify exact response bytes, blob byte size, ZIP magic, and `Content-Disposition`.
- Use a case number containing `#` and a deliberately different stored blob name, so the regression covers the reported filename edge case.

The new example fails against the old controller implementation because the response has the wrong encoding and no explicit filename, then passes with this change.

### How is this **tested**? (please write rspec and jest tests!) 💖💪

- `bundle exec rspec spec/requests/case_court_reports_spec.rb:55` — 4 examples, 0 failures
- `bundle exec standardrb app/controllers/case_court_reports_controller.rb spec/requests/case_court_reports_spec.rb` — passed
- `ruby -c` for both changed Ruby files — passed
- `git diff --check` — passed
- Full `spec/requests/case_court_reports_spec.rb`: 27 examples passed; three unchanged index examples could not render because the local test setup did not contain the built `application.js` asset. The focused DOCX context and all changed-code checks pass.

### Screenshots please :)

Not applicable; this changes the binary download response and request coverage, with no visual UI changes.

### Feelings gif (optional)

AI disclosure: I used an AI coding assistant to help inspect the issue, implement the focused change and regression coverage, and run the checks listed above. I reviewed the final diff and test results before submitting.
