### PR TITLE
Make bin/setup fail fast, fail clearly, and stop dropping the dev DB

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 RUBY_VERSION="$(cat .ruby-version | tr -d '\n')"
 
 # copy the file only if it doesn't already exist

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,4 +11,6 @@ if [ "$RUBY_VERSION" != "4.0.6" ]; then
 	echo "Ruby $RUBY_VERSION installed"
 fi
 
-bin/setup
+# --reset builds the development database from scratch. This is a brand new
+# container, so there is no local data to lose.
+bin/setup --reset

--- a/.github/workflows/shell_lint.yml
+++ b/.github/workflows/shell_lint.yml
@@ -1,0 +1,80 @@
+name: Shell lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.sh'
+      - '**/*.bash'
+      - 'bin/**'
+      - 'docker/**'
+      - '.devcontainer/**'
+      - '.github/workflows/shell_lint.yml'
+  pull_request:
+    branches:
+      - main
+      - rfg-event-2025
+    paths:
+      - '**/*.sh'
+      - '**/*.bash'
+      - 'bin/**'
+      - 'docker/**'
+      - '.devcontainer/**'
+      - '.github/workflows/shell_lint.yml'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install shellcheck if the runner image lacks it
+        run: |
+          if ! command -v shellcheck > /dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y shellcheck
+          fi
+          shellcheck --version
+
+      - name: Shellcheck
+        # Many scripts here have no extension (bin/dev, docker/*), and bin/ also
+        # holds Ruby scripts, so select by shebang rather than by path.
+        #
+        # --severity=warning: the tree still has ~35 info/style findings, mostly
+        # SC2086 (unquoted variables) in bin/git_hooks and docker. Those are
+        # worth fixing, but gating on them today would mean rewriting scripts
+        # unrelated to whatever PR is being reviewed. Lower this as they get
+        # cleaned up.
+        run: |
+          set -eu
+
+          list=$(mktemp)
+          trap 'rm -f "$list"' EXIT
+
+          {
+            git ls-files -- '*.sh' '*.bash'
+            git ls-files | while IFS= read -r file; do
+              [ -f "$file" ] || continue
+              if head -n 1 "$file" |
+                  grep -qE '^#!.*[ /](bash|sh|dash|ksh)$'; then
+                printf '%s\n' "$file"
+              fi
+            done
+          } | sort -u > "$list"
+
+          count=$(wc -l < "$list" | tr -d '[:space:]')
+          if [ "$count" -eq 0 ]; then
+            echo "No shell scripts found -- check the discovery logic above."
+            exit 1
+          fi
+
+          echo "Checking $count shell scripts:"
+          sed 's/^/  /' "$list"
+          echo
+
+          xargs shellcheck --severity=warning -- < "$list"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ CASA is a Rails app used by CASA (Court Appointed Special Advocate) chapters to 
 
 | Task | Command |
 |---|---|
-| One-time setup | `bin/setup` |
+| One-time setup | `bin/setup` (safe to re-run; `--reset` to rebuild the dev DB, `--skip-assets` to skip npm) |
 | Run app (web + JS/CSS watchers) | `bin/dev` then visit http://localhost:3000 |
 | Run full RSpec suite | `bin/rails spec` |
 | Run a single spec file | `bundle exec rspec spec/path/to/file_spec.rb` |

--- a/README.md
+++ b/README.md
@@ -204,17 +204,33 @@ Run these commands before starting the installation process:
 </details>
 
 <details>
-<summary>bin/setup fails with a credentials error</summary>
+<summary>bin/setup says it cannot connect to postgres</summary>
 
-1. Open the `.env` file.
-2. Update `POSTGRES_USER` and `POSTGRES_PASSWORD` to match your PostgreSQL credentials.
-3. Run `bin/setup`
+`bin/setup` checks the database before doing anything slow, and prints the host, port
+and user it tried. Either postgres is not running, or the credentials in `.env` are
+wrong — update `POSTGRES_USER`, `POSTGRES_PASSWORD` and `DATABASE_HOST` to match your
+PostgreSQL setup and re-run `bin/setup`.
+</details>
+
+<details>
+<summary>I want to throw away my local data and start over</summary>
+
+Run `bin/setup --reset`. By default `bin/setup` preserves the development database;
+`--reset` drops, recreates and reseeds it.
 </details>
 
 ## Running the App / Verifying Installation
 1. `cd casa/`
 1. Run `bin/setup`
 1. Run `bin/dev` and visit http://localhost:3000/ to see the app running.
