### PR TITLE
Update Reimbursement policy to allow only admins to mark reimbursements as complete

### DIFF
--- a/app/policies/reimbursement_policy.rb
+++ b/app/policies/reimbursement_policy.rb
@@ -11,6 +11,6 @@ class ReimbursementPolicy < ApplicationPolicy
   end
 
   def change_complete_status?
-    index? && reimbursement_enabled?
+    is_admin? && reimbursement_enabled?
   end
 end

--- a/app/views/reimbursements/_reimbursement_toggle.html.erb
+++ b/app/views/reimbursements/_reimbursement_toggle.html.erb
@@ -2,9 +2,13 @@
     The checkbox auto-submits a PATCH to change_complete_status (CSP-safe: the auto-submit
     controller calls requestSubmit on change), which redirects back to the queue. The wrapping
     <label> associates the checkbox, and the id is row-unique. %>
-<%= form_with model: reimbursement, url: reimbursement_mark_as_complete_path(reimbursement), method: :patch, data: {controller: "auto-submit", action: "change->auto-submit#submit"}, class: "reimbursement-complete-form" do |form| %>
-  <label class="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap">
-    <%= form.check_box :reimbursement_complete, id: "reimbursement_complete_#{reimbursement.id}", class: check_class %>
-    <span class="text-sm text-slate-700"><%= @complete_status ? "Complete" : "Mark complete" %></span>
-  </label>
+<% if policy(:reimbursement).change_complete_status? %>
+  <%= form_with model: reimbursement, url: reimbursement_mark_as_complete_path(reimbursement), method: :patch, data: {controller: "auto-submit", action: "change->auto-submit#submit"}, class: "reimbursement-complete-form" do |form| %>
+    <label class="inline-flex cursor-pointer items-center gap-2 whitespace-nowrap">
+      <%= form.check_box :reimbursement_complete, id: "reimbursement_complete_#{reimbursement.id}", class: check_class %>
+      <span class="text-sm text-slate-700"><%= @complete_status ? "Complete" : "Mark complete" %></span>
+    </label>
+  <% end %>
+<% else %>
+  <span class="text-sm text-slate-700"><%= reimbursement.reimbursement_complete ? "Complete" : "Needs review" %></span>
 <% end %>

--- a/spec/policies/reimbursement_policy_spec.rb
+++ b/spec/policies/reimbursement_policy_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe ReimbursementPolicy do
   let(:organization) { build(:casa_org, users: [volunteer, supervisor, casa_admin]) }
 
   context "when org reimbursement is enabled" do
-    permissions :index?, :change_complete_status? do
+    permissions :index? do
       it { is_expected.to permit(casa_admin) }
       it { is_expected.to permit(supervisor) }
+      it { is_expected.not_to permit(volunteer) }
+    end
+
+    permissions :change_complete_status? do
+      it { is_expected.to permit(casa_admin) }
+      it { is_expected.not_to permit(supervisor) }
       it { is_expected.not_to permit(volunteer) }
     end
   end

--- a/spec/requests/reimbursements_spec.rb
+++ b/spec/requests/reimbursements_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe ReimbursementsController, type: :request do
       expect(case_contact.reload.reimbursement_complete).to be_truthy
     end
 
+    context "when the signed-in user is a supervisor" do
+      let(:supervisor) { create(:supervisor) }
+
+      before { sign_in(supervisor) }
+
+      it "redirects away without changing the reimbursement status" do
+        patch reimbursement_mark_as_complete_url(case_contact, case_contact: {reimbursement_complete: true})
+
+        expect(response).to redirect_to(root_url)
+        expect(response).to have_http_status(:redirect)
+        expect(case_contact.reload.reimbursement_complete).to be_falsey
+      end
+    end
+
     it "sends a notification to the case_contact's creator" do
       expect do
         patch reimbursement_mark_as_complete_url(case_contact, case_contact: {reimbursement_complete: true})


### PR DESCRIPTION
### What changed, and _why_?

It was found that Supervisors could mark reimbursements complete, but that was not intended behavior.

- Updated reimbursement policy to only allow admins to mark complete.
- Updated reimbursements view to only show status for non-admins.

### How is this **tested**? (please write rspec and jest tests!) 💖💪
- Updated reimbursement policy spec
- updated reimbursement system spec
- Verified desired behavior through local functional testing

### Screenshots please :)
<img width="904" height="551" alt="image" src="https://github.com/user-attachments/assets/e4e41734-b87f-46b3-8c2a-af460b04fdf9" />