### PR TITLE
Fix nightly issue-auto-unassign failure (Projects classic API retired)

### DIFF
--- a/.github/workflows/issue-auto-unassign.yml
+++ b/.github/workflows/issue-auto-unassign.yml
@@ -22,13 +22,9 @@ jobs:
         run: echo "Unassigned issues = ${{steps.unassign_issues.outputs.unassigned_issues}}"
       - name: Print the warned issues
         run: echo "Warned issues = ${{steps.unassign_issues.outputs.warned_issues}}"
-      - name: Move unassigned issues from In Progress to To Do
-        uses: bjthompson805/move-issues@4d2c991804d44e11541302f32eb71659f3a0435d # v1
-        id: move_issues
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          issues: ${{steps.unassign_issues.outputs.unassigned_issues}}
-          from_column: '8461148'
-          to_column: '15690587'
-      - name: Print moved issues
-        run: echo "Moved issues = ${{steps.move_issues.outputs.moved_issues}}"
+      # The "move unassigned issues from In Progress to To Do" step was removed:
+      # it used bjthompson805/move-issues, which drives the retired Projects
+      # (classic) REST API (/projects/columns/{id}/cards). Columns 8461148 and
+      # 15690587 no longer resolve, so the step 404'd on every nightly run and
+      # failed the whole workflow. Re-add via the Projects v2 GraphQL API
+      # (e.g. actions/add-to-project) if the board move is still wanted.


### PR DESCRIPTION
## What's broken

`.github/workflows/issue-auto-unassign.yml` has failed on **every** nightly run for weeks — it's the only consistently red workflow on `main`. Core CI (rspec, ruby_lint, erb_lint, npm, yaml_lint, factory_bot_lint, security, docker) is green.

Last run: [32316495594](https://github.com/rubyforgood/casa/actions/runs/32316495594)

```
Run bjthompson805/move-issues@4d2c991
  from_column: 8461148
  to_column: 15690587

RequestError [HttpError]: Not Found
  url: 'https://api.github.com/projects/columns/8461148/cards?per_page=100&page=0'
  status: '404'
```

## Root cause

The `move-issues` action drives the **retired Projects (classic) REST API**. Both hardcoded column IDs are gone:

```
$ gh api projects/columns/8461148   # 404 Not Found
$ gh api projects/columns/15690587  # 404 Not Found
```

The 404 surfaces as an unhandled octokit rejection, so the step exits non-zero and the whole run goes red — even though the unassign/warn steps before it had already completed successfully. The daily red run masks whether the bot is actually doing its job.

## Fix

Remove the card-move step and the print step that consumed its output, leaving a comment explaining why. The workflow's actual purpose — unassigning and warning on stale issues — is untouched and now reports its own status honestly.

If the board move is still wanted, it needs re-implementing against the Projects v2 GraphQL API (e.g. `actions/add-to-project`) with the new project/field IDs — worth a follow-up issue rather than blocking this.

## Notes / out of scope

- Four other workflows still reference Projects classic concepts and are worth auditing separately: `add-labels-based-on-column.yml`, `remove-label-based-on-column.yml`, `after-deploy.yml`, and `issue-auto-close-done.yml` (which triggers on the `project_card` event that classic boards no longer emit). They currently pass — the actions appear to no-op rather than throw — so they're likely silently dead rather than loudly broken.
- Separate non-blocking warning in the same run: `rubyforgood/unassign-issues` still targets Node 20 and is being force-run on Node 24.

## Verification

- `YAML.load_file` parses cleanly; matches the repo's `.yamllint` (2-space indent, no document-start).
- Cannot fully verify end-to-end until a scheduled or `workflow_dispatch` run fires on `main` after merge — the remaining steps are unchanged from the ones already succeeding today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)