+
+`bin/setup` is safe to re-run — it preserves your development database. Options:
+
+| Flag | Effect |
+|---|---|
+| `--reset` | Drop, recreate and reseed the development database (destroys local data) |
+| `--skip-assets` | Skip `npm ci` and the JS/CSS builds |
+| `--help` | List the options |
 
 ### QA Environment
 

--- a/bin/git_hooks/lint
+++ b/bin/git_hooks/lint
@@ -32,10 +32,12 @@ case $diff_policy in
     ;;
 
   --unpushed)
-    if [ -z "$(git ls-remote --heads origin ${current_branch})" ]; then
-      changed_file_list=$(git diff --name-only HEAD~$(git cherry -v main ${current_branch} | wc -l) HEAD)
+    if [ -z "$(git ls-remote --heads origin "${current_branch}")" ]; then
+      # wc -l pads with whitespace on BSD/macOS, so strip it before interpolating.
+      unpushed_count=$(git cherry -v main "${current_branch}" | wc -l | tr -d '[:space:]')
+      changed_file_list=$(git diff --name-only "HEAD~${unpushed_count}" HEAD)
     else
-      changed_file_list=$(git diff --name-only origin/${current_branch}..HEAD)
+      changed_file_list=$(git diff --name-only "origin/${current_branch}..HEAD")
     fi
     ;;
 
@@ -55,7 +57,7 @@ lint_time=$(date +%s)
 if test $erb_changed_count -gt 0; then
   log info "Linting via erblint"
 
-  cd $repo_root/app
+  cd "$repo_root/app" || exit 1
 
   if ! [ -x "$(command -v bundle)" ]; then
     log error "Command bundle could not be found"
@@ -71,7 +73,7 @@ fi
 if test $factory_changed_count -gt 0; then
   log info "Linting via factory:lint"
 
-  cd $repo_root/app
+  cd "$repo_root/app" || exit 1
 
   if ! [ -x "$(command -v bundle)" ]; then
     log error "Command bundle could not be found"
@@ -87,7 +89,7 @@ fi
 if test $js_changed_count -gt 0; then
   log info "Linting javasript via standard"
 
-  cd $repo_root/app
+  cd "$repo_root/app" || exit 1
 
   if ! [ -x "$(command -v npm)" ]; then
     log error "Command npm could not be found"
@@ -103,7 +105,7 @@ fi
 if test $rb_changed_count -gt 0; then
   log info "Linting via standardrb"
 
-  cd $repo_root
+  cd "$repo_root" || exit 1
 
   if ! [ -x "$(command -v bundle)" ]; then
     log error "Command bundle could not be found"
@@ -116,7 +118,7 @@ if test $rb_changed_count -gt 0; then
   fi
 fi
 
-cd $repo_root
+cd "$repo_root" || exit 1
 for file in $(git diff --name-only); do
   last_modified_time=$(date -r $file +%s)
   if [ $last_modified_time -ge $lint_time ] ; then

--- a/bin/git_hooks/update-dependencies
+++ b/bin/git_hooks/update-dependencies
@@ -28,7 +28,7 @@ fi
 
 log info "Checking javascript dependency status"
 
-if [ $(git diff HEAD@{1}..HEAD@{0} -- "package-lock.json" | wc -l) -gt 0 ] || [ $(git diff HEAD@{1}..HEAD@{0} -- "package.json" | wc -l) -gt 0 ]; then
+if ! git diff --quiet "HEAD@{1}..HEAD@{0}" -- package-lock.json package.json; then
   log info "Updating JavaScript dependencies"
   npm install
 fi

--- a/bin/setup
+++ b/bin/setup
@@ -1,62 +1,196 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
+require "json"
+require "optparse"
+
+# Unbuffered, so progress and error output stay in order when this is piped to a
+# log rather than a terminal (e.g. the Codespaces post-create script).
+$stdout.sync = true
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
+# Raises on failure. Use for steps where a non-zero exit is a hard stop.
 def system!(*args)
   system(*args, exception: true)
 end
 
