### PR TITLE
fix linter error

### DIFF
--- a/app/services/supervisor_dashboard.rb
+++ b/app/services/supervisor_dashboard.rb
@@ -9,7 +9,7 @@ class SupervisorDashboard
   RECENT_CONTACT_DAYS = 60
   RECENT_HOURS_DAYS = 30
 
-  Row = Struct.new(:volunteer, :cases_count, :status, :last_contact_on, :contacts_recent, :minutes_recent, keyword_init: true) do
+  Row = Struct.new(:volunteer, :cases_count, :status, :last_contact_on, :contacts_recent, :minutes_recent) do
     def needs_followup?
       status == :follow_up
     end

--- a/app/services/volunteer_dashboard.rb
+++ b/app/services/volunteer_dashboard.rb
@@ -4,7 +4,7 @@
 class VolunteerDashboard
   RECENT_HOURS_DAYS = 30
 
-  Row = Struct.new(:casa_case, :last_contact_on, keyword_init: true) do
+  Row = Struct.new(:casa_case, :last_contact_on) do
     def needs_contact?
       last_contact_on.nil? || (Date.current - last_contact_on.to_date).to_i > Volunteer::CONTACT_MADE_IN_DAYS_NUM
     end


### PR DESCRIPTION
### What changed, and _why_?
The linter prints these errors
```
standard: Use Ruby Standard Style (https://github.com/standardrb/standard)
  app/services/supervisor_dashboard.rb:12:108: Style/RedundantStructKeywordInit: Remove the redundant `keyword_init: true`.
  app/services/volunteer_dashboard.rb:7:50: Style/RedundantStructKeywordInit: Remove the redundant `keyword_init: true`.
```

because for `Struct`s `keyword_init: true` has been the default since ruby 3.2 so there's no need to explicitly have it in the code

### How is this **tested**? (please write rspec and jest tests!) 💖💪
Waiting for CI
