### PR TITLE
Fix emancipation checklist.

### DIFF
--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -71,7 +71,7 @@ export class Toggler {
 
   manageTogglerText () {
     if (this.emancipationCategory.attr('data-is-open') === 'true') {
-      this.categoryCollapseIcon.text('-')
+      this.categoryCollapseIcon.text('–')
     } else if (this.emancipationCategory.attr('data-is-open') === 'false') {
       this.categoryCollapseIcon.text('+')
     }

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -71,7 +71,7 @@ export class Toggler {
 
   manageTogglerText () {
     if (this.emancipationCategory.attr('data-is-open') === 'true') {
-      this.categoryCollapseIcon.text('−')
+      this.categoryCollapseIcon.text('-')
     } else if (this.emancipationCategory.attr('data-is-open') === 'false') {
       this.categoryCollapseIcon.text('+')
     }

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -71,20 +71,25 @@ export class Toggler {
 
   manageTogglerText () {
     if (this.emancipationCategory.attr('data-is-open') === 'true') {
-      this.categoryCollapseIcon.text('–')
+      this.categoryCollapseIcon.text('−')
     } else if (this.emancipationCategory.attr('data-is-open') === 'false') {
       this.categoryCollapseIcon.text('+')
     }
   }
 
+  setOpen (isOpen) {
+    this.emancipationCategory.attr('data-is-open', isOpen ? 'true' : 'false')
+    this.emancipationCategory.data('is-open', isOpen)
+  }
+
   openChildren () {
     this.categoryOptionsContainer.show()
-    this.emancipationCategory.attr('data-is-open', 'true')
+    this.setOpen(true)
   }
 
   closeChildren () {
     this.categoryOptionsContainer.hide()
-    this.emancipationCategory.attr('data-is-open', 'false')
+    this.setOpen(false)
   }
 
   deselectChildren (notifierCallback) {
@@ -107,61 +112,67 @@ $(() => { // JQuery's callback for the DOM loading
   const notificationsElement = $('#notifications')
   emancipationPage.notifier = new Notifier(notificationsElement)
 
+  // Labels have no `for=` so JS owns checked state after the AJAX save. A click on the
+  // <input> itself still toggles natively *before* the wrapper handler runs, which inverted
+  // add/delete and then flipped the box back — persist was right, the DOM was wrong.
+  $('.emancipation-category-check-box, .emancipation-option-check-box, .emancipation-radio-button').on('click', function (event) {
+    event.preventDefault()
+  })
+
   $('.category-collapse-icon').on('click', function () {
-    const categoryCollapseIcon = $(this)
-    const emancipationCategory = categoryCollapseIcon.parent()
+    const emancipationCategory = $(this).parent()
     const toggler = new Toggler(emancipationCategory)
 
     if (emancipationCategory.attr('data-is-open') === 'true') {
       toggler.closeChildren()
-      toggler.manageTogglerText()
-    } else if (emancipationCategory.attr('data-is-open') === 'false') {
+    } else {
       toggler.openChildren()
-      toggler.manageTogglerText()
     }
+    toggler.manageTogglerText()
   })
 
   $('.emacipation-category-input-label-pair').on('click', function () {
-    const emacipationCategoryInputLabelPair = $(this)
-    const emancipationCategory = emacipationCategoryInputLabelPair.parent()
+    const emancipationCategory = $(this).parent()
     const toggler = new Toggler(emancipationCategory)
     const categoryCheckbox = emancipationCategory.find('.emancipation-category-check-box')
-    const categoryCheckboxChecked = categoryCheckbox.is(':checked')
+    const categoryCheckboxChecked = categoryCheckbox.prop('checked')
 
-    if (!emancipationCategory.data('disabled')) {
-      emancipationCategory.data('disabled', true)
-      emancipationCategory.addClass('disabled')
-      categoryCheckbox.prop('disabled', 'disabled')
-
-      let saveAction,
-        doneCallback
-
-      if (categoryCheckboxChecked) {
-        doneCallback = () => {
-          toggler.manageTogglerText()
-          toggler.deselectChildren((text) => emancipationPage.notifier.notify('Unchecked ' + text, 'info'))
-        }
-        saveAction = 'delete_category'
-      } else {
-        doneCallback = () => {
-          toggler.openChildren()
-          toggler.manageTogglerText()
-        }
-        saveAction = 'add_category'
-      }
-
-      saveCheckState(saveAction, categoryCheckbox.val())
-        .done(function () {
-          doneCallback()
-          categoryCheckbox.prop('checked', !categoryCheckboxChecked)
-          toggler.manageTogglerText()
-        })
-        .always(function () {
-          emancipationCategory.data('disabled', false)
-          emancipationCategory.removeClass('disabled')
-          categoryCheckbox.prop('disabled', false)
-        })
+    if (emancipationCategory.data('disabled')) {
+      return
     }
+
+    emancipationCategory.data('disabled', true)
+    emancipationCategory.addClass('disabled')
+    categoryCheckbox.prop('disabled', true)
+
+    let saveAction,
+      doneCallback
+
+    if (categoryCheckboxChecked) {
+      doneCallback = () => {
+        toggler.closeChildren()
+        toggler.manageTogglerText()
+        toggler.deselectChildren((text) => emancipationPage.notifier.notify('Unchecked ' + text, 'info'))
+      }
+      saveAction = 'delete_category'
+    } else {
+      doneCallback = () => {
+        toggler.openChildren()
+        toggler.manageTogglerText()
+      }
+      saveAction = 'add_category'
+    }
+
+    saveCheckState(saveAction, categoryCheckbox.val())
+      .done(function () {
+        doneCallback()
+        categoryCheckbox.prop('checked', !categoryCheckboxChecked)
+      })
+      .always(function () {
+        emancipationCategory.data('disabled', false)
+        emancipationCategory.removeClass('disabled')
+        categoryCheckbox.prop('disabled', false)
+      })
   })
 
   $('.check-item').on('click', function () {
@@ -185,12 +196,14 @@ $(() => { // JQuery's callback for the DOM loading
 
         radioComponent.data('disabled', true)
         radioComponent.addClass('disabled')
-        radioInput.prop('disabled', 'disabled')
+        radioInput.prop('disabled', true)
       })
 
       saveCheckState('set_option', checkElement.val())
         .done(function () {
           checkElement.prop('checked', true)
+        })
+        .always(function () {
           radioButtons.each(function () {
             const radioComponent = $(this)
             const radioInput = radioComponent.find('input')
@@ -201,25 +214,25 @@ $(() => { // JQuery's callback for the DOM loading
           })
         })
     } else { // Expecting type=checkbox
+      const originallyChecked = checkElement.prop('checked')
+
       checkComponent.data('disabled', true)
       checkComponent.addClass('disabled')
-      checkElement.prop('disabled', 'disabled')
+      checkElement.prop('disabled', true)
 
-      const originallyChecked = checkElement.prop('checked')
-      let asyncCall
+      const asyncCall = originallyChecked
+        ? saveCheckState('delete_option', checkElement.val())
+        : saveCheckState('add_option', checkElement.val())
 
-      if (!originallyChecked) {
-        asyncCall = saveCheckState('add_option', checkElement.val())
-      } else {
-        asyncCall = saveCheckState('delete_option', checkElement.val())
-      }
-
-      asyncCall.done(function () {
-        checkComponent.data('disabled', false)
-        checkComponent.removeClass('disabled')
-        checkElement.prop('checked', !originallyChecked)
-        checkElement.prop('disabled', false)
-      })
+      asyncCall
+        .done(function () {
+          checkElement.prop('checked', !originallyChecked)
+        })
+        .always(function () {
+          checkComponent.data('disabled', false)
+          checkComponent.removeClass('disabled')
+          checkElement.prop('disabled', false)
+        })
     }
   })
 })

--- a/app/javascript/src/case_emancipation.js
+++ b/app/javascript/src/case_emancipation.js
@@ -77,19 +77,16 @@ export class Toggler {
     }
   }
 
-  setOpen (isOpen) {
-    this.emancipationCategory.attr('data-is-open', isOpen ? 'true' : 'false')
-    this.emancipationCategory.data('is-open', isOpen)
-  }
-
   openChildren () {
     this.categoryOptionsContainer.show()
-    this.setOpen(true)
+    this.emancipationCategory.attr('data-is-open', 'true')
+    this.emancipationCategory.data('is-open', true)
   }
 
   closeChildren () {
     this.categoryOptionsContainer.hide()
-    this.setOpen(false)
+    this.emancipationCategory.attr('data-is-open', 'false')
+    this.emancipationCategory.data('is-open', false)
   }
 
   deselectChildren (notifierCallback) {
@@ -112,9 +109,6 @@ $(() => { // JQuery's callback for the DOM loading
   const notificationsElement = $('#notifications')
   emancipationPage.notifier = new Notifier(notificationsElement)
 
-  // Labels have no `for=` so JS owns checked state after the AJAX save. A click on the
-  // <input> itself still toggles natively *before* the wrapper handler runs, which inverted
-  // add/delete and then flipped the box back — persist was right, the DOM was wrong.
   $('.emancipation-category-check-box, .emancipation-option-check-box, .emancipation-radio-button').on('click', function (event) {
     event.preventDefault()
   })

--- a/app/views/emancipations/show.html.erb
+++ b/app/views/emancipations/show.html.erb
@@ -26,7 +26,7 @@
       <% @emancipation_form_data.each do |category| %>
         <h2 class="emancipation-category no-select flex items-center justify-between gap-3 border-b border-slate-100 py-2.5 last:border-b-0" data-is-open="<%= emancipation_category_checkbox_checked(@current_case, category) ? "true" : "false" %>">
           <div class="emacipation-category-input-label-pair flex cursor-pointer items-center gap-2.5">
-            <%= tag.input(type: "checkbox", class: "emancipation-category-check-box #{check_class}", value: category.id, checked: emancipation_category_checkbox_checked(@current_case, category), aria: {label: category.name}) %>
+            <%= tag.input(type: "checkbox", class: "emancipation-category-check-box pointer-events-none #{check_class}", value: category.id, checked: emancipation_category_checkbox_checked(@current_case, category), aria: {label: category.name}) %>
             <div class="text-sm font-medium text-slate-800"><%= category.name %></div>
           </div>
           <% if category.emancipation_options.count > 0 %>
@@ -37,16 +37,16 @@
           <% category.emancipation_options.each do |option| %>
             <div class="check-item flex cursor-pointer items-center gap-2.5 py-1 text-sm text-slate-700">
               <% if category.mutually_exclusive %>
-                <%= tag.input(type: "radio", id: "O#{option.id}", class: "emancipation-radio-button #{radio_class}", name: "C#{category.id}", value: option.id, checked: emancipation_option_checkbox_checked(@current_case, option), aria: {label: option.name}) %>
+                <%= tag.input(type: "radio", id: "O#{option.id}", class: "emancipation-radio-button pointer-events-none #{radio_class}", name: "C#{category.id}", value: option.id, checked: emancipation_option_checkbox_checked(@current_case, option), aria: {label: option.name}) %>
               <% else %>
-                <%= tag.input(type: "checkbox", id: "O#{option.id}", class: "emancipation-option-check-box #{check_class}", value: option.id, checked: emancipation_option_checkbox_checked(@current_case, option), aria: {label: option.name}) %>
+                <%= tag.input(type: "checkbox", id: "O#{option.id}", class: "emancipation-option-check-box pointer-events-none #{check_class}", value: option.id, checked: emancipation_option_checkbox_checked(@current_case, option), aria: {label: option.name}) %>
               <% end %>
               <label><%= option.name %></label>
             </div>
           <% end %>
-          <%# The labels intentionally have no for= matching the inputs: JS sets checkbox state after
-              the AJAX save succeeds, and a real label/control pair would toggle natively on top of
-              that. The inputs carry aria-label instead, so they still have an accessible name. %>
+          <%# The labels intentionally have no for= matching the inputs, and the inputs are
+              pointer-events-none: JS sets checked after the AJAX save, and a native toggle on
+              click inverted add/delete vs the DOM. Inputs keep aria-label for an accessible name. %>
         </div>
       <% end %>
     </div>

--- a/spec/system/casa_cases/emancipation/show_spec.rb
+++ b/spec/system/casa_cases/emancipation/show_spec.rb
@@ -1,17 +1,16 @@
 require "rails_helper"
 
 RSpec.describe "casa_cases/show", type: :system do
-  let(:organization) { build(:casa_org) }
-  let(:volunteer) { build(:volunteer, casa_org: organization) }
-  let(:casa_case) { build(:casa_case, casa_org: organization) }
+  let(:organization) { create(:casa_org) }
+  let(:volunteer) { create(:volunteer, casa_org: organization) }
+  let(:casa_case) { create(:casa_case, casa_org: organization) }
   let!(:case_assignment) { create(:case_assignment, volunteer: volunteer, casa_case: casa_case) }
-  let!(:emancipation_category) { build(:emancipation_category, mutually_exclusive: true) }
+  let!(:emancipation_category) { create(:emancipation_category, mutually_exclusive: true) }
   let!(:emancipation_option) { create(:emancipation_option, emancipation_category: emancipation_category) }
-  let(:supervisor) { create(:supervisor, casa_org: organization) }
 
   before do
     sign_in user
-    visit casa_case_emancipation_path(casa_case.id)
+    visit casa_case_emancipation_path(casa_case)
   end
 
   context "volunteer user", :js do
@@ -22,23 +21,61 @@ RSpec.describe "casa_cases/show", type: :system do
       expect(page).to have_content(emancipation_category.name)
     end
 
-    it "opens through main input, selects an option, and unselects option through main input" do
-      emancipation_category = page.find(".emancipation-category")
-      find(".emacipation-category-input-label-pair").click
+    it "checks a category to open options, selects an option, and unchecks the category to hide them" do
+      category = page.find(".emancipation-category", text: emancipation_category.name)
+
+      expect(category).to have_css(".emancipation-category-check-box:not(:checked)")
+      expect(category["data-is-open"]).to eq("false")
+
+      category.find(".emacipation-category-input-label-pair").click
+
+      expect(category).to have_css(".emancipation-category-check-box:checked")
       expect(page).to have_content(emancipation_option.name)
-      expect(emancipation_category["data-is-open"]).to match(/true/)
-      find(".check-item").click
-      find(".emacipation-category-input-label-pair").click
+      expect(category["data-is-open"]).to eq("true")
+      expect(casa_case.reload.emancipation_categories).to include(emancipation_category)
+
+      find(".check-item", text: emancipation_option.name).click
+
+      expect(page).to have_css(".check-item input:checked")
+      expect(casa_case.reload.emancipation_options).to include(emancipation_option)
+
+      category.find(".emacipation-category-input-label-pair").click
+
+      expect(category).to have_css(".emancipation-category-check-box:not(:checked)")
       expect(page).to have_css(".success-notification", text: "Unchecked #{emancipation_option.name}")
-      expect(emancipation_category["data-is-open"]).to match(/true/)
+      expect(category["data-is-open"]).to eq("false")
+      expect(page).to have_css(".category-options", visible: :hidden)
+      expect(casa_case.reload.emancipation_categories).not_to include(emancipation_category)
+      expect(casa_case.reload.emancipation_options).not_to include(emancipation_option)
+    end
+
+    it "toggles a non-exclusive option and persists it" do
+      checkbox_category = create(:emancipation_category, mutually_exclusive: false)
+      checkbox_option = create(:emancipation_option, emancipation_category: checkbox_category)
+      visit casa_case_emancipation_path(casa_case)
+
+      category = page.find(".emancipation-category", text: checkbox_category.name)
+      category.find(".emacipation-category-input-label-pair").click
+      expect(category).to have_css(".emancipation-category-check-box:checked")
+
+      option = find(".check-item", text: checkbox_option.name)
+      option.click
+      expect(option).to have_css("input:checked")
+      expect(casa_case.reload.emancipation_options).to include(checkbox_option)
+
+      option.click
+      expect(option).to have_css("input:not(:checked)")
+      expect(casa_case.reload.emancipation_options).not_to include(checkbox_option)
     end
 
     it "shows and hides the options through collapse icon" do
-      emancipation_category = page.find(".emancipation-category")
-      find(".category-collapse-icon").click
-      expect(emancipation_category["data-is-open"]).to match(/true/)
-      find(".category-collapse-icon").click
-      expect(emancipation_category["data-is-open"]).to match(/false/)
+      emancipation_category_el = page.find(".emancipation-category", text: emancipation_category.name)
+      emancipation_category_el.find(".category-collapse-icon").click
+      expect(emancipation_category_el["data-is-open"]).to eq("true")
+      expect(page).to have_content(emancipation_option.name)
+      emancipation_category_el.find(".category-collapse-icon").click
+      expect(emancipation_category_el["data-is-open"]).to eq("false")
+      expect(page).not_to have_content(emancipation_option.name)
     end
   end
 end


### PR DESCRIPTION
### What github issue is this PR for, if any?
Ruby For Good issue: "As volunteer, in Emancipation Checklist when I click new factors above the list it says “Bad Request x minimize notifications”"

### What changed, and _why_?
This PR fixes the front-end and back-end persistence for the emancipation checklist. 


### How is this **tested**? (please write rspec and jest tests!) 💖💪
Manual checking and unchecking of emancipation category and option checkboxes.
Updated emancipation/show_spec.rb passes.


### Screenshots please :)
Screenshot of unfixed behavior.
<img width="2436" height="1078" alt="image" src="https://github.com/user-attachments/assets/696126eb-11e0-4893-bc67-6a17682ddb15" />



### Feelings gif (optional)
:grinning: :grinning: 