-FileUtils.chdir APP_ROOT do
-  # This script is a way to set up or update your development environment automatically.
-  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
-  # Add necessary setup steps to this file.
-  expected_ruby_version = `cat .ruby-version`.chomp
-  current_ruby_version = `ruby -v`.chomp
-  unless current_ruby_version.include?(expected_ruby_version)
-    puts "Ruby version must be #{expected_ruby_version}. You are on #{current_ruby_version}"
+# Returns false on failure. Use where a non-zero exit is a branch, not an error
+# (e.g. `bundle check` failing just means we need to `bundle install`).
+def try_system(*args)
+  system(*args)
+end
+
+def abort_with(message)
+  abort "\n#{message}\n"
+end
+
+def step(title)
+  puts "\n== #{title} =="
+end
+
+# Parse KEY=value lines out of a dotenv-style file. Hand-rolled because this
+# runs before `bundle install`, so the dotenv gem is not available yet.
+def parse_env_file(path)
+  return {} unless File.exist?(path)
+
+  File.readlines(path).each_with_object({}) do |line, env|
+    next if line.strip.empty? || line.strip.start_with?("#")
+
+    key, _, value = line.strip.partition("=")
+    next if key.empty?
+
+    env[key] = value.gsub(/\A["']|["']\z/, "")
+  end
+end
+
+options = {reset: ENV["FORCE_DB_RESET"] == "1", assets: true}
+OptionParser.new do |opts|
+  opts.banner = "Usage: bin/setup [options]"
+  opts.on("--reset", "Drop, recreate and reseed the development database (destroys local data)") { options[:reset] = true }
+  opts.on("--skip-assets", "Skip npm install and the JS/CSS builds") { options[:assets] = false }
+  opts.on("-h", "--help", "Show this message") do
+    puts opts
     exit
   end
+end.parse!
 
-  puts "\n== Installing dependencies =="
-  system! 'gem install foreman'
+FileUtils.chdir APP_ROOT do
+  # This script sets up your development environment. It is safe to re-run: by
+  # default the database is prepared, not reset, so local data survives.
+  # Use `bin/update` after pulling main; use this script for first-time setup.
+  #
+  # Everything cheap is checked up front, so a misconfigured machine fails in
+  # seconds rather than after several minutes of `bundle install`.
+  step "Checking prerequisites"
+
+  # .env comes first: the database check below reads its values.
+  unless File.exist?(".env")
+    puts "Creating .env from .env.example"
+    FileUtils.cp ".env.example", ".env"
+  end
+
+  env = parse_env_file(".env")
+  missing_keys = parse_env_file(".env.example").keys - env.keys
+  if missing_keys.any?
+    puts "⚠️  .env is missing keys that .env.example defines: #{missing_keys.join(", ")}"
+    puts "   Copy them over from .env.example if something behaves unexpectedly."
+  end
+
+  expected_ruby_version = File.read(".ruby-version").strip
+  if expected_ruby_version != RUBY_VERSION
+    abort_with <<~MSG
+      Ruby #{expected_ruby_version} is required, but this is Ruby #{RUBY_VERSION}.
+
+      With rbenv:  rbenv install #{expected_ruby_version} && rbenv rehash
+      With rvm:    rvm install #{expected_ruby_version} && rvm use #{expected_ruby_version}
+      With asdf:   asdf install ruby #{expected_ruby_version}
+    MSG
+  end
+  puts "Ruby #{RUBY_VERSION} ✓"
+
+  node_version = `node --version 2>/dev/null`.strip
+  abort_with <<~MSG if node_version.empty?
+    Node.js was not found on your PATH.
+
+    Install nvm (https://github.com/nvm-sh/nvm), then run `nvm install` from this
+    directory to pick up the version in .nvmrc.
+  MSG
+
+  expected_node_major = JSON.parse(File.read("package.json")).dig("engines", "node").to_s[/\d+/]
+  actual_node_major = node_version[/\d+/]
+  if expected_node_major && actual_node_major != expected_node_major
+    abort_with <<~MSG
+      Node.js #{expected_node_major}.x is required, but this is #{node_version}.
+
+      Run `nvm install` from this directory to install the version in .nvmrc.
+    MSG
+  end
+  puts "Node #{node_version} ✓"
+
+  # Confirm postgres is up AND that the credentials in .env work. This is the
+  # single most common setup failure, so it is worth catching before the slow
+  # steps rather than surfacing it as a Rails connection error later.
+  db_host = env.fetch("DATABASE_HOST", "localhost")
+  db_port = env.fetch("POSTGRES_PORT", "5432")
+  db_user = env["POSTGRES_USER"].to_s
+  db_connection_hint = <<~HINT
+    Checked host=#{db_host} port=#{db_port} user=#{db_user.empty? ? "(unset)" : db_user}, from your .env file.
+
+    - Not running? Start postgres (`brew services start postgresql` on macOS), or see
+      doc/DOCKER.md if you run it in a container.
+    - Wrong credentials? Update POSTGRES_USER / POSTGRES_PASSWORD / DATABASE_HOST in .env.
+  HINT
+
+  if try_system("command -v psql > /dev/null 2>&1")
+    # psql validates credentials, not just reachability.
+    psql_env = {"PGPASSWORD" => env["POSTGRES_PASSWORD"].to_s, "PGCONNECT_TIMEOUT" => "5"}
+    psql_cmd = ["psql", "-h", db_host, "-p", db_port, "-U", db_user, "-d", "postgres", "-c", "select 1"]
+    unless try_system(psql_env, *psql_cmd, out: File::NULL, err: File::NULL)
+      abort_with "Could not connect to postgres.\n\n#{db_connection_hint}"
+    end
+    puts "PostgreSQL connection ✓"
+  elsif try_system("command -v pg_isready > /dev/null 2>&1")
+    unless try_system("pg_isready", "-h", db_host, "-p", db_port, out: File::NULL, err: File::NULL)
+      abort_with "PostgreSQL is not accepting connections.\n\n#{db_connection_hint}"
+    end
+    puts "PostgreSQL is accepting connections ✓ (install psql to also verify credentials)"
+  else
+    puts "⚠️  Neither psql nor pg_isready found; skipping the database connection check."
+  end
+
+  step "Installing dependencies"
   # Pin bundler to a version Heroku supports for our Ruby. Match Heroku's
   # supported Ruby/Bundler pairings as they evolve:
   # https://devcenter.heroku.com/articles/ruby-support-reference#supported-ruby-versions
-  system! 'gem install bundler -v 4.0.6 --conservative'
-  system!('bundle check') || system!('bundle install')
+  system! "gem install bundler -v 4.0.6 --conservative"
+  try_system("bundle check") || system!("bundle install")
 
-  # puts '\n== Copying sample files =='
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  if options[:reset]
+    step "Resetting database"
+    puts "Dropping, recreating and reseeding the development database."
+    system! "bin/rails db:reset"
+  else
+    step "Preparing database"
+    puts "Creating and seeding the database if needed; existing local data is preserved."
+    puts "Pass --reset to drop and reseed from scratch."
+    system! "bin/rails db:prepare"
+  end
+  system! "bin/rails db:test:prepare"
 
-  unless File.exist?('.env')
-    puts "\n== Setup .env file from .env.example =="
-    system!('cp .env.example .env')
+  step "Removing old logs and tempfiles"
+  system! "bin/rails log:clear tmp:clear"
+
+  step "Running post-deployment tasks"
+  system! "bin/rake after_party:run"
+
+  if options[:assets]
+    step "Installing npm packages"
+    unless try_system("npm ci")
+      abort_with <<~MSG
+        `npm ci` failed.
+
+        It installs strictly from package-lock.json, so this usually means the lockfile
+        and package.json disagree. Try `npm install` to reconcile them, and check the
+        output above for the offending package.
+      MSG
+    end
+
+    step "Building assets"
+    system! "npm run build"
+    system! "npm run build:css"
   end
 
-  puts "\n== Preparing database =="
-  puts '⚠️  If you use docker to run postgres, make sure your database is running ⚠️'
-  system! 'bin/rails db:reset'
-  system! 'bin/rails db:test:prepare'
+  puts <<~DONE
 
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+    == Done ==
 
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+    Next steps:
+      1. bin/dev
+      2. Open http://localhost:3000/users/sign_in
+      3. Log in as volunteer1@example.com / 12345678
+         (also supervisor1@example.com, casa_admin1@example.com — same password)
 
-  puts "\n== Running post-deployment tasks =="
-  system! 'bin/rake after_party:run'
-
-  puts "\n== Installing npm packages =="
-  system!('npm ci') || abort('install npm and try again')
-
-  puts "\n== Building assets =="
-  system!('npm run build')
-  system!('npm run build:css')
-
-  puts "\n== Done =="
+    After pulling main, run bin/update rather than bin/setup.
+  DONE
 end

--- a/docker/run
+++ b/docker/run
@@ -19,4 +19,4 @@ function cleanup {
 
 trap cleanup EXIT
 
-docker compose run web $@
+docker compose run web "$@"


### PR DESCRIPTION
## Why

`bin/setup` is the first thing a new contributor runs. Today it has two control-flow bugs, destroys local data on every run, and surfaces its single most common failure several minutes in.

## Bugs fixed

**1. `bundle check || bundle install` could never fall through.**

```ruby
def system!(*args) = system(*args, exception: true)
system!('bundle check') || system!('bundle install')
```

`exception: true` means a failing `bundle check` *raises*; the `||` is dead code. Verified:

```
RAISED: RuntimeError: Command failed with exit 1: false
```

So the one situation the line exists for — gems not installed yet, i.e. every fresh clone — crashed the script instead of installing them. `bin/update:20` already had the correct non-raising form. This PR adds an explicit `try_system` for commands whose non-zero exit is a branch rather than an error, and uses it here and for `npm ci` (whose `|| abort` was unreachable too, and whose message blamed a missing npm for what is almost always a lockfile mismatch).

**2. The Ruby version mismatch path exited 0.**

Bare `exit` reports success, so `.devcontainer/post-create.sh` and any CI caller treated "wrong Ruby, nothing installed" as a clean setup. Now aborts non-zero, with the install command for rbenv/rvm/asdf.

## Stops dropping the development database

`bin/rails db:reset` ran unconditionally — directly under a comment claiming the script "is idempotent, so that you can run it at any time". Re-running setup silently destroyed local data.

- Default is now `db:prepare`: creates and seeds when needed, preserves what is there.
- `--reset` (or `FORCE_DB_RESET=1`) keeps the destructive path, explicitly. `.devcontainer/post-create.sh` passes it, since a fresh container has nothing to lose.

## Fails fast instead of late

Postgres reachability used to be a printed warning (`⚠️ If you use docker to run postgres, make sure your database is running`), and Node was never checked at all — so a wrong Node blew up on `npm ci` at the very end, after the full DB seed. All cheap validation now runs before the first `gem install`:

- `.env` created from `.env.example`, plus a warning listing keys that `.env.example` defines and `.env` lacks (previously these silently drifted).
- Exact Ruby version comparison. The old check was `current_ruby_version.include?(expected)`, so `ruby 4.0.61` would have passed.
- Node presence and major version against `engines.node`.
- A real postgres connection attempt with the `.env` values, via `psql` (validates the user too) falling back to `pg_isready`, or skipped with a note if neither is installed.

Errors name the variable to change:

```
Could not connect to postgres.

Checked host=localhost port=5499 user=postgres, from your .env file.

- Not running? Start postgres (`brew services start postgresql` on macOS), or see
  doc/DOCKER.md if you run it in a container.
- Wrong credentials? Update POSTGRES_USER / POSTGRES_PASSWORD / DATABASE_HOST in .env.
```

This replaces the README's "bin/setup fails with a credentials error" troubleshooting entry.

## Smaller things

- Drops `gem install foreman` — `bin/dev` already installs foreman on demand.
- Drops `bin/rails restart`, which restarts nothing on a fresh clone.
- Adds `--skip-assets` and `--help`.
- `$stdout.sync = true`, so progress and error output stay in order when piped to a log rather than a terminal (the Codespaces post-create case).
- Ends with the actual next steps — `bin/dev`, the URL, and the seed login — at the moment you need them.

## Verification

Preflight paths exercised individually against a sandboxed app root, all with the real code from `bin/setup`:

| Case | Result |
|---|---|
| Happy path | passes, `exit=0` |
| Wrong Ruby version | aborts, `exit=1`, prints rbenv/rvm/asdf commands |
| Postgres down (bad port) | aborts, `exit=1`, names host/port/user |
| Bad `POSTGRES_USER` | aborts, `exit=1` |
| Key missing from `.env` | warns, names the key, continues |
| Node absent from PATH | aborts, `exit=1`, points at `nvm install` |
| Node major mismatch (v20) | aborts, `exit=1` |
| Neither psql nor pg_isready | warns that the DB check was skipped, continues |

Full `bin/setup` run end to end in a clean worktree with no `.env` (so it exercised first-time setup): green, `exit=0`, through `db:prepare`, `db:test:prepare`, `after_party:run`, `npm ci` and both asset builds. `standardrb bin/setup` is clean.

One caveat on the wrong-password case: my local postgres uses `trust` auth, so a bad password connects anyway and the check passes. The check does catch a bad user, a bad host and a bad port. Credential validation is therefore only meaningful where postgres actually requires a password — worth knowing, though it is strictly better than the previous warning-only behavior.

A second back-to-back run failed on `db:test:prepare` with `PG::ObjectInUse` — a stale `rspec` process on my machine was holding `casa_test`. Pre-existing and unrelated; the original script fails identically there.

## Docs updated

`README.md` (troubleshooting entry replaced, flags table added), `.devcontainer/post-create.sh` (`--reset`), `CLAUDE.md` command table.

## Not in this PR

`bin/setup` and `bin/update` remain near-duplicates with their own divergent `system!` semantics. Extracting a shared helper would stop them drifting again, but it touches a second entrypoint, so I left it out to keep this diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: shellcheck CI job

The repo has 24 shell scripts and no shell linter, so a new `Shell lint` workflow runs shellcheck over them.

Scripts are selected **by shebang, not by path** — most have no extension (`bin/dev`, `docker/*`), and `bin/` also holds Ruby scripts, so neither a glob nor a directory list gets the set right. Verified on the runner: 24 scripts found, job green in 10s, and no Ruby script picked up.

Gated at `--severity=warning`. The tree still has ~35 info/style findings, mostly SC2086 (unquoted variables) across `bin/git_hooks/` and `docker/`. Those are worth fixing, but gating on them now would mean rewriting scripts unrelated to whatever PR is under review — the same gradual-adoption stance as `.standard_todo.yml`. A comment in the workflow says to lower the threshold as they get cleaned up.

### Findings fixed to make it green

Two of these were live bugs, not style nits:

**`bin/git_hooks/lint` — the `--unpushed` path was broken on macOS.**

```sh
git diff --name-only HEAD~$(git cherry -v main ${current_branch} | wc -l) HEAD
```

`wc -l` pads its output with spaces on BSD/macOS, and the substitution was unquoted, so word splitting handed git `HEAD~` and `1` as two arguments:

```
$ git diff --name-only HEAD~$(git cherry -v main "${current_branch}" | wc -l) HEAD
fatal: ambiguous argument '1': unknown revision or path not in the working tree.
```

Now strips the padding into a variable and quotes it; the rewritten form returns the expected file list. (Linux `wc -l` doesn't pad, which is why this survived.) Also adds `|| exit 1` to five bare `cd`s (SC2164), so a failed `cd` can no longer run a linter against the wrong directory.

**`docker/run` — unquoted `$@` re-split arguments** (SC2068), so `docker/run rspec -e "some example"` lost its quoting. Now `"$@"`.

**`bin/git_hooks/update-dependencies`** (SC2046, SC1083) — replaced the two-branch `[ $(git diff ... | wc -l) -gt 0 ]` test with a single `git diff --quiet` over both pathspecs. Verified equivalent against a purpose-built repo across lockfile-only, `package.json`-only, and unrelated changes:

| reflog range | old expression | new expression |
|---|---|---|
| lockfile change | CHANGED | CHANGED |
| package.json change | CHANGED | CHANGED |
| unrelated change | unchanged | unchanged |

**`.devcontainer/post-create.sh`** — added a shebang (SC2148); it had none.

### Gate verification

Beyond the green run, I confirmed the job actually fails when it should: adding a new extensionless script with an SC2164 defect was discovered and failed the step (exit 1); fixing the defect returned it to exit 0.

`yamllint` on the new workflow produces the same two warnings (`truthy` on `on:`, comment spacing on the pinned action SHA) as every existing workflow, and no errors.

## CI status

Green except `ruby_lint`, which is **red on `main` too** — the last two `main` runs failed with `Style/RedundantStructKeywordInit` in `app/services/supervisor_dashboard.rb` and `app/services/volunteer_dashboard.rb`, from a standard/rubocop version bump. Neither file is touched here; this PR changes no Ruby outside `bin/setup`. Worth its own one-line PR.

The `docker` job failed once on `spec/system/case_contacts/contact_topic_answers_spec.rb:38` and **passed on re-run** — a flaky system spec (the file has a history of de-flaking commits). That job runs `docker compose exec` directly and never invokes `docker/run`, and the same suite passed in the `rspec` job on the first try.

<details>
<summary>Superseded note</summary>


`ruby_lint` is red on this PR, but it is red on `main` too — the last two `main` runs failed with `Style/RedundantStructKeywordInit` in `app/services/supervisor_dashboard.rb` and `app/services/volunteer_dashboard.rb`, from a standard/rubocop version bump. Neither file is touched here. Worth its own one-line PR.

</details>
