### PR TITLE
Lint cleanup in VolunteersController

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -227,7 +227,7 @@ class VolunteersController < ApplicationController
   end
 
   def skip_volunteer_email_reconfirmation
-    return unless update_volunteer_params[:email].present?
+    return if update_volunteer_params[:email].blank?
     return if update_volunteer_params[:email] == @volunteer.email
 
     @volunteer.skip_reconfirmation!


### PR DESCRIPTION
## Why

`standardrb app/controllers/volunteers_controller.rb` reports one offense on `main`:

```
app/controllers/volunteers_controller.rb:230:12: Rails/Blank: Use `if update_volunteer_params[:email].blank?` instead of `unless update_volunteer_params[:email].present?`.
```

## What

- Fixes that `Rails/Blank` offense. The file is now clean under the project linter (`bin/lint` / Standard.rb).

Follow-up commits on this branch extract the index filter-param building and the reactivation SMS body out of the controller, which shrinks `index`, `create`, and a 332-char line — the offenses vanilla RuboCop's `Metrics/*` cops flag (those cops are disabled by Standard.rb, so this is a readability change, not a CI requirement).

## How to verify

```
bundle exec standardrb app/controllers/volunteers_controller.rb
bundle exec rspec spec/system/volunteers
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